### PR TITLE
feat(analysis): universal Analysis canvas page (/analysis)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -61,20 +61,6 @@ select; (b) a resampling step that emits overlapping sub-tracks as first-class r
 per-image frame-interval normalisation so cross-rate comparison needs no manual skip. Settle the
 storage/UX before building. Not urgent.
 
-**#00036** — **Universal "Analysis canvas" page** (deferred)
-A standalone canvas (sidebar entry already present at `/analysis`, disabled + "coming soon") that
-hosts the SAME plot canvas as the per-module pages but with the **module filter off** — every plot
-spec is offerable, so a user can combine plots across modules / images / segmentations on one board.
-Notes for when we build it:
-- It's `SummaryCanvas` with `module={null}` (already supported: `loadSpecs()` fetches all specs, the
-  panel-state/persistence keys use `summary:universal`). Add a route + a thin `AnalysisModule.vue`
-  page (image multi-select like behaviour). Drop the `disabled/soon` flags on the sidebar item.
-- Decide the page's image-source UX: it should let you pick images from the active set (and maybe
-  across sets later). The populations endpoint already unions across selected images/segmentations.
-- Likely shares the future interactive-panel family (gating scatter, cluster-heatmap) once those
-  land — this is where `PlotSpec.family` (`summary` vs `interactive`) finally gets consumed to route
-  a spec to the right panel component.
-
 **#00037** — **Whiteboard plot integration** (deferred)
 Plot nodes in the chain whiteboard (`ChainModule.vue`). A collapsible **"Plots"** box is already in
 the palette (under "Module functions") with a "coming soon" placeholder. Notes:
@@ -232,6 +218,18 @@ batch it rather than churn standalone.
 ---
 
 ## Fixed
+
+**#00036** — **Universal "Analysis canvas" page** (2026-07-01)
+A standalone canvas at `/analysis` that hosts the SAME plot canvas as the per-module pages but with
+the **module filter off** — every plot spec is offerable, so plots can be combined across modules /
+images / segmentations on one board. Thin as anticipated: `SummaryCanvas` already supported the
+universal mode (no `module` prop → `loadSpecs()` fetches all specs, persistence keys use
+`summary:universal`). Added `AnalysisModule.vue` (a `ModuleLayout` with image multi-select + a
+`#below-table` `SummaryCanvas`, no TaskRunner — visualise-only), registered the `/analysis` route,
+and dropped the `disabled/soon` flags on the existing sidebar entry (now `requiresProject`). Image
+selection namespaces under the `analysis` scope; the populations endpoint already unions across the
+selected images/segmentations. (Future interactive-panel routing via `PlotSpec.family` is still
+pending — see the interactive-panel family work.) See `docs/UI.md` → "Analysis-plot canvas".
 
 **#00062** — **`pixi install` fails on macOS-arm64 building `cvxopt` from source** (2026-07-01)
 A tester on macOS-arm64 got past the installer download but `pixi install` failed: `Failed to build

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -520,7 +520,8 @@ aggregation is a PACKAGE function, the route is thin, rendering is frontend-only
   node (native), PNG rasterises it at the DPR-aware `EXPORT_SCALE`. The summaries equivalent of `ScatterGL` for the big point
   clouds.
 These canvas components are **generic** (`components/canvas/`, NOT under a module) so every module
-page — and the universal canvas (Phase 4) — reuses them unchanged:
+page — and the universal **Analysis canvas** (`/analysis`, `AnalysisModule.vue`: `SummaryCanvas` with
+no `module` prop → all specs) — reuses them unchanged:
 - **`components/canvas/SummaryPanel.vue`** — one summary plot, wrapping `CanvasPanel`. Layout: the
   **controls row** (`#actions`) holds a **measure dropdown** (from the spec's `measureOptions`) and a
   **chart-type dropdown** (from `chartTypes`, shown when >1); the secondary options — **Split by**
