### PR TITLE
Fix installer 404 while only prereleases exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ are fast).
 
 **1 · Install** — in a terminal:
 ```sh
-curl -LsSf https://github.com/schienstockd/cecelia/releases/latest/download/install.sh | sh
+curl -LsSf https://raw.githubusercontent.com/schienstockd/cecelia/main/install.sh | sh
 ```
 
 **2 · Point at your projects folder** — create `~/cecelia/custom.toml`:
@@ -52,7 +52,7 @@ It opens in your browser at <http://localhost:8080>. Image import is ready to us
 
 **1 · Install** — in Terminal:
 ```sh
-curl -LsSf https://github.com/schienstockd/cecelia/releases/latest/download/install.sh | sh
+curl -LsSf https://raw.githubusercontent.com/schienstockd/cecelia/main/install.sh | sh
 ```
 
 **2 · Point at your projects folder** — create `~/cecelia/custom.toml`:
@@ -72,7 +72,7 @@ It opens in your browser at <http://localhost:8080>. Image import is ready to us
 
 **1 · Install** — in PowerShell (no admin rights needed; everything installs in your user account):
 ```powershell
-irm https://github.com/schienstockd/cecelia/releases/latest/download/install.ps1 | iex
+irm https://raw.githubusercontent.com/schienstockd/cecelia/main/install.ps1 | iex
 ```
 
 **2 · Point at your projects folder** — create `C:\Users\<you>\cecelia\custom.toml`:

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -111,9 +111,17 @@ OS-independent:
    `.pixi`/`node_modules`/`.CondaPkg` — those are provisioned/regenerated on the user's machine.
 3. Publish a GitHub Release with `cecelia.tar.gz` + `install.sh` + `install.ps1` as assets.
 
