### PR TITLE
docs: require agents to ask before every commit/PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,9 @@ When adding a new task, also register it in `app/src/tasks/task_registry.jl`:
 
 **Git workflow:** branch + PR for everything; **never commit or push to `main`** (releases are
 tagged off `main` after merge). Full conventions — branch naming, commit style, how PRs are
-opened, release tagging — are in [`docs/DEV.md`](docs/DEV.md). Agents commit/push only when asked.
+opened, release tagging — are in [`docs/DEV.md`](docs/DEV.md). **Agents: ask before every commit
+and before opening/pushing a PR — explicitly, each time; don't commit or push proactively** (a
+"go ahead" to do the work is not approval to commit it).
 
 **Dev dir config — single source of truth:** `cecelia-pineapple/.env`
 ```

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -12,8 +12,11 @@ Repository: `git@github.com:schienstockd/cecelia.git` (default branch **`main`**
 docs and one-line fixes. Never `git commit`/`git push` directly onto `main`. Releases are tagged
 off `main` *after* the PR has merged (see below).
 
-Agents (Claude Code): **commit or push only when the user explicitly asks.** If the current
-branch is `main`, branch first.
+Agents (Claude Code): **ask before every commit and before opening/pushing a PR — explicitly,
+each time.** Do not commit or push proactively, even mid-task or after a general "go ahead" to do
+the work: approval to *make a change* is not approval to *commit* it. First show the file list and
+the proposed commit message(s) (and the branch), then wait for confirmation. If the current branch
+is `main`, branch first.
 
 ## Branches
 
@@ -58,7 +61,8 @@ relevant doc in the same change (see `CLAUDE.md` → the *Keep the docs current*
 
 ## Pull requests
 
-Open a PR against `main` for review; **Dom reviews and merges** (PR #1 merged this way).
+Open a PR against `main` for review; **Dom reviews and merges** (PR #1 merged this way). An agent
+**asks first** (see the golden rule) before pushing the branch or opening the PR.
 
 - The `gh` CLI is **not installed in the agent environment**. An agent therefore **pushes the
   branch and relays the PR-creation URL** (the `https://github.com/schienstockd/cecelia/pull/new/<branch>`


### PR DESCRIPTION
Agents must ask explicitly before each commit and before opening/pushing a PR; a general go-ahead to do the work is not approval to commit it. Codified in DEV.md (golden-rule + PR sections) and the CLAUDE.md Development line.