### PR TITLE
feat(clustering): pop layer (clust/trackclust) + UMAP endpoint

### DIFF
--- a/api/src/gating_api.jl
+++ b/api/src/gating_api.jl
@@ -90,11 +90,23 @@ _fetch(img, vn) = cols -> (label_props(img; value_name = vn) |> lp -> select_col
 _track_motility_cols(img, vn) = (p = img_track_props_path(img, vn);
     isfile(p) ? col_names(label_props(p); data_type = :vars) : String[])
 
+# every column the per-track table provides DIRECTLY (no cell→track aggregation): motility (vars)
+# + track-table obs (lineage, and `clusters.{suffix}` written by clustTracks). Passed to
+# `track_cell_measures` as the free set so a `trackclust` filter on `clusters.{suffix}` isn't
+# mistaken for a cell measure to aggregate.
+_track_free_cols(img, vn) = (p = img_track_props_path(img, vn);
+    isfile(p) ? vcat(col_names(label_props(p); data_type = :vars),
+                     col_names(label_props(p); data_type = :obs)) : String[])
+
+# pop_types whose membership is evaluated over the per-track table (one point per track):
+# `track` (hand-drawn per-track gates) and `trackclust` (a `clusters.{suffix}` filter).
+_track_grained(pop_type) = String(pop_type) in ("track", "trackclust")
+
 # track data source: ONE row per track (`track_props`, label == track_id). The requested columns
-# (gate channels / plot axes) drive which cell measures get aggregated (`track_cell_measures`);
-# motility comes free. This is the `pop_type="track"` analogue of `_fetch` (docs/POPULATION.md).
+# (gate channels / plot axes / filter measure) drive which cell measures get aggregated
+# (`track_cell_measures`); motility + track-table obs come free. The track analogue of `_fetch`.
 _track_fetch(img, vn) = cols -> track_props(img; value_name = vn,
-    cell_measures = track_cell_measures(cols, _track_motility_cols(img, vn)))
+    cell_measures = track_cell_measures(cols, _track_free_cols(img, vn)))
 
 # load + recompute a map (membership ready). For `flow`/`live` the data source is the cell table
 # and the transient napari-selection pop is injected so it is queryable like any population; for
@@ -102,7 +114,7 @@ _track_fetch(img, vn) = cols -> track_props(img; value_name = vn,
 # does not apply, so it is not injected.
 function _live_map(img, vn, pop_type)
     m = load_pop_map(img; value_name = vn, pop_type = pop_type)
-    is_track = pop_type == "track"
+    is_track = _track_grained(pop_type)
     is_track || _inject_napari_pop!(m, img)
     recompute!(m, is_track ? _track_fetch(img, vn) : _fetch(img, vn))
     m
@@ -137,10 +149,10 @@ end
 # read the raw x/y vectors for the scatter (one row per cell, or per track for pop_type="track"),
 # optionally subset to a population, before transform.
 function _plot_xy_raw(img, vn, pop_type, x, y, pop)
-    if pop_type == "track"
+    if _track_grained(pop_type)
         # per-track scatter: one point per track from `track_props` (label == track_id)
         tp = track_props(img; value_name = vn,
-                         cell_measures = track_cell_measures([x, y], _track_motility_cols(img, vn)))
+                         cell_measures = track_cell_measures([x, y], _track_free_cols(img, vn)))
         (x in names(tp) && y in names(tp)) || return (Float64[], Float64[])
         if !is_root(pop)
             m = _live_map(img, vn, pop_type)
@@ -339,6 +351,48 @@ function api_gating_plotdata(req::HTTP.Request)
     200, collect(reinterpret(UInt8, buf))
 end
 