-`install.sh`/`install.ps1` then download `…/releases/latest/download/cecelia.tar.gz`, install
-Pixi + Juliaup if missing, run `pixi install` (which resolves the GPU variant per-OS from
-`pixi.toml`'s platform-gated torch) + `julia --project=api instantiate`, and create the launcher.
+Users bootstrap the installer from `raw.githubusercontent.com/…/main/install.{sh,ps1}` — **not**
+`releases/latest/download/…`. GitHub's `releases/latest` endpoint only ever resolves to a
+*non-prerelease* release, so while we're on release candidates (all `v*-rcN` marked prerelease) it
+404s; the raw path on `main` is always available. `install.{sh,ps1}` then resolve the newest
+published release themselves via the GitHub API (`/repos/…/releases`, newest first — *includes*
+prereleases) and download that tag's `cecelia.tar.gz`. `CECELIA_VERSION=v0.1.0-rcN` pins a specific
+tag. Once a stable (non-prerelease) release is cut, `releases/latest` also starts working, but the
+API-resolve path keeps working for RC-only states — so no installer change is needed at that point.
+They then install Pixi + Juliaup if missing, run `pixi install` (which resolves the GPU variant
+per-OS from `pixi.toml`'s platform-gated torch) + `julia --project=api instantiate`, and create the
+launcher.
 **First-run size:** the env is multi-GB and downloads at install time. `install.ps1` is authored but
 **not yet verified on Windows hardware** — the first real test is a Windows machine / runner.
 

--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,7 @@
 # prebuilt frontend, so no Node needed), provisions the environment, and adds a Start Menu
 # shortcut. Re-runnable.
 #
-#   powershell -ExecutionPolicy Bypass -c "irm https://github.com/schienstockd/cecelia/releases/latest/download/install.ps1 | iex"
+#   powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/schienstockd/cecelia/main/install.ps1 | iex"
 #
 # NOTE: authored on Linux and not yet verified on Windows hardware — first real test is a
 # Windows CI runner. See docs/SHIPPING.md.
@@ -37,11 +37,17 @@ if (-not $Julia -and -not (Test-Path (Join-Path $env:USERPROFILE '.juliaup\bin\j
 if (-not $Julia) { $Julia = Join-Path $env:USERPROFILE '.juliaup\bin\julia.exe' }
 
 # ── Download the release bundle ────────────────────────────────────────────────
-$Url = if ($Version -eq 'latest') {
-  "https://github.com/$Repo/releases/latest/download/cecelia.tar.gz"
-} else {
-  "https://github.com/$Repo/releases/download/$Version/cecelia.tar.gz"
+# GitHub's `releases/latest` endpoint only ever resolves to a NON-prerelease release, so while the
+# project is still on release candidates (v*-rcN, all marked prerelease) it 404s. Resolve the newest
+# published release ourselves via the API — it lists prereleases too, newest first.
+if ($Version -eq 'latest') {
+  Say 'Resolving the latest release...'
+  $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases" -Headers @{ 'User-Agent' = 'cecelia-installer' }
+  $Version = $rel[0].tag_name
+  if (-not $Version) { throw 'Could not resolve the latest release from the GitHub API.' }
+  Say "Latest release is $Version"
 }
+$Url = "https://github.com/$Repo/releases/download/$Version/cecelia.tar.gz"
 $Tmp = New-TemporaryFile
 Say "Downloading $Url"
 Invoke-WebRequest -Uri $Url -OutFile $Tmp

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 # prebuilt frontend, so no Node is needed), provisions the environment, and adds a desktop
 # launcher. Re-runnable — it replaces the install in place.
 #
-#   curl -LsSf https://github.com/schienstockd/cecelia/releases/latest/download/install.sh | sh
+#   curl -LsSf https://raw.githubusercontent.com/schienstockd/cecelia/main/install.sh | sh
 #
 # Env overrides:  CECELIA_VERSION=v0.1.0  CECELIA_HOME=~/.local/share/cecelia
 set -eu
@@ -43,11 +43,17 @@ JULIA="$(command -v julia 2>/dev/null || echo "$HOME/.juliaup/bin/julia")"
 [ -x "$JULIA" ] || err "Julia not found after install — open a new terminal and re-run."
 
 # ── Download the release bundle ──────────────────────────────────────────────
+# GitHub's `releases/latest` endpoint only ever resolves to a NON-prerelease release, so while the
+# project is still on release candidates (v*-rcN, all marked prerelease) it 404s. Resolve the newest
+# published release ourselves via the API — it lists prereleases too, newest first.
 if [ "$VERSION" = "latest" ]; then
-  URL="https://github.com/$REPO/releases/latest/download/cecelia.tar.gz"
-else
-  URL="https://github.com/$REPO/releases/download/$VERSION/cecelia.tar.gz"
+  say "Resolving the latest release…"
+  VERSION="$(curl -fsSL "https://api.github.com/repos/$REPO/releases" \
+             | grep -m1 '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+  [ -n "$VERSION" ] || err "Could not resolve the latest release from the GitHub API."
+  say "Latest release is $VERSION"
 fi
+URL="https://github.com/$REPO/releases/download/$VERSION/cecelia.tar.gz"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 say "Downloading $URL"


### PR DESCRIPTION
## Summary

A tester hit `curl: (56) ... 404` on macOS and Linux. Root cause: only pre-releases exist (`v0.1.0-rc1/rc2/rc3`, all `prerelease: true`), and GitHub's `releases/latest` endpoint only ever resolves to a **non-prerelease** release — so both the bootstrap `curl` (fetching `install.sh`) and the in-script tarball download 404.

## Changes

- **Bootstrap** from `raw.githubusercontent.com/schienstockd/cecelia/main/install.{sh,ps1}` (always available) instead of `releases/latest/download/…`. Updated README (×3) + both script header comments.
- **`install.sh` / `install.ps1`** now resolve the newest published release themselves via the GitHub API (`/repos/…/releases`, newest-first, **includes** prereleases) and download that tag's `cecelia.tar.gz`. `CECELIA_VERSION=v0.1.0-rc3` still pins a specific tag.
- **`docs/SHIPPING.md`** documents the rationale; keeps working once a stable release is cut, no future installer change needed.

**Verified live:** tag resolves to `v0.1.0-rc3` → asset URL 200, raw `main/install.sh` 200, `sh -n` clean.

**Note:** takes effect for users only after this is on `main` (bootstrap pulls raw main) — the tester should retry post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)