@@ -556,7 +557,7 @@ page — and the universal canvas (Phase 4) — reuses them unchanged:
   `SeriesPicker` (summary canvas) and `PopulationManager` (gating / cluster canvas), so the styling
   knobs live in ONE place. `PopulationManager` renders it only when the host passes a `vis` bag (the
   cluster canvas does; the gate canvas doesn't) — the "add plot styling to the pop manager" keyword.
-  The future universal analysis canvas gets the same controls for free.
+  The universal Analysis canvas (`/analysis`) gets the same controls for free.
 - **`plots/export.ts`** — the **shared** plot-export plumbing (`svgToImageURL` PNG/SVG rasterise,
   `svgOf`, `downloadDataUrl`/`downloadBlob`, `rowsToCsv`, and `elementToImageURL`). Used by
   `PlotChart.toImageURL` AND the bespoke cluster panels, so a plot that renders its own `<svg>` exports

--- a/docs/todo/ANALYSIS_CANVAS_PLAN.md
+++ b/docs/todo/ANALYSIS_CANVAS_PLAN.md
@@ -1,0 +1,132 @@
+# Multipage Analysis Canvas — design & build plan
+
+Status: **planning** (branch `feat/multipage-analysis-canvas`). This is a parked plan (like
+`CLUSTERING_PLAN.md`); the durable parts get promoted into `docs/ANALYSIS.md` as we build.
+
+## Goal
+
+Turn the universal Analysis page (`/analysis`, TODO #00036, already built as a thin `SummaryCanvas`
+with `module=null`) into a **tabbed, multipage analysis workspace**:
+
+- **One interface to every plot** — summary plots (all module specs) *and* interactive plots (UMAP,
+  heatmap, and the new gating-strategy plot) offerable on any board.
+- **Tabs = multiple canvases** so the user builds several boards and compares data side by side.
+- **Gating-strategy plot** — reproduce the old R gating-hierarchy figure (`.flowPlotGatedRaster`) as
+  a canvas plot type.
+- **Multipage PDF export** — one page per tab.
+
+## Locked decisions (2026-07-01)
+
+1. **Gating-strategy plot lives on the canvas** as an interactive plot type (like UMAP), offerable on
+   any tab — not a separate page. Keeps "all plots in one place"; a tab can be dedicated to it.
+2. **PDF is generated client-side with `pdf-lib`** — capture each tab to SVG/PNG in-browser, compose
+   pages. Keeps rendering frontend-only (layer boundary), no backend round-trip, vector where possible.
+3. **Tabs are scoped to `/analysis` only** for this first cut. Per-module pages keep their single
+   canvas; generalise later if wanted.
+
+## What already exists (foundation)
+
+- **Universal canvas**: `AnalysisModule.vue` → `SummaryCanvas` with no `module` → all summary specs.
+- **Two panel families**:
+  - *Summary* — server-aggregated (`POST /api/plot_data`) → `SummaryPanel`/`PlotChart` (Observable
+    Plot). **Wired into the universal canvas.**
+  - *Interactive* — client/WebGL, own fetch+renderer → `InteractivePanel` + `interactiveViews.ts`
+    (today only `umap`). **Only the cluster page hosts these.** `PlotSpec.family` (`summary` vs
+    `interactive`) is defined but **not yet consumed** to route a spec to the right panel in one
+    canvas — this plan lands that.
+- **Canvas state keyed by string** (`canvasPanels` store: `summary:universal`, `gate:flow`, …), panel
+  geometry + per-panel state already persist across navigation → **tabs are just more keys**.
+- **Gating-hierarchy inputs already exist as routes** (`api/src/gating_api.jl`):
+  - `/api/gating/popmap` → nested tree `{name, gate, filter, children}` (the hierarchy + gate specs).
+  - `/api/gating/density` → binary `Float32` `bins×bins` raster for a pop in x/y channels.
+  - `/api/gating/plotdata` → binary interleaved points (scatter fallback for small pops).
+  - `/api/gating/plotmeta` → `n`, extents, ticks, scatter-vs-density mode, axis labels.
+  - `/api/gating/stats` → `{count, parentCount, pctParent}` (the child %).
+  - Gate spec (`app/src/gating/gates.jl`) is self-contained: `x_channel, y_channel, x_transform,
+    y_transform` + geometry in **transformed** coords (rectangle min/max or polygon vertices).
+- **`GateOverlay.vue` + `ScatterGL`** already render a density/scatter + gate geometry on the gating
+  page → directly reusable per hierarchy sub-panel.
+- **Export**: `plots/export.ts` (`elementToImageURL`, `plotHostToImageURL`, `svgToImageURL`) captures
+  a panel to PNG/SVG today. **No PDF tooling yet.**
+
+## The R reference (`.flowPlotGatedRaster`, `plotFlowGatingServer.R`)
+
+For a chosen root pop: get its leaves grouped **by parent × gate-channel-pair**. For each group,
+render the *parent* population's cells as a 2D density raster (or contour) in the gate's two channels,
+overlay each child's gate polygon (rectangle → 4-corner path; polygon → boundary, closed), and a
+label = `child name + "<pct>%"` (of parent, from stats). All sub-panels arranged in an `nRow×nCol`
+grid (`ggpubr::ggarrange`). Options: label size, show contours vs raster, show pop colours, direct
+leaves only, rows/cols. This maps 1:1 onto the routes above — no new aggregation needed, just a walk.
+
+---
+
+## Build sequence (phased, each independently shippable)
+
+### Phase A — Tabbed boards on `/analysis`
+- New `analysisTabs` Pinia store (per-project): `tabs: [{id, name}]`, `activeId`, order; persisted like
+  `canvasPanels`. Each tab drives a canvas key `analysis:tab:<id>` (passed to `SummaryCanvas` as its
+  persistence namespace instead of the fixed `universal`).
+- Tab bar UI in `AnalysisModule.vue`: add / rename (double-click) / reorder (drag) / duplicate /
+  close, with an active-tab underline. Confirm-on-close if the tab has panels.
+- **Persistence rule** (CLAUDE.md): tab list + active tab + per-tab panels/geometry all persisted;
+  cleared on project close (extend `canvasPanels.clear()` sibling).
+- Migration: the current single `analysis` canvas becomes "Tab 1".
+- **Checkpoint**: multiple independent boards, panels survive navigation, no gating/PDF yet.
+
+### Phase B — Interactive plots in the universal canvas (`PlotSpec.family` routing)
+- Teach `SummaryCanvas` (or a thin wrapper it delegates to) to offer BOTH: summary specs
+  (`/api/plots/definitions`) and interactive views (`interactiveViews.ts` / interactive-family specs),
+  and route each opened panel to `SummaryPanel` vs `InteractivePanel` by `family`.
+- "+ Plot…" menu groups: **Summary** vs **Interactive**.
+- **Checkpoint**: UMAP/heatmap can be dropped onto an analysis tab alongside summary plots.
+
+### Phase C — Gating-strategy plot (interactive view)
+- `components/plots/GatingStrategyView.vue` + one line in `interactiveViews.ts`
+  (`gatingStrategy: { label: 'Gating strategy', component }`).
+- Controls (persisted in panel `state`): image (single, from selection), `valueName`, `popType`
+  (flow/live), root pop, contours vs raster, show pop colours, direct-leaves-only, label size,
+  grid rows/cols.
+- Data flow: `GET /api/gating/popmap` → walk tree from root → group children by parent × gate
+  channel-pair → per group: `GET /api/gating/density` (parent pop, gate's x/y channels+transforms) +
+  child gate geometry from the popmap node + `GET /api/gating/stats` per child (pctParent). Render each
+  group as a sub-cell (reuse `ScatterGL` + `GateOverlay`), tile in an internal CSS grid.
+- **Possible backend helper**: if the client-side tree walk / leaf-grouping gets heavy, add a thin
+  `/api/gating/hierarchy` that returns the grouped plot plan (parent, x/y, child gates, stats) in one
+  call — package logic in `app/src`, route thin (per ARCHITECTURE). Decide during build; start client-side.
+- `defineExpose({ exportFormats, exportAs })` so it plugs into `InteractivePanel`'s export + the PDF.
+- **Checkpoint**: gating hierarchy renders on a tab and exports as a single PNG/SVG.
+
+### Phase D — Multipage PDF of tabs
+- `pixi`-independent frontend dep: **`pdf-lib`** (`npm i pdf-lib` in `frontend/`). Cross-check the
+  license (MIT) is compatible with GPL-3 (it is; note in third-party acknowledgements at cleanup).
+- `plots/pdf.ts`: `exportTabsToPdf(tabs)` — for each tab, arrange+capture its panels to an image
+  (reuse `plotHostToImageURL` for WebGL/canvas panels, `svgToImageURL`/`elementToImageURL` for
+  Observable-Plot panels), embed one page per tab (page size = board bounds, with a title header).
+  Vector for pure-SVG panels where feasible; raster for WebGL.
+- UI: an "Export PDF" button on the tab bar → all tabs; (stretch) a per-tab "add to PDF" toggle.
+- **Checkpoint**: multipage PDF, one page per tab, matches on-screen layout.
+
+### Phase E — Docs
+- Write **`docs/ANALYSIS.md`**: what the analysis canvas is, tabs model + persistence keys, the two
+  plot families and how `family` routes them, the gating-strategy plot (inputs, the R lineage), and
+  PDF export. Cross-reference from `CLAUDE.md` doc table, `docs/UI.md` (§ Analysis-plot canvas),
+  `docs/PLOTS.md`, `docs/POPULATION.md`.
+- Update `docs/UI.md` (tabs + interactive-in-universal), `docs/API.md` (if `/api/gating/hierarchy`
+  lands), `docs/TODO.md` (close #00036 follow-ups; the interactive-family routing note).
+
+## Open questions / risks
+
+- **Tree walk location** (client vs a new `/api/gating/hierarchy`): start client-side off `popmap`;
+  promote to a backend helper only if the per-child stats/density fan-out is too chatty.
+- **PDF fidelity for WebGL panels**: gating-strategy/UMAP are canvas pixels → raster pages (need
+  `preserveDrawingBuffer`, already used by `plotHostToImageURL`). Observable-Plot panels can be true
+  vector. Mixed-fidelity pages are acceptable; document it.
+- **`live` (track) gating** hierarchy: popmap supports `popType=track` with a separate sidecar; the
+  gating-strategy plot should work for `flow` first, then confirm `live`/`track`.
+- **Per-tab image source**: tabs share the page's image multi-select for now; revisit if a tab needs
+  its own image set.
+
+## Third-party / license
+
+`pdf-lib` (MIT) — add to the third-party acknowledgements list at the shipping/cleanup pass
+(see `project_license` / TODO #00060).

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -46,7 +46,7 @@ const groups: { heading: string; items: NavItem[] }[] = [
       { to: '/clust-cells',  label: 'Cluster cells',  icon: 'pi-palette', tip: 'Leiden cluster cells (intensities + morphology), then define populations from clusters.', requiresProject: true },
       { to: '/clust-tracks', label: 'Cluster tracks', icon: 'pi-sitemap',      tip: 'Leiden cluster tracks (motility + HMM/behaviour), then define populations from clusters.', requiresProject: true },
       { to: '/spatial', label: 'Spatial', icon: 'pi-map',          tip: 'Spatial neighbourhood and proximity analysis.', disabled: true, soon: true },
-      { to: '/analysis', label: 'Analysis canvas', icon: 'pi-clone', tip: 'Free-form canvas combining plots across modules, images and segmentations.', disabled: true, soon: true },
+      { to: '/analysis', label: 'Analysis canvas', icon: 'pi-clone', tip: 'Free-form canvas combining plots across modules, images and segmentations.', requiresProject: true },
     ],
   },
   {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -21,6 +21,7 @@ import TrackingModule from './modules/TrackingModule.vue'
 import BehaviourModule from './modules/BehaviourModule.vue'
 import ClusterCellsModule  from './modules/ClusterCellsModule.vue'
 import ClusterTracksModule from './modules/ClusterTracksModule.vue'
+import AnalysisModule    from './modules/AnalysisModule.vue'
 
 const pinia = createPinia()
 
@@ -37,6 +38,7 @@ const router = createRouter({
     { path: '/behaviour', component: BehaviourModule, meta: { label: 'Behaviour' } },
     { path: '/clust-cells',  component: ClusterCellsModule,  meta: { label: 'Cluster cells' } },
     { path: '/clust-tracks', component: ClusterTracksModule, meta: { label: 'Cluster tracks' } },
+    { path: '/analysis',  component: AnalysisModule,   meta: { label: 'Analysis canvas' } },
     { path: '/tasks',     component: TasksModule,     meta: { label: 'Tasks' } },
     { path: '/chain',     component: ChainModule,     meta: { label: 'Whiteboard' } },
     { path: '/settings',  component: SettingsModule,  meta: { label: 'Settings' } },

--- a/frontend/src/modules/AnalysisModule.vue
+++ b/frontend/src/modules/AnalysisModule.vue
@@ -1,0 +1,26 @@
+<!--
+  Universal "Analysis canvas" page (TODO #00036). The SAME summary-plot canvas as the per-module
+  pages, but with the MODULE FILTER OFF: `SummaryCanvas` mounted with no `module` prop offers EVERY
+  plot spec, so plots can be combined across modules / images / segmentations on one board. Pick one
+  OR MORE images from the active set (multi-select); the populations endpoint unions across the
+  selected images/segmentations.
+
+  No TaskRunner (`#right`) — this page only visualises existing results, it doesn't run tasks. Image
+  selection + panel state persist under their own scopes (`analysis` for the selection, `summary:universal`
+  inside SummaryCanvas), independent of the per-module pages. See docs/UI.md → "Analysis-plot canvas".
+-->
+<script setup lang="ts">
+import ModuleLayout from '../components/ModuleLayout.vue'
+import CollapsibleSection from '../components/CollapsibleSection.vue'
+import SummaryCanvas from '../components/canvas/SummaryCanvas.vue'
+</script>
+
+<template>
+  <ModuleLayout module="analysis" :show-attrs="true" :show-filter="true">
+    <template #below-table="{ selectedUids }">
+      <CollapsibleSection label="Plots" :max-height="'none'">
+        <SummaryCanvas :image-uids="selectedUids" />
+      </CollapsibleSection>
+    </template>
+  </ModuleLayout>
+</template>


### PR DESCRIPTION
## feat(analysis): universal Analysis canvas page (`/analysis`)

Builds TODO #00036. The universal canvas mode was already supported by `SummaryCanvas`, so this is thin.

- **`AnalysisModule.vue`** — a `ModuleLayout` (image multi-select) hosting `SummaryCanvas` with **no `module` prop** → offers *every* summary plot spec across modules / images / segmentations on one board. No TaskRunner (visualise-only).
- Register the `/analysis` route; un-disable the existing sidebar entry (now `requiresProject`).
- Persistence: panel state under `summary:universal`, image selection under the `analysis` scope.
- Move #00036 to Fixed; update `docs/UI.md`.
- Park the follow-on design in **`docs/todo/ANALYSIS_CANVAS_PLAN.md`**: tabbed multipage boards, interactive plots in the universal canvas via `PlotSpec.family`, the gating-strategy hierarchy plot, and client-side multipage PDF export.

`vue-tsc` + `vite build` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)