+# ── GET /api/plots/umap → binary Float32 [x,y,clusterCode, …] per point ───────
+# The UMAP scatter for a clustering pop_type: the `obsm['X_umap.{suffix}']` embedding + the
+# `clusters.{suffix}` code per point (frontend colours by code). `clust` reads the cell table;
+# `trackclust` reads the per-track table (one point per track). Optionally subset to a population's
+# membership (`pop`). Cluster codes are small ints → exact in Float32; an unclustered row → -1.
+function api_plots_umap(req::HTTP.Request)
+    q = HTTP.queryparams(HTTP.URI(req.target))
+    img, err = _gating_image(get(q, "projectUid", ""), get(q, "imageUid", ""))
+    err === nothing || return err
+    vn       = _resolve_vn(img, get(q, "valueName", ""))
+    pop_type = get(q, "popType", "clust")
+    suffix   = get(q, "suffix", "default")
+    pop      = get(q, "pop", ROOT)
+    umap_key = "X_umap.$suffix"; clust_col = "clusters.$suffix"
+
+    # data table: trackclust → per-track table; clust → cell table
+    path = _track_grained(pop_type) ? img_track_props_path(img, vn) : img_label_props_path(img, vn)
+    isfile(path) || return _gerr(404, "No labelProps/track table for value_name=$vn")
+    xy = obsm(label_props(path), umap_key)              # (n_obs, 2), obs order
+    size(xy, 1) == 0 && return _gerr(404, "No $umap_key — run clustering with UMAP enabled")
+    # cluster codes aligned to obs order (label + the code column, same obs order as obsm)
+    cdf = label_props(path) |> select_cols([clust_col]) |> as_df
+    codes = clust_col in names(cdf) ? cdf[!, clust_col] : fill(missing, nrow(cdf))
+
+    keep = trues(size(xy, 1))
+    if !is_root(pop)
+        m = _live_map(img, vn, pop_type)
+        has_pop(m, pop) || return _gerr(404, "Population not found: $pop")
+        sel  = Set(cells_in_pop(m, pop))
+        keep = BitVector(l in sel for l in cdf.label)
+    end
+
+    idx = findall(keep)
+    buf = Vector{Float32}(undef, 3 * length(idx))
+    @inbounds for (j, i) in enumerate(idx)
+        buf[3j-2] = Float32(xy[i, 1]); buf[3j-1] = Float32(xy[i, 2])
+        c = codes[i]
+        buf[3j]   = (c isa Number && !ismissing(c)) ? Float32(c) : -1f0
+    end
+    200, collect(reinterpret(UInt8, buf))
+end
+
 # ── GET /api/gating/density → binary Float32 grid (bins×bins, row-major) ──────
 function api_gating_density(req::HTTP.Request)
     q = HTTP.queryparams(HTTP.URI(req.target))
@@ -421,6 +475,16 @@ function api_gating_pop_update(body_bytes::Vector{UInt8})
     p = pop_at(m, String(body["path"]))
     haskey(body, "colour") && (p.colour = String(body["colour"]))
     haskey(body, "show")   && (p.show = Bool(body["show"]))
+    # filter update — the tick-cluster-into-population UX toggles which cluster IDs belong to a
+    # `clust`/`trackclust` pop by rewriting its filter (typically filter_values). Mutates only the
+    # keys present in the `filter` dict, so a `{values:[…]}` tick leaves measure/fun untouched.
+    flt = get(body, "filter", nothing)
+    if flt !== nothing
+        haskey(flt, "measure")     && (p.filter_measure = get(flt, "measure", nothing))
+        haskey(flt, "fun")         && (p.filter_fun = get(flt, "fun", nothing))
+        haskey(flt, "values")      && (p.filter_values = get(flt, "values", nothing))
+        haskey(flt, "default_all") && (p.filter_default_all = Bool(get(flt, "default_all", false)))
+    end
     200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
 end
 

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -130,6 +130,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_gating_plotdata(req)
         elseif path == "/api/gating/density"
             api_gating_density(req)
+        elseif path == "/api/plots/umap"
+            api_plots_umap(req)
         elseif path == "/api/plots/definitions"
             api_plot_definitions(req)
         elseif path == "/api/plots/populations"

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -31,6 +31,7 @@ export LabelProps, label_props, as_df, as_matrix, add_obs, drop_obs, write_categ
 export select_cols, view_cols, view_channel_cols, view_centroid_cols, view_label_col
 export filter_rows, sort_by, rename_channels!
 export col_names, channel_columns, centroid_columns, temporal_columns
+export obsm, obsm_keys
 
 # ── Gating engine: transforms, gates, density ─────────────────────────────────
 export AxisTransform, LinearTransform, LogTransform, AsinhTransform, LogicleTransform

