### PR TITLE
Fixes: pixi ome-types regression, napari t=0 overlay, gating on un-segmented images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ See also:
 - [`docs/ROADMAP.md`](docs/ROADMAP.md) — temporary forward goals: phases (behaviour/HMM → clustering → freeze v1.0 → packaging/distribution → self-update) + post-v1 backlog. Consult before starting a new phase.
 - [`docs/MILESTONES.md`](docs/MILESTONES.md) — durable, append-only ledger of what landed and how it was packaged (the counterpart to the throwaway roadmap). Add an entry at each freeze/release.
 - [`docs/SHIPPING.md`](docs/SHIPPING.md) — distribution architecture & rationale: Pixi/constructor + browser stack (Julia serves the built frontend; no Tauri/Electron), packaging/update model, and non-obvious env decisions (cellpose-v3 pin, dropped coastal, GPU/RAPIDS parked, run-via-`pixi run`). The *why*, paired with INSTALL.md's *how*.
+- [`docs/DEV.md`](docs/DEV.md) — development workflow: branch + PR conventions (never commit/push to `main`), commit style, how PRs are opened/merged (gh not in the agent env → relay the PR URL), and how releases are tagged off `main`.
 
 **Keep the docs current — update the relevant file in the same change, not after.**
 
@@ -38,6 +39,7 @@ See also:
 | HTTP/WS routes, request/response shapes, binary responses | `docs/API.md` |
 | Deferring a known-better approach (ecosystem/scale not ready) | `docs/FUTURE.md` |
 | Packaging, distribution, env rationale (Pixi/constructor, why) | `docs/SHIPPING.md` |
+| Branching, commits, PRs, release tagging (dev workflow) | `docs/DEV.md` |
 
 > **Fatigue warning:** Agentic programming is cognitively demanding — directing architecture decisions without a flow state is draining in a way that's easy to underestimate. If we've gone two or more rounds on the same question without clear progress, or if an important aspect of the implementation keeps being deferred or glossed over, stop and say so explicitly. Either surface the blocker clearly for the user to decide, or add it to `docs/TODO.md` and move on. Don't push through circular discussions — flag them.
 
@@ -247,6 +249,10 @@ When adding a new task, also register it in `app/src/tasks/task_registry.jl`:
 ---
 
 ## Development
