### PR TITLE
feat(clustering): add clustTracks (set-scope track clustering)

### DIFF
--- a/app/py/tasks/clustPops/cluster_run.py
+++ b/app/py/tasks/clustPops/cluster_run.py
@@ -39,9 +39,6 @@ def run(params):
         log.log("[ERROR] cluster_cells: no segments or no feature columns")
         return
 
-    cluster_col = f"clusters.{suffix}"
-    umap_key    = f"X_umap.{suffix}"
-
     # ── pool every segment's cells into one matrix (one row per cell, tagged by segment) ──
     log.log(f">> Pooling {len(segments)} segment(s) on {len(feature_cols)} feature(s)")
     frames = []
@@ -113,30 +110,10 @@ def run(params):
         log=log.log,
     )
 
-    # clusters are scanpy categorical strings ("0".."N") — store as INTEGER codes (not strings):
-    # the new stack auto-detects integer obs columns as categorical (track_props.jl), and consumers
-    # pass the column through the `categorical` override above the 20-level cap.
-    codes = adata.obs["clusters"].astype(int).to_numpy()
-    n_clusters = len(np.unique(codes))
-    has_umap = "X_umap" in adata.obsm
-    log.log(f">> {n_clusters} clusters; writing {cluster_col}"
-            + (f" + obsm['{umap_key}']" if has_umap else " (no UMAP)"))
-
-    # ── split back per segment and write into each labelProps ──
-    for seg in segments:
-        mask = (adata.obs["uID"].to_numpy() == seg["uID"]) & \
-               (adata.obs["valueName"].to_numpy() == seg["valueName"])
-        if not mask.any():
-            continue
-        sub_labels = adata.obs["label"].to_numpy()[mask]
-        sub_codes  = codes[mask]
-        view = LabelPropsView(seg["propsPath"]).add_obs(
-            pd.DataFrame({"label": sub_labels, cluster_col: sub_codes}))
-        if has_umap:
-            view = view.add_obsm(umap_key, sub_labels, adata.obsm["X_umap"][mask])
-        view.save()
-        view.close()
-        log.log(f"> wrote {seg['uID']}/{seg['valueName']}: {mask.sum()} cells")
+    # ── split back per segment and write into each cell labelProps (shared write-back) ──
+    # clusters are scanpy categorical strings ("0".."N"); the helper stores INTEGER codes (a
+    # `clusters.*` name-rule pins them categorical above the level cap — see track_props.jl).
+    clustering_utils.split_back_and_write(adata, segments, suffix, log=log.log)
 
     log.log(">> cluster_cells done")
 