--- a/app/src/gating/population_manager.jl
+++ b/app/src/gating/population_manager.jl
@@ -235,13 +235,20 @@ function from_tree(tree::AbstractDict)::PopulationMap
 end
 
 # ── Persistence: {task_dir}/gating/{value_name}[__tracks].json ───────────────────
-# `track` gates (gates on per-track measures, evaluated against {vn}__tracks.h5ad) live in a
-# separate sidecar `gating/{vn}__tracks.json`, mirroring the per-track h5ad naming. `flow` gates
-# stay in `gating/{vn}.json`. The `track` map's data source is the track table, but the tree
-# format + engine are identical (track-gating = flow-gating with the data source swapped).
+# Each pop_type with its OWN stored map gets a distinct sidecar suffix, mirroring the data source
+# it gates over: `flow` → `gating/{vn}.json` (cell gates); `track` → `gating/{vn}__tracks.json`
+# (per-track gates); `clust`/`trackclust` → `gating/{vn}__clust.json` / `__trackclust.json`
+# (cluster-membership pops — a filter on the `clusters.{suffix}` column written by clustPops/
+# clustTracks). The tree format + engine are identical across types (only the data source +
+# membership rule differ). `live` is NOT here: it is derived off the `flow` map (no own file).
+const POP_MAP_SUFFIX = Dict{String,String}(
+    "track"      => TRACK_PROPS_SUFFIX,   # "__tracks"
+    "clust"      => "__clust",
+    "trackclust" => "__trackclust",
+)
 gating_dir(task_dir::AbstractString) = joinpath(task_dir, "gating")
 gating_path(task_dir::AbstractString, value_name::AbstractString; pop_type::AbstractString="flow") =
-    joinpath(gating_dir(task_dir), value_name * (pop_type == "track" ? TRACK_PROPS_SUFFIX : "") * ".json")
+    joinpath(gating_dir(task_dir), value_name * get(POP_MAP_SUFFIX, pop_type, "") * ".json")
 
 """Write the map to `{task_dir}/gating/{value_name}[__tracks].json` (by `m.pop_type`)."""
 function save_pop_map!(m::PopulationMap, task_dir::AbstractString)
@@ -443,15 +450,18 @@ end
 # generic `_pop_df` core (membership is by `label`, which here IS the track_id). `granularity=:track`
 # returns the gated track rows; `granularity=:cell` expands them to member cells.
 function _pop_df_track_gating(img::CciaImage, pops, default_vn::AbstractString;
+                              pop_type::AbstractString="track",
                               cell_measures=String[], categorical=String[], pop_cols=nothing,
                               unique_labels::Bool=true, drop_na::Bool=false,
                               granularity::Symbol=:track)::DataFrame
-    # one track_props table per value_name (label == track_id); cache within this call
+    # one track_props table per value_name (label == track_id); cache within this call. The
+    # cluster column (`clusters.{suffix}`, written by clustTracks into the track table obs) comes
+    # free via track_props' motility leftjoin, so `trackclust` membership needs no cell_measures.
     tp_cache = Dict{String,DataFrame}()
     get_tp(vn) = get!(tp_cache, vn) do
         track_props(img; value_name=vn, cell_measures=cell_measures, categorical=categorical)
     end
-    load_map = vn -> load_pop_map(img; value_name=vn, pop_type="track")
+    load_map = vn -> load_pop_map(img; value_name=vn, pop_type=pop_type)
     fetch = function (vn, cols)
         tp = get_tp(vn)
         isempty(tp) && return DataFrame(label=Int[])
@@ -460,7 +470,7 @@ function _pop_df_track_gating(img::CciaImage, pops, default_vn::AbstractString;
         select(tp, keep)
     end
 
-    trackdf = _pop_df(load_map, fetch, "track", pops; default_vn=default_vn,
+    trackdf = _pop_df(load_map, fetch, pop_type, pops; default_vn=default_vn,
                       pop_cols=pop_cols, unique_labels=unique_labels, drop_na=drop_na)
     granularity === :track ? trackdf : _expand_tracks_to_cells(img, trackdf)
 end
@@ -709,12 +719,15 @@ function pop_df(img::CciaImage, pop_type::AbstractString, pops;
     flush_cache && delete!(img._pop_df_cache, ckey)
     haskey(img._pop_df_cache, ckey) && return copy(img._pop_df_cache[ckey]::DataFrame)
 
-    # `track` pop_type: gates are defined directly on per-track properties (one point per track),
-    # stored in `gating/{vn}__tracks.json`, evaluated over the `track_props` table. `granularity`
-    # selects the return shape (:track rows, or :cell-expanded member cells). Distinct from the
-    # `live`+:track path below, which gates CELL properties and then aggregates to tracks.
-    if String(pop_type) == "track"
-        df = _pop_df_track_gating(img, pops, resolved_vn; cell_measures=cell_measures,
+    # `track` / `trackclust` pop_types: membership is defined directly on per-track properties
+    # (one point per track), evaluated over the `track_props` table — `track` via hand-drawn gates
+    # in `gating/{vn}__tracks.json`, `trackclust` via a `clusters.{suffix}` filter in
+    # `gating/{vn}__trackclust.json`. `granularity` selects the return shape (:track rows, or
+    # :cell-expanded member cells). Distinct from the `live`+:track path below, which gates CELL
+    # properties and then aggregates to tracks.
+    if String(pop_type) in ("track", "trackclust")
+        df = _pop_df_track_gating(img, pops, resolved_vn; pop_type=String(pop_type),
+                                  cell_measures=cell_measures,
                                   categorical=categorical, pop_cols=pop_cols,
                                   unique_labels=unique_labels, drop_na=drop_na,
                                   granularity=granularity)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -1613,6 +1613,37 @@ end
         @test isempty(pop_paths(m))
     end
 
+    # ── clust / trackclust pop types (cluster-membership populations) ─────────────
+    # A cluster pop is a filter on the `clusters.{suffix}` column (clustPops/clustTracks output):
+    # filter_fun="in", filter_values=[ticked cluster ids]. Stored in its own sidecar so it never
+    # collides with flow gates. Headless — membership via a recompute! closure (no fixture).
+    @testset "clust / trackclust pop types" begin
+        td = mktempdir()
+        # each clustering pop_type routes to its OWN gating sidecar (no collision with flow's {vn}.json)
+        @test endswith(gating_path(td, "B"; pop_type="flow"),       joinpath("gating", "B.json"))
+        @test endswith(gating_path(td, "B"; pop_type="clust"),      joinpath("gating", "B__clust.json"))
+        @test endswith(gating_path(td, "B"; pop_type="trackclust"), joinpath("gating", "B__trackclust.json"))
+        @test endswith(gating_path(td, "B"; pop_type="track"),      joinpath("gating", "B__tracks.json"))
+
+        # cluster pop membership = filter "in" over the cluster code column
+        m = PopulationMap(pop_type="clust", value_name="B")
+        add_pop!(m, "myeloid"; filter_measure="clusters.default", filter_fun="in",
+                 filter_values=[1, 3], colour="#10b981")
+        fetch = _ -> DataFrame("label" => [10, 11, 12, 13, 14],
+                               "clusters.default" => [0, 1, 2, 3, 1])
+        recompute!(m, fetch)
+        @test Set(cells_in_pop(m, "/myeloid")) == Set([11, 13, 14])   # codes ∈ {1,3}
+
+        # save/load round-trip → own file, filter fields preserved, flow file untouched
+        save_pop_map!(m, td)
+        @test isfile(gating_path(td, "B"; pop_type="clust"))
+        @test !isfile(gating_path(td, "B"; pop_type="flow"))
+        m2 = load_pop_map(td, "B"; pop_type="clust")
+        @test pop_at(m2, "/myeloid").filter_measure == "clusters.default"
+        @test pop_at(m2, "/myeloid").filter_fun == "in"
+        @test Set(pop_at(m2, "/myeloid").filter_values) == Set([1, 3])
+    end
+
     # ── Summary-canvas population picker (plot_pop_types / plot_population_groups) ──
     # The logic the /api/plots/populations route delegates to — pure, so tested here (the route is a
     # thin wrapper). Covers granularity→pop_type selection, cross-image + cross-pop_type union/dedup,

--- a/docs/API.md
+++ b/docs/API.md
@@ -89,7 +89,7 @@ coordinates live in **transformed** space; `xTicks`/`yTicks` give `{pos, label}`
 |---|---|
 | `/api/gating/pop/add` | `name`, `parent` (default `root`), `colour`, `show`, `gate` (gate spec) or `filter` `{measure,fun,values,default_all}`, `is_track` |
 | `/api/gating/pop/set-gate` | `path`, `gate` (gate spec) |
-| `/api/gating/pop/update` | `path`, `colour?`, `show?` (recolour / visibility) |
+| `/api/gating/pop/update` | `path`, `colour?`, `show?` (recolour / visibility), `filter? {measure?,fun?,values?,default_all?}` (only the keys present are mutated — the tick-cluster-into-pop UX rewrites `filter.values` to retoggle which cluster IDs belong to a `clust`/`trackclust` pop) |
 | `/api/gating/pop/delete` | `path` (cascades to descendants) |
 | `/api/gating/pop/rename` | `path`, `newName` (cascades child paths) → also returns `path` (new) |
 
@@ -127,6 +127,7 @@ cells. Thin wrappers over the package `plot_summary_data` (`docs/ARCHITECTURE.md
 
 | Method | Path | Params | Response |
 |---|---|---|---|
+| GET | `/api/plots/umap` | `…,popType=clust\|trackclust,suffix,pop?` | **binary** `Float32` interleaved `[x0,y0,code0,x1,y1,code1,…]` — the `obsm['X_umap.{suffix}']` embedding + `clusters.{suffix}` code per point (unclustered → `-1`). `clust` reads the cell table; `trackclust` the per-track table (one point per track). Optional `pop` subsets to a population's membership. The UMAP-scatter data source for the cluster module pages. |
 | GET | `/api/plots/definitions` | `module?` (filter) | flat array of plot-type specs (PACKAGE JSON under `app/src/plotDefinitions/`; each carries `module`, `chartTypes`, `dataSource`, `scopeModes`, `params`). The frontend groups by module (per-module canvas) or shows all (universal canvas). |
 | GET | `/api/plots/populations` | `{projectUid, popType?, granularity?,` **image selector:** `setUid [+imageUids subset]` **or** `imageUid}` | populations available across the selected images, **grouped by segmentation** (union; dedup by `(popType,path)` per segmentation, first image wins colour/name): `[{valueName, populations:[{path,name,colour,popType}]}]`. Derived pops (`derived_pop_paths`, e.g. `/_tracked` under `live`) are added since they're injected at query time, not stored. **`granularity="track"` unions `live` + `track` pops** (a track plot shows `live` `/_tracked` *and* track gates from `{vn}__tracks.json`); each population carries the `popType` it must be fetched under, so the panel groups series by popType and issues one `/api/plot_data` request per group. This is the read-only series picker for the summary canvas. (Route is a thin wrapper over the package `plot_population_groups` / `plot_pop_types` — logic + tests live in `app/src`.) |
 | GET | `/api/plots/attrs` | `{projectUid, setUid [+imageUids? subset]}` | image-attribute names + distinct values across the set's images: `{attrs:[{name, values:[…]}]}`. Powers the summary canvas "compare → by attribute" picker (group images by e.g. `Treatment`). Single image (no `setUid`) → `{attrs:[]}`. |

--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -10,11 +10,13 @@ gating module. Gating is one way to *define* a population; the manager, the unif
 
 ## Population types
 
-| type | membership defined by | data source |
-|------|----------------------|-------------|
-| `flow` | gates (polygon, rectangle; later ellipse/quadrant/boolean) on cell measurements | gate strategy + H5AD |
-| `clust`| cluster assignment (Leiden/UMAP) | H5AD `.obs` column |
-| `live` | tracking (btrack links cells across time) + optional track-measure filters | H5AD `.obs` (`track_id`) |
+| type | membership defined by | data source | stored sidecar |
+|------|----------------------|-------------|----------------|
+| `flow` | gates (polygon, rectangle; later ellipse/quadrant/boolean) on cell measurements | gate strategy + H5AD | `gating/{vn}.json` |
+| `live` | tracking (btrack links cells across time) + optional track-measure filters | H5AD `.obs` (`track_id`) | none (derived off `flow`) |
+| `track` | gates on **per-track** properties (one point per track) | `track_props` (motility + on-read aggregates) | `gating/{vn}__tracks.json` |
+| `clust` | a filter on the **cell** cluster column (`filter_fun="in"` over `clusters.{suffix}`) | cell H5AD `.obs` column (clustPops) | `gating/{vn}__clust.json` |
+| `trackclust` | a filter on the **track** cluster column (`filter_fun="in"` over `clusters.{suffix}`) | per-track table `.obs` column (clustTracks) | `gating/{vn}__trackclust.json` |
 
 All types share: a population tree (name, colour, path, parent, show), a `pop_df`
 accessor returning a filtered `DataFrame` regardless of type, and membership that is
@@ -63,11 +65,21 @@ matching labels + labelProps — `ccid.json` stays lean:
 Plain JSON — readable by Julia and Python. (This supersedes the earlier
 `ARCHITECTURE.md:248` "gating in ccid.json" plan.)
 
-`clust`/`live` populations span multiple value_names (their path prefix names the
-segmentation). They are **derived populations** — membership from a column rule, not a stored
-gate — so they need **no** pop-map storage of their own: `pop_df` reads the `flow` gates and
-layers the derived filter on at read time (see "Reserved namespace" under `pop_df` below). The
-canonical case, a `live` **tracked** pop, is `flow gate ∩ track_id > 0`.
+`live` populations span multiple value_names (their path prefix names the segmentation). They are
+**derived populations** — membership from a column rule layered on the `flow` gates, not a stored
+gate — so they need **no** pop-map storage of their own: `pop_df` reads the `flow` gates and layers
+the derived filter on at read time (see "Reserved namespace" under `pop_df` below). The canonical
+case, a `live` **tracked** pop, is `flow gate ∩ track_id > 0`.
+
+**`clust`/`trackclust` populations are *stored* filter pops**, not derived/transient ones: the user
+names a population and ticks cluster IDs into it, so each is persisted in its own sidecar
+(`gating/{vn}__clust.json` / `__trackclust.json`) as a `Population` carrying
+`filter_measure="clusters.{suffix}"`, `filter_fun="in"`, `filter_values=[ids]` (no gate). Created via
+`pop/add` with a `filter` dict and retoggled via `pop/update`'s `filter` (Decision 10 — no dedicated
+endpoint). Membership is still **derived at read time** (`recompute!` applies the filter over the
+cluster column), never written into the H5AD; only the *definition* (which IDs) is stored. `clust`
+evaluates over the cell table (`:cell`), `trackclust` over `track_props` (`:track`, with
+expand-to-cells for `:cell`) — exactly mirroring `flow` and `track` respectively.
 
 ## `pop_df` — unified accessor
 


### PR DESCRIPTION
Completes the clustering backend: cluster assignments written by clustPops/ clustTracks are now usable as populations, and there's a UMAP data endpoint for the frontend.

Pop layer:
- Register clust (cell) + trackclust (track) pop types. gating_path routes each to its own sidecar ({vn}__clust.json / __trackclust.json) via POP_MAP_SUFFIX — no collision with flow's {vn}.json.
- pop_df: clust rides the default cell path; trackclust routes through a parametrised _pop_df_track_gating (track_props, :track + expand-to-cells).
- Cluster pops are STORED filter pops (filter_fun="in" over clusters.{suffix}), created via pop/add's filter dict (Decision 10 — no new endpoint). Extended pop/update to mutate filter for the tick-cluster-into-pop UX.
- API helpers treat trackclust as track-grained; _track_free_cols stops clusters.*/lineage being aggregated as cell measures.

UMAP endpoint:
- GET /api/plots/umap?popType=clust|trackclust&suffix&pop? -> binary Float32 [x,y,code,...] (obsm X_umap.{suffix} + clusters.{suffix}; clust=cell table, trackclust=track table; optional pop subset). Exported obsm/obsm_keys.
- Heatmap reuses _matrix_agg (no new backend).

Tests: headless pop-type testset (gating_path routing, filter membership, storage round-trip). 616 pass, 0 fail (the 1 broken is the pre-existing Python-parity skip). Docs: POPULATION.md (pop-types table + stored-filter-pop semantics), API.md (umap route + pop/update filter), CLUSTERING_PLAN progress.