### PR TITLE
Add collapsible left nav + right function/tasks panel

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -202,6 +202,12 @@ Owns the full two-column layout, SetBar, image selection state, attr filtering, 
 
 The attr filter panel renders automatically when `show-filter="true"` and the active set has images with `attr` values. It disappears when there are no attr keys, so it is safe to leave enabled even for modules that may or may not have attrs.
 
+**Collapsible chrome (free up working space).** Two persisted toggles, both in the `settings` store (`localStorage`):
+- **Left nav** — the `pi-bars` button in `AppHeader` toggles `settings.sidebarCollapsed`; `AppSidebar` `v-show`s its `<nav>` off, so the main canvas reclaims the full width. (The `v-show` lives on the `<nav>`, not on the `<AppSidebar>` element — the component has two root nodes, so a component-level `v-show` has no single root to bind and silently no-ops.)
+- **Right panel** — `ModuleLayout` wraps the `#right` slot (TaskRunner / MetadataPanel / custom) with a thin always-visible left-edge handle (`pi-angle-double-*`) that toggles `settings.rightPanelCollapsed`. Collapsed → only the handle remains; the function/tasks panel folds away to the right. Every module page gets this for free.
+
+Both default expanded and persist across sessions/navigation.
+
 ---
 
 ## ImageTable component

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useWsStore } from '../stores/ws'
+import { useSettingsStore } from '../stores/settings'
 
 const ws = useWsStore()
