### PR TITLE
Canvas export/theme cleanup (#00061) + gate plot fixes

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -42,29 +42,6 @@ when a set-level mutating task lands.
 
 ## Medium priority
 
-**#00061** — **Canvas plot cleanup phase: export + gate-plot polish**
-Grab-bag of plot-canvas polish to do together in a cleanup pass (surfaced while wiring cluster/gate
-export):
-- **Gate plot: export footer overlays the plot.** The `#footer` Export dropdown added to
-  `GatePlotPanel` sits over the plot area (the gate panel's body isn't laid out to reserve footer
-  space like `CanvasPanel`'s other users). Reserve room / restructure so the footer doesn't cover the
-  scatter.
-- **Exported PNGs are very pixelated.** `rasterize()` in `plots/export.ts` renders at 2×. Bump the
-  scale factor (or make it configurable / DPR-aware) so exported images are crisp; also check the
-  `elementToImageURL` foreignObject path scales the same.
-- **UMAP doesn't appear in the exported PNG.** `plotHostToImageURL` composites `<canvas>` layers, but
-  the UMAP capture still comes out without the scatter — likely the regl canvas isn't being drawn to
-  the export canvas (timing: capture before a redraw, or the composited canvas rect/offset is wrong,
-  or regl's backing store size ≠ CSS size so `drawImage` needs the device-pixel dimensions). Verify
-  the WebGL layer is actually composited (it has `preserveDrawingBuffer` from regl-scatterplot).
-- **UMAP + heatmap don't respond to the dark-theme (VisProps) knob.** The HMM panels + pop-manager
-  now share `PlotOptions`/`vis`, but `ClusterHeatmapPanel` builds its `BuildOpts` from a bare
-  `defaultVis()` (ignores the panel's `vis` prop), and `UmapView` hardcodes the scatter background
-  (`#0d0b1a`). Wire the canvas `vis` (at least `darkTheme`) into both so the whole cluster canvas
-  themes consistently — heatmap: pass the panel `vis` into `opts`; UMAP: derive `backgroundColor` +
-  legend/label ink from `vis.darkTheme`.
-Do these as one focused canvas-export/theme cleanup rather than piecemeal.
-
 **#00057** — **Update README for the install / run / update flow (and switch to versioned releases)**
 Once the shipping functions are all in — the installer (constructor/pixi-pack), the `pixi run app`
 launcher (done), and the update path (`pixi run update` done; in-app button pending) — rewrite
@@ -255,6 +232,44 @@ batch it rather than churn standalone.
 ---
 
 ## Fixed
+
+**#00061** — **Canvas plot cleanup phase: export + gate-plot polish** (2026-07-01)
+Canvas-export/theme cleanup, done as one pass (incl. several follow-ups from testing):
+- **Gate plot x-axis label no longer clipped by the footer.** The gate panel's overhead (stacked
+  axis controls + the plot's `min-height:200` + 68px label margins) overflowed the default 440px
+  panel, so the panel's `overflow:hidden` clipped the x-axis label right at the footer row (it
+  wasn't a true z-overlap — `CanvasPanel` is a flex column). Dropped `.panel-plot` `min-height` to
+  150px so plot + bottom margin + footer all fit.
+- **Exported PNGs are crisp — and the scatter is re-rendered, not upscaled.** `plots/export.ts` has
+  two DPR-aware scales: `EXPORT_SCALE = min(4, 2×DPR)` for the SVG plots (vector → crisp at any
+  factor) and a higher `RASTER_SCALE = min(8, 4×DPR)` for the WebGL/canvas composites. The point
+  cloud can't be upscaled crisply from its CSS×DPR backing store, so `plotHostToImageURL` accepts an
+  `opts.hiRes(cv, scale)` resolver and EVERY stacked canvas re-renders itself at export scale:
+  `ScatterGL.exportCanvas` uses regl-scatterplot's `export({scale})` (on a transparent ground, so the
+  cloud composites over the fill without a second opaque layer hiding it — this was the gate plot's
+  "points not shown"); `PlotLayers`/`GateOverlay` re-paint their canvas2D content onto a scale×
+  offscreen canvas (the gates were previously rendered only at screen DPR → "gates really low res").
+  Wired for both UMAP (single WebGL canvas) and the gate plot (WebGL + two canvas2D layers).
+- **UMAP now appears in the exported PNG.** Root cause was in the overlay pass, not the WebGL
+  capture: `elementToImageURL({blankCanvases})` hid the `<canvas>` but kept its opaque ancestor
+  background (`.uv-plot { background:#0d0b1a }`), which painted over the separately-composited
+  scatter. Now the canvas's ancestor chain has its background cleared in the clone (siblings like the
+  legend keep theirs).
+- **Gate-plot export no longer clips the axis names.** The x/y axis labels are positioned at
+  negative offsets *outside* `.panel-plot`; capture now targets a `.plot-capture` wrapper whose
+  padding holds the label margins, so the axis names land inside the exported region.
+- **UMAP + heatmap honour the dark-theme knob.** `ClusterHeatmapPanel` merges its `vis` prop into
+  the `BuildOpts` (PlotChart already themes off `opts.darkTheme`); `UmapView` derives the scatter
+  ground + label chip + **legend box background/ink** from `vis.darkTheme` (light mode gave dark ink
+  on the app's dark panel → unreadable pop names) and threads a `backgroundColor` prop into
+  `ScatterGL` (was hardcoded `#0d0b1a`). `ClusterPlots` passes `panelVis()` to the heatmap and into
+  the interactive-view context so both follow the pop-manager's global/local styling scope.
+- **Gate plot loads/renders on first open.** Two parts: `ScatterGL.render()` now re-syncs the regl
+  size (`resize()`) on every draw, so a freshly-opened floating panel that hadn't laid out when the
+  first draw fired no longer stays blank until a reflow; and `GatePlotPanel`'s store-readiness fetch
+  is a single `{ immediate: true }` watch on `[columns, imageUid, valueName]`, so the first
+  appearance loads whether the gating store became ready before or after the panel mounted (it used
+  to stay empty until the user nudged a dropdown).
 
 **#00060** — **Added LICENSE (GPL-3-or-later) + THIRD_PARTY acknowledgements** (2026-06-30)
 Added the GPLv3 text as `LICENSE` (the license is **not a free choice** — the parent

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -517,7 +517,7 @@ aggregation is a PACKAGE function, the route is thin, rendering is frontend-only
   `buildPlotOptions(Plot, data, opts)` to get a `Plot.plot()` options object, injects the panel's
   width/height, and appends the node. Resize is trivial (no Vega signal graph): a `ResizeObserver` on
   the host just re-renders with the new size. Exposes `toImageURL('png'|'svg')` — SVG serialises the
-  node (native), PNG rasterises it 2×. The summaries equivalent of `ScatterGL` for the big point
+  node (native), PNG rasterises it at the DPR-aware `EXPORT_SCALE`. The summaries equivalent of `ScatterGL` for the big point
   clouds.
 These canvas components are **generic** (`components/canvas/`, NOT under a module) so every module
 page — and the universal canvas (Phase 4) — reuses them unchanged:
@@ -566,9 +566,20 @@ page — and the universal canvas (Phase 4) — reuses them unchanged:
   (plain `svgToImageURL` captures only the svg). `plotHostToImageURL(host, bg)` exports **WebGL /
   canvas2D** plots (UMAP scatter, gate plot): it composites every `<canvas>` in the host (pass 1) then
   the HTML/SVG overlay layer on top (pass 2), because canvas pixels can't be serialised via
-  `foreignObject`. This needs the WebGL context created with `preserveDrawingBuffer` — `ScatterGL`
-  pre-creates it (`getContext('webgl', { preserveDrawingBuffer: true })` before regl, which reuses the
-  canvas's existing context). Every cluster plot (UMAP, heatmap, HMM states/transitions) and the gate
+  `foreignObject`. This needs the WebGL context created with `preserveDrawingBuffer` — regl-scatterplot
+  already does this, so `ScatterGL` needs no context pre-creation. **Subtlety (#00061):** the pass-2
+  overlay clone hides the `<canvas>` (`blankCanvases`) but must also **clear the canvas's ancestor
+  backgrounds**, or an opaque plot-area background (e.g. UMAP's `#0d0b1a`) paints over the pass-1
+  scatter and the point cloud vanishes from the PNG. **Crispness:** two DPR-aware scales —
+  `EXPORT_SCALE = min(4, 2×DPR)` for the SVG rasterise path (vector, crisp at any factor) and a higher
+  `RASTER_SCALE = min(8, 4×DPR)` for `plotHostToImageURL`. A WebGL canvas can't be upscaled crisply
+  from its CSS×DPR backing store, so `plotHostToImageURL(host, bg, { hiRes })` takes a resolver and
+  **every stacked canvas re-renders itself at export scale**: `ScatterGL.exportCanvas` via
+  regl-scatterplot's `export({scale})` (on a transparent ground so the cloud composites cleanly), and
+  the gate plot's canvas2D layers (`PlotLayers`, `GateOverlay`) re-paint their content onto a scale×
+  offscreen canvas. The captured host must also include any axis-label
+  margins (the gate plot exports a `.plot-capture` wrapper, not the inner `.panel-plot`, so the axis
+  names aren't clipped). Every cluster plot (UMAP, heatmap, HMM states/transitions) and the gate
   plot carry a footer **duplicate** and/or **export** dropdown. A registered interactive view opts into
   export by exposing `exportFormats: string[]` + `exportAs(kind)` via `defineExpose`; `InteractivePanel`
   surfaces the dropdown generically (UMAP → PNG + CSV). `plots/plot.ts` also exports `paletteRange(vis, n)` (palette → colour list, or

--- a/frontend/src/components/plots/GateOverlay.vue
+++ b/frontend/src/components/plots/GateOverlay.vue
@@ -165,6 +165,15 @@ function drawHandles(g: GateSpec, colour: string) {
     g.vertices.forEach(v => { const [px, py] = dataToPx(v[0], v[1]); dot(px, py) })
   }
 }
+// the committed gate outlines + labels (substitute the draft for the one being edited). Split out so
+// the hi-res export can re-paint just these — handles / in-progress shapes are live-interaction only.
+function paintGates() {
+  for (const g of props.gates ?? []) {
+    const spec = g.path === editPath && draft.value ? draft.value : g.gate
+    strokeShape(spec, g.colour || '#fafafa')
+    if (props.showLabels) drawGateLabel(spec, g.path, g.colour || '#fafafa')
+  }
+}
 function draw() {
   if (!ctx || !canvasEl.value) return
   const dpr = window.devicePixelRatio || 1
@@ -173,12 +182,7 @@ function draw() {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
   ctx.clearRect(0, 0, w, h)
 
-  // existing gates (substitute the draft for the one being edited)
-  for (const g of props.gates ?? []) {
-    const spec = g.path === editPath && draft.value ? draft.value : g.gate
-    strokeShape(spec, g.colour || '#fafafa')
-    if (props.showLabels) drawGateLabel(spec, g.path, g.colour || '#fafafa')
-  }
+  paintGates()
   // handles on the hovered / edited gate
   const active = editPath ? gateOf(editPath) : hover.value ? gateOf(hover.value.path) : undefined
   if (active && props.mode === 'off') {
@@ -200,6 +204,25 @@ function draw() {
     for (const p of polyPts.value) { ctx.beginPath(); ctx.arc(p[0], p[1], 3, 0, 2 * Math.PI); ctx.fill() }
   }
 }
+
+// hi-res export (see plots/export.ts): re-paint the committed gates onto a scale× offscreen canvas
+// so gate outlines/labels are crisp instead of the compositor upscaling the screen-DPR canvas. Swap
+// the module `ctx` to the offscreen context (draw helpers target it via toPx/size), then restore.
+async function exportCanvas(scale: number): Promise<HTMLCanvasElement | null> {
+  if (!canvasEl.value) return null
+  const { w, h } = size(); if (!w || !h) return null
+  const off = document.createElement('canvas')
+  off.width = Math.max(1, Math.round(w * scale)); off.height = Math.max(1, Math.round(h * scale))
+  const octx = off.getContext('2d'); if (!octx) return null
+  const saved = ctx
+  ctx = octx
+  octx.setTransform(scale, 0, 0, scale, 0, 0)
+  octx.clearRect(0, 0, w, h)
+  paintGates()
+  ctx = saved                                  // the live canvas's context object was never touched
+  return off
+}
+defineExpose({ exportCanvas, getCanvas: () => canvasEl.value })
 
 // ── editing: apply a handle drag to the draft ──
 function applyEdit(p: [number, number]) {

--- a/frontend/src/components/plots/PlotLayers.vue
+++ b/frontend/src/components/plots/PlotLayers.vue
@@ -123,17 +123,11 @@ function drawDots(points: Float32Array, colour: string) {
   }
 }
 
-function draw() {
-  if (!ctx || !canvasEl.value) return
-  const dpr = window.devicePixelRatio || 1
-  const { w, h } = size()
-  canvasEl.value.width = Math.max(1, w * dpr); canvasEl.value.height = Math.max(1, h * dpr)
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-  ctx.clearRect(0, 0, w, h)
-  ctx.lineJoin = 'round'
-
+// paint the layer content (contours + pop overlay) with the current `ctx`; toPx uses size() (CSS px)
+// so it's resolution-independent — the transform on the target ctx sets the actual pixel density.
+function paintContent() {
+  ctx!.lineJoin = 'round'
   if (props.renderMode === 'contour' && props.basePoints?.length) drawContours(props.basePoints, '#cbd5e1')
-
   if (props.showPops) {
     for (const pop of props.popLayers) {
       if (!pop.points?.length) continue
@@ -141,6 +135,34 @@ function draw() {
     }
   }
 }
+function draw() {
+  if (!ctx || !canvasEl.value) return
+  const dpr = window.devicePixelRatio || 1
+  const { w, h } = size()
+  canvasEl.value.width = Math.max(1, w * dpr); canvasEl.value.height = Math.max(1, h * dpr)
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.clearRect(0, 0, w, h)
+  paintContent()
+}
+
+// hi-res export (see plots/export.ts): re-paint the same content onto a scale× offscreen canvas so
+// the contours/dots are crisp instead of the compositor upscaling the screen-DPR canvas. We swap the
+// module `ctx` to the offscreen context so the existing draw helpers target it, then restore.
+async function exportCanvas(scale: number): Promise<HTMLCanvasElement | null> {
+  if (!canvasEl.value) return null
+  const { w, h } = size(); if (!w || !h) return null
+  const off = document.createElement('canvas')
+  off.width = Math.max(1, Math.round(w * scale)); off.height = Math.max(1, Math.round(h * scale))
+  const octx = off.getContext('2d'); if (!octx) return null
+  const saved = ctx
+  ctx = octx
+  octx.setTransform(scale, 0, 0, scale, 0, 0)
+  octx.clearRect(0, 0, w, h)
+  paintContent()
+  ctx = saved                                  // the live canvas's context object was never touched
+  return off
+}
+defineExpose({ exportCanvas, getCanvas: () => canvasEl.value })
 
 watch(() => [props.viewExtents, props.renderMode, props.basePoints, props.popLayers, props.showPops, props.viewTick],
       draw, { deep: true })

--- a/frontend/src/components/plots/ScatterGL.vue
+++ b/frontend/src/components/plots/ScatterGL.vue
@@ -30,8 +30,9 @@ const props = withDefaults(defineProps<{
   // `points`) + the colour palette. ScatterGL stays dumb — the caller maps codes→palette slots.
   categories?: Float32Array | null
   palette?: string[]
+  backgroundColor?: string                 // scatter ground; caller themes it (UMAP dark/light)
 }>(), { colorMode: 'density', pointSize: 3, opacity: 1, flatColor: '#8b8b8b',
-        categories: null, palette: () => [] })
+        categories: null, palette: () => [], backgroundColor: '#0d0b1a' })
 
 // FlowJo "pseudocolour" blue-heat ramp (R: .flowColorRampBlueHeat, flowHelpers.R:775),
 // low end lifted off pure black so sparse points stay visible on the dark background, and
@@ -156,7 +157,7 @@ async function ensure() {
     aspectRatio: aspect(),         // fill the rectangle (no square letterboxing) → overlays align
     pointSize: props.pointSize,
     opacity: props.opacity,
-    backgroundColor: '#0d0b1a',
+    backgroundColor: props.backgroundColor,
     lassoInitiator: false,         // gating uses explicit gates, never lasso
     cameraIsFixed: true,           // lock the camera at identity → [-1,1] maps to canvas edges
   })
@@ -168,6 +169,11 @@ async function ensure() {
 async function render() {
   await ensure()
   if (!scatterplot) return
+  // sync the regl size to the current box on every draw: on first appearance the floating panel may
+  // not have laid out when the initial render fires, so the scatter would draw at a stale/zero size
+  // and stay blank until some later event (changing a dropdown) forced a redraw. Cheap no-op when
+  // the size is unchanged.
+  resize()
   const { x, y } = xy()
   if (props.colorMode === 'category' && x.length && (props.palette?.length ?? 0) > 0) {
     // colour-by-category (e.g. cluster on a UMAP): map each point's palette index → [0,1] so regl
@@ -194,14 +200,58 @@ function resize() {
   scatterplot.set({ width: w, height: h, aspectRatio: aspect() })
 }
 
+// hi-res export: regl-scatterplot re-renders the point cloud at `scale`× (its on-screen backing
+// store is only CSS×DPR, so compositing the live canvas upscales → pixelated). Returns an offscreen
+// canvas at the higher resolution for the export compositor to draw crisply. See plots/export.ts.
+// We render on a TRANSPARENT ground (not the opaque backgroundColor) so the export is points-only —
+// it composites over the host's ground fill without a second opaque layer hiding the cloud, and
+// works the same for the gate plot (navy fill) and UMAP (themed fill). Falls back to null (→ the
+// compositor draws the live canvas) if the re-render fails, so points always appear.
+async function exportCanvas(scale: number): Promise<HTMLCanvasElement | null> {
+  if (!scatterplot || !canvasEl.value) return null
+  // Snapshot the current on-screen frame FIRST. regl-scatterplot blits its WebGL output into this 2D
+  // user canvas, so it always holds exactly what's on screen (points + background). This is the
+  // guaranteed fallback: `export()` can throw or blank (observed on the gate scatter) and leave the
+  // live canvas mid-resize, so we must copy it BEFORE calling export.
+  const live = canvasEl.value
+  const snap = document.createElement('canvas'); snap.width = live.width; snap.height = live.height
+  snap.getContext('2d')?.drawImage(live, 0, 0)
+  try {
+    // hi-res re-render on a transparent ground (composites over the host fill without a second opaque
+    // layer). Use it only if it actually painted something; otherwise fall through to the snapshot.
+    scatterplot.set({ backgroundColor: [0, 0, 0, 0] })
+    const data = await scatterplot.export({ scale }) as ImageData
+    scatterplot.set({ backgroundColor: props.backgroundColor })
+    if (data && data.width) {
+      let painted = false
+      for (let i = 3; i < data.data.length; i += 4 * 97) { if (data.data[i] !== 0) { painted = true; break } }
+      if (painted) {
+        const c = document.createElement('canvas'); c.width = data.width; c.height = data.height
+        const cx = c.getContext('2d')
+        if (cx) { cx.putImageData(data, 0, 0); return c }
+      }
+    }
+  } catch {
+    // export() can leave the live canvas mid-resize — restore the on-screen render
+    scatterplot?.set({ backgroundColor: props.backgroundColor })
+    resize(); render()
+  }
+  return snap.width ? snap : null   // fallback: the pre-export on-screen frame (screen resolution)
+}
+defineExpose({ exportCanvas, getCanvas: () => canvasEl.value })
+
 watch(() => props.points, render)
 // new data → re-render (camera is fixed; extents drive the [-1,1] normalisation)
 watch(() => props.extents, render, { deep: true })
 watch([() => props.colorMode, () => props.opacity, () => props.pointSize, () => props.flatColor], render)
 watch([() => props.categories, () => props.palette], render)
+watch(() => props.backgroundColor, bg => { scatterplot?.set({ backgroundColor: bg }); render() })
 
 onMounted(() => {
-  render()
+  // defer the first render one frame: a freshly-opened floating panel hasn't laid out yet, so box()
+  // would measure 0×0 and regl would draw nothing until some later reflow (the "toggle a pop and it
+  // appears" symptom). rAF lets layout settle so the initial draw is at the real size.
+  requestAnimationFrame(() => render())
   // observe the PARENT (panel-plot) — the canvas itself is pinned by regl and won't fire resizes
   const target = canvasEl.value?.parentElement ?? canvasEl.value
   if (target) {

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -18,6 +18,7 @@ import { ref, computed, watch, onMounted, useTemplateRef } from 'vue'
 import { useLogStore } from '../../stores/log'
 import ScatterGL from './ScatterGL.vue'
 import { plotHostToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
+import type { VisProps } from '../../plots/plot'
 
 const props = defineProps<{
   projectUid: string; imageUids: string[]; setUid: string | null
@@ -25,11 +26,25 @@ const props = defineProps<{
   // populations whose eye is on in the manager: colour their clusters in the pop colour, grey the
   // rest. Empty → plain colour-by-cluster. Live from the gating store via ClusterPlots' viewContext.
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
+  vis?: VisProps                 // canvas plot styling — here we honour the dark-theme knob
   state: { labels?: boolean }
 }>()
 const log = useLogStore()
 const labels = computed({ get: () => props.state.labels !== false, set: v => (props.state.labels = v) })
 const unit = computed(() => (props.popType === 'trackclust' ? 'tracks' : 'cells'))
+
+// dark-theme knob (default dark, like the summary plots): drives the scatter ground + label chip.
+const dark = computed(() => props.vis?.darkTheme !== false)
+const ground = computed(() => (dark.value ? '#0d0b1a' : '#ffffff'))
+// label chip + legend ink follow the theme so they stay legible on the exported ground (a light
+// ground with the app's light legend ink was invisible — #00061 follow-up).
+const labelStyle = computed(() => dark.value
+  ? { color: '#111', background: 'rgba(255,255,255,0.85)', borderColor: 'rgba(0,0,0,0.35)' }
+  : { color: '#f5f5f5', background: 'rgba(20,20,28,0.82)', borderColor: 'rgba(255,255,255,0.35)' })
+const legendInk = computed(() => (dark.value ? '#e6e6e6' : '#111'))
+// legend box background follows the theme too — in light mode the dark ink sat on the app's dark
+// panel surface (unreadable on the canvas); give it a light box so the pop names are legible.
+const legendBg = computed(() => (dark.value ? 'transparent' : '#ffffff'))
 
 const PALETTE = [
   '#ef4444', '#f59e0b', '#10b981', '#3b82f6', '#a78bfa', '#ec4899', '#14b8a6', '#eab308',
@@ -149,9 +164,13 @@ onMounted(load)
 // ── export (surfaced by the host InteractivePanel via defineExpose) ──
 // PNG composites the WebGL scatter + the HTML labels/legend (plots/export.ts); CSV is x,y,cluster.
 const plotEl = useTemplateRef<HTMLElement>('plotEl')
+const scatterRef = useTemplateRef<{ exportCanvas(scale: number): Promise<HTMLCanvasElement | null>; getCanvas(): HTMLCanvasElement | null }>('scatterRef')
+// re-render the scatter at export resolution so the point cloud is crisp (not a 2×-upscaled 1× canvas)
+const hiRes = async (cv: HTMLCanvasElement, scale: number) =>
+  cv === scatterRef.value?.getCanvas() ? (await scatterRef.value?.exportCanvas(scale) ?? null) : null
 function exportAs(kind: string) {
   const stem = `umap_${props.suffix}`.replace(/[^\w.-]+/g, '_')
-  if (kind === 'png') plotHostToImageURL(plotEl.value, '#0d0b1a').then(url => url && downloadDataUrl(`${stem}.png`, url))
+  if (kind === 'png') plotHostToImageURL(plotEl.value, ground.value, { hiRes }).then(url => url && downloadDataUrl(`${stem}.png`, url))
   else if (kind === 'csv') {
     const pts = points.value, codes = codesRef.value
     if (!pts || !codes) return
@@ -174,19 +193,20 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs })
       <span v-if="total" class="uv-count">{{ total.toLocaleString() }} {{ unit }} · {{ legend.length }} clusters</span>
     </div>
     <div ref="plotEl" class="uv-body">
-      <div class="uv-plot">
+      <div class="uv-plot" :style="{ background: ground }">
         <template v-if="points && points.length">
-          <ScatterGL :points="points" :extents="extents" color-mode="category"
-                     :categories="categories" :palette="palette" :point-size="4" :opacity="0.9" />
+          <ScatterGL ref="scatterRef" :points="points" :extents="extents" color-mode="category"
+                     :categories="categories" :palette="palette" :point-size="4" :opacity="0.9"
+                     :background-color="ground" />
           <span v-for="c in centroids" v-show="labels" :key="c.label" class="uv-label"
-                :style="{ left: lx(c.x), top: ly(c.y) }">{{ c.label }}</span>
+                :style="{ left: lx(c.x), top: ly(c.y), ...labelStyle }">{{ c.label }}</span>
         </template>
         <div v-else class="uv-empty">
           <i :class="['pi', loading ? 'pi-spin pi-spinner' : 'pi-chart-scatter']" />
           <p>{{ loading ? 'Loading…' : (err || 'Select clustered image(s) to view the UMAP.') }}</p>
         </div>
       </div>
-      <div v-if="legend.length" class="uv-legend">
+      <div v-if="legend.length" class="uv-legend" :style="{ color: legendInk, background: legendBg }">
         <div v-for="l in legend" :key="l.label" class="leg-row">
           <span class="leg-dot" :style="{ background: l.colour }" />
           <span class="leg-lbl">{{ l.label }}</span>
@@ -214,6 +234,8 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs })
 .uv-legend { width: 9.5rem; flex-shrink: 0; overflow-y: auto; border: 1px solid var(--cc-border); border-radius: 5px; padding: 5px; }
 .leg-row { display: flex; align-items: center; gap: 5px; padding: 1px 2px; font-size: 11px; }
 .leg-dot { width: 0.65rem; height: 0.65rem; border-radius: 50%; flex-shrink: 0; }
-.leg-lbl { flex: 1; color: var(--cc-text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.leg-n { color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
+/* legend ink is themed inline on .uv-legend (light on dark ground, dark on light) so it stays
+   legible in the exported PNG; children inherit it. */
+.leg-lbl { flex: 1; color: inherit; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.leg-n { color: inherit; opacity: 0.7; font-variant-numeric: tabular-nums; }
 </style>

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -14,7 +14,7 @@ import { useLogStore } from '../../stores/log'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import PlotChart from '../../components/plots/PlotChart.vue'
-import { defaultVis, plotDataToCsv, type BuildOpts } from '../../plots/plot'
+import { defaultVis, plotDataToCsv, type BuildOpts, type VisProps } from '../../plots/plot'
 import { downloadDataUrl, downloadBlob } from '../../plots/export'
 import type { PlotDataResponse } from '../../plots/types'
 
@@ -27,6 +27,7 @@ const props = defineProps<{
   // profile) instead of the raw cluster IDs. Empty → per-cluster. `clusterIds` is carried only so
   // the reload watch fires when the cluster→pop assignment changes (membership changes, same path).
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
+  vis?: VisProps                 // canvas plot styling (dark-theme etc.) — see ClusterPlots panelVis
   state: { features?: string[] }
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
@@ -45,8 +46,10 @@ const features = computed(() => props.state.features ?? [])
 const heatmap = ref<PlotDataResponse | null>(null)
 const loading = ref(false)
 const err = ref('')
+// merge the canvas vis (dark-theme, font size, legend, …) over the defaults so the pop-manager
+// styling knobs drive the heatmap too; the matrix-specific fields below stay fixed regardless.
 const opts = computed<BuildOpts>(() => ({
-  ...defaultVis(), chartType: 'heatmap', byImage: false, normalize: false, errorMetric: 'sd', colorOf: () => '#8888aa',
+  ...defaultVis(), ...(props.vis ?? {}), chartType: 'heatmap', byImage: false, normalize: false, errorMetric: 'sd', colorOf: () => '#8888aa',
 }))
 const label = (raw: string) => props.nameMap[raw] ?? raw
 

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -202,6 +202,7 @@ watch([projectUid, () => props.imageUids.join(','), () => props.popType], loadFe
 const ctxFor = (s: ClusterPanelState) => ({
   projectUid: projectUid.value, imageUids: validUids.value, setUid: setUid.value,
   popType: props.popType, suffix: suffix.value, shownPops: shownPopsFor(panelHL(s)),
+  vis: panelVis(s),   // canvas styling (dark-theme etc.) — interactive views read it if they theme
 })
 
 // the population row the manager treats as selected (clicking a row); cluster ticking is per-row,
@@ -278,7 +279,8 @@ onMounted(() => {
           <ClusterHeatmapPanel v-else-if="p.state.kind === 'heatmap'" :index="i" :arrange="p.arrange"
                             :active="p.id === activeId" :project-uid="projectUid" :set-uid="setUid"
                             :image-uids="validUids" :pop-type="popType" :suffix="suffix"
-                            :feature-options="featureOptions" :name-map="nameMap" :shown-pops="shownPopsFor(panelHL(p.state))" :state="p.state"
+                            :feature-options="featureOptions" :name-map="nameMap" :shown-pops="shownPopsFor(panelHL(p.state))"
+                            :vis="panelVis(p.state)" :state="p.state"
                             :persist-key="`clust:${popType}:${p.id}`"
                             @activate="activeId = p.id" @remove="remove(p.id)" @duplicate="duplicatePanel(p.state)" />
           <!-- HMM behaviour plots (track clustering) -->

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -12,7 +12,7 @@
   user selects in the manager.
 -->
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, useTemplateRef } from 'vue'
+import { ref, computed, watch, useTemplateRef } from 'vue'
 import { useGatingStore, isReservedPopName, type GateSpec, type TransformSpec } from '../../stores/gating'
 import { useLogStore } from '../../stores/log'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
@@ -190,12 +190,26 @@ function fmtTick(label: string): string {
   return label
 }
 
-// export the plot area (WebGL scatter + contour/pop layers + gate overlay + axis ticks) as a PNG —
-// composited via plots/export.ts (canvas pixels + HTML/canvas2D overlays). The scatter ground is navy.
+// export the plot area (WebGL scatter + contour/pop layers + gate overlay + axis ticks + labels) as a
+// PNG — composited via plots/export.ts (canvas pixels + HTML/canvas2D overlays). The capture host is
+// `.plot-capture` (which INCLUDES the axis-label margins), not `.panel-plot`, so the x/y axis names
+// aren't clipped off the bottom/left edge. The scatter is re-rendered hi-res so points stay crisp.
 const plotEl = useTemplateRef<HTMLElement>('plotEl')
+type LayerExport = { exportCanvas(scale: number): Promise<HTMLCanvasElement | null>; getCanvas(): HTMLCanvasElement | null }
+const scatterRef = useTemplateRef<LayerExport>('scatterRef')
+const layersRef = useTemplateRef<LayerExport>('layersRef')
+const overlayRef = useTemplateRef<LayerExport>('overlayRef')
+// each stacked canvas (WebGL scatter + canvas2D contours/gates) re-renders itself at export scale so
+// nothing is upscaled from the screen-DPR backing store; route each live canvas to its layer.
+const hiRes = async (cv: HTMLCanvasElement, scale: number) => {
+  for (const r of [scatterRef, layersRef, overlayRef]) {
+    if (cv === r.value?.getCanvas()) return (await r.value?.exportCanvas(scale)) ?? null
+  }
+  return null
+}
 function exportPng() {
   const stem = `gate_${xChan.value}_${yChan.value}`.replace(/[^\w.-]+/g, '_')
-  plotHostToImageURL(plotEl.value, '#0d0b1a').then(url => url && downloadDataUrl(`${stem}.png`, url))
+  plotHostToImageURL(plotEl.value, '#0d0b1a', { hiRes }).then(url => url && downloadDataUrl(`${stem}.png`, url))
 }
 
 function ensureChannels() {
@@ -204,8 +218,12 @@ function ensureChannels() {
   if (!cols.includes(xChan.value)) xChan.value = g.channels[(props.index * 2) % Math.max(1, g.channels.length)] ?? cols[0]
   if (!cols.includes(yChan.value)) yChan.value = g.channels[(props.index * 2 + 1) % Math.max(1, g.channels.length)] ?? cols[Math.min(1, cols.length - 1)]
 }
-watch(() => g.columns, () => { ensureChannels(); fetchPlot() })
-watch([() => g.imageUid, () => g.valueName], () => { ensureChannels(); fetchPlot() })
+// store readiness (channels/image/segmentation): pick default axes then load. `immediate` so the
+// first appearance fetches whether the store became ready BEFORE this panel mounted (values already
+// set → fires now) or AFTER (fires again on change) — previously the plot stayed empty on first open
+// until the user nudged a dropdown.
+watch([() => g.columns, () => g.imageUid, () => g.valueName],
+      () => { ensureChannels(); fetchPlot() }, { immediate: true, flush: 'post' })
 watch([xChan, yChan, xt, yt, parent, () => props.axisFromZero], fetchPlot)
 watch(() => props.highlight, loadPopLayers, { deep: true })
 // another plot changed the gate of the population we display (or an ancestor) → refresh smoothly
@@ -214,7 +232,7 @@ watch(parentVersion, refreshMembership)
 // a highlighted pop's membership changed elsewhere → refresh just its colour layer
 const hlVersion = computed(() => (props.highlight ?? []).reduce((s, p) => s + (g.popVersion[p] ?? 0), 0))
 watch(hlVersion, loadPopLayers)
-onMounted(() => { ensureChannels(); fetchPlot() })
+// initial load is handled by the { immediate: true } store-readiness watch above.
 </script>
 
 <template>
@@ -254,12 +272,13 @@ onMounted(() => { ensureChannels(); fetchPlot() })
         <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to display; new gates are its children'">
         <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select></label>
     </div>
-    <div ref="plotEl" class="panel-plot">
-      <ScatterGL :points="points" :extents="extents" :color-mode="baseColorMode"
+    <div ref="plotEl" class="plot-capture">
+     <div class="panel-plot">
+      <ScatterGL ref="scatterRef" :points="points" :extents="extents" :color-mode="baseColorMode"
                  :opacity="baseOpacity" :point-size="basePointSize" />
-      <PlotLayers :view-extents="viewExtents" :render-mode="renderMode" :base-points="points"
+      <PlotLayers ref="layersRef" :view-extents="viewExtents" :render-mode="renderMode" :base-points="points"
                   :pop-layers="popLayers" :show-pops="showPops" :view-tick="viewTick" />
-      <GateOverlay :extents="viewExtents" :mode="mode" :gates="currentGates" :view-tick="viewTick"
+      <GateOverlay ref="overlayRef" :extents="viewExtents" :mode="mode" :gates="currentGates" :view-tick="viewTick"
                    :line-width="gateLineWidth" :show-labels="gateLabels"
                    @draw="onDraw" @edit="onEdit" @cancel="mode = 'off'" />
       <span class="axisline axisline-x" />
@@ -282,6 +301,7 @@ onMounted(() => { ensureChannels(); fetchPlot() })
         <button class="cc-btn cc-btn-ghost" @click="pending = null">×</button>
         <span v-if="nameReserved" class="name-hint">names can't start with “_” (reserved for tracked / clustering)</span>
       </div>
+     </div>
     </div>
   </CanvasPanel>
 </template>
@@ -311,8 +331,16 @@ onMounted(() => { ensureChannels(); fetchPlot() })
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button.on { background: var(--cc-accent); color: #fff; }
 .cc-btn.on { border-color: var(--cc-accent); color: var(--cc-accent); }
-/* fills the resizable panel; generous margins so axes/labels have breathing room */
-.panel-plot { position: relative; flex: 1; min-height: 200px; margin: 18px 22px 50px 84px; }
+/* capture host for PNG export: the axis labels/ticks live in this padding (relative to .panel-plot,
+   at negative offsets), so exporting THIS element — not .panel-plot — includes the x/y axis names
+   instead of clipping them at the edge (#00061). The label-space that used to be .panel-plot's
+   margin is now this padding. min-height is modest so plot + padding + footer all fit inside the
+   default panel height without the panel's overflow:hidden clipping the bottom label. */
+.plot-capture { position: relative; flex: 1; min-height: 218px; min-width: 0; display: flex; box-sizing: border-box;
+  padding: 18px 22px 50px 84px; }
+/* min-width:0 so this flex-row item can shrink below the scatter canvas's intrinsic width — without
+   it the panel grows on resize-right but won't shrink back on resize-left. */
+.panel-plot { position: relative; flex: 1; min-height: 150px; min-width: 0; }
 .axisline { position: absolute; background: var(--cc-border); pointer-events: none; }
 .axisline-x { left: 0; right: 0; bottom: 0; height: 1px; }
 .axisline-y { left: 0; top: 0; bottom: 0; width: 1px; }

--- a/frontend/src/plots/export.ts
+++ b/frontend/src/plots/export.ts
@@ -15,9 +15,17 @@ export async function svgToImageURL(svg: SVGSVGElement | null, type: 'png' | 'sv
   return await rasterize(svgUrl, w, h)
 }
 
-// rasterise an SVG data URL onto a 2× canvas over a white ground → PNG data URL
+const DPR = (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1)
+// SVG plots (heatmap, HMM, summary charts) rasterise crisply at any factor since they're vector, so
+// DPR×2 (capped 4×) is plenty and keeps file sizes sane.
+const EXPORT_SCALE = Math.min(4, 2 * DPR)
+// Raster/WebGL composites (UMAP + gate scatter) have NO vector fallback — the point cloud is a
+// bitmap. ScatterGL.exportCanvas re-renders it at this scale, so push it higher for a crisp PNG.
+const RASTER_SCALE = Math.min(8, 4 * DPR)
+
+// rasterise an SVG data URL onto a hi-DPI canvas over a white ground → PNG data URL
 async function rasterize(svgUrl: string, w: number, h: number): Promise<string | null> {
-  const scale = 2
+  const scale = EXPORT_SCALE
   return await new Promise<string | null>(resolve => {
     const img = new Image()
     img.onload = () => {
@@ -60,7 +68,16 @@ export async function elementToImageURL(el: HTMLElement | null, type: 'png' | 's
   inlineComputedStyles(el, clone)
   const transparent = !bg || bg === 'transparent'
   if (transparent) clone.style.background = 'transparent'
-  if (opts.blankCanvases) for (const cv of Array.from(clone.querySelectorAll('canvas'))) (cv as HTMLElement).style.visibility = 'hidden'
+  if (opts.blankCanvases) for (const cv of Array.from(clone.querySelectorAll('canvas'))) {
+    (cv as HTMLElement).style.visibility = 'hidden'
+    // the canvas's ancestors' (opaque) backgrounds would paint OVER the separately-composited canvas
+    // pixels in plotHostToImageURL and hide them — clear them so pass-1 shows through. Non-ancestor
+    // siblings (legend, labels) keep their backgrounds.
+    for (let a = cv.parentElement; a && a !== clone; a = a.parentElement) {
+      (a as HTMLElement).style.background = 'transparent'; (a as HTMLElement).style.backgroundColor = 'transparent'
+    }
+    clone.style.background = 'transparent'; clone.style.backgroundColor = 'transparent'
+  }
   clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml')
   const xml = new XMLSerializer().serializeToString(clone)
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">` +
@@ -76,16 +93,21 @@ function loadImg(url: string): Promise<HTMLImageElement | null> {
 
 // Capture a host that contains <canvas> layers (WebGL scatter + canvas2D overlays) PLUS HTML/SVG
 // overlays (legend, ticks, axis labels) — the interactive plots (UMAP, gate plot). Canvas pixels
-// can't be serialised via foreignObject, so we composite in two passes onto one 2× canvas:
-//   1. draw every <canvas> in the host at its offset (needs the WebGL context created with
-//      preserveDrawingBuffer — ScatterGL does this);
+// can't be serialised via foreignObject, so we composite in two passes onto one hi-DPI canvas:
+//   1. draw every <canvas> in the host at its offset (WebGL reads back via regl-scatterplot's
+//      preserveDrawingBuffer; opts.hiRes swaps in a higher-res re-render for crisp output);
 //   2. draw the HTML/SVG overlay layer on top (canvases blanked so they don't cover pass 1).
 // Returns a PNG data URL (raster; SVG makes no sense for a rasterised point cloud).
-export async function plotHostToImageURL(host: HTMLElement | null, bg: string): Promise<string | null> {
+// `opts.hiRes(cv, scale)` lets a caller supply a HIGHER-RESOLUTION replacement for a specific canvas
+// (ScatterGL.exportCanvas re-renders the WebGL point cloud at `scale`× — its on-screen backing store
+// is only CSS×DPR, so drawing the live canvas would upscale and pixelate). Resolver returns null →
+// composite the live canvas as-is (canvas2D overlays with no hi-res path).
+export async function plotHostToImageURL(host: HTMLElement | null, bg: string,
+  opts: { hiRes?: (cv: HTMLCanvasElement, scale: number) => Promise<CanvasImageSource | null> } = {}): Promise<string | null> {
   if (!host) return null
   const w = host.clientWidth || host.offsetWidth, h = host.clientHeight || host.offsetHeight
   if (!w || !h) return null
-  const scale = 2
+  const scale = RASTER_SCALE
   const c = document.createElement('canvas'); c.width = w * scale; c.height = h * scale
   const ctx = c.getContext('2d'); if (!ctx) return null
   ctx.scale(scale, scale)
@@ -93,7 +115,8 @@ export async function plotHostToImageURL(host: HTMLElement | null, bg: string): 
   const hr = host.getBoundingClientRect()
   for (const cv of Array.from(host.querySelectorAll('canvas'))) {
     const r = cv.getBoundingClientRect()
-    try { ctx.drawImage(cv, r.left - hr.left, r.top - hr.top, r.width, r.height) } catch { /* tainted/empty */ }
+    const hi = opts.hiRes ? await opts.hiRes(cv, scale) : null
+    try { ctx.drawImage(hi ?? cv, r.left - hr.left, r.top - hr.top, r.width, r.height) } catch { /* tainted/empty */ }
   }
   const overlayUrl = await elementToImageURL(host, 'svg', 'transparent', { blankCanvases: true })
   if (overlayUrl) { const img = await loadImg(overlayUrl); if (img) ctx.drawImage(img, 0, 0, w, h) }


### PR DESCRIPTION
## Canvas export/theme cleanup (#00061) + gate plot fixes

Closes the four-item **#00061** cleanup plus a batch of export/theme/render follow-ups found while testing.

### Export
- Two DPR-aware scales: `EXPORT_SCALE = min(4, 2×DPR)` for SVG plots (vector), higher `RASTER_SCALE = min(8, 4×DPR)` for WebGL/canvas composites.
- `plotHostToImageURL(host, bg, { hiRes })` — every stacked canvas re-renders at export scale: `ScatterGL.exportCanvas` via regl-scatterplot's `export({scale})` on a **transparent** ground, with a **pre-export snapshot fallback** so the point cloud always appears even when `export()` blanks (seen on the gate scatter); `PlotLayers`/`GateOverlay` re-paint their canvas2D content at scale.
- UMAP now appears in its PNG (clear the canvas's ancestor backgrounds in the overlay clone). Gate export no longer clips the axis names (capture a `.plot-capture` wrapper that includes the label margins).

### Theme
- UMAP + heatmap honour the dark-theme (`VisProps`) knob: heatmap merges `vis` into `BuildOpts`; `UmapView` derives ground + labels + **legend box/ink** from `vis.darkTheme` and threads `backgroundColor` into `ScatterGL`. `ClusterPlots` passes `panelVis()` to both.

### Gate plot
- Renders/loads on **first open**: `ScatterGL.render()` re-syncs the regl size each draw; `GatePlotPanel` uses one `{ immediate: true, flush: 'post' }` store-readiness fetch.
- Footer no longer clips the x-axis label (`min-height` lowered); `min-width: 0` so the panel can shrink again after being widened.

Frontend typechecks clean (`vue-tsc -b`). Docs updated: `docs/TODO.md` (#00061 → Fixed), `docs/UI.md`.

**Known follow-ups:** gate pseudocolor may export at screen resolution when regl `export()` blanks for it (falls back to snapshot); confirm both gate plots load on first open and UMAP still crisp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)