--- a/app/py/tasks/clustTracks/cluster_run.py
+++ b/app/py/tasks/clustTracks/cluster_run.py
@@ -1,0 +1,94 @@
+"""
+clustTracks.cluster (set-scope) — Python runner.
+
+The track analogue of `clustPops/cluster_run.py`. Clusters TRACKS pooled across the whole set so
+cluster IDs are comparable, then writes `clusters.{suffix}` (integer-code obs) + `obsm['X_umap.{suffix}']`
+back into each segmentation's per-TRACK table (`{vn}__tracks.h5ad`, label == track_id) — so they flow
+through `track_props` and are gateable as `trackclust`.
+
+Unlike the cell runner, the feature matrix arrives INLINE (params `X`/`uIDs`/`valueNames`/`labels`),
+not as paths to read: track features are motility ⊕ on-read aggregates (HMM-state / transition
+frequencies, per-track cell-measure means) that only Julia's `track_props` can produce (compute-on-read,
+nothing persisted — see app/src/tracking/track_props.jl and tasks/clustTracks/cluster.jl). So Julia
+builds the matrix and this script just clusters it and writes the labels back. The scanpy engine
+(`find_populations`) and the per-segment write-back (`split_back_and_write`) are shared with the cell
+runner — only the matrix assembly differs.
+
+Invoked by `app/src/tasks/clustTracks/cluster.jl` via a params JSON. Params:
+  suffix                output column suffix → clusters.{suffix} / X_umap.{suffix}
+  segments              [{uID, valueName, propsPath}] — propsPath is each per-track table to write
+  featureCols           per-track feature column names (var of the matrix)
+  X                     n_tracks × n_features matrix (JSON null = NaN)
+  uIDs, valueNames      per-row segment tags (parallel to X rows)
+  labels                per-row track_id (== the per-track table's obs label index)
+  resolution, normaliseAxis, normaliseToMedian, maxFraction, normalisePercentile,
+  normalisePercentileBottom, transformation, logBase, createUmap, usePaga, pagaThreshold, randomState
+"""
+import numpy as np
+
+# `py.*` resolves via PYTHONPATH=app/, set by the Julia launcher (app/src/py_runner.jl::run_py).
+import py.utils.script_utils as script_utils
+import py.utils.clustering_utils as clustering_utils
+
+
+def run(params):
+    log = script_utils.get_logfile_utils(params)
+
+    suffix       = script_utils.get_param(params, "suffix", default="default")
+    segments     = script_utils.get_param(params, "segments", default=[])
+    feature_cols = script_utils.get_param(params, "featureCols", default=[])
+    rows_uid     = script_utils.get_param(params, "uIDs", default=[])
+    rows_vn      = script_utils.get_param(params, "valueNames", default=[])
+    rows_label   = script_utils.get_param(params, "labels", default=[])
+    X_in         = script_utils.get_param(params, "X", default=[])
+
+    if len(segments) == 0 or len(feature_cols) == 0 or len(X_in) == 0:
+        log.log("[ERROR] cluster_tracks: no segments / features / tracks")
+        return
+
+    # ── build the feature AnnData from the inline matrix (JSON null → NaN) ──
+    log.log(f">> {len(X_in)} tracks pooled across the set on {len(feature_cols)} feature(s)")
+    import anndata as ad
+    X = np.array([[np.nan if v is None else v for v in row] for row in X_in], dtype=np.float32)
+    adata = ad.AnnData(X)
+    adata.var_names = list(feature_cols)
+    adata.obs_names = [str(i) for i in range(X.shape[0])]
+    adata.obs["uID"]       = np.asarray(rows_uid, dtype=object)
+    adata.obs["valueName"] = np.asarray(rows_vn, dtype=object)
+    adata.obs["label"]     = np.asarray(rows_label)
+
+    # ── cluster the whole set at once (shared scanpy engine) ──
+    clustering_utils.find_populations(
+        adata,
+        resolution=script_utils.get_param(params, "resolution", default=1.0),
+        axis=script_utils.get_param(params, "normaliseAxis", default="channels"),
+        to_median=script_utils.get_param(params, "normaliseToMedian", default=False),
+        max_fraction=script_utils.get_param(params, "maxFraction", default=0.0),
+        percentile=script_utils.get_param(params, "normalisePercentile", default=99.8),
+        percentile_bottom=script_utils.get_param(params, "normalisePercentileBottom", default=0.0),
+        transformation=script_utils.get_param(params, "transformation", default="NONE"),
+        log_base=script_utils.get_param(params, "logBase", default=0),
+        create_umap=script_utils.get_param(params, "createUmap", default=True),
+        use_paga=script_utils.get_param(params, "usePaga", default=False),
+        paga_threshold=script_utils.get_param(params, "pagaThreshold", default=0.1),
+        backend="auto",
+        random_state=script_utils.get_param(params, "randomState", default=0),
+        log=log.log,
+    )
+
+    # ── split back per segment and write into each per-track table (shared write-back) ──
+    clustering_utils.split_back_and_write(adata, segments, suffix, log=log.log)
+
+    log.log(">> cluster_tracks done")
+
+
+def main():
+    params = script_utils.script_params()
+    if params is None:
+        print("[ERROR] no --params file", flush=True)
+        return
+    run(params)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/py/utils/clustering_utils.py
+++ b/app/py/utils/clustering_utils.py
@@ -19,7 +19,10 @@ CUDA-only) is built but parked — see ~/cc-workspace/cecelia/CLUSTERING_PLAN.md
 import importlib.util
 
 import numpy as np
+import pandas as pd
 import scanpy as sc
+
+from py.utils.label_props_utils import LabelPropsView
 
 
 # ── backend detection (cached) ───────────────────────────────────────────────────
