### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         # macos-latest is arm64 (M-series) — the exact osx-arm64 target the workspace builds for.
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Installs Pixi and materialises the default environment from pixi.lock (cached per platform).
       - name: Install Pixi + Python env
@@ -49,12 +49,12 @@ jobs:
 
       # Julia stays on juliaup/this action in dev + CI (not in the Pixi env). pixi run inherits PATH.
       - name: Install Julia
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@v3
         with:
           version: '1.12'
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
 


### PR DESCRIPTION
GitHub is forcing Node 20 actions onto Node 24 and will remove Node 20 from runners in Sept 2026. Bump to the majors whose runtime is Node 24:
- actions/checkout   v4 -> v5
- actions/setup-node v4 -> v5
- julia-actions/setup-julia v2 -> v3 (v3 requires Node 24)

Clears the "Node.js 20 is deprecated" warning on CI and Release.