+
+**Git workflow:** branch + PR for everything; **never commit or push to `main`** (releases are
+tagged off `main` after merge). Full conventions — branch naming, commit style, how PRs are
+opened, release tagging — are in [`docs/DEV.md`](docs/DEV.md). Agents commit/push only when asked.
 
 **Dev dir config — single source of truth:** `cecelia-pineapple/.env`
 ```

--- a/api/src/gating_api.jl
+++ b/api/src/gating_api.jl
@@ -67,6 +67,12 @@ function _resolve_vn(img::CciaImage, requested::AbstractString)::String
     (!isempty(requested) && haskey(img.label_props, requested)) ? String(requested) : _active_vn(img)
 end
 
+# true when the image actually has a labelProps table (i.e. it has been segmented/measured). An
+# image that hasn't been segmented yet has none — `versioned_keys` is empty — so gating/membership
+# endpoints that read the cell table must degrade gracefully rather than let `label_props` throw a
+# 500. (Once segmented — static images included — labelProps exist and the normal path applies.)
+_has_label_props(img::CciaImage)::Bool = !isempty(versioned_keys(img.label_props))
+
 # pick the channel-name version whose length matches the intensity-column count
 # (handles AF-corrected images with extra channels); fall back to the active version.
 function _matching_channel_version(versions::AbstractDict, n_channels::Int)::String
@@ -188,6 +194,16 @@ function api_gating_channels(req::HTTP.Request)
     img, err = _gating_image(get(q, "projectUid", ""), get(q, "imageUid", ""))
     err === nothing || return err
     vn = _resolve_vn(img, get(q, "valueName", ""))
+    # image not segmented yet: no labelProps → nothing is gateable. Return empty rather than 500ing
+    # when the gating UI probes channels for it (label_props would throw "No labelProps …"). After
+    # segmentation the image has labelProps and the normal path below runs.
+    if !_has_label_props(img)
+        return 200, JSON3.write((;
+            columns = String[], channels = String[], channelNames = String[],
+            channelNameVersions = Dict{String,Any}(), obsColumns = String[],
+            cellMeasures = String[], trackAggregates = String[],
+            valueNames = String[], valueName = vn, popType = get(q, "popType", "flow")))
+    end
     # track gating: the gateable axes are the per-track properties — motility (the track table's
     # var columns, directly gateable) plus on-read aggregates of any cell measure. We return the
     # motility columns + the aggregatable cell measures + the aggregate suffixes so the client can

--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -328,7 +328,11 @@ function api_napari_show_populations(body_bytes::Vector{UInt8})
     isnothing(v) && return 400, JSON3.write((; error = "Napari not running"))
 
     pops = Vector{Dict{String,Any}}()
-    if show
+    # an image not segmented yet has no labelProps → no populations to show; fall through with
+    # empty `pops` (the bridge then just clears any existing pop layers) rather than 500ing in
+    # `_live_map` → `label_props` ("No labelProps for value_name=… on image …"). After segmentation
+    # the image has labelProps and populations resolve normally.
+    if show && _has_label_props(img)
         m = _live_map(img, vn, pop_type)
         # include the root (whole segmentation) so all cells are visible/selectable in napari
         root_labs = Int.(cells_in_pop(m, "root"))

--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -220,7 +220,7 @@ function api_projects_create(body_bytes::Vector{UInt8})
     body = try JSON3.read(String(body_bytes)) catch
         return 400, JSON3.write((; error="Invalid JSON body"))
     end
-    name = strip(String(get(body, :name, "")))
+    name = String(strip(String(get(body, :name, ""))))
     type = String(get(body, :type, "static"))
     isempty(name) && return 400, JSON3.write((; error="Project name is required"))
     type ∉ ("static", "live", "flow") && return 400, JSON3.write((; error="Invalid project type: $type"))
@@ -295,7 +295,7 @@ function api_projects_rename(body_bytes::Vector{UInt8})
         return 400, JSON3.write((; error="Invalid JSON body"))
     end
     uid  = String(get(body, :uid,  ""))
-    name = strip(String(get(body, :name, "")))
+    name = String(strip(String(get(body, :name, ""))))
     isempty(uid)  && return 400, JSON3.write((; error="uid required"))
     isempty(name) && return 400, JSON3.write((; error="name required"))
     proj_dir = joinpath(projects_dir(), uid)

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -1,0 +1,92 @@
+# Development workflow
+
+How we change this repo: branches, commits, pull requests, releases. For *what* the code
+does see the per-area docs linked from [`CLAUDE.md`](../CLAUDE.md); for the dev loop and
+testing commands see the **Development** and **Testing** sections of `CLAUDE.md`.
+
+Repository: `git@github.com:schienstockd/cecelia.git` (default branch **`main`**).
+
+## Golden rule — never commit or push to `main`
+
+`main` is protected by convention. **All work lands via a feature branch + pull request**, even
+docs and one-line fixes. Never `git commit`/`git push` directly onto `main`. Releases are tagged
+off `main` *after* the PR has merged (see below).
+
+Agents (Claude Code): **commit or push only when the user explicitly asks.** If the current
+branch is `main`, branch first.
+
+## Branches
+
+Branch off the latest `main`, named with a conventional-commit-style prefix matching the change:
+
+```
+feat/<short-slug>      # new feature        e.g. feat/leiden-clustering
+fix/<short-slug>       # bug fix            e.g. fix/track-id-nan
+docs/<short-slug>      # documentation      e.g. docs/ci-badges
+chore/<short-slug>     # deps, tooling, infra  e.g. chore/drop-pythoncall
+refactor/<short-slug>  # behaviour-preserving cleanup
+```
+
+```bash
+git switch main && git pull
+git switch -c feat/<short-slug>
+```
+
+Keep a branch scoped to one logical change. Don't pile an unrelated fix onto a branch that
+already has someone else's work in progress — branch again.
+
+## Commits
+
+Conventional-commits style, matching the existing history (`feat(import): …`,
+`docs(readme): …`, `chore: …`):
+
+```
+<type>(<scope>): <imperative summary>
+```
+
+`type` ∈ `feat | fix | docs | chore | refactor | test | perf`. Scope is optional but
+encouraged (`import`, `update`, `gating`, …).
+
+When a commit is authored by Claude Code, end the message with the trailer:
+
+```
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+Ship the test in the same commit as the code (see `CLAUDE.md` → **Testing**), and update the
+relevant doc in the same change (see `CLAUDE.md` → the *Keep the docs current* table).
+
+## Pull requests
+
+Open a PR against `main` for review; **Dom reviews and merges** (PR #1 merged this way).
+
+- The `gh` CLI is **not installed in the agent environment**. An agent therefore **pushes the
+  branch and relays the PR-creation URL** (the `https://github.com/schienstockd/cecelia/pull/new/<branch>`
+  link printed by `git push`) for Dom to open — it does not attempt `gh pr create`.
+- End PR bodies (when an agent drafts one) with:
+
+  ```
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  ```
+
+```bash
+git push -u origin feat/<short-slug>
+# relay the "Create a pull request" URL git prints
+```
+
+## CI
+
+Every push/PR runs `.github/workflows/ci.yml` (smoke: fresh checkout → `pixi install` →
+`julia … instantiate` → frontend build → server serves `/api/health` + the frontend). Keep it
+green before requesting a merge. See `docs/SHIPPING.md` for the release pipeline.
+
+## Releases
+
+Cut **off `main`** after the relevant PRs have merged, by pushing a tag:
+
+- `v*` tag → `.github/workflows/release.yml` builds the OS-independent `cecelia.tar.gz` bundle
+  and publishes a GitHub Release with the install scripts.
+- **Hyphenated tags are prereleases** (`v0.1.0-rc1`); a clean `vX.Y.Z` is the public release that
+  makes the `releases/latest` install one-liner resolve.
+
+Rationale and the full packaging/update model live in [`docs/SHIPPING.md`](SHIPPING.md).

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -146,6 +146,19 @@ class NapariState:
             self._viewer.dims.ndisplay = 3
             self._viewer.reset_view()
 
+    def _time_axis_len(self):
+        """Length of the image's `t` axis, or None if there is no `t` axis / no data loaded.
+        Reads from the full (channel-inclusive) data shape, since `self._axes` includes `c`."""
+        if not self._axes or not self._im_data:
+            return None
+        low = [a.lower() for a in self._axes]
+        if "t" not in low:
+            return None
+        try:
+            return int(self._im_data[0].shape[low.index("t")])
+        except Exception:
+            return None
+
     def _setup_timestamp(self, path: str):
         """For timecourse data (a `t` axis), show an elapsed-time text overlay (top-left) that updates
         as the t slider moves — `t_index × frame_interval`, formatted H:MM:SS. The frame interval is
@@ -162,6 +175,13 @@ class NapariState:
                 pass
             self._ts_handler = None
         if "t" not in axes:
+            ov.visible = False
+            return
+        # bioformats2raw writes a full TCZYX series, so a single-timepoint image still carries a
+        # singleton `t` axis. Without this guard that showed a misleading "t = 0" overlay on images
+        # that have no real timecourse — treat a length-1 time axis as "no timecourse".
+        t_len = self._time_axis_len()
+        if t_len is not None and t_len <= 1:
             ov.visible = False
             return
         t_idx = axes.index("t")

--- a/pixi.lock
+++ b/pixi.lock
@@ -222,6 +222,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/ae/0eeb22806c4157a9199f65a93374e5ff5c4d2cc1411b5d25053bcd9e6b91/napari_svg-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
@@ -257,6 +258,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/6a/1000cad1700ab0af4d1b1d0a9c23c34badddb4f547c008bde2a6c61968f1/ome_types-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/ff/847841bacfbefc97a00036e0fce5a0f086b640756dc38caea5e1bb002655/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
@@ -398,6 +400,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/ae/0eeb22806c4157a9199f65a93374e5ff5c4d2cc1411b5d25053bcd9e6b91/napari_svg-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
@@ -429,6 +432,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/6a/1000cad1700ab0af4d1b1d0a9c23c34badddb4f547c008bde2a6c61968f1/ome_types-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
       win-64:
@@ -572,6 +576,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d0/ae/0eeb22806c4157a9199f65a93374e5ff5c4d2cc1411b5d25053bcd9e6b91/napari_svg-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl
@@ -601,6 +606,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/6a/1000cad1700ab0af4d1b1d0a9c23c34badddb4f547c008bde2a6c61968f1/ome_types-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
@@ -5600,6 +5606,30 @@ packages:
   - pytest-cov ; extra == 'test'
   - pytest-xdist ; extra == 'test'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl
+  name: xsdata
+  version: '26.2'
+  sha256: 85a591a4405d903416afbd4a917e8dda8ea44641a3e66d72134bc2a31b3c16b0
+  requires_dist:
+  - typing-extensions>=4.12.0
+  - click>=8.0.0 ; extra == 'cli'
+  - jinja2>=3.0.0 ; extra == 'cli'
+  - toposort>=1.9 ; extra == 'cli'
+  - ruff>=0.9.8 ; extra == 'cli'
+  - mkdocs ; extra == 'docs'
+  - mkdocs-gen-files ; extra == 'docs'
+  - mkdocs-literate-nav ; extra == 'docs'
+  - mkdocs-material ; extra == 'docs'
+  - mkdocs-minify-plugin ; extra == 'docs'
+  - mkdocstrings[python] ; extra == 'docs'
+  - markdown-exec[ansi] ; extra == 'docs'
+  - lxml>=5.0.0 ; extra == 'lxml'
+  - requests>=2.28.0 ; extra == 'soap'
+  - pre-commit>=3.0.0 ; extra == 'test'
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-benchmark>=4.0.0 ; extra == 'test'
+  - pytest-cov>=5.0.0 ; extra == 'test'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl
   name: tqdm
   version: 4.68.3
@@ -6534,6 +6564,23 @@ packages:
   requires_dist:
   - colorama ; sys_platform == 'win32'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/fc/6a/1000cad1700ab0af4d1b1d0a9c23c34badddb4f547c008bde2a6c61968f1/ome_types-0.6.3-py3-none-any.whl
+  name: ome-types
+  version: 0.6.3
+  sha256: ce9753ff351bbc534ee5c5038d3cf60b1e4c13d69ad2e6b5a5b75de2a52521a5
+  requires_dist:
+  - pydantic-core>=2.20.0 ; python_full_version >= '3.13'
+  - pydantic-extra-types>=2.0.0
+  - pydantic>=2.4.0
+  - xsdata>=24.4
+  - ruff==0.13.2 ; extra == 'build'
+  - xsdata[cli]>=24.7 ; extra == 'build'
+  - lxml>=4.8.0 ; extra == 'lxml'
+  - lxml>=5.0 ; python_full_version >= '3.11' and extra == 'lxml'
+  - lxml>=5.3 ; python_full_version >= '3.13' and extra == 'lxml'
+  - pint>=0.15 ; extra == 'pint'
+  - pint>=0.25 ; python_full_version >= '3.13' and extra == 'pint'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl
   name: pyzmq
   version: 27.1.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,6 +43,10 @@ btrack       = ">=0.7"
 # Leiden clustering (cells + tracks), CPU path. GPU (RAPIDS) is parked — see the gpu stub
 # below and ~/cc-workspace/cecelia/CLUSTERING_PLAN.md.
 leidenalg    = ">=0.10"
+# OME-XML metadata reader (physical pixel sizes, units, time_increment). Imported at module load
+# by app/py/utils/ome_xml_utils.py → pulled in by cleanup/segment/measure tasks and the napari
+# bridge. Was lost in the requirements.txt→pixi switch; missing it breaks those tasks at import.
+ome-types    = ">=0.5"
 
 # --- PyTorch: CUDA build on Linux/Windows, default (MPS/CPU) build on macOS -------------------
 # The cu124 wheel index only carries linux/win wheels, so torch/torchvision MUST be declared


### PR DESCRIPTION
Bundle of small fixes found while loading images after the pixi switch, plus the dev-workflow doc.

## Fixes

### `fix(deps)`: restore `ome-types` dropped in the pixi switch
`ome-types` was lost in the `requirements.txt` → `pixi.toml` migration. `app/py/utils/ome_xml_utils.py`
imports it at module load, so it broke **cleanup (af/cellpose/drift), segmentation (`cellpose_run`,
`measure_run`)** and dim_utils with `ModuleNotFoundError: No module named 'ome_types'`. The napari
bridge's OME-XML reads were degrading silently to defaults too.
Re-added `ome-types>=0.5` (resolves to 0.6.3); verified the failing import and `ome_xml_utils` load.

### `fix(napari)`: hide the "t = 0" overlay for single-timepoint images
`bioformats2raw` writes a full TCZYX series, so a non-timecourse image still carries a singleton `t`
axis. The timestamp overlay only checked that a `t` axis *existed*, showing a misleading "t = 0".
Now guarded on the `t`-axis length (> 1) via a new `_time_axis_len` helper.

### `fix(api)`: degrade gracefully on images without labelProps
An image that hasn't been segmented yet has no labelProps, so `GET /api/gating/channels` and
`POST /api/napari/show-populations` returned unhandled 500s from `label_props()`. They now return
empty gateable columns / no populations. After segmentation (**static images included**) labelProps
exist and the normal path runs.

### `fix(api)`: coerce stripped project name to `String`
`strip()` returns a `SubString`; wrap in `String()` in `api_projects_create`/`api_projects_rename`.

### `docs`: add `DEV.md`
Dev/git workflow — branch+PR conventions (never commit/push to `main`), commit style, PR/release
flow. Referenced from `CLAUDE.md` (See-also, docs table, Development section).

## Verification
- `ome-types`: import + `ome_xml_utils` load confirmed in the pixi env.
- `napari_bridge.py` byte-compiles; `gating_api.jl` / `napari_api.jl` parse-check clean.
- API fixes require a backend restart (not Revise-tracked); bridge fix needs `pixi run stop-napari`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)