@@ -158,6 +161,56 @@ def find_populations(adata, resolution: float = 1.0, axis: str = "channels",
             sc.tl.umap(adata, random_state=random_state)
 
     return adata.obs["clusters"], adata.obsm.get("X_umap")
+
+
+# ── shared write-back (cells + tracks) ─────────────────────────────────────────────
+def split_back_and_write(adata, segments, suffix: str, log=None):
+    """Split a pooled, clustered AnnData back per segment and write the cluster assignment
+    into each segment's labelProps via `LabelPropsView` (the sanctioned writer — CLAUDE.md).
+
+    Granularity-blind, like `find_populations`: the caller decides what a "segment" and a "label"
+    mean. For `clustPops` a segment is one (image, segmentation) and `label` is the CELL label;
+    for `clustTracks` a segment is one (image, segmentation) and `label` is the track_id (the
+    per-track table's obs index). Either way the mechanics are identical, so this lives here once
+    rather than being re-implemented per runner.
+
+    Requirements:
+      • `adata.obs` carries `uID`, `valueName`, `label` (label matching each target file's index).
+      • `adata.obs['clusters']` holds the scanpy categorical string codes ("0".."N").
+      • each `segments` entry is a dict with `uID`, `valueName`, `propsPath` (the h5ad to write).
+
+    Writes integer-code `clusters.{suffix}` obs (the new stack auto-detects integer obs as a
+    categorical code set; a `clusters.*` name-rule pins it categorical above the level cap — see
+    track_props.jl) and, when present, `obsm['X_umap.{suffix}']`. Returns the number of clusters."""
+    _log = log if callable(log) else (lambda _m: None)
+
+    cluster_col = f"clusters.{suffix}"
+    umap_key    = f"X_umap.{suffix}"
+
+    codes      = adata.obs["clusters"].astype(int).to_numpy()
+    n_clusters = len(np.unique(codes))
+    has_umap   = "X_umap" in adata.obsm
+    _log(f">> {n_clusters} clusters; writing {cluster_col}"
+         + (f" + obsm['{umap_key}']" if has_umap else " (no UMAP)"))
+
+    uid_arr   = adata.obs["uID"].to_numpy()
+    vn_arr    = adata.obs["valueName"].to_numpy()
+    label_arr = adata.obs["label"].to_numpy()
+
+    for seg in segments:
+        mask = (uid_arr == seg["uID"]) & (vn_arr == seg["valueName"])
+        if not mask.any():
+            continue
+        sub_labels = label_arr[mask]
+        view = LabelPropsView(seg["propsPath"]).add_obs(
+            pd.DataFrame({"label": sub_labels, cluster_col: codes[mask]}))
+        if has_umap:
+            view = view.add_obsm(umap_key, sub_labels, adata.obsm["X_umap"][mask])
+        view.save()
+        view.close()
+        _log(f"> wrote {seg['uID']}/{seg['valueName']}: {int(mask.sum())} rows")
+
+    return n_clusters
 
 
 def _find_gpu(adata, resolution: float, create_umap: bool, random_state: int):

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -63,7 +63,7 @@ export CellposeCorrect
 export CellposeSegment
 export MeasureLabels
 export BayesianTracking, TrackMeasures
-export ClustPops
+export ClustPops, ClustTracks
 export detect_motion_dims, MotionDims
 export AfCorrect, DriftCorrect, CompositeTask
 
@@ -124,6 +124,7 @@ include("tasks/tracking/track_measures.jl")
 include("tasks/behaviour/hmm_states.jl")
 include("tasks/behaviour/hmm_transitions.jl")
 include("tasks/clustPops/cluster.jl")
+include("tasks/clustTracks/cluster.jl")
 include("tasks/task_registry.jl")
 include("tasks/scheduler.jl")
 include("tasks/chain.jl")

--- a/app/src/plotting/plot_data.jl
+++ b/app/src/plotting/plot_data.jl
@@ -159,7 +159,7 @@ function _summary_agg(df::DataFrame, chart_type::AbstractString;
     # detected measure type (numeric vs categorical) so the panel can offer only the applicable
     # chart types (docs/PLOTS.md §2). Auto-detection is shared with track_props (`_is_categorical_col`).
     mtype = (measure !== nothing && String(measure) in names(df)) ?
-            (_is_categorical_col(df[!, String(measure)]) ? "categorical" : "numeric") : "numeric"
+            (_is_categorical_col(df[!, String(measure)], String(measure)) ? "categorical" : "numeric") : "numeric"
     if chart_type == "points"
         # raw (downsampled) values per series — the data source for strip/jitter and (client-side
         # density) violin charts. No server aggregation beyond the per-group downsample.

--- a/app/src/tasks/clustTracks/cluster.jl
+++ b/app/src/tasks/clustTracks/cluster.jl
@@ -1,0 +1,137 @@
+# ── clustTracks.cluster — Leiden clustering of TRACKS across a set ───────────────
+#
+# Set-scope task (port of clusterTracks `clusterTracks`): pools the selected track populations
+# across ALL the set's images/segmentations and clusters them ONCE, so cluster IDs are comparable
+# across the whole set. The track analogue of `clustPops` — same shape, one feature unit per TRACK
+# instead of per cell.
+#
+# Division of labour (docs/ARCHITECTURE.md boundaries):
+#   • Julia resolves membership (`pop_df(:track)` over `popsToCluster`) AND builds the per-track
+#     feature matrix via `track_props` — motility (stored in `{vn}__tracks.h5ad`) ⊕ on-read
+#     aggregates of per-cell measures (HMM-state / transition frequencies, intensity / morphology
+#     means). These aggregates are compute-on-read (nothing persisted — `track_props.jl`), so ONLY
+#     Julia can produce them; we therefore hand Python the feature MATRIX inline rather than a path.
+#     (Contrast `clustPops`, whose features are stored cell columns Python reads itself. The
+#     divergence is forced by the data model, not duplication — the shared pieces are the scanpy
+#     engine `find_populations` and the write-back `split_back_and_write`.)
+#   • Python (`clustTracks/cluster_run.py`) runs the shared scanpy engine and writes
+#     `clusters.{suffix}` (integer-code obs) + `obsm['X_umap.{suffix}']` back into each
+#     segmentation's per-TRACK table (label == track_id). Those flow through `track_props`
+#     automatically → gateable as `trackclust`.
+#
+# Why on-read (not stored) aggregates: HMM (and transitions) is computed AFTER track_measures by a
+# separate task, so persisting it per-track would couple independent tasks and go stale when cell
+# measures change. Computing it on the fly is a columnar read + one groupby — negligible next to the
+# Leiden/UMAP that follow. See CLUSTERING_PLAN.md (Decision 9).
+
+using DataFrames: nrow, groupby, names
+
+struct ClustTracks <: CciaTask end
+
+function _run_task(::ClustTracks, imgs::Vector{CciaImage}, params::Dict{String,Any};
+                   on_log::Function      = line -> println(line),
+                   on_progress::Function = (n, t) -> nothing,
+                   on_process::Function  = _ -> nothing)
+    isempty(imgs) && (on_log("[ERROR] clustTracks: no images"); return nothing)
+
+    pops = _str_list(params, "popsToCluster")           # shared with clustPops (cluster.jl)
+    isempty(pops) && (on_log("[ERROR] clustTracks: select at least one track population"); return nothing)
+    pop_type = string(get(params, "popType", "track"))
+    suffix   = string(get(params, "valueNameSuffix", "default"))
+    feature_cols = _str_list(params, "clusterMeasures") # per-track property column names
+    isempty(feature_cols) &&
+        (on_log("[ERROR] clustTracks: select feature columns (motility / HMM / aggregates) to cluster on"); return nothing)
+
+    on_log("[INFO] clustTracks: $(length(imgs)) image(s), pops=$(pops), " *
+           "features=$(feature_cols), suffix=$suffix")
+    on_progress(1, 4)
+
+    uids = [img.uid for img in imgs]
+
+    # ── which base cell measures must be aggregated to produce the requested track-property cols ──
+    # motility columns (free from the track table) need no aggregation; everything else maps back to
+    # the base per-cell measure via `track_cell_measures`. Motility set is the same across the set
+    # (one acquisition / same track_measures run) — read it from the first image's track table.
+    mot_cols = (p = img_track_props_path(imgs[1], pops_value_name(pops, imgs[1]));
+                isfile(p) ? col_names(label_props(p); data_type = :vars) : String[])
+    cell_measures = track_cell_measures(feature_cols, mot_cols)
+
+    # ── pooled per-track features: one row per track tagged with uID + value_name + track_id ──
+    # pop_type="track" → `track_props` (motility ⊕ on-read aggregates), one point per track.
+    df = pop_df(imgs, uids, pop_type, pops;
+                granularity = :track, cell_measures = cell_measures, pop_cols = String[])
+    nrow(df) == 0 && (on_log("[ERROR] clustTracks: no tracks for pops=$(pops)"); return nothing)
+    on_progress(2, 4)
+
+    missing_cols = setdiff(feature_cols, names(df))
+    isempty(missing_cols) ||
+        on_log("[WARN] clustTracks: requested features not present, dropped: $(missing_cols)")
+    present_cols = intersect(feature_cols, names(df))
+    isempty(present_cols) &&
+        (on_log("[ERROR] clustTracks: none of the requested feature columns exist in the track table"); return nothing)
+
+    # ── build the inline feature matrix (rows tagged by segment + track_id; NaN → JSON null) ──
+    # `label` is the track table's obs index (== track_id), so the write-back aligns by it.
+    rows_uid   = String[string(r) for r in df.uID]
+    rows_vn    = String[string(r) for r in df.value_name]
+    rows_label = Int[Int(r) for r in df.label]
+    X = Vector{Vector{Any}}(undef, nrow(df))
+    for (i, row) in enumerate(eachrow(df))
+        X[i] = Any[_jsonsafe(row[c]) for c in present_cols]
+    end
+
+    # ── one segment per (uID, value_name): its per-TRACK table path (write-back target) ──
+    img_by_uid = Dict(img.uid => img for img in imgs)
+    segments = Vector{Dict{String,Any}}()
+    for g in groupby(df, [:uID, :value_name])
+        uid = string(first(g.uID)); vn = string(first(g.value_name))
+        img = get(img_by_uid, uid, nothing); img === nothing && continue
+        push!(segments, Dict{String,Any}(
+            "uID" => uid, "valueName" => vn,
+            "propsPath" => img_track_props_path(img, vn)))
+    end
+    isempty(segments) && (on_log("[ERROR] clustTracks: no segments resolved"); return nothing)
+    on_log("[INFO] $(length(segments)) segment(s), $(nrow(df)) tracks, $(length(present_cols)) features")
+
+    # ── hand off to the Python engine runner (inline matrix; cf. module docstring) ──
+    task_params = Dict{String,Any}(
+        "suffix" => suffix, "segments" => segments,
+        "featureCols" => present_cols,
+        "uIDs" => rows_uid, "valueNames" => rows_vn, "labels" => rows_label, "X" => X,
+        "resolution" => get(params, "resolution", 1.0),
+        "normaliseAxis" => string(get(params, "normaliseAxis", "channels")),
+        "normaliseToMedian" => Bool(get(params, "normaliseToMedian", false)),
+        "maxFraction" => get(params, "maxFraction", 0.0),
+        "normalisePercentile" => get(params, "normalisePercentile", 99.8),
+        "normalisePercentileBottom" => get(params, "normalisePercentileBottom", 0.0),
+        "transformation" => string(get(params, "transformation", "NONE")),
+        "logBase" => get(params, "logBase", 0),
+        "createUmap" => Bool(get(params, "mergeUmap", true)),
+        "usePaga" => Bool(get(params, "usePaga", false)),
+        "pagaThreshold" => get(params, "pagaThreshold", 0.1),
+        "randomState" => 0)
+    on_progress(3, 4)
+
+    ok = run_py("tasks/clustTracks/cluster_run.py", task_params, task_run_dir(imgs[1]._dir);
+                on_log = on_log, on_process = on_process)
+    ok || (on_log("[ERROR] clustTracks: Python runner failed"); return nothing)
+    on_progress(4, 4)
+
+    on_log("[INFO] clustTracks done → clusters.$suffix (per-track)")
+    Dict{String,Any}("suffix" => suffix, "segments" => length(segments),
+                     "tracks" => nrow(df), "features" => length(present_cols))
+end
+
+# value_name of the first value-name-prefixed pop (for the set-wide motility-column probe). Pops
+# are prefixed as "{value_name}/{pop path}" (e.g. "A/root") — the segmentation key is the part
+# before the FIRST slash (mirrors `_group_pops_by_value_name`). Root / unprefixed pops fall back
+# to the image's active segmentation. Motility columns are identical across the set, so any one
+# segment suffices.
+function pops_value_name(pops::Vector{String}, img::CciaImage)::String
+    for p in pops
+        (startswith(p, "/") || is_root(p)) && continue
+        idx = findfirst('/', p)
+        idx === nothing || return p[1:idx-1]
+    end
+    string(get(img.label_props, "_active", "default"))
+end

--- a/app/src/tasks/clustTracks/cluster.json
+++ b/app/src/tasks/clustTracks/cluster.json
@@ -1,7 +1,7 @@
 {
-  "task": "clusterCells",
-  "fun_name": "clustPops.cluster",
-  "label": "Cluster cells",
+  "task": "clusterTracks",
+  "fun_name": "clustTracks.cluster",
+  "label": "Cluster tracks",
   "category": "Clustering",
   "env": ["local"],
   "resource_pool": "default",
@@ -12,35 +12,27 @@
       "label": "Suffix",
       "type": "text",
       "default": "default",
-      "tip": "Output column suffix → clusters.<suffix> and obsm['X_umap.<suffix>']. Keeps multiple resolutions / re-clusterings side by side."
+      "tip": "Output column suffix → clusters.<suffix> and obsm['X_umap.<suffix>'] on the per-track table. Keeps multiple resolutions / re-clusterings side by side."
     },
     {
       "key": "popsToCluster",
-      "label": "Populations",
+      "label": "Track populations",
       "type": "popSelection",
-      "popType": "flow",
+      "popType": "track",
       "multiple": true,
       "acrossSegmentations": true,
+      "includeRoot": true,
       "default": [],
-      "tip": "Populations to cluster, across any segmentation (e.g. A/root, B/root, C/root, or gated subsets). All selected cells from all selected images are clustered jointly, so cluster IDs are comparable across the set."
+      "tip": "Track populations to cluster, across any segmentation (e.g. A/root, B/root, or gated track subsets). All selected tracks from all selected images are clustered jointly, so cluster IDs are comparable across the set."
     },
     {
       "key": "clusterMeasures",
       "label": "Cluster on",
       "type": "labelPropsColsSelection",
+      "popType": "track",
       "multiple": true,
-      "includeChannels": true,
       "default": [],
-      "tip": "Feature columns to cluster on — channel intensities (mean_intensity_N) and/or object/morphology measures (area, sphericity, …)."
-    },
-    {
-      "key": "refChannel",
-      "label": "Reference channel",
-      "type": "labelPropsColsSelection",
-      "multiple": false,
-      "includeChannels": true,
-      "default": "",
-      "tip": "Optional: divide each intensity feature by this channel before normalisation (ratiometric). Leave empty for none."
+      "tip": "Per-track feature columns — celltrackR motility (live.track.speed, …), HMM-state / transition frequencies, and per-track aggregates of cell measures (mean_intensity_N.mean, area.median, …)."
     },
     {
       "key": "resolution",
@@ -67,15 +59,15 @@
       "params": [
         { "key": "normaliseAxis", "label": "Axis", "type": "select", "default": "channels",
           "options": [
-            { "value": "channels", "label": "Per channel (percentile)" },
-            { "value": "cells",    "label": "Per cell (total)" },
+            { "value": "channels", "label": "Per feature (percentile)" },
+            { "value": "cells",    "label": "Per track (total)" },
             { "value": "NONE",     "label": "No normalisation" }
           ],
-          "tip": "Per-channel percentile rescale to [0,1], per-cell total normalisation, or none." },
-        { "key": "normaliseToMedian", "label": "Normalise to median", "type": "bool", "default": false, "tip": "Divide each channel by its median before the percentile rescale." },
-        { "key": "maxFraction", "label": "Max fraction (per-cell)", "type": "float", "min": 0, "max": 1, "step": 0.01, "default": 0, "tip": "Per-cell normalisation: exclude channels exceeding this fraction of a cell's total (0 = off)." },
-        { "key": "normalisePercentile", "label": "Top percentile", "type": "float", "min": 50, "max": 100, "step": 0.1, "default": 99.8, "tip": "Upper percentile mapped to 1.0 in per-channel normalisation." },
-        { "key": "normalisePercentileBottom", "label": "Bottom percentile", "type": "float", "min": 0, "max": 50, "step": 0.1, "default": 0, "tip": "Lower percentile mapped to 0.0 in per-channel normalisation." }
+          "tip": "Per-feature percentile rescale to [0,1], per-track total normalisation, or none." },
+        { "key": "normaliseToMedian", "label": "Normalise to median", "type": "bool", "default": false, "tip": "Divide each feature by its median before the percentile rescale." },
+        { "key": "maxFraction", "label": "Max fraction (per-track)", "type": "float", "min": 0, "max": 1, "step": 0.01, "default": 0, "tip": "Per-track normalisation: exclude features exceeding this fraction of a track's total (0 = off)." },
+        { "key": "normalisePercentile", "label": "Top percentile", "type": "float", "min": 50, "max": 100, "step": 0.1, "default": 99.8, "tip": "Upper percentile mapped to 1.0 in per-feature normalisation." },
+        { "key": "normalisePercentileBottom", "label": "Bottom percentile", "type": "float", "min": 0, "max": 50, "step": 0.1, "default": 0, "tip": "Lower percentile mapped to 0.0 in per-feature normalisation." }
       ]
     },
     {

--- a/app/src/tasks/task_registry.jl
+++ b/app/src/tasks/task_registry.jl
@@ -41,6 +41,10 @@ function _spec_path(::ClustPops)
     joinpath(@__DIR__, "clustPops", "cluster.json")
 end
 
+function _spec_path(::ClustTracks)
+    joinpath(@__DIR__, "clustTracks", "cluster.json")
+end
+
 function _spec_path(::AfCorrect)
     joinpath(@__DIR__, "cleanupImages", "af_correct.json")
 end
@@ -87,6 +91,7 @@ function _fun_name_map()::Dict{String, CciaTask}
         "behaviour.hmm_transitions"         => HmmTransitions(),
         "behaviour.hmm"                     => CompositeTask("behaviour.hmm"),
         "clustPops.cluster"                 => ClustPops(),
+        "clustTracks.cluster"               => ClustTracks(),
         "segment.cellposeMeasure"           => CompositeTask("segment.cellposeMeasure"),
         "cleanupImages.afCorrect"           => AfCorrect(),
         "cleanupImages.driftCorrect"        => DriftCorrect(),

--- a/app/src/tracking/track_props.jl
+++ b/app/src/tracking/track_props.jl
@@ -29,7 +29,11 @@ const _MAX_CATEGORICAL_LEVELS = 20
 # numeric, but a small-range integer COUNT could be misread — pass it in `numeric` to force it (or
 # `categorical` to force the other way). The first rule is exact, so the cleanest path for a true
 # categorical is to have the producing task write it as an anndata `categorical`.
-function _is_categorical_col(col)::Bool
+function _is_categorical_col(col, name::AbstractString="")::Bool
+    # name-rule: cluster assignments are always a categorical code set, however many clusters —
+    # a high-resolution run can exceed the integer-level cap below, but the codes are never a count.
+    # `clusters` (exact) or `clusters.{suffix}` (clustPops/clustTracks output).
+    (name == "clusters" || startswith(name, "clusters.")) && return true
     nonmissingtype(eltype(col)) <: Real || return true            # String / categorical-encoded
     vals = _finite_vals(col)
     isempty(vals) && return false
@@ -86,7 +90,7 @@ function track_props(img::CciaImage; value_name::Union{AbstractString,Nothing}=n
         # auto-detect type from the decoded column; `categorical`/`numeric` kwargs force the call
         is_cat = m in categorical ? true :
                  m in numeric     ? false :
-                 _is_categorical_col(cell[!, m])
+                 _is_categorical_col(cell[!, m], m)
         if is_cat
             cats = sort(unique(_catkey(v) for v in cell[!, m]
                                if !(v isa Missing) && !(v isa Real && !isfinite(v))))

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -148,6 +148,18 @@ end
             ClustPops(), Dict{String,Any}("resolution" => "not-a-number"))
     end
 
+    # ── Dispatch + param validation — ClustTracks (clustTracks.cluster, set-scope) ───
+    @testset "Param validation — ClustTracks" begin
+        @test _task_from_fun_name("clustTracks.cluster") isa ClustTracks
+        @test task_scope(ClustTracks()) == "set"
+        # resolution is float min=0/max=5 — out of range must be rejected
+        @test_throws ParamValidationError validate_params(
+            ClustTracks(), Dict{String,Any}("resolution" => 99))
+        # wrong type where float expected
+        @test_throws ParamValidationError validate_params(
+            ClustTracks(), Dict{String,Any}("resolution" => "not-a-number"))
+    end
+
     # ── Image round-trip (status + attr) ────────────────────────────────────────
     # Regression guard: save!(img) must persist status and attr, not silently drop them.
     @testset "Image status/attr round-trip" begin
@@ -2309,6 +2321,10 @@ end
             @test Cecelia._is_categorical_col([1, 2, missing])                 # integer codes (Missing-union) too
             @test !Cecelia._is_categorical_col([10.12, 11.3, 9.8])             # continuous floats → numeric (speed)
             @test !Cecelia._is_categorical_col(Float64.(1:100))               # wide-spread integers → numeric (counts/area)
+            # name-rule: cluster code columns are categorical regardless of level count (>cap clusters)
+            @test Cecelia._is_categorical_col(Float64.(1:100), "clusters")          # exact name
+            @test Cecelia._is_categorical_col(Float64.(1:100), "clusters.default")  # clusters.{suffix}
+            @test !Cecelia._is_categorical_col(Float64.(1:100), "area")             # other names keep the heuristic
             # `st` is an integer code (1/2) → auto-detected categorical with NO override → freq cols
             auto = track_props(img; value_name="B", cell_measures=["st"])
             @test "st.1" in names(auto) && "st.2" in names(auto) && !("st.mean" in names(auto))

--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -43,6 +43,25 @@ Read it through the same `LabelProps` chain (the reader is grain-agnostic — `l
 here). The unified accessor surfaces it as `pop_df(img, "live", pops; granularity=:track)` — see
 `docs/POPULATION.md`.
 
+### Clustering output — `clusters.{suffix}` obs + `obsm['X_umap.{suffix}']`
+
+The Leiden clustering tasks write their result back through the `LabelProps` writer (no new files):
+
+| Producer | Writes into | `clusters.{suffix}` | `obsm['X_umap.{suffix}']` |
+|---|---|---|---|
+| `clustPops.cluster` | the per-**cell** `{value_name}.h5ad` | one code per cell | per-cell 2-D embedding |
+| `clustTracks.cluster` | the per-**track** `{value_name}__tracks.h5ad` | one code per track (`label`=`track_id`) | per-track 2-D embedding |
+
+- **`clusters.{suffix}`** holds **integer cluster codes** (not strings) — the stack auto-detects
+  integer obs as a categorical code set. A `clusters.*` **name-rule** in `_is_categorical_col`
+  (`track_props.jl`) pins it categorical even when a high-resolution run exceeds the integer-level
+  cap (codes are never a count). The `{suffix}` lets multiple resolutions / re-clusterings coexist.
+- Both run **set-scope** (clustered jointly across the selected images), so codes are comparable
+  across the set. They feed the `clust` / `trackclust` pop types (cluster membership = a `clusters.{suffix}`
+  filter) — see `docs/POPULATION.md`.
+- `obsm['X_umap.{suffix}']` is the plotting embedding (the UMAP chart reads it); written only when
+  *Calculate UMAP* is on.
+
 ### Feature names
 
 **Morphology (2D)**


### PR DESCRIPTION
Port of the old clusterTracks: Leiden-cluster tracks pooled across a set so cluster IDs are comparable. Mirrors clustPops, with two principled differences.

- Features come from track_props (motility stored in {vn}__tracks.h5ad, plus on-read aggregates: HMM-state/transition frequencies + cell-measure means). Julia builds the matrix and passes it INLINE to Python, because those aggregates are compute-on-read and only Julia can produce them (clustPops reads stored cell columns by path — divergence forced by the data model).
- HMM-per-track is NOT persisted: on-read aggregation is a columnar read + one groupby (negligible next to Leiden/UMAP), and persisting would couple track_measures<->HMM and go stale. track_props stays compute-on-read.
- Clusters written to each {vn}__tracks.h5ad (label == track_id) -> flow through track_props, gateable as trackclust.

Shared code (one-canonical-helper rule): extract split_back_and_write into clustering_utils.py; both runners use it. Only matrix assembly differs.

Drive-by fixes:
- _is_categorical_col pins clusters.* categorical regardless of level count (a high-res run exceeds the int-level cap but codes are never a count); applied at both callers (track_props loop + plot_data mtype).
- clustPops JSON fun_name was clust.cluster_cells != registry clustPops.cluster -> a GUI launch would not resolve. Corrected to clustPops.cluster.

Register in task_registry.jl + Cecelia.jl. Tests: dispatch + param-validation for both tasks; _is_categorical_col name-rule cases. Docs: CLUSTERING_PLAN.md progress block + DATAMODEL.md clustering-output section.