+const settings = useSettingsStore()
 
 const statusLabel: Record<string, string> = {
   connected:    'Connected',
@@ -19,6 +21,11 @@ const statusTip: Record<string, string> = {
 
 <template>
   <header class="app-header">
+    <button class="nav-toggle" @click="settings.sidebarCollapsed = !settings.sidebarCollapsed"
+      v-tooltip.bottom="settings.sidebarCollapsed ? 'Show menu' : 'Hide menu'"
+      :aria-label="settings.sidebarCollapsed ? 'Show menu' : 'Hide menu'">
+      <i class="pi pi-bars" />
+    </button>
     <span class="logo">🍍 Cecelia</span>
 
     <span class="spacer" />
@@ -46,6 +53,21 @@ const statusTip: Record<string, string> = {
   flex-shrink: 0;
   z-index: 100;
 }
+
+.nav-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--cc-text-dim);
+  padding: 0.25rem 0.4rem;
+  border-radius: 0.3rem;
+  font-size: 0.9rem;
+  margin-left: -0.3rem;
+}
+.nav-toggle:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 
 .logo {
   font-weight: 700;

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
+import { useSettingsStore } from '../stores/settings'
 import ProjectPanel from './ProjectPanel.vue'
 import ViewerPanel from './ViewerPanel.vue'
 
 const projectMeta = useProjectMetaStore()
+const settings = useSettingsStore()
 const showPanel = ref(false)
 
 // Track which groups are collapsed (all open by default, except Dev)
@@ -75,7 +77,7 @@ function isNavDisabled(item: NavItem): boolean {
 </script>
 
 <template>
-  <nav class="sidebar">
+  <nav class="sidebar" v-show="!settings.sidebarCollapsed">
 
     <!-- ── Project block ───────────────────────────────────────────────── -->
     <div class="project-block">

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -31,6 +31,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useProjectStore } from '../stores/project'
+import { useSettingsStore } from '../stores/settings'
 import SetBar from './SetBar.vue'
 import ImageTable from './ImageTable.vue'
 import CollapsibleSection from './CollapsibleSection.vue'
@@ -57,6 +58,7 @@ const emit = defineEmits<{
 }>()
 
 const project    = useProjectStore()
+const settings   = useSettingsStore()
 const activeSet  = computed(() => project.activeSet())
 // namespace remembered selections per module so they don't bleed across pages (docs/UI.md)
 const selScope   = computed(() => props.module ?? 'default')
@@ -255,13 +257,23 @@ function onSelectionChange(uids: string[]) {
         </div>
       </div>
 
-      <!-- ── Right: module-specific panel ─────────────────────────── -->
-      <slot
-        name="right"
-        :set-uid="activeSet?.uid"
-        :selected-uids="selectedUids"
-        :selected-names="selectedNames"
-      />
+      <!-- ── Right: module-specific panel (collapsible to free up space) ── -->
+      <div v-if="$slots.right" class="right-panel" :class="{ collapsed: settings.rightPanelCollapsed }">
+        <button class="right-handle"
+          @click="settings.rightPanelCollapsed = !settings.rightPanelCollapsed"
+          v-tooltip.left="settings.rightPanelCollapsed ? 'Show functions panel' : 'Hide functions panel'"
+          :aria-label="settings.rightPanelCollapsed ? 'Show functions panel' : 'Hide functions panel'">
+          <i :class="['pi', settings.rightPanelCollapsed ? 'pi-angle-double-left' : 'pi-angle-double-right']" />
+        </button>
+        <div v-show="!settings.rightPanelCollapsed" class="right-slot">
+          <slot
+            name="right"
+            :set-uid="activeSet?.uid"
+            :selected-uids="selectedUids"
+            :selected-names="selectedNames"
+          />
+        </div>
+      </div>
 
     </div>
   </div>
@@ -290,6 +302,31 @@ function onSelectionChange(uids: string[]) {
   overflow: hidden;
   min-width: 0;
 }
+
+/* ── Right panel (collapsible) ──────────────────────────────────────────────
+   A thin always-visible handle on the left edge toggles the slot; when collapsed
+   only the handle remains, so the function/tasks panel folds away to the right. */
+.right-panel {
+  display: flex;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+.right-handle {
+  flex-shrink: 0;
+  width: 1.1rem;
+  border: none;
+  border-left: 1px solid var(--cc-border);
+  background: var(--cc-surface-1);
+  color: var(--cc-text-dim);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.12s, color 0.12s;
+}
+.right-handle:hover { background: var(--cc-surface-2); color: var(--cc-text); }
+.right-handle .pi { font-size: 0.7rem; }
+.right-slot { display: flex; min-height: 0; overflow: hidden; }
 
 .action-bar {
   display: flex;

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -46,6 +46,11 @@ export const useSettingsStore = defineStore('settings', () => {
   // populations but for the Tracks overlay. Default off (heavier). Mirrors napariShowPopulations.
   const napariShowGatedTracks = ref(localStorage.getItem('cc.napariShowGatedTracks') === 'true')
 
+  // ── Layout: collapse the main nav sidebar (left) and the module function/tasks panel (right)
+  // to free up working space. Both default expanded, both persist across sessions.
+  const sidebarCollapsed = ref(localStorage.getItem('cc.sidebarCollapsed') === 'true')
+  const rightPanelCollapsed = ref(localStorage.getItem('cc.rightPanelCollapsed') === 'true')
+
   // per-image label-layer visibility: { [imageUid]: { [valueName]: boolean } }
   // unknown labels default to true; persisted across sessions
   const _labelVisStore = ref<Record<string, Record<string, boolean>>>(
@@ -88,6 +93,8 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(napariShowTracks,         v => localStorage.setItem('cc.napariShowTracks',         String(v)))
   watch(napariColourBy,           v => localStorage.setItem('cc.napariColourBy',           String(v)))
   watch(napariShowGatedTracks,    v => localStorage.setItem('cc.napariShowGatedTracks',    String(v)))
+  watch(sidebarCollapsed,         v => localStorage.setItem('cc.sidebarCollapsed',         String(v)))
+  watch(rightPanelCollapsed,      v => localStorage.setItem('cc.rightPanelCollapsed',      String(v)))
 
-  return { taskListAutoFollow, napariUpdateImage, napariAutoSaveLayerProps, napariShow3D, napariAsDask, napariPointSize, napariShowPopulations, napariShowTracks, napariShowGatedTracks, napariColourBy, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility }
+  return { taskListAutoFollow, napariUpdateImage, napariAutoSaveLayerProps, napariShow3D, napariAsDask, napariPointSize, napariShowPopulations, napariShowTracks, napariShowGatedTracks, napariColourBy, sidebarCollapsed, rightPanelCollapsed, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility }
 })


### PR DESCRIPTION
## Collapsible left nav + right function/tasks panel

Two persisted layout toggles to free up working space.

- **Left nav** — a `pi-bars` button in the header hides/shows the sidebar (`settings.sidebarCollapsed`); the main canvas reclaims the full width. The `v-show` is on the `<nav>` inside `AppSidebar` (not the component element — `AppSidebar` has two root nodes, so a component-level `v-show` silently no-ops).
- **Right panel** — `ModuleLayout` wraps the `#right` slot (TaskRunner / MetadataPanel / custom) with a thin always-visible left-edge handle that folds it away to the right (`settings.rightPanelCollapsed`). Every module page gets this for free.

Both default expanded and persist across sessions/navigation (localStorage, via the `settings` store). Docs updated in `docs/UI.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)