### PR TITLE
Feat/analysis canvas tabs

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -274,6 +274,24 @@ function api_napari_close(body_bytes::Vector{UInt8})
     end
 end
 
+# ── REST: POST /api/napari/screenshot ─────────────────────────────────────────
+# Capture the current napari CANVAS to a PNG and stream the bytes back (octet-stream, like the gating
+# binary routes). Used by the Analysis-canvas image / filmstrip slots. `send` is request-reply, so the
+# bridge has finished writing the file by the time `save_screenshot!` returns — read then delete it.
+function api_napari_screenshot(body_bytes::Vector{UInt8})
+    v = _viewer()
+    (isnothing(v) || !_viewer_alive()) && return 400, JSON3.write((; error = "Napari not running"))
+    path = tempname() * ".png"
+    try
+        save_screenshot!(v, path; canvas_only = true)
+        return 200, read(path)   # Vector{UInt8} → octet-stream (server.jl)
+    catch e
+        return 500, JSON3.write((; error = sprint(showerror, e)))
+    finally
+        isfile(path) && rm(path; force = true)
+    end
+end
+
 # ── REST: POST /api/napari/restart ────────────────────────────────────────────
 
 function api_napari_restart(body_bytes::Vector{UInt8})

--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -2,8 +2,17 @@ using Dates
 
 # ── Chain template CRUD ───────────────────────────────────────────────────────
 
+# Per-project persisted UI config lives under `<proj>/settings/` (chains, analysis-canvas boards, …).
+_settings_dir_for_project(project_uid::String) = joinpath(projects_dir(), project_uid, "settings")
+
 function _chains_dir_for_project(project_uid::String)
-    joinpath(projects_dir(), project_uid, "chains")
+    newdir = joinpath(_settings_dir_for_project(project_uid), "chains")
+    olddir = joinpath(projects_dir(), project_uid, "chains")   # legacy location (pre-settings/)
+    if isdir(olddir) && !isdir(newdir)
+        try; mkpath(_settings_dir_for_project(project_uid)); mv(olddir, newdir)
+        catch e; @warn "Could not migrate chains into settings/" project=project_uid exception=e; end
+    end
+    newdir
 end
 
 function api_chains_list(req::HTTP.Request)
@@ -266,8 +275,17 @@ function api_projects_load(body_bytes::Vector{UInt8})
     proj_obj = load_project(uid)
     sets     = [_set_payload(s) for s in proj_obj._sets]
 
+    # Analysis-canvas boards saved with the project (settings/); null when none saved yet.
+    boards = nothing
+    boards_file = joinpath(_settings_dir_for_project(uid), "analysisBoards.json")
+    if isfile(boards_file)
+        try; boards = JSON3.read(read(boards_file, String)); catch e
+            @warn "Could not read analysis boards" uid exception=e
+        end
+    end
+
     @info "Opened project" name=get(project, "name", "?") uid sets=length(sets)
-    200, JSON3.write((; project, sets))
+    200, JSON3.write((; project, sets, boards))
 end
 
 function api_projects_save(body_bytes::Vector{UInt8})
@@ -286,6 +304,18 @@ function api_projects_save(body_bytes::Vector{UInt8})
         open(meta_file, "w") do io; JSON3.write(io, raw); end
     catch e
         @warn "Could not update project metadata" uid exception=e
+    end
+
+    # persist the Analysis-canvas boards (tabs + grid layouts + captured screenshots) under settings/ so
+    # they survive reopen. Opaque JSON owned by the frontend — we just store/return it verbatim.
+    boards = get(body, :boards, nothing)
+    if boards !== nothing
+        try
+            settings = _settings_dir_for_project(uid); mkpath(settings)
+            open(joinpath(settings, "analysisBoards.json"), "w") do io; JSON3.write(io, boards); end
+        catch e
+            @warn "Could not save analysis boards" uid exception=e
+        end
     end
     200, JSON3.write((; ok=true))
 end

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -184,6 +184,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_napari_open(body_bytes)
         elseif path == "/api/napari/close"
             api_napari_close(body_bytes)
+        elseif path == "/api/napari/screenshot"
+            api_napari_screenshot(body_bytes)
         elseif path == "/api/napari/restart"
             api_napari_restart(body_bytes)
         elseif path == "/api/napari/show-labels"

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,6 +33,7 @@ that resolve objects and call package functions.
 | GET | `/api/fs/list`, `/api/pools`, `/api/tasks/definitions` | filesystem, pools, task specs |
 | GET | `/api/chains`, `/api/chains/get`, POST `/api/chains/{save,delete}` | chain templates |
 | GET | `/api/napari/status`, POST `/api/napari/{open,close,restart,show-labels,show-populations,start-selection,stop-selection,event}` | napari bridge + gating linked brushing |
+| POST | `/api/napari/screenshot` | `projectUid` | **binary** PNG of the current napari canvas (`canvas_only`) — `save_screenshot!` to a temp file → stream the bytes → delete. `400` if napari not running. Feeds the Analysis-canvas image / filmstrip slots. |
 | — | **Gating** (below) | population manager + gating |
 
 Task execution + status flow over **WS** (`task:run`/`task:status`/…), not HTTP — see

--- a/docs/OBJECTMODEL.md
+++ b/docs/OBJECTMODEL.md
@@ -24,6 +24,9 @@ Sets group images for processing. An image belongs to one set but lives independ
 {projects_dir}/{proj_uid}/
   project.json              — project manifest (set_uids list)
   .cecelia.lock             — naive write lock (see Transactions)
+  settings/                 — per-project UI config (persisted on Save project)
+    chains/{name}.json      — chain/whiteboard templates (migrated from the legacy top-level chains/)
+    analysisBoards.json     — Analysis-canvas tabs + grid layouts + captured screenshots
   0/
     {image_uid}/            — image data (OME-ZARR, written by bioformats2raw or tasks)
   1/

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -519,9 +519,21 @@ aggregation is a PACKAGE function, the route is thin, rendering is frontend-only
   the host just re-renders with the new size. Exposes `toImageURL('png'|'svg')` — SVG serialises the
   node (native), PNG rasterises it at the DPR-aware `EXPORT_SCALE`. The summaries equivalent of `ScatterGL` for the big point
   clouds.
+The universal **Analysis canvas** (`/analysis`, `AnalysisModule.vue`) is **multipage**: `TabbedCanvas`
+wraps N independent boards, each a `SummaryCanvas` with no `module` prop (→ all plot specs). The tab
+LIST (names/order/active) lives in the `analysisTabs` store; each board's plots persist in
+`canvasPanels` under the canvas key `analysis:{projectUid}:tab:{id}` — i.e. tabs reuse the whole
+existing canvas machinery via `SummaryCanvas`'s optional `canvasKey` prop (which overrides the default
+`summary:{module|universal}` namespace and MUST be paired with a `:key` so setup re-runs on switch).
+Only the active board is mounted; switching tabs re-binds that board's stored panels. Boards are
+per-project — `TabbedCanvas` is `:key`ed by projectUid, and `analysisTabs`/`canvasPanels` are cleared
+on project open/close (`stores/project.ts`). Closing a tab calls `canvasPanels.drop(key)`. In-memory
+like the rest of the canvas state (survives navigation, not a full reload). Roadmap for the rest of the
+multipage feature (interactive plots in the universal canvas, gating-strategy plot, multipage PDF):
+`docs/todo/ANALYSIS_CANVAS_PLAN.md`.
+
 These canvas components are **generic** (`components/canvas/`, NOT under a module) so every module
-page — and the universal **Analysis canvas** (`/analysis`, `AnalysisModule.vue`: `SummaryCanvas` with
-no `module` prop → all specs) — reuses them unchanged:
+page — and the Analysis canvas — reuses them unchanged:
 - **`components/canvas/SummaryPanel.vue`** — one summary plot, wrapping `CanvasPanel`. Layout: the
   **controls row** (`#actions`) holds a **measure dropdown** (from the spec's `measureOptions`) and a
   **chart-type dropdown** (from `chartTypes`, shown when >1); the secondary options — **Split by**

--- a/docs/todo/ANALYSIS_CANVAS_PLAN.md
+++ b/docs/todo/ANALYSIS_CANVAS_PLAN.md
@@ -15,6 +15,15 @@ with `module=null`) into a **tabbed, multipage analysis workspace**:
   a canvas plot type.
 - **Multipage PDF export** — one page per tab.
 
+## Invariants
+
+- **Read-only.** The Analysis canvas visualises existing populations/measures ONLY — it never mutates
+  gates or population definitions (no `PopulationManager`, no gate draw/edit, no `pop/*` writes). Gate/pop
+  DEFINITION stays on the Gate page. See memory `project_analysis_canvas_readonly`.
+- **Reuse, don't fork.** The gating-strategy plot renders scatter+gate exactly like `GatePlotPanel`, so
+  it reuses the same primitives (`ScatterGL`/`PlotLayers`/`GateOverlay`, `mode='off'`) — extract a shared
+  read-only "gate scatter cell" if needed; do NOT write a second gate renderer.
+
 ## Locked decisions (2026-07-01)
 
 1. **Gating-strategy plot lives on the canvas** as an interactive plot type (like UMAP), offerable on
@@ -23,6 +32,51 @@ with `module=null`) into a **tabbed, multipage analysis workspace**:
    pages. Keeps rendering frontend-only (layer boundary), no backend round-trip, vector where possible.
 3. **Tabs are scoped to `/analysis` only** for this first cut. Per-module pages keep their single
    canvas; generalise later if wanted.
+
+## Design update — LAYOUT model (2026-07-02, supersedes free-floating for /analysis)
+
+The analysis canvas is for producing **comparable, exportable figures**, so each tab is a **grid
+layout**, not free-floating windows (free-floating stays on the exploratory gate/cluster pages).
+
+4. **Each tab = a grid LAYOUT = one PDF page.** Generic **N×M** grid (pick rows×cols) **plus a few
+   presets** (1-up, 2-up, 2×2, 1+2, 1 big + 3). Uniform slots; drag to swap; empty slots allowed. A
+   uniform grid paginates cleanly (the page IS the grid) — we deliberately avoid a snap/reflow engine
+   (a dep, and variable tile sizes reintroduce the pagination problem).
+5. **Every plot type is offerable in a slot** — ALL summary specs (`module=null`) **and ALL interactive
+   views** (UMAP, cluster heatmap, HMM state/transitions, gating-strategy). Interactive views carry
+   their context (e.g. clustering suffix) as **per-slot config** set on the plot itself.
+6. **Pop picker is DOCKED, not a slot, and excluded from the PDF.** It's a control, not content — a
+   collapsible right rail (reuse `SeriesPicker`/`PopulationPanelShell`, docked not floating) driving the
+   ACTIVE slot's pop selection (global/local scope as today). Pop names/colours appear on the plots
+   themselves (legends), so the picker never needs to render into a page.
+7. **"Image" slot type (static raster).** A slot can hold an image instead of a plot. First source: a
+   **napari screenshot** (camera button) — the bridge already has `save_screenshot(path, canvas_only)`
+   / Julia `save_screenshot!`; add `POST /api/napari/screenshot` (capture to temp PNG → stream bytes,
+   like other binary responses), frontend stores the PNG in slot state and `<img>`s it. Embeds directly
+   into the PDF. Greyed out unless napari is running with an image open. (Arbitrary upload could follow.)
+
+**Reuse note:** only the CONTAINER changes (free-floating → grid of slots). The plot components
+(`SummaryPanel`, `InteractivePanel` + views, gating-strategy `GateScatterCell`) render inside slots
+unchanged. Extract SummaryCanvas's data logic (spec/pop/attr loading + compare state) into a composable
+shared by `SummaryCanvas` (per-module, free-floating) and the new `LayoutCanvas` (analysis, grid) — no
+duplication. `CanvasPanel` + `PopulationPanelShell` gain a `docked` mode (fill-in-flow, no float/drag)
+so the same panel/picker chrome works in a slot / right rail.
+
+8. **Layout = a TEMPLATE LIBRARY, not just uniform N×M (2026-07-02).** Each template defines its slots
+   as CSS-grid areas/spans. A generated uniform N×M is one family; **rectangular "comic plates"**
+   (varied-size panels + gutters + rounded frames — the big-panel-plus-strip, 2+1, 3×3, etc.) are more
+   entries in the same library. One mechanism serves scientific grids AND creative image plates; both
+   paginate cleanly to PDF.
+9. **Angled full-layout panels: DEFERRED (pushed back).** True slanted/trapezoidal *layout* panels need
+   a slanted-gutter layout engine + polygon hit-testing + PDF fidelity, and they degrade axed plots.
+   Out of this build.
+10. **Filmstrip slot: IN (the sanctioned "angled" use).** One RECTANGULAR slot holding **N images**
+    (horizontal or vertical) with thin separators + a per-image caption/headline — for pipeline montages
+    (raw → denoised → segmented → tracked). The slot stays a plain grid rectangle (no layout-engine or
+    hit-testing cost) and holds image-only content (no axes to distort), so **angled separators are cheap
+    and contained**: `clip-path` diagonal edges on the image cells within the slot. Build STRAIGHT
+    separators as the baseline + an ANGLED option. Each cell's image = a napari screenshot (reuse the
+    image-slot capture) — a filmstrip is effectively a multi-cell image slot.
 
 ## What already exists (foundation)
 
@@ -62,55 +116,98 @@ leaves only, rows/cols. This maps 1:1 onto the routes above — no new aggregati
 
 ## Build sequence (phased, each independently shippable)
 
-### Phase A — Tabbed boards on `/analysis`
-- New `analysisTabs` Pinia store (per-project): `tabs: [{id, name}]`, `activeId`, order; persisted like
-  `canvasPanels`. Each tab drives a canvas key `analysis:tab:<id>` (passed to `SummaryCanvas` as its
-  persistence namespace instead of the fixed `universal`).
-- Tab bar UI in `AnalysisModule.vue`: add / rename (double-click) / reorder (drag) / duplicate /
-  close, with an active-tab underline. Confirm-on-close if the tab has panels.
-- **Persistence rule** (CLAUDE.md): tab list + active tab + per-tab panels/geometry all persisted;
-  cleared on project close (extend `canvasPanels.clear()` sibling).
-- Migration: the current single `analysis` canvas becomes "Tab 1".
-- **Checkpoint**: multiple independent boards, panels survive navigation, no gating/PDF yet.
+### Phase A — Tabbed boards on `/analysis` ✅ DONE (free-floating; superseded by A2)
+- `analysisTabs` store (per-project tab list/active), `TabbedCanvas` (add/rename/drag-reorder/close),
+  `canvasPanels.drop(key)`, cleared per-project. Each tab mounted a free-floating `SummaryCanvas`.
+- **A2 (rework) — grid LAYOUT per tab.** Replace the per-tab free-floating `SummaryCanvas` with a new
+  `components/canvas/LayoutCanvas.vue`: a grid (N×M control + presets) of SLOTS. `TabbedCanvas` mounts
+  `LayoutCanvas` per tab (keyed `analysis:tab:<id>`). Each slot holds one plot (or image); drag to swap;
+  empty slots allowed. Grid choice + per-slot content/config persist in the tab's store entry.
+  - Extract SummaryCanvas's data logic (spec/pop/attr loading, compare state) into `useSummaryData`
+    composable; `LayoutCanvas` and `SummaryCanvas` both use it (no fork).
+  - **Docked pop picker** (right rail, collapsible, NOT a slot, NOT in PDF) drives the active slot.
+  - **Checkpoint**: grid layouts with slots, drag-swap, presets; picker docked.
 
-### Phase B — Interactive plots in the universal canvas (`PlotSpec.family` routing)
-- Teach `SummaryCanvas` (or a thin wrapper it delegates to) to offer BOTH: summary specs
-  (`/api/plots/definitions`) and interactive views (`interactiveViews.ts` / interactive-family specs),
-  and route each opened panel to `SummaryPanel` vs `InteractivePanel` by `family`.
-- "+ Plot…" menu groups: **Summary** vs **Interactive**.
-- **Checkpoint**: UMAP/heatmap can be dropped onto an analysis tab alongside summary plots.
+### Phase B — Full plot catalog in slots (`PlotSpec.family` routing)
+- A slot's "+ add" offers the full catalog: ALL summary specs (`/api/plots/definitions`, `module=null`)
+  + ALL interactive views (`interactiveViews.ts`: UMAP, cluster heatmap, HMM, gating-strategy), grouped
+  **Summary / Interactive / Image**. Route slot content to `SummaryPanel` / `InteractivePanel` / image
+  by kind (`PlotSpec.family` + view registry).
+- Interactive views carry per-slot config (e.g. clustering suffix for UMAP/heatmap) since the analysis
+  page has no page-level suffix — the slot config supplies the context the cluster page gets page-level.
+- **Checkpoint**: any plot type from any module page can be placed in a slot.
 
-### Phase C — Gating-strategy plot (interactive view)
-- `components/plots/GatingStrategyView.vue` + one line in `interactiveViews.ts`
-  (`gatingStrategy: { label: 'Gating strategy', component }`).
-- Controls (persisted in panel `state`): image (single, from selection), `valueName`, `popType`
-  (flow/live), root pop, contours vs raster, show pop colours, direct-leaves-only, label size,
-  grid rows/cols.
-- Data flow: `GET /api/gating/popmap` → walk tree from root → group children by parent × gate
-  channel-pair → per group: `GET /api/gating/density` (parent pop, gate's x/y channels+transforms) +
-  child gate geometry from the popmap node + `GET /api/gating/stats` per child (pctParent). Render each
-  group as a sub-cell (reuse `ScatterGL` + `GateOverlay`), tile in an internal CSS grid.
+### Phase C — Gating-strategy plot (interactive view, READ-ONLY)
+- **C1 — extract the shared render cell (anti-dup).** Pull `GatePlotPanel`'s plot BODY (the
+  `.plot-capture` block: `ScatterGL` + `PlotLayers` + `GateOverlay` + ticks/axis labels + export host,
+  plus the `orientGate`/`fmtTick`/`tickX-Y` helpers) into a presentational `components/plots/GateScatterCell.vue`.
+  Props: `points, extents, viewExtents, xTicks, yTicks, gates(read-only outlines+labels), xLabel, yLabel,
+  popLayers, renderMode`. `GateOverlay` takes `mode` + emits `draw`/`edit` so `GatePlotPanel` keeps its
+  interactivity by passing `mode` and handling emits; the Analysis canvas passes `mode='off'` (read-only).
+  Refactor `GatePlotPanel` to render the cell — behaviour-preserving; verify the Gate page still works.
+- **C2 — the hierarchy view.** `components/plots/GatingStrategyView.vue` + one line in
+  `interactiveViews.ts` (`gatingStrategy: { label: 'Gating strategy', component }`). Read-only.
+  - Controls (persisted in panel `state`): image (single, from selection), `valueName`, `popType`
+    (flow/live), root pop, contours vs raster, show pop colours, direct-leaves-only, label size,
+    grid rows/cols.
+  - Data flow (same stateless routes `GatePlotPanel` uses — no store mutation): `GET /api/gating/popmap`
+    → walk tree from root → group children by parent × gate channel-pair → per group:
+    `GET /api/gating/plotmeta`+`density`/`plotdata` (parent pop, gate's x/y channels+transforms) + child
+    gate geometry from the popmap node + `GET /api/gating/stats` per child (pctParent). Render each group
+    as a `GateScatterCell` (`mode='off'`, gate outlines + `name + %` labels), tiled in an internal CSS grid.
 - **Possible backend helper**: if the client-side tree walk / leaf-grouping gets heavy, add a thin
   `/api/gating/hierarchy` that returns the grouped plot plan (parent, x/y, child gates, stats) in one
   call — package logic in `app/src`, route thin (per ARCHITECTURE). Decide during build; start client-side.
 - `defineExpose({ exportFormats, exportAs })` so it plugs into `InteractivePanel`'s export + the PDF.
-- **Checkpoint**: gating hierarchy renders on a tab and exports as a single PNG/SVG.
+- **Checkpoint**: gating hierarchy renders on a tab (read-only) and exports as a single PNG/SVG.
 
-### Phase D — Multipage PDF of tabs
+### Phase D — Image slot + filmstrip slot (napari screenshots)
+- Backend: `POST /api/napari/screenshot` (`projectUid, imageUid?`) → `_ensure_viewer!`/alive check →
+  `save_screenshot!(v, tmpPath; canvas_only=true)` (already exists) → read the PNG → stream bytes
+  (binary response, like gating plotdata). `400` if napari not running.
+- Frontend: an **Image** slot kind (one PNG) + a **Filmstrip** slot kind (N PNGs in a row/column, each
+  with a caption; straight separators baseline + angled `clip-path` option — decision 10). A **camera**
+  action captures the current napari view into the slot / next filmstrip cell (greyed unless napari is
+  alive). PNGs stored as data URLs in slot state; embed directly into the PDF.
+- **Checkpoint**: a napari snapshot (single or a raw→segmented→tracked strip) sits in a slot and exports.
+
+### Phase E — Multipage PDF of tabs
 - `pixi`-independent frontend dep: **`pdf-lib`** (`npm i pdf-lib` in `frontend/`). Cross-check the
   license (MIT) is compatible with GPL-3 (it is; note in third-party acknowledgements at cleanup).
-- `plots/pdf.ts`: `exportTabsToPdf(tabs)` — for each tab, arrange+capture its panels to an image
-  (reuse `plotHostToImageURL` for WebGL/canvas panels, `svgToImageURL`/`elementToImageURL` for
-  Observable-Plot panels), embed one page per tab (page size = board bounds, with a title header).
-  Vector for pure-SVG panels where feasible; raster for WebGL.
-- UI: an "Export PDF" button on the tab bar → all tabs; (stretch) a per-tab "add to PDF" toggle.
-- **Checkpoint**: multipage PDF, one page per tab, matches on-screen layout.
+- `plots/pdf.ts`: `exportTabsToPdf(tabs)` — **one page per tab, rendered as that tab's grid** (uniform
+  slots → clean pagination). Per slot: reuse `plotHostToImageURL` (WebGL/canvas), `svgToImageURL`/
+  `elementToImageURL` (Observable-Plot), or the stored PNG (image slot). Vector for pure-SVG where
+  feasible; raster for WebGL. The docked pop picker is NOT walked.
+- UI: an "Export PDF" button on the tab bar → all tabs; (stretch) a per-tab include toggle.
+- **Embed the plotted data as CSV attachments** (`pdf-lib` `attach()`): one file, with each summary plot's
+  aggregated data (bins / mean±err / box stats / frequency / heatmap cells — the existing per-plot CSV)
+  embedded so it shows in the viewer's attachments pane, named `${tab}_slot-${i}_${label}.csv`. Lets a
+  user re-plot in Prism/Excel from the same file. Requires each plot component to expose its data as a
+  CSV STRING (SummaryPanel already builds it for its Export→CSV — expose a `getCsv()`/`getData()` via
+  defineExpose instead of only downloading). Image/filmstrip slots have no data; the gating-strategy plot
+  MAY attach a per-population stats table (count / %parent). NB it's the PLOTTED (aggregated) data, not
+  raw per-cell rows.
+- **Checkpoint**: multipage PDF, one page per tab, matches the on-screen grid, with per-plot CSVs attached.
 
-### Phase E — Docs
-- Write **`docs/ANALYSIS.md`**: what the analysis canvas is, tabs model + persistence keys, the two
-  plot families and how `family` routes them, the gating-strategy plot (inputs, the R lineage), and
-  PDF export. Cross-reference from `CLAUDE.md` doc table, `docs/UI.md` (§ Analysis-plot canvas),
-  `docs/PLOTS.md`, `docs/POPULATION.md`.
+### Phase C-rework — Gating-strategy montage layout (2026-07-02 feedback)
+Current `GatingStrategyView` reflows badly: sub-panel count varies by segmentation (parent×gate-pair
+groups → C has 3, A has 1), panels render elongated (auto-fill + tall min-height), the montage grows
+vertically, and the source population isn't clearly shown. Re-checked R (`.flowPlotGatedRaster`):
+one sub-plot per (parent × gate channel-pair), titled with the PARENT (`ggtitle(xParent)`), gates
+labelled child name+%, arranged via `ggarrange(nrow, ncol)` (user-set grid).
+- **Square panels**: `aspect-ratio: 1` on each `GateScatterCell` cell — flow plots square, not stretched.
+- **Fixed-columns grid** (like R's nrow×ncol): a `columns` control (default 2); N square panels flow into
+  that many columns and SCROLL within the slot (never grow it) — consistent regardless of panel count.
+- **Source population shown**: sub-panel title = parent population path/lineage; image + segmentation in
+  the view header; child gates keep name+%.
+- Keep the "no gates under root" message.
+- (Filmstrip vertical growth: constrain the vertical strip to scroll within the slot too.)
+
+### Phase F — Docs
+- Write **`docs/ANALYSIS.md`**: what the analysis canvas is, the tabs+layout model + persistence keys,
+  the plot families (summary/interactive/image) and how slots route them, the gating-strategy plot
+  (inputs, the R lineage), the napari-screenshot slot, and PDF export. Cross-reference from `CLAUDE.md`
+  doc table, `docs/UI.md` (§ Analysis-plot canvas), `docs/PLOTS.md`, `docs/POPULATION.md`, `docs/NAPARI.md`.
 - Update `docs/UI.md` (tabs + interactive-in-universal), `docs/API.md` (if `/api/gating/hierarchy`
   lands), `docs/TODO.md` (close #00036 follow-ups; the interactive-family routing note).
 
@@ -130,3 +227,96 @@ leaves only, rows/cols. This maps 1:1 onto the routes above — no new aggregati
 
 `pdf-lib` (MIT) — add to the third-party acknowledgements list at the shipping/cleanup pass
 (see `project_license` / TODO #00060).
+
+## Phase G — Include the clustering plots (UMAP + cluster heatmap)
+
+Goal: the analysis canvas can host **every** module plot, including the clustering UMAP and the cluster
+heatmap. These differ from the gating/summary plots in the CONTEXT they need:
+
+- `popType` is `clust` / `trackclust` (not `flow`/`live`).
+- a **suffix** (which clustering run) — page-level in `ClusterPlots`, like picking a segmentation.
+- **shownPops**: highlighted cluster populations resolved to `{path,name,colour,clusterIds}` (from the
+  clust popmap) — UMAP colours those clusters, the heatmap breaks out columns per population.
+
+`UmapView` and `ClusterHeatmapPanel` already take all of this as **props** (fed by `ClusterPlots`), so
+they are reusable; what's missing for the analysis canvas is *where the context comes from*.
+
+### Two models (decision needed)
+
+- **A — self-contained cluster views (recommended).** Mirror `GatingStrategyView`: a slot-local wrapper
+  view owns its `popType` + `suffix` selectors in its own toolbar, loads the clust popmap + `shownPops`,
+  and manages its own highlight/labels. The shared right-rail pop picker stays *only* for summary plots.
+  A board can then mix a flow gating slot and a clust UMAP slot with **no global popType entanglement**.
+  Cost: a thin wrapper per view + a shared `useClusterContext` composable (suffix list + popmap→shownPops)
+  extracted from `ClusterPlots` so the logic isn't duplicated.
+- **B — canvas-level popType switch.** The right-rail picker gains a popType selector (flow/live/clust/
+  trackclust); when clust, it lists cluster pops and cluster slots consume the shared suffix + highlight.
+  Simpler mental model for an all-cluster board, but messy on a MIXED board (one global popType can't
+  serve a flow slot and a clust slot at once) and couples the shared picker to per-run suffix state.
+
+Recommendation: **A**. It's consistent with the already-shipped self-contained `gatingStrategy` view,
+keeps `useSummaryData`/the pop picker unchanged, and avoids the mixed-board conflict. Extract
+`useClusterContext(projectUid, setUid, imageUids, popType)` → `{ suffixes, suffix, loadShownPops(highlighted) }`
+and reuse it in both `ClusterPlots` and the new analysis wrappers (no divergent re-implementation).
+
+### Sketch (model A)
+- New `components/plots/ClusterUmapView.vue` + `ClusterHeatmapView.vue` (registry entries `clusterUmap`,
+  `clusterHeatmap`) — toolbar: popType (clust/trackclust) · suffix · labels/features · highlight; body =
+  the existing `UmapView` / `ClusterHeatmapPanel`.
+- Add them to `ANALYSIS_VIEWS` (LayoutCanvas) under an "Interactive"/"Clustering" optgroup.
+- Export: both are canvas composites → already crisp via the montage-style hi-res path (expose each
+  cell's `hiRes`, as `GateScatterCell` now does).
+
+### Model C — active-slot-driven pop manager (CHOSEN, supersedes A/B)
+
+The shared right-rail pop manager becomes **context-sensitive to the ACTIVE slot** rather than to a
+global popType. You never pick a canvas-wide popType; the picker simply follows the slot you've selected.
+
+Each slot advertises a small **population interface**:
+```
+{ popType, suffix?, pops(): PickerGroup[], selected(): string[], toggle(pop), noPicker?: boolean }
+```
+- summary slot → flow/live pops; toggle = add/remove a (segmentation, pop) SERIES to plot (today's behaviour)
+- cluster UMAP / heatmap slot → clust/trackclust pops for its run; toggle = HIGHLIGHT that cluster-pop
+  (UMAP colours it, heatmap breaks out its column)
+- gating-strategy / filmstrip → `noPicker` (self-contained / no pops)
+
+The right rail renders the ACTIVE slot's interface: its `pops()` and reflects `selected()`; a click calls
+its `toggle()`. Switching the active slot re-points the picker. Per-slot selection lives in that slot's
+persisted `state` (global-scope option can stay for summary plots as it is today).
+
+Implementation notes:
+- Extract `useClusterContext(projectUid,setUid,imageUids,popType)` → `{ suffixes, suffix, loadShownPops }`
+  from `ClusterPlots`; the cluster slots reuse it (no divergent re-implementation).
+- `SeriesPicker` already renders grouped pops + selection + emits toggle — keep it; just feed it the
+  active slot's `pops()/selected()` and route `@toggle` to the active slot's handler.
+- Cluster views (`ClusterUmapView`/`ClusterHeatmapView`) wrap the existing `UmapView`/`ClusterHeatmapPanel`
+  and expose the pop interface + `hiRes` (montage-style crisp export).
+- Keep gating-strategy self-contained (it already is); it reports `noPicker`.
+
+#### Scope on a mixed board — "global" is per applicable family
+
+`global` must NOT mean "every slot on the board" (the board mixes popTypes). It means **shared across the
+slots applicable to the manager's current context** — the same popType family the manager is showing:
+- active = flow/live summary → global toggle affects all flow/live summary slots; cluster slots untouched.
+- active = cluster (clust/trackclust) → global highlight affects all cluster slots (UMAP + cluster heatmap
+  together); flow/summary slots untouched.
+- local → active slot only (unchanged).
+
+So store the global selection **per family** (e.g. `shared.selByFamily[popTypeKey]`), not one flat list,
+and apply a global toggle only to slots whose pop interface reports that family. A slot never receives
+pops it can't consume. (`useSummaryData`'s current single global `sel` becomes the flow/live family entry.)
+
+#### Reservations to honour when building Phase G
+1. **Family key includes the suffix for cluster** — cluster IDs are per-run, so global highlight is
+   shared only among cluster slots on the SAME run: family key `clust:<suffix>` / `trackclust:<suffix>`,
+   NOT bare `clust`. (Flow/live family key is just the popType.)
+2. **`SeriesPicker` must serve both pop shapes without a fork** — segmentation→pops (summary) AND a
+   run's cluster pops. Map cluster pops into the picker's group model (or generalise it); do not clone it.
+3. **Cluster heatmap is SVG (summary-family)** → crisp export via the SVG path (`SummaryPanel.exportImage`
+   style), NOT the WebGL montage hi-res path. Only the UMAP is WebGL.
+4. **Migrate saved boards** — SKIPPED (no real boards exist yet, per Dom). The per-family bag
+   (`selByFamily`) can replace the flat `shared.sel` outright; no load-time shim needed.
+5. **No regression to summary toggling** — flow/live becomes one family; existing `useSummaryData`
+   `gSel`/`toggleTarget` behaviour must be preserved exactly.
+6. **Active-slot edge cases** — empty / `noPicker` active slot → neutral picker state; sane default target.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@primeuix/themes": "^2.0.3",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/core": "^1.48.2",
+        "pdf-lib": "^1.17.1",
         "pinia": "^3.0.4",
         "primeicons": "^7.0.0",
         "primevue": "^4.5.5",
@@ -260,6 +261,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@primeuix/styled": {
@@ -2189,6 +2208,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -2201,6 +2226,24 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@primeuix/themes": "^2.0.3",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/core": "^1.48.2",
+    "pdf-lib": "^1.17.1",
     "pinia": "^3.0.4",
     "primeicons": "^7.0.0",
     "primevue": "^4.5.5",

--- a/frontend/src/components/canvas/CanvasPanel.vue
+++ b/frontend/src/components/canvas/CanvasPanel.vue
@@ -20,7 +20,10 @@ const props = withDefaults(defineProps<{
   arrange?: ArrangeCmd | null
   // when set (`${canvasKey}:${panelId}`), drag position + size persist here across navigation
   persistKey?: string
-}>(), { active: false, removable: true, arrange: null })
+  // DOCKED: fill the parent slot (Analysis-canvas grid layout) instead of free-floating — no drag,
+  // no resize, no geometry persistence. Keeps the header/actions/body/footer chrome.
+  docked?: boolean
+}>(), { active: false, removable: true, arrange: null, docked: false })
 const emit = defineEmits<{ activate: [number]; remove: [] }>()
 
 const collapsed = ref(false)
@@ -44,6 +47,7 @@ function persist() {
 }
 watch(pos, persist, { deep: true })           // covers drag + Tile/Cascade
 onMounted(() => {
+  if (props.docked) return   // docked panels fill their slot; no saved geometry / resize tracking
   if (saved && root.value) { root.value.style.width = saved.w + 'px'; root.value.style.height = saved.h + 'px' }
   if (props.persistKey && root.value && typeof ResizeObserver !== 'undefined') {
     ro = new ResizeObserver(persist); ro.observe(root.value)   // covers manual resize
@@ -53,13 +57,14 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
 </script>
 
 <template>
-  <div ref="root" class="panel" :class="{ active, collapsed }"
-       :style="{ left: pos.x + 'px', top: pos.y + 'px' }" @mousedown="emit('activate', index)">
+  <div ref="root" class="panel" :class="{ active, collapsed, docked }"
+       :style="docked ? undefined : { left: pos.x + 'px', top: pos.y + 'px' }" @mousedown="emit('activate', index)">
     <!-- title row: the WHOLE row drags (like PopulationManager); buttons stop the drag -->
-    <div class="panel-head" @mousedown.prevent="startDrag" v-tooltip.bottom="'Drag to move'">
-      <span class="panel-title"><i class="pi pi-arrows-alt drag-icon" />{{ title }}</span>
+    <div class="panel-head" @mousedown.prevent="docked || startDrag($event)"
+         v-tooltip.bottom="docked ? undefined : 'Drag to move'">
+      <span class="panel-title"><i v-if="!docked" class="pi pi-arrows-alt drag-icon" />{{ title }}</span>
       <span class="panel-spacer" />
-      <button class="panel-collapse" v-tooltip.bottom="collapsed ? 'Expand' : 'Collapse'"
+      <button v-if="!docked" class="panel-collapse" v-tooltip.bottom="collapsed ? 'Expand' : 'Collapse'"
               @mousedown.stop @click.stop="collapsed = !collapsed">
         <i :class="collapsed ? 'pi pi-chevron-down' : 'pi pi-chevron-up'" />
       </button>
@@ -86,6 +91,10 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
   width: 460px; height: 440px; min-width: 340px; min-height: 320px; resize: both; z-index: 5;
   transition: border-color 0.12s, box-shadow 0.12s; }
 .panel.active { border-color: #ff8c1a; box-shadow: 0 0 0 1px #ff8c1a, 0 6px 22px rgba(0,0,0,0.45); z-index: 6; }
+/* docked: fill the grid slot, no float/drag/resize/shadow */
+.panel.docked { position: static; width: 100%; height: 100%; min-width: 0; min-height: 0; resize: none;
+  box-shadow: none; z-index: auto; }
+.panel.docked .panel-head { cursor: default; }
 /* collapsed: box shrinks to just the header (overrides any inline/resized height); no resize handle */
 .panel.collapsed { height: auto !important; min-height: 0 !important; resize: none; }
 .panel-head { display: flex; align-items: center; gap: 8px; padding: 5px 8px; cursor: move;

--- a/frontend/src/components/canvas/InteractivePanel.vue
+++ b/frontend/src/components/canvas/InteractivePanel.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   context: Record<string, unknown>
   state: Record<string, unknown>
   duplicable?: boolean            // show a footer Duplicate button (host wires @duplicate)
+  docked?: boolean                // fill a grid slot (Analysis canvas) instead of free-floating
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
 const entry = computed(() => INTERACTIVE_VIEWS[props.view])
@@ -29,10 +30,13 @@ const viewRef = useTemplateRef<any>('viewRef')
 const exportFormats = computed<string[]>(() => viewRef.value?.exportFormats ?? [])
 const FMT_LABEL: Record<string, string> = { png: 'Image (PNG)', svg: 'Image (SVG)', csv: 'Data (CSV)' }
 function onExport(kind: string) { if (kind) viewRef.value?.exportAs?.(kind) }
+// plot-only, light-theme PNG for the PDF export — delegated to the view if it implements exportImage
+async function exportImage(): Promise<string | null> { return (await viewRef.value?.exportImage?.()) ?? null }
+defineExpose({ exportImage })
 </script>
 
 <template>
-  <CanvasPanel :index="index" :active="active" :arrange="arrange" :persist-key="persistKey"
+  <CanvasPanel :index="index" :active="active" :arrange="arrange" :persist-key="persistKey" :docked="docked"
                :title="entry?.label ?? view"
                @activate="emit('activate', $event)" @remove="emit('remove')">
     <component v-if="entry" :is="entry.component" ref="viewRef" v-bind="context" :state="state" />
@@ -40,7 +44,7 @@ function onExport(kind: string) { if (kind) viewRef.value?.exportAs?.(kind) }
     <template v-if="duplicable || exportFormats.length" #footer>
       <button v-if="duplicable" class="ip-iconbtn" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same settings) to tweak one thing'"><i class="pi pi-copy" /></button>
-      <select v-if="exportFormats.length" class="ip-export" v-tooltip.top="'Export the shown plot'"
+      <select v-if="exportFormats.length && !docked" class="ip-export" v-tooltip.top="'Export the shown plot'"
               @change="onExport(($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
         <option value="">⤓ Export</option>
         <option v-for="f in exportFormats" :key="f" :value="f">{{ FMT_LABEL[f] ?? f }}</option>

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -1,0 +1,366 @@
+<!--
+  Grid LAYOUT canvas for one Analysis tab (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase A2). A template
+  (uniform N×M or a rectangular "comic plate") defines SLOTS; each slot holds one plot. This is the
+  READ-ONLY analysis surface (project_analysis_canvas_readonly): plots are chosen from the full spec
+  catalog and populations are picked in the DOCKED right-rail SeriesPicker — no gate/pop mutation.
+
+  Reuse: the plot data + view-state come from useSummaryData (shared with the free-floating
+  SummaryCanvas); each filled slot renders a DOCKED SummaryPanel (fills the slot, no float/drag). Only
+  the container differs from SummaryCanvas — the panels/picker are the same components in `docked` mode.
+
+  Persistence: the template + per-slot content + the shared view bag live in the analysisLayout store
+  under this tab's `canvasKey`; the parent (TabbedCanvas) :keys us by it so a tab switch rebinds.
+-->
+<script setup lang="ts">
+import { computed, watch, ref, useTemplateRef } from 'vue'
+import { plotHostToImageURL } from '../../plots/export'
+import { useProjectStore } from '../../stores/project'
+import { useProjectMetaStore } from '../../stores/projectMeta'
+import { useAnalysisLayoutStore, type SlotContent } from '../../stores/analysisLayout'
+import { useSummaryData } from '../../composables/useSummaryData'
+import { tkey, parseTkey } from '../../plots/series'
+import { defaultVis, type VisProps } from '../../plots/plot'
+import { UNIFORM_PRESETS, COMIC_PRESETS, uniform } from '../../plots/layoutTemplates'
+import type { SeriesTarget } from '../../plots/types'
+import SummaryPanel from './SummaryPanel.vue'
+import InteractivePanel from './InteractivePanel.vue'
+import { INTERACTIVE_VIEWS } from './interactiveViews'
+import SeriesPicker from './SeriesPicker.vue'
+
+const props = defineProps<{ imageUids: string[]; module?: string | null; canvasKey: string }>()
+
+const project = useProjectStore()
+const meta = useProjectMetaStore()
+const layout = useAnalysisLayoutStore()
+
+const projectUid = computed(() => meta.current?.uid ?? '')
+const imageUid = computed(() => props.imageUids[0] ?? null)
+const setUid = computed(() => project.activeSetUid)
+
+layout.ensure(props.canvasKey)
+const entry = computed(() => layout.entries[props.canvasKey])
+// minmax(0, 1fr) — NOT bare 1fr (= minmax(auto,1fr)). Bare 1fr lets a cell grow to its content's
+// min-size, and a plot's ResizeObserver then re-renders taller → the grid keeps growing. minmax(0,1fr)
+// pins every track to an equal share of the (bounded) grid height, so content clips/scrolls instead.
+// board-level slot height: rows share a fixed total height (rowHeight × rows); the board scrolls in the
+// page if it's taller than the viewport. Default 320px/row.
+const rowHeight = computed({ get: () => entry.value.rowHeight ?? 320, set: v => (entry.value.rowHeight = v) })
+const gridStyle = computed(() => ({
+  gridTemplateColumns: entry.value.colTracks ?? `repeat(${entry.value.cols}, minmax(0, 1fr))`,
+  gridTemplateRows: entry.value.rowTracks ?? `repeat(${entry.value.rows}, minmax(0, 1fr))`,
+  height: `${rowHeight.value * entry.value.rows + 8 * (entry.value.rows - 1)}px`,
+}))
+
+// shared summary-plot data + view-state (same composable the free-floating canvas uses)
+const {
+  specs, specById, segPops, seriesColor, reloadToken, validSelKeys,
+  compareMode, compareAttr, compareAttr2, scope, gSel, gVis, poolGroups,
+  canCompare, panelSetUid, panelImageUids, panelScope, panelGroupAttr, attrOptions2, setAttrs,
+} = useSummaryData({
+  projectUid, imageUids: computed(() => props.imageUids), setUid, module: props.module,
+  shared: computed(() => entry.value.shared),
+})
+
+// ── slot content: active slot, add/clear, drag-swap ──────────────────────────────────────────────
+const activeContent = computed<SlotContent | null>(() => entry.value.contents[entry.value.activeIndex] ?? null)
+type PState = { sel: string[]; vis: VisProps; [k: string]: unknown }
+const st = (c: SlotContent): PState => c.state as PState
+
+// interactive views offerable here today (self-contained context). UMAP / cluster heatmap need
+// per-slot clustering context (a suffix picker) — a follow-up; only list the analysis-ready ones.
+const ANALYSIS_VIEWS = ['gatingStrategy']
+const interactiveOptions = computed(() => ANALYSIS_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
+// image-content views (napari screenshot slots) — grouped separately in the picker
+const IMAGE_VIEWS = ['filmstrip']
+const imageOptions = computed(() => IMAGE_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
+
+// the "+ Plot" value is "summary:<specId>" or "interactive:<viewKey>"
+function addPlot(i: number, val: string) {
+  if (!val) return
+  const sep = val.indexOf(':'); const kind = val.slice(0, sep); const ref = val.slice(sep + 1)
+  if (kind === 'summary') layout.setContent(props.canvasKey, i, { kind: 'summary', ref, state: { specId: ref, sel: [], vis: defaultVis() } })
+  else if (kind === 'interactive') layout.setContent(props.canvasKey, i, { kind: 'interactive', ref, state: {} })
+  layout.setActive(props.canvasKey, i)
+}
+function clearSlot(i: number) { layout.setContent(props.canvasKey, i, null) }
+
+// generic context handed to an interactive view in a slot (self-contained views read what they need)
+const ctxFor = () => ({ projectUid: projectUid.value, imageUids: props.imageUids, setUid: setUid.value, vis: activeVis.value })
+
+// duplicate a slot's plot into the NEXT EMPTY slot (deep-copy its state so you can tweak one thing);
+// no-op if the grid is full.
+function nextEmpty(from: number): number {
+  const c = entry.value.contents
+  for (let k = 1; k <= c.length; k++) { const j = (from + k) % c.length; if (!c[j]) return j }
+  return -1
+}
+function duplicateSlot(i: number) {
+  const src = entry.value.contents[i]
+  if (!src) return
+  const j = nextEmpty(i)
+  if (j < 0) return
+  layout.setContent(props.canvasKey, j, { kind: src.kind, ref: src.ref, state: JSON.parse(JSON.stringify(src.state)) })
+  layout.setActive(props.canvasKey, j)
+}
+
+// drag reorder via the slot's GRIP handle only (so interacting with the plot itself never starts a
+// drag); drop swaps the two slots' contents.
+const dragFrom = { i: -1 }
+function onDrop(i: number) { if (dragFrom.i >= 0) layout.swap(props.canvasKey, dragFrom.i, i); dragFrom.i = -1 }
+
+// ── global/local scope (drives eye-selection + vis), targeting the ACTIVE slot when local ─────────
+const panelSel = (c: SlotContent) => scope.value === 'global' ? gSel.value : (st(c).sel ?? [])
+const panelVis = (c: SlotContent) => scope.value === 'global' ? gVis.value : (st(c).vis ?? defaultVis())
+const activeSel = computed(() => scope.value === 'global' ? gSel.value : (activeContent.value ? st(activeContent.value).sel : []))
+const activeVis = computed(() => scope.value === 'global' ? gVis.value : (activeContent.value ? st(activeContent.value).vis : defaultVis()))
+const toggle = (arr: string[], v: string) => arr.includes(v) ? arr.filter(x => x !== v) : [...arr, v]
+function toggleTarget(valueName: string, pop: string, pt: string) {
+  const k = tkey(pt, valueName, pop)
+  if (scope.value === 'global') gSel.value = toggle(gSel.value, k)
+  else if (activeContent.value) st(activeContent.value).sel = toggle(st(activeContent.value).sel ?? [], k)
+}
+function setVis(patch: Partial<VisProps>) {
+  if (scope.value === 'global') gVis.value = { ...gVis.value, ...patch }
+  else if (activeContent.value) st(activeContent.value).vis = { ...(st(activeContent.value).vis ?? defaultVis()), ...patch }
+}
+const panelSeries = (c: SlotContent): SeriesTarget[] => panelSel(c).map(parseTkey)
+
+// prune vanished pops from every slot's local selection (the composable prunes the global one). Guard on
+// a non-empty segPops — it's transiently [] during load/image-switch, and pruning then would wipe (and
+// then persist-empty) a restored per-slot selection.
+watch(segPops, () => {
+  if (!segPops.value.length) return
+  for (const c of entry.value.contents) if (c && Array.isArray(st(c).sel)) st(c).sel = st(c).sel.filter(k => validSelKeys.value.has(k))
+})
+
+// ── PDF export: capture each filled slot to a PNG (hiding the drag grips), keyed by its grid-area ──
+const gridRef = useTemplateRef<HTMLElement>('gridRef')
+const capturing = ref(false)
+function labelFor(c: SlotContent): string {
+  return c.kind === 'summary' ? (specById.value[c.ref]?.label ?? c.ref) : (INTERACTIVE_VIEWS[c.ref]?.label ?? c.ref)
+}
+// panel instances by slot index, so we can ask each for a PLOT-ONLY, LIGHT-theme image (no chrome) and
+// pull the summary plot's aggregated CSV. Both panel types expose exportImage(); summary also getCsv().
+type SummaryRef = { getCsv(): string | null; exportImage(): Promise<string | null> }
+type ExportRef = { exportImage(): Promise<string | null> }
+const summaryRefs = new Map<number, SummaryRef>()
+const interactiveRefs = new Map<number, ExportRef>()
+function setSummaryRef(i: number, el: unknown) { if (el) summaryRefs.set(i, el as SummaryRef); else summaryRefs.delete(i) }
+function setInteractiveRef(i: number, el: unknown) { if (el) interactiveRefs.set(i, el as ExportRef); else interactiveRefs.delete(i) }
+
+type PdfSlotOut = { rect: { x: number; y: number; w: number; h: number }; png: string | null; name: string; csv?: string | null }
+async function capturePage() {
+  const gridEl = gridRef.value
+  if (!gridEl) return { aspect: 1, slots: [] as PdfSlotOut[] }
+  const slotEls = Array.from(gridEl.querySelectorAll('.lc-slot')) as HTMLElement[]
+  capturing.value = true
+  await new Promise(r => requestAnimationFrame(() => r(null)))   // let the grip-hide take effect
+  // measure the grid + each slot so the PDF reproduces the ON-SCREEN layout (spans, plates, row height,
+  // gaps) exactly — the board IS the layout guide, so slots land at their real proportions/positions.
+  const gr = gridEl.getBoundingClientRect()
+  const slots: PdfSlotOut[] = []
+  try {
+    for (let i = 0; i < entry.value.contents.length; i++) {
+      const c = entry.value.contents[i]
+      const el = slotEls[i]
+      if (!c || !el) continue
+      // prefer the panel's plot-only light-theme export; fall back to a white-ground DOM snapshot
+      // (e.g. filmstrip/image slots, which are already screenshots) with the chrome hidden.
+      let png: string | null = null
+      if (c.kind === 'summary') png = await summaryRefs.get(i)?.exportImage() ?? null
+      else if (c.kind === 'interactive') png = await interactiveRefs.get(i)?.exportImage?.() ?? null
+      if (!png) png = await plotHostToImageURL(el, '#ffffff')
+      const csv = c.kind === 'summary' ? (summaryRefs.get(i)?.getCsv() ?? null) : null
+      const sr = el.getBoundingClientRect()
+      const rect = { x: (sr.left - gr.left) / gr.width, y: (sr.top - gr.top) / gr.height,
+                     w: sr.width / gr.width, h: sr.height / gr.height }
+      slots.push({ rect, png, name: labelFor(c), csv })
+    }
+  } finally { capturing.value = false }
+  return { aspect: gr.width / Math.max(1, gr.height), slots }
+}
+// the shown (aggregated) data for every summary slot — for the standalone CSV export (data → Prism)
+function collectCsvs(): { name: string; csv: string | null }[] {
+  const out: { name: string; csv: string | null }[] = []
+  for (let i = 0; i < entry.value.contents.length; i++) {
+    const c = entry.value.contents[i]
+    if (c?.kind === 'summary') out.push({ name: labelFor(c), csv: summaryRefs.get(i)?.getCsv() ?? null })
+  }
+  return out
+}
+defineExpose({ capturePage, collectCsvs })
+</script>
+
+<template>
+  <div class="layout-canvas">
+    <div v-if="!imageUid" class="lc-empty">Select one or more images above to plot.</div>
+    <template v-else>
+      <!-- controls, grouped so nothing crowds: Layout row (uniform + custom sliders), Plates row
+           (varied presets, wraps to two lines), then the data/compare row. -->
+      <div class="lc-bar">
+        <div class="lc-row">
+          <span class="lc-lbl">Layout</span>
+          <div class="seg" v-tooltip.bottom="'Uniform grids'">
+            <button v-for="t in UNIFORM_PRESETS" :key="t.id"
+                    @click="layout.applyTemplate(canvasKey, t)"
+                    :class="{ on: entry.cols === t.cols && entry.rows === t.rows && entry.slotAreas.length === t.slots.length }">
+              {{ t.label }}
+            </button>
+          </div>
+          <div class="lc-nm" v-tooltip.bottom="'Custom uniform grid'">
+            <span class="lc-lbl">cols</span>
+            <input type="range" min="1" max="6" :value="entry.cols"
+                   @input="layout.applyTemplate(canvasKey, uniform(+($event.target as HTMLInputElement).value, entry.rows))" />
+            <span class="lc-val">{{ entry.cols }}</span>
+            <span class="lc-lbl">rows</span>
+            <input type="range" min="1" max="6" :value="entry.rows"
+                   @input="layout.applyTemplate(canvasKey, uniform(entry.cols, +($event.target as HTMLInputElement).value))" />
+            <span class="lc-val">{{ entry.rows }}</span>
+          </div>
+          <div class="lc-nm" v-tooltip.bottom="'Slot height (applies to all slots on the board)'">
+            <span class="lc-lbl">height</span>
+            <input type="range" min="160" max="720" step="10" :value="rowHeight"
+                   @input="rowHeight = +($event.target as HTMLInputElement).value" />
+          </div>
+          <!-- compare + pool sit at the right of the layout row -->
+          <div class="lc-right">
+            <div v-if="canCompare" class="lc-compare"
+                 v-tooltip.bottom="'Compare across the selected images'">
+              <span class="lc-lbl">compare</span>
+              <select v-model="compareMode">
+                <option value="image">this image</option>
+                <option value="per_image">per image</option>
+                <option value="summarised">pooled</option>
+                <option value="by_attr" :disabled="!setAttrs.length">by attribute</option>
+              </select>
+              <template v-if="compareMode === 'by_attr'">
+                <select v-model="compareAttr"><option v-for="a in setAttrs" :key="a.name" :value="a.name">{{ a.name }}</option></select>
+                <template v-if="attrOptions2.length">
+                  <span class="lc-x">×</span>
+                  <select v-model="compareAttr2">
+                    <option value="">none</option>
+                    <option v-for="a in attrOptions2" :key="a.name" :value="a.name">{{ a.name }}</option>
+                  </select>
+                </template>
+              </template>
+            </div>
+            <label class="lc-pool" v-tooltip.bottom="'Pool across populations and images so each plot shows one series per Split-by group only'">
+              <input type="checkbox" v-model="poolGroups" /> pool to groups
+            </label>
+          </div>
+        </div>
+        <div class="lc-row">
+          <span class="lc-lbl">Plates</span>
+          <div class="seg seg-wrap" v-tooltip.bottom="'Comic plates — varied-size panels'">
+            <button v-for="t in COMIC_PRESETS" :key="t.id" @click="layout.applyTemplate(canvasKey, t)"
+                    :class="{ on: entry.slotAreas.join('|') === t.slots.join('|') }">{{ t.label }}</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="lc-body">
+        <!-- the grid of slots -->
+        <div ref="gridRef" class="lc-grid" :class="{ capturing }" :style="gridStyle">
+          <div v-for="(area, i) in entry.slotAreas" :key="i" class="lc-slot"
+               :class="{ active: i === entry.activeIndex, filled: !!entry.contents[i] }"
+               :style="{ gridArea: area }"
+               @dragover.prevent @drop.prevent="onDrop(i)"
+               @mousedown="layout.setActive(canvasKey, i)">
+            <!-- grip: the ONLY drag source, so dragging inside the plot never starts a reorder -->
+            <div v-if="entry.contents[i]" class="lc-grip" draggable="true"
+                 @dragstart="dragFrom.i = i" @dragend="dragFrom.i = -1"
+                 v-tooltip.bottom="'Drag to move / swap'"><i class="pi pi-arrows-alt" /></div>
+            <!-- summary plot -->
+            <SummaryPanel v-if="entry.contents[i]?.kind === 'summary' && specById[entry.contents[i]!.ref]"
+                          :ref="el => setSummaryRef(i, el)"
+                          :index="i" :active="i === entry.activeIndex" :docked="true" :arrange="null"
+                          :spec="specById[entry.contents[i]!.ref]"
+                          :project-uid="projectUid" :image-uid="imageUid"
+                          :set-uid="panelSetUid" :image-uids="panelImageUids" :scope="panelScope"
+                          :group-attr="panelGroupAttr" :series="panelSeries(entry.contents[i]!)" :series-color="seriesColor"
+                          :vis="panelVis(entry.contents[i]!)" :ui="entry.contents[i]!.state" :collapse-series="poolGroups"
+                          :reload-token="reloadToken" :persist-key="`${canvasKey}:slot:${i}`"
+                          @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)" />
+            <!-- interactive plot (UMAP / gating-strategy / …) -->
+            <InteractivePanel v-else-if="entry.contents[i]?.kind === 'interactive' && INTERACTIVE_VIEWS[entry.contents[i]!.ref]"
+                              :ref="el => setInteractiveRef(i, el)"
+                              :index="i" :active="i === entry.activeIndex" :docked="true"
+                              :view="entry.contents[i]!.ref" :context="ctxFor()" :state="entry.contents[i]!.state"
+                              :duplicable="true" :persist-key="`${canvasKey}:slot:${i}`"
+                              @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)" />
+            <!-- empty slot: add a plot (summary spec or interactive view) -->
+            <div v-else class="lc-add">
+              <select v-tooltip.bottom="'Add a plot to this slot'"
+                      @change="addPlot(i, ($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
+                <option value="">+ Plot…</option>
+                <optgroup label="Summary">
+                  <option v-for="s in specs" :key="s.id" :value="`summary:${s.id}`">{{ s.label }}</option>
+                </optgroup>
+                <optgroup v-if="interactiveOptions.length" label="Interactive">
+                  <option v-for="v in interactiveOptions" :key="v.key" :value="`interactive:${v.key}`">{{ v.label }}</option>
+                </optgroup>
+                <optgroup v-if="imageOptions.length" label="Image">
+                  <option v-for="v in imageOptions" :key="v.key" :value="`interactive:${v.key}`">{{ v.label }}</option>
+                </optgroup>
+              </select>
+              <span class="lc-add-hint">empty slot</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- docked pop picker (control, not content — excluded from PDF) -->
+        <div class="lc-rail">
+          <SeriesPicker :groups="segPops" :selected="activeSel" :scope="scope" :vis="activeVis" :docked="true"
+                        @toggle="toggleTarget" @update:scope="scope = $event" @update:vis="setVis" />
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.layout-canvas { display: flex; flex-direction: column; }
+.lc-empty { padding: 20px; color: var(--cc-text-dim); }
+.lc-bar { display: flex; flex-direction: column; gap: 6px; padding: 8px 4px; font-size: 12px; flex-shrink: 0; }
+.lc-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+/* sits right after the sliders (NOT pushed to the far right) so it doesn't shift when the compare
+   dropdown changes width (e.g. "by attribute" adds selects) */
+.lc-right { display: flex; align-items: center; gap: 10px; }
+.lc-lbl { color: var(--cc-text-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+.lc-sep { width: 1px; height: 1.4rem; background: var(--cc-border); }
+.lc-nm { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
+.lc-nm input[type="range"] { width: 5rem; }
+.lc-val { min-width: 0.9rem; text-align: center; font-weight: 700; color: var(--cc-text); }
+.seg-wrap { flex-wrap: wrap; }
+/* wrapped seg buttons keep separators between rows too */
+.seg-wrap button { border-left: 1px solid var(--cc-border); border-top: 1px solid var(--cc-border); }
+.lc-compare { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim);
+  padding: 2px 8px; border: 1px solid var(--cc-border); border-radius: 6px; }
+.lc-x { opacity: 0.6; }
+.lc-pool { display: flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 4px 8px; cursor: pointer; font-size: 11px; }
+.seg button + button { border-left: 1px solid var(--cc-border); }
+.seg button:hover { color: var(--cc-text); }
+.seg button.on { background: #2d1b69; color: #c4b5fd; }
+/* the board sizes to its grid (rowHeight × rows); the page's panel-scroll handles overflow */
+.lc-body { display: flex; align-items: flex-start; gap: 8px; }
+.lc-grid { flex: 1; display: grid; gap: 8px; padding: 4px; overflow: hidden; }
+.lc-slot { position: relative; border: 1px dashed var(--cc-border); border-radius: 6px; overflow: hidden;
+  display: flex; min-width: 0; min-height: 0; background: var(--cc-bg); }
+.lc-slot.filled { border-style: solid; }
+.lc-slot.active { border-color: #7c3aed; }
+/* drag grip: sits in the docked panel header's empty spacer (left of the remove button) */
+.lc-grip { position: absolute; top: 5px; right: 2.3rem; z-index: 7; width: 1.4rem; height: 1.4rem;
+  display: flex; align-items: center; justify-content: center; cursor: grab; font-size: 0.62rem;
+  color: var(--cc-text-dim); background: var(--cc-surface-1); border: 1px solid var(--cc-border);
+  border-radius: 4px; opacity: 0.4; transition: opacity 0.1s, color 0.1s; }
+.lc-slot:hover .lc-grip { opacity: 1; }
+.lc-grip:hover { color: var(--cc-text); border-color: #7c3aed; }
+.lc-grip:active { cursor: grabbing; }
+/* hide the drag grips while capturing so they don't appear in the exported PDF */
+.lc-grid.capturing .lc-grip { display: none; }
+.lc-add { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; }
+.lc-add-hint { color: var(--cc-text-dim); font-size: 11px; opacity: 0.6; }
+.lc-rail { flex-shrink: 0; width: 300px; overflow-y: auto; }
+</style>

--- a/frontend/src/components/canvas/PopulationPanelShell.vue
+++ b/frontend/src/components/canvas/PopulationPanelShell.vue
@@ -13,36 +13,43 @@ import { useFloatingPanel } from '../../composables/useFloatingPanel'
 import PlotOptions from './PlotOptions.vue'
 import type { VisProps } from '../../plots/plot'
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   title?: string
   count?: number | string          // shown at the right of the header (population count)
   scope: 'global' | 'local'
   // when provided, the shared PlotOptions styling block renders above the footer (obeys `scope`)
   vis?: VisProps
   optionsSections?: ('layout' | 'points' | 'colours' | 'labels')[]
-}>(), { title: 'Populations', count: undefined, vis: undefined, optionsSections: undefined })
+  // DOCKED: render in-flow (a fixed rail, e.g. the Analysis-canvas layout) instead of a draggable
+  // floating box — no absolute positioning, no drag, full width of its container.
+  docked?: boolean
+}>(), { title: 'Populations', count: undefined, vis: undefined, optionsSections: undefined, docked: false })
 const emit = defineEmits<{
   'update:scope': ['global' | 'local']
   'update:vis': [patch: Partial<VisProps>]
 }>()
 
 const collapsed = ref(false)
-// drag-to-move, clamped to the workspace; open at the top-right so it doesn't start on the plots
+// drag-to-move, clamped to the workspace; open at the top-right so it doesn't start on the plots.
+// (docked mode ignores all of this — it renders in-flow.)
 const panel = useTemplateRef<HTMLElement>('panel')
 const { pos, startDrag } = useFloatingPanel(panel)
 onMounted(() => {
+  if (props.docked) return
   const par = panel.value?.offsetParent as HTMLElement | null
   if (par) pos.value = { x: Math.max(16, par.clientWidth - (panel.value!.offsetWidth || 300) - 16), y: 16 }
 })
+function onHeaderDown(e: MouseEvent) { if (!props.docked) startDrag(e) }
 </script>
 
 <template>
-  <div ref="panel" class="pop-manager" :style="{ left: pos.x + 'px', top: pos.y + 'px' }">
-    <div class="pm-header" @mousedown.prevent="startDrag">
+  <div ref="panel" class="pop-manager" :class="{ docked }"
+       :style="docked ? undefined : { left: pos.x + 'px', top: pos.y + 'px' }">
+    <div class="pm-header" @mousedown.prevent="onHeaderDown">
       <i class="pi pi-sitemap" />
       <span class="pm-title">{{ title }}</span>
       <span v-if="count !== undefined" class="pm-count">{{ count }}</span>
-      <button class="pm-icon" v-tooltip.left="collapsed ? 'Expand' : 'Collapse'"
+      <button v-if="!docked" class="pm-icon" v-tooltip.left="collapsed ? 'Expand' : 'Collapse'"
               @click.stop="collapsed = !collapsed">
         <i :class="collapsed ? 'pi pi-chevron-down' : 'pi pi-chevron-up'" />
       </button>
@@ -79,6 +86,9 @@ onMounted(() => {
   border-radius: 6px; box-shadow: 0 6px 24px rgba(0,0,0,0.4);
   font-size: 12px; color: var(--cc-text); user-select: none;
 }
+/* docked: in-flow rail (no float/drag/shadow), fills its container column */
+.pop-manager.docked { position: static; z-index: auto; width: 100%; box-shadow: none; }
+.pop-manager.docked .pm-header { cursor: default; }
 .pm-header {
   display: flex; align-items: center; gap: 6px; padding: 6px 8px;
   cursor: move; border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2);

--- a/frontend/src/components/canvas/SeriesPicker.vue
+++ b/frontend/src/components/canvas/SeriesPicker.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   selected: string[]                  // selected target keys (tkey), in the current scope
   scope: 'global' | 'local'
   vis: VisProps                       // visual properties for the current scope
+  docked?: boolean                    // render in a fixed rail (Analysis canvas) instead of floating
 }>()
 const emit = defineEmits<{
   toggle: [valueName: string, pop: string, popType: string]
@@ -35,7 +36,7 @@ const depthOf = (path: string) => Math.max(0, path.split('/').length - 2)
 </script>
 
 <template>
-  <PopulationPanelShell :count="total" :scope="scope" :vis="vis"
+  <PopulationPanelShell :count="total" :scope="scope" :vis="vis" :docked="docked"
                         @update:scope="emit('update:scope', $event)" @update:vis="emit('update:vis', $event)">
     <div v-if="!total" class="pm-empty">No populations in the selected segmentations.</div>
     <template v-for="grp in groups" :key="grp.valueName">

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -14,33 +14,31 @@
   module filter off.
 -->
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from 'vue'
+import { computed, watch, useTemplateRef } from 'vue'
 import { useProjectStore } from '../../stores/project'
 import { useProjectMetaStore } from '../../stores/projectMeta'
-import { useWsStore } from '../../stores/ws'
 import { useCanvasPanels } from '../../composables/useCanvasPanels'
-import { useViewState } from '../../composables/useViewState'
+import { useSummaryData } from '../../composables/useSummaryData'
 import SeriesPicker from './SeriesPicker.vue'
 import SummaryPanel from './SummaryPanel.vue'
 import { tkey, parseTkey } from '../../plots/series'
 import { defaultVis, type VisProps } from '../../plots/plot'
-import type { PlotSpec, PlotSeries, SegmentationPops, SeriesTarget, ChartType } from '../../plots/types'
+import type { SeriesTarget, ChartType } from '../../plots/types'
 
-const props = defineProps<{ imageUids: string[]; module?: string | null }>()
+// `canvasKey` OPTIONALLY overrides the persistence namespace (default `summary:{module|universal}`).
+// The tabbed Analysis canvas passes `analysis:{projectUid}:tab:{id}` per tab so each board persists
+// independently; parents that switch the key MUST also `:key` this component by it so setup re-runs.
+const props = defineProps<{ imageUids: string[]; module?: string | null; canvasKey?: string }>()
+const ckey = props.canvasKey ?? `summary:${props.module ?? 'universal'}`
 const project = useProjectStore()
 const meta = useProjectMetaStore()
-const ws = useWsStore()
 
 const projectUid = computed(() => meta.current?.uid ?? '')
 const imageUid = computed(() => props.imageUids[0] ?? null)   // drives "this image" plots
 const setUid = computed(() => project.activeSetUid)
 
-// ── canvas state: panels (per-plot) + canvas-level view options (persisted) ─────────────────────
-// Per-panel state lives in the panel objects; canvas-LEVEL options live in the `shared` bag via
-// useViewState — declare every option in the defaults below and it persists across navigation with
-// NO per-field wiring (the forget-proof, Shiny-reactiveValues-style mechanism; see useViewState.ts).
-// PanelState carries the per-PLOT options too (chartType/measure/bins/… — edited inside SummaryPanel)
-// so those persist as well.
+// per-plot state (edited inside SummaryPanel; persists in the panel objects). Canvas-level view state
+// + all shared data (specs/pops/attrs, compare/scope/global sel+vis) come from useSummaryData below.
 interface PanelState {
   specId: string; sel: string[]; vis: VisProps
   chartType?: ChartType; measure?: string; bins?: number; normalize?: boolean; errorMetric?: 'sd' | 'sem' | 'ci95'
@@ -50,96 +48,13 @@ interface PanelState {
 const canvasRef = useTemplateRef<HTMLElement>('canvasRef')
 const { panels, activeId, activePanel, shared, add, remove, arrangeGrid, arrangeCascade } =
   useCanvasPanels<PanelState>(canvasRef, () => ({ specId: specs.value[0]?.id ?? '', sel: [], vis: defaultVis() }),
-    `summary:${props.module ?? 'universal'}`)
-const { compareMode, compareAttr, compareAttr2, scope, sel: gSel, vis: gVis, poolGroups } = useViewState(shared, {
-  // compare mode: 'image' = first selected image; 'per_image' = one series per image; 'summarised' =
-  // pooled; 'by_attr' = group images by the `compareAttr` attribute (one series per attribute value)
-  compareMode: 'image' as 'image' | 'per_image' | 'summarised' | 'by_attr',
-  compareAttr: '' as string,                  // primary image attribute to group by (when by_attr)
-  compareAttr2: '' as string,                 // optional interaction attribute (combined as primary.secondary)
-  scope: 'global' as 'global' | 'local',     // global = one value for every plot; local = active plot only
-  sel: [] as string[],                        // global-scope eye-selected target keys (tkey)
-  vis: defaultVis() as VisProps,              // global-scope visual properties
-  // pool across populations AND images so series form only by a plot's "Split by" level (one series
-  // per group, e.g. per HMM state) — generic, applies to every plot on the canvas.
-  poolGroups: false as boolean,
-})
-const canCompare = computed(() => !!setUid.value && props.imageUids.length > 1)
-const crossImage = computed(() => compareMode.value !== 'image' && canCompare.value)
-const panelSetUid = computed(() => crossImage.value ? setUid.value : null)
-const panelImageUids = computed(() => crossImage.value ? props.imageUids : undefined)
-const panelScope = computed<'per_image' | 'summarised'>(() =>
-  compareMode.value === 'summarised' ? 'summarised' : 'per_image')
-
-// image attributes available across the set (for the "by attribute" compare mode); the chosen one is
-// sent as `groupAttr` so images sharing a value pool into one series labelled by the value.
-const setAttrs = ref<{ name: string; values: string[] }[]>([])
-async function loadAttrs() {
-  if (!setUid.value || !canCompare.value) { setAttrs.value = []; return }
-  const p = new URLSearchParams({ projectUid: projectUid.value, setUid: setUid.value })
-  if (props.imageUids.length) p.set('imageUids', props.imageUids.join(','))
-  try { setAttrs.value = (await (await fetch(`/api/plots/attrs?${p}`)).json()).attrs ?? [] }
-  catch { setAttrs.value = [] }
-}
-// default the attribute once when entering by_attr / when the list loads; keep the interaction valid
-watch([compareMode, setAttrs, compareAttr], () => {
-  if (compareMode.value === 'by_attr' && !compareAttr.value && setAttrs.value.length)
-    compareAttr.value = setAttrs.value[0].name
-  if (compareAttr2.value && (compareAttr2.value === compareAttr.value
-      || !setAttrs.value.some(a => a.name === compareAttr2.value)))
-    compareAttr2.value = ''
-})
-// the chosen attribute(s) to group by — primary + optional interaction (combined as primary.secondary,
-// like the old R paste0(axisX, ".", interaction)). Empty when not in by_attr mode.
-const panelGroupAttr = computed<string[]>(() =>
-  compareMode.value === 'by_attr' && crossImage.value
-    ? [compareAttr.value, compareAttr2.value].filter(Boolean) : [])
-// interaction options exclude the primary (no "A.A")
-const attrOptions2 = computed(() => setAttrs.value.filter(a => a.name !== compareAttr.value))
-
-// ── available plot types (per-module registry; null module = universal canvas → all specs) ──────
-const specs = ref<PlotSpec[]>([])
-const specById = computed(() => Object.fromEntries(specs.value.map(s => [s.id, s])))
-// the populations available depend on the pop_type; the per-module specs share one (e.g. behaviour
-// → "live"). Use the first spec's pop_type for the picker (default "live").
-const popType = computed(() => specs.value[0]?.dataSource.popType ?? 'live')
-// track-granularity plots union live + track pops in the picker (see /api/plots/populations). Use
-// "track" if ANY spec in this module is track-granularity (the module can mix cell + track plots,
-// and specs[0] may be a cell plot) so track gates are always available where a track plot exists.
-const granularity = computed(() => specs.value.some(s => s.dataSource.granularity === 'track') ? 'track' : 'cell')
-async function loadSpecs() {
-  const q = props.module ? `?module=${encodeURIComponent(props.module)}` : ''
-  try { specs.value = await (await fetch(`/api/plots/definitions${q}`)).json() } catch { specs.value = [] }
-}
-
-// ── populations available across the selected images, grouped by segmentation ───────────────────
-const segPops = ref<SegmentationPops[]>([])
-// colour by population, keyed by `value_name + path` (= the plot series' `pop` id) — colour is per
-// population and independent of pop_type, so this key omits popType (unlike the selection tkey).
-const popColors = computed(() => {
-  const m = new Map<string, string>()
-  for (const g of segPops.value) for (const p of g.populations) m.set(`${g.valueName}${p.path}`, p.colour)
-  return m
-})
-async function loadPops() {
-  if (!imageUid.value && !props.imageUids.length) { segPops.value = []; return }
-  const p = new URLSearchParams({ projectUid: projectUid.value, popType: popType.value, granularity: granularity.value })
-  if (setUid.value) { p.set('setUid', setUid.value); if (props.imageUids.length) p.set('imageUids', props.imageUids.join(',')) }
-  else if (imageUid.value) p.set('imageUid', imageUid.value)
-  try { segPops.value = await (await fetch(`/api/plots/populations?${p}`)).json() }
-  catch { segPops.value = [] }
-}
-
-// live updates: the server broadcasts `gating:popmap` after any gate mutation (gate page, napari,
-// other clients). A `live` population's gates live in the `flow` map, so refresh regardless of the
-// broadcast's popType — refetch the population list AND bump a token so the panels re-pull data
-// (membership may have changed without any prop changing).
-const reloadToken = ref(0)
-function onPopmap(d: unknown) {
-  const m = d as { imageUid?: string }
-  if (m.imageUid && props.imageUids.length && !props.imageUids.includes(m.imageUid)) return
-  loadPops(); reloadToken.value++
-}
+    ckey)
+// shared summary-plot data + canvas-level view-state (identical whether plots float or sit in a grid)
+const {
+  specs, specById, segPops, seriesColor, reloadToken, validSelKeys,
+  compareMode, compareAttr, compareAttr2, scope, gSel, gVis, poolGroups,
+  canCompare, panelSetUid, panelImageUids, panelScope, panelGroupAttr, attrOptions2, setAttrs,
+} = useSummaryData({ projectUid, imageUids: computed(() => props.imageUids), setUid, module: props.module, shared })
 
 // global/local scope governs BOTH the eye-selection AND the visual properties (like the gating
 // PopulationManager): global = one value shared by every plot, local = the active plot's own.
@@ -160,14 +75,6 @@ function setVis(patch: Partial<VisProps>) {
 // a panel's series = its selected target keys parsed back into {valueName, pop}
 const panelSeries = (s: PanelState): SeriesTarget[] => panelSel(s).map(parseTkey)
 
-// series colour: always the POPULATION colour, so the same population reads identically across
-// images (the user compares populations, not images — facet/x-position separates the images). When
-// the population manager colour isn't available, the panel's palette option (distinct/Okabe-Ito/…)
-// reassigns by series order. `s.pop` is the value_name+path id.
-function seriesColor(s: PlotSeries): string {
-  return popColors.value.get(s.pop) ?? '#7c93b8'
-}
-
 function addPanel(specId: string) { if (specId) { add(); const p = panels.value.at(-1); if (p) p.state.specId = specId } }
 
 // Duplicate a panel: new panel with a deep copy of the source's state (spec, series selection,
@@ -178,20 +85,8 @@ function duplicatePanel(src: { state: PanelState }) {
   if (p) p.state = { ...src.state, sel: [...src.state.sel], vis: { ...src.state.vis } }
 }
 
-// reload populations when the image selection / pop_type changes; prune selections for pops that
-// vanished (deselected image, changed segmentation set).
-watch([() => props.imageUids.join(','), popType, setUid], () => { loadPops(); loadAttrs() })
-watch(() => segPops.value, () => {
-  const exist = new Set<string>()
-  for (const g of segPops.value) for (const p of g.populations) exist.add(tkey(p.popType, g.valueName, p.path))
-  gSel.value = gSel.value.filter(k => exist.has(k))
-  for (const p of panels.value) p.state.sel = p.state.sel.filter(k => exist.has(k))
-})
-onMounted(async () => {
-  ws.on('gating:popmap', onPopmap)
-  await loadSpecs(); await loadPops(); await loadAttrs()
-})
-onUnmounted(() => ws.off('gating:popmap', onPopmap))
+// useSummaryData prunes the GLOBAL selection when pops vanish; prune each panel's LOCAL selection here.
+watch(segPops, () => { for (const p of panels.value) p.state.sel = p.state.sel.filter(k => validSelKeys.value.has(k)) })
 </script>
 
 <template>
@@ -246,7 +141,7 @@ onUnmounted(() => ws.off('gating:popmap', onPopmap))
                         :group-attr="panelGroupAttr"
                         :series="panelSeries(p.state)" :series-color="seriesColor" :vis="panelVis(p.state)"
                         :ui="p.state" :collapse-series="poolGroups"
-                        :reload-token="reloadToken" :persist-key="`summary:${props.module ?? 'universal'}:${p.id}`"
+                        :reload-token="reloadToken" :persist-key="`${ckey}:${p.id}`"
                         @activate="activeId = p.id" @remove="remove(p.id)"
                         @duplicate="duplicatePanel(p)" />
         </template>

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -35,9 +35,10 @@ const props = defineProps<{
   collapseSeries?: boolean             // pool across pops & images → series by the groupBy level only
   reloadToken?: number                 // bumped by the host to force a refetch (live gate updates)
   persistKey?: string                  // CanvasPanel geometry persistence key
+  docked?: boolean                     // fill a grid slot (Analysis canvas) instead of free-floating
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
-const plotRef = useTemplateRef<{ toImageURL(t: 'png' | 'svg'): Promise<string | null> }>('plotRef')
+const plotRef = useTemplateRef<{ toImageURL(t: 'png' | 'svg', light?: boolean): Promise<string | null> }>('plotRef')
 
 const param = (k: string, d: unknown) => props.spec.params?.find(p => p.key === k)?.default ?? d
 const measureOpts = computed(() => props.spec.dataSource.measureOptions ?? [props.spec.dataSource.measure])
@@ -223,9 +224,13 @@ async function fetchData() {
   } finally { loading.value = false }
 }
 
-// errorMetric is render-only (the bar response carries sd/sem/ci95) → not a fetch trigger
+// errorMetric is render-only (the bar response carries sd/sem/ci95) → not a fetch trigger.
+// matrixCategory is included because for heatmaps the category resolves ASYNC (from obsCols loaded on
+// mount) — without it the heatmap's first fetch bails ("pick a category") and never re-runs until the
+// user re-picks. (Vue batches multi-source watches, so a user pick that changes groupBy + category
+// still fires once.)
 watch([() => props.series, measure, chartType, bins, normalize, groupBy, () => props.collapseSeries,
-       matrixMode, zscore, matrixNormalize,
+       matrixMode, zscore, matrixNormalize, matrixCategory,
        () => props.imageUid, () => props.setUid, () => props.groupAttr,
        () => props.imageUids, () => props.scope, () => props.reloadToken], fetchData, { deep: true })
 onMounted(fetchData)
@@ -265,11 +270,16 @@ function exportAs(kind: string) {
     })
   }
 }
+// the shown (aggregated) data as a CSV string — for embedding into the PDF export as an attachment
+function getCsv(): string | null { return result.value ? plotDataToCsv(result.value) : null }
+// a plot-only, LIGHT-theme PNG for the PDF export (no panel chrome; dark theme is on-screen only)
+async function exportImage(): Promise<string | null> { return (await plotRef.value?.toImageURL('png', true)) ?? null }
+defineExpose({ getCsv, exportImage })
 </script>
 
 <template>
   <CanvasPanel :index="index" :active="active" :arrange="arrange" :title="spec.label"
-               :persist-key="persistKey"
+               :persist-key="persistKey" :docked="docked"
                @activate="emit('activate', $event)" @remove="emit('remove')">
     <template #actions>
       <!-- primary: what to plot + how (the single-measure picker is irrelevant for the matrix grid) -->
@@ -355,10 +365,11 @@ function exportAs(kind: string) {
     <!-- utility actions live in the footer so the header/controls never clip -->
     <template #footer>
       <button class="sp-iconbtn" type="button" @click="emit('duplicate')"
-              v-tooltip.top="'Duplicate this plot (same series + settings) to tweak one thing'">
+              v-tooltip.top="docked ? 'Duplicate this plot into the next empty slot' : 'Duplicate this plot (same series + settings) to tweak one thing'">
         <i class="pi pi-copy" />
       </button>
-      <select class="sp-export" v-tooltip.top="'Export the shown plot'" :disabled="!result"
+      <!-- per-plot export is dropped in a slot (the whole page exports to PDF); keep it when floating -->
+      <select v-if="!docked" class="sp-export" v-tooltip.top="'Export the shown plot'" :disabled="!result"
               @change="exportAs(($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
         <option value="">⤓ Export</option>
         <option value="csv">Data (CSV)</option>

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -1,0 +1,213 @@
+<!--
+  Multipage canvas: a tab bar over N independent boards, each an isolated SummaryCanvas
+  (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase A). The tab LIST lives in the `analysisTabs` store; each
+  board's plots persist in `canvasPanels` under the canvas key `${groupKey}:tab:${id}`, so tabs reuse
+  the whole existing canvas machinery. Only the ACTIVE board is mounted (keyed by its canvas key, so
+  switching tabs re-binds that board's stored panels); inactive boards persist in the store.
+
+  Boards are per-project (`groupKey = analysis:{projectUid}`); the parent MUST `:key` this component by
+  projectUid so a project switch remounts it. Add / rename (double-click) / drag-reorder / close tabs.
+-->
+<script setup lang="ts">
+import { ref, computed, nextTick, useTemplateRef } from 'vue'
+import { useProjectMetaStore } from '../../stores/projectMeta'
+import { useAnalysisTabsStore } from '../../stores/analysisTabs'
+import { useCanvasPanelsStore } from '../../stores/canvasPanels'
+import { exportTabsToPdf } from '../../plots/pdf'
+import { downloadBlob } from '../../plots/export'
+import { useLogStore } from '../../stores/log'
+import LayoutCanvas from './LayoutCanvas.vue'
+
+const props = defineProps<{ imageUids: string[]; module?: string | null }>()
+
+const meta = useProjectMetaStore()
+const tabsStore = useAnalysisTabsStore()
+const panelsStore = useCanvasPanelsStore()
+const log = useLogStore()
+
+const projectUid = computed(() => meta.current?.uid ?? '')
+const groupKey = `analysis:${projectUid.value}`
+tabsStore.ensure(groupKey)   // seed the first board
+
+// derive reactively FROM THE STORE (not a captured return value) so mutations re-render
+const group = computed(() => tabsStore.entries[groupKey])
+const tabs = computed(() => group.value?.tabs ?? [])
+const activeId = computed(() => group.value?.activeId ?? 0)
+const canvasKey = (id: number) => `${groupKey}:tab:${id}`
+const activeKey = computed(() => canvasKey(activeId.value))
+
+// inline rename
+const editingId = ref<number | null>(null)
+const editText = ref('')
+function startRename(id: number, name: string) { editingId.value = id; editText.value = name }
+function commitRename() {
+  if (editingId.value != null) tabsStore.renameTab(groupKey, editingId.value, editText.value)
+  editingId.value = null
+}
+
+function addTab() { tabsStore.addTab(groupKey) }
+
+function closeTab(id: number) {
+  const n = panelsStore.entries[canvasKey(id)]?.panels.length ?? 0
+  if (n > 0 && !confirm(`Close this board and its ${n} plot${n === 1 ? '' : 's'}?`)) return
+  panelsStore.drop(canvasKey(id))
+  tabsStore.removeTab(groupKey, id)
+}
+
+// drag-reorder
+const dragId = ref<number | null>(null)
+function onDrop(targetId: number) {
+  if (dragId.value == null || dragId.value === targetId) { dragId.value = null; return }
+  const toIndex = tabs.value.findIndex(t => t.id === targetId)
+  tabsStore.reorderTab(groupKey, dragId.value, toIndex)
+  dragId.value = null
+}
+
+// ── Export every tab to a multipage PDF (one page per tab = its grid) ──────────────────────────────
+// Only the ACTIVE board is mounted, so we visit each tab in turn, let it render, capture its slots, then
+// restore the original tab. (Timing is a fixed settle delay — plots have no unified "loaded" signal.)
+type CapturedPage = { aspect: number; slots: { rect: { x: number; y: number; w: number; h: number }; png: string | null; name?: string; csv?: string | null }[] }
+const layoutRef = useTemplateRef<{ capturePage: () => Promise<CapturedPage>
+  collectCsvs: () => { name: string; csv: string | null }[] }>('layoutRef')
+const exporting = ref(false)
+const safe = (s: string) => s.replace(/[^\w.-]+/g, '_')
+async function exportPdf() {
+  if (exporting.value || !group.value || !tabs.value.length) return
+  exporting.value = true
+  const original = group.value.activeId
+  try {
+    const pages = []
+    for (const t of tabs.value) {
+      tabsStore.setActive(groupKey, t.id)
+      await nextTick()
+      await new Promise(r => setTimeout(r, 1400))   // let the board's plots fetch + render before capture
+                                                    // (a mid-render WebGL frame exports sparse/blurry)
+      const page = await layoutRef.value?.capturePage?.()
+      if (page) pages.push({ title: t.name, aspect: page.aspect, slots: page.slots })
+    }
+    tabsStore.setActive(groupKey, original)
+    await nextTick()
+    if (pages.length) await exportTabsToPdf(pages, 'analysis.pdf')
+    log.info('Exported analysis boards to PDF.', { source: 'analysis' })
+  } catch (e) {
+    log.error(`PDF export failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'analysis' })
+  } finally { exporting.value = false }
+}
+
+// Export the shown data of every summary plot as one CSV per plot (ready to re-plot in Prism). Same
+// visit-each-tab dance as the PDF (only the active board is mounted); the browser may prompt once to
+// allow multiple downloads.
+async function exportCsv() {
+  if (exporting.value || !group.value || !tabs.value.length) return
+  exporting.value = true
+  const original = group.value.activeId
+  try {
+    let n = 0
+    for (const t of tabs.value) {
+      tabsStore.setActive(groupKey, t.id)
+      await nextTick()
+      await new Promise(r => setTimeout(r, 600))   // let the board's plots fetch before reading their data
+      for (const { name, csv } of layoutRef.value?.collectCsvs?.() ?? []) {
+        if (!csv) continue
+        downloadBlob(`${safe(t.name)}_${safe(name)}.csv`, new Blob([csv], { type: 'text/csv' }))
+        n++
+      }
+    }
+    tabsStore.setActive(groupKey, original)
+    await nextTick()
+    log.info(n ? `Exported ${n} plot CSV${n === 1 ? '' : 's'}.` : 'No summary-plot data to export.', { source: 'analysis' })
+  } catch (e) {
+    log.error(`CSV export failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'analysis' })
+  } finally { exporting.value = false }
+}
+</script>
+
+<template>
+  <div class="tabbed-canvas">
+    <div class="tab-bar" role="tablist">
+      <div
+        v-for="t in tabs" :key="t.id"
+        class="tab" :class="{ active: t.id === activeId }"
+        role="tab" :aria-selected="t.id === activeId"
+        draggable="true"
+        @click="tabsStore.setActive(groupKey, t.id)"
+        @dblclick="startRename(t.id, t.name)"
+        @dragstart="dragId = t.id"
+        @dragover.prevent
+        @drop.prevent="onDrop(t.id)"
+        v-tooltip.bottom="'Double-click to rename · drag to reorder'"
+      >
+        <input
+          v-if="editingId === t.id" class="tab-edit" :value="editText"
+          @input="editText = ($event.target as HTMLInputElement).value"
+          @blur="commitRename" @keydown.enter="commitRename" @keydown.esc="editingId = null"
+          @click.stop :ref="el => (el as HTMLInputElement | null)?.focus()"
+        />
+        <template v-else>
+          <span class="tab-name">{{ t.name }}</span>
+          <button
+            v-if="tabs.length > 1" class="tab-close" type="button"
+            @click.stop="closeTab(t.id)" v-tooltip.bottom="'Close board'" aria-label="Close board"
+          ><i class="pi pi-times" /></button>
+        </template>
+      </div>
+      <button class="tab-add" type="button" @click="addTab" v-tooltip.bottom="'New board'" aria-label="New board">
+        <i class="pi pi-plus" />
+      </button>
+      <button class="tab-pdf" type="button" @click="exportPdf" :disabled="exporting"
+              v-tooltip.bottom="'Export all boards to a multipage PDF (one page per board)'">
+        <i class="pi pi-file-pdf" /> {{ exporting ? 'exporting…' : 'PDF' }}
+      </button>
+      <button class="tab-csv" type="button" @click="exportCsv" :disabled="exporting"
+              v-tooltip.bottom="'Export the shown data of every summary plot as CSV (one file per plot)'">
+        <i class="pi pi-file-excel" /> CSV
+      </button>
+    </div>
+
+    <!-- only the active board is mounted; keyed by its canvas key so a tab switch re-binds the layout -->
+    <LayoutCanvas ref="layoutRef" :key="activeKey" :canvas-key="activeKey" :module="module" :image-uids="imageUids" />
+  </div>
+</template>
+
+<style scoped>
+.tabbed-canvas { display: flex; flex-direction: column; height: 100%; }
+.tab-bar {
+  display: flex; align-items: stretch; gap: 2px; flex-wrap: wrap;
+  border-bottom: 1px solid var(--cc-border); padding: 4px 2px 0; flex-shrink: 0;
+}
+.tab {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; font-size: 12px; cursor: pointer; user-select: none;
+  color: var(--cc-text-dim); background: var(--cc-surface-1);
+  border: 1px solid var(--cc-border); border-bottom: none;
+  border-radius: 6px 6px 0 0; max-width: 16rem;
+}
+.tab:hover { color: var(--cc-text); }
+.tab.active { color: var(--cc-text); background: var(--cc-bg); border-color: #7c3aed; }
+.tab-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tab-edit { font-size: 12px; width: 8rem; background: var(--cc-surface-2); color: var(--cc-text);
+  border: 1px solid #7c3aed; border-radius: 3px; padding: 1px 4px; }
+.tab-close {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 1rem; height: 1rem; border: none; border-radius: 3px;
+  background: transparent; color: var(--cc-text-dim); cursor: pointer; font-size: 0.6rem;
+}
+.tab-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
+.tab-add {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 1.8rem; border: none; background: transparent; color: var(--cc-text-dim);
+  cursor: pointer; font-size: 0.75rem; margin-left: 2px;
+}
+.tab-add:hover { color: var(--cc-text); }
+.tab-pdf { display: inline-flex; align-items: center; gap: 5px; margin-left: auto; margin-bottom: 2px;
+  padding: 3px 10px; font-size: 11px; border: 1px solid var(--cc-border); border-radius: 5px;
+  background: var(--cc-surface-1); color: var(--cc-text-dim); cursor: pointer; }
+.tab-pdf:hover:not(:disabled) { color: var(--cc-text); border-color: #7c3aed; }
+.tab-pdf:disabled { opacity: 0.5; cursor: default; }
+/* CSV sits right next to PDF (PDF already carries the margin-left:auto that pushes the pair right) */
+.tab-csv { display: inline-flex; align-items: center; gap: 5px; margin-left: 4px; margin-bottom: 2px;
+  padding: 3px 10px; font-size: 11px; border: 1px solid var(--cc-border); border-radius: 5px;
+  background: var(--cc-surface-1); color: var(--cc-text-dim); cursor: pointer; }
+.tab-csv:hover:not(:disabled) { color: var(--cc-text); border-color: #7c3aed; }
+.tab-csv:disabled { opacity: 0.5; cursor: default; }
+</style>

--- a/frontend/src/components/canvas/interactiveViews.ts
+++ b/frontend/src/components/canvas/interactiveViews.ts
@@ -1,5 +1,7 @@
 import type { Component } from 'vue'
 import UmapView from '../plots/UmapView.vue'
+import GatingStrategyView from '../plots/GatingStrategyView.vue'
+import ImageStripView from '../plots/ImageStripView.vue'
 
 // Registry of INTERACTIVE plot views (client/WebGL point clouds with per-point interaction, e.g.
 // regl ScatterGL), keyed by a stable view id. This is the counterpart to SUMMARY plots — those are
@@ -17,6 +19,8 @@ export interface InteractiveView {
 
 export const INTERACTIVE_VIEWS: Record<string, InteractiveView> = {
   umap: { label: 'UMAP', component: UmapView },
+  gatingStrategy: { label: 'Gating strategy', component: GatingStrategyView },
+  filmstrip: { label: 'Image / strip', component: ImageStripView },
 }
 
 export const isInteractiveView = (key: string): boolean => key in INTERACTIVE_VIEWS

--- a/frontend/src/components/plots/GateOverlay.vue
+++ b/frontend/src/components/plots/GateOverlay.vue
@@ -21,11 +21,12 @@ type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
 const props = withDefaults(defineProps<{
   extents: Ext                              // LIVE (zoom-synced) view extents
   mode: 'off' | 'rectangle' | 'polygon'
-  gates?: { path: string; colour: string; gate: GateSpec }[]
+  gates?: { path: string; colour: string; gate: GateSpec; label?: string }[]
   viewTick?: number                          // bump → redraw (camera moved)
   lineWidth?: number                         // gate stroke width
   showLabels?: boolean                       // draw the population name on each gate
-}>(), { lineWidth: 1.5, showLabels: false })
+  readonly?: boolean                         // fully static: draw outlines only, never move/resize/draw
+}>(), { lineWidth: 1.5, showLabels: false, readonly: false })
 const emit = defineEmits<{ draw: [Partial<GateSpec>]; edit: [{ path: string; gate: GateSpec }]; cancel: [] }>()
 
 const canvasEl = useTemplateRef<HTMLCanvasElement>('canvasEl')
@@ -140,13 +141,14 @@ function strokeShape(g: GateSpec, colour: string, lw = props.lineWidth) {
   }
   c.stroke()
 }
-// subtle population-name label centred just above the gate's top edge
-function drawGateLabel(g: GateSpec, path: string, colour: string) {
+// subtle population-name label centred just above the gate's top edge. An explicit `label` overrides
+// the derived name (the gating-strategy plot passes "name  pct%").
+function drawGateLabel(g: GateSpec, path: string, colour: string, label?: string) {
   const pts = (g.kind === 'rectangle' ? rectCorners(g) : (g.vertices ?? [])).map(p => dataToPx(p[0], p[1]))
   if (!pts.length) return
   const xs = pts.map(p => p[0]), ys = pts.map(p => p[1])
   const cx = (Math.min(...xs) + Math.max(...xs)) / 2, top = Math.min(...ys)
-  const name = path.split('/').filter(Boolean).pop() ?? ''
+  const name = label ?? (path.split('/').filter(Boolean).pop() ?? '')
   const c = ctx!; c.save()
   c.font = 'bold 12px system-ui, sans-serif'; c.textAlign = 'center'; c.textBaseline = 'bottom'
   c.lineJoin = 'round'; c.lineWidth = 3; c.strokeStyle = 'rgba(0,0,0,0.7)'   // dark halo for legibility
@@ -171,7 +173,7 @@ function paintGates() {
   for (const g of props.gates ?? []) {
     const spec = g.path === editPath && draft.value ? draft.value : g.gate
     strokeShape(spec, g.colour || '#fafafa')
-    if (props.showLabels) drawGateLabel(spec, g.path, g.colour || '#fafafa')
+    if (props.showLabels) drawGateLabel(spec, g.path, g.colour || '#fafafa', g.label)
   }
 }
 function draw() {
@@ -269,6 +271,7 @@ function onEditUp() {
 
 // ── proximity: toggle overlay pointer-events so regl keeps pan/zoom in empty space ──
 function onParentMove(e: MouseEvent) {
+  if (props.readonly) return   // read-only: overlay never becomes interactive (no move/resize)
   if (props.mode !== 'off' || editHandle) return
   const h = hitTest(evtPx(e))
   hover.value = h

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -1,0 +1,159 @@
+<!--
+  The shared scatter+gate PLOT BODY: a WebGL scatter (ScatterGL) + contour/population layer
+  (PlotLayers) + canvas2D gate layer (GateOverlay), with axis lines/ticks/labels and PNG export. This
+  is the ONE gate-scatter renderer — extracted from GatePlotPanel so the read-only gating-strategy plot
+  (Analysis canvas) reuses it instead of forking a second one (feedback_use_existing_framework).
+
+  It renders whatever it's given: the host owns data fetching, axis selection, and gate state. Interactive
+  use (Gate page) passes `mode` = rectangle/polygon and handles @draw/@edit; read-only use (Analysis
+  canvas) passes `mode='off'` so nothing can be drawn or edited. Host-specific overlays (e.g. the gate
+  naming input) go in the default slot (absolutely positioned inside the plot body).
+
+  Exposes `exportImage(bg)` → composites the stacked canvases + HTML/canvas2D overlays to a PNG data URL
+  (each layer re-renders hi-res), so both hosts export identically.
+-->
+<script setup lang="ts">
+import { useTemplateRef } from 'vue'
+import type { GateSpec } from '../../stores/gating'
+import ScatterGL from './ScatterGL.vue'
+import PlotLayers, { type PopLayer } from './PlotLayers.vue'
+import GateOverlay from './GateOverlay.vue'
+import { plotHostToImageURL } from '../../plots/export'
+
+type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
+
+withDefaults(defineProps<{
+  points: Float32Array | null
+  extents: Ext                                   // fixed full-data range (ScatterGL)
+  viewExtents: Ext                               // live (zoom-synced) extents (PlotLayers/GateOverlay/ticks)
+  xTicks: { pos: number; label: string }[]
+  yTicks: { pos: number; label: string }[]
+  gates?: { path: string; colour: string; gate: GateSpec; label?: string }[]   // gate outlines (label overrides name)
+  xLabel: string
+  yLabel: string
+  popLayers?: PopLayer[]                         // coloured child-pop overlays
+  renderMode?: 'points' | 'contour'
+  showPops?: boolean
+  mode?: 'off' | 'rectangle' | 'polygon'         // 'off' = read-only (no draw/edit)
+  gateLineWidth?: number
+  gateLabels?: boolean
+  viewTick?: number
+  loading?: boolean
+  compact?: boolean                              // tight chrome for small montage panels (gating strategy)
+  readonly?: boolean                             // static gates — no move/resize (read-only Analysis canvas)
+}>(), {
+  gates: () => [], popLayers: () => [], renderMode: 'points', showPops: false,
+  mode: 'off', gateLineWidth: 1.5, gateLabels: false, viewTick: 0, loading: false, compact: false, readonly: false,
+})
+const emit = defineEmits<{ draw: [Partial<GateSpec>]; edit: [{ path: string; gate: GateSpec }]; cancel: [] }>()
+
+// ticks positioned against the LIVE view extents so labels track pan/zoom
+const tickX = (pos: number, e: Ext) => `${((pos - e.xMin) / Math.max(1e-9, e.xMax - e.xMin)) * 100}%`
+const tickY = (pos: number, e: Ext) => `${(1 - (pos - e.yMin) / Math.max(1e-9, e.yMax - e.yMin)) * 100}%`
+// abbreviate big numbers (262144 → 262.1k) so axis labels don't crowd; leave small ones as-is
+function fmtTick(label: string): string {
+  const n = parseFloat(label)
+  if (!isFinite(n)) return label
+  const a = Math.abs(n), trim = (s: string) => s.replace(/\.0$/, '')
+  if (a >= 1e9) return trim((n / 1e9).toFixed(1)) + 'G'
+  if (a >= 1e6) return trim((n / 1e6).toFixed(1)) + 'M'
+  if (a >= 1e3) return trim((n / 1e3).toFixed(1)) + 'k'
+  return label
+}
+
+// export: each stacked canvas (WebGL scatter + canvas2D contours/gates) re-renders itself at export
+// scale so nothing is upscaled from the screen-DPR backing store; route each live canvas to its layer.
+const hostEl = useTemplateRef<HTMLElement>('hostEl')
+type LayerExport = { exportCanvas(scale: number): Promise<HTMLCanvasElement | null>; getCanvas(): HTMLCanvasElement | null }
+const scatterRef = useTemplateRef<LayerExport>('scatterRef')
+const layersRef = useTemplateRef<LayerExport>('layersRef')
+const overlayRef = useTemplateRef<LayerExport>('overlayRef')
+const hiRes = async (cv: HTMLCanvasElement, scale: number) => {
+  for (const r of [scatterRef, layersRef, overlayRef]) {
+    if (cv === r.value?.getCanvas()) return (await r.value?.exportCanvas(scale)) ?? null
+  }
+  return null
+}
+// `light` = flip the ink/border vars (via .cc-light) so ticks/axis names read dark on a white ground —
+// used by the PDF export (dark theme is only for on-screen display).
+// The flow scatter is a RASTER, so its export sharpness is set by the scale relative to the on-screen
+// size. A small on-screen plot exports soft — so aim for a fixed ~2200px long side (scale bounded 4–14×)
+// regardless of slot size; regl scales point size with it, keeping the look constant but crisp.
+async function exportImage(bg = '#0d0b1a', light = false): Promise<string | null> {
+  const el = hostEl.value
+  if (light) el?.classList.add('cc-light')
+  const px = el ? Math.max(el.clientWidth, el.clientHeight) : 0
+  const scale = px ? Math.min(14, Math.max(4, Math.ceil(2200 / px))) : undefined
+  try { return await plotHostToImageURL(el, bg, { hiRes, scale }) }
+  finally { if (light) el?.classList.remove('cc-light') }
+}
+// `hiRes` is exposed so a host that captures a LARGER element containing several of these cells (the
+// gating-strategy MONTAGE grid) can still re-render each cell's canvases at export scale — otherwise the
+// montage would composite every subplot at screen resolution.
+defineExpose({ exportImage, hiRes })
+
+// base render look: density for plain points; dim/flat backdrop for contour or pop-colour modes
+function baseColorMode(renderMode: string, showPops: boolean): 'density' | 'flat' {
+  return renderMode === 'points' && !showPops ? 'density' : 'flat'
+}
+</script>
+
+<template>
+  <div ref="hostEl" class="plot-capture" :class="{ compact }">
+    <div class="panel-plot">
+      <ScatterGL ref="scatterRef" :points="points" :extents="extents"
+                 :color-mode="baseColorMode(renderMode, showPops)"
+                 :opacity="renderMode === 'contour' ? 0.22 : showPops ? 0.35 : 1"
+                 :point-size="renderMode === 'contour' ? 2 : 3" />
+      <PlotLayers ref="layersRef" :view-extents="viewExtents" :render-mode="renderMode" :base-points="points"
+                  :pop-layers="popLayers" :show-pops="showPops" :view-tick="viewTick" />
+      <GateOverlay ref="overlayRef" :extents="viewExtents" :mode="mode" :gates="gates" :view-tick="viewTick"
+                   :line-width="gateLineWidth" :show-labels="gateLabels" :readonly="readonly"
+                   @draw="emit('draw', $event)" @edit="emit('edit', $event)" @cancel="emit('cancel')" />
+      <span class="axisline axisline-x" />
+      <span class="axisline axisline-y" />
+      <span v-for="t in xTicks" :key="'x'+t.pos" class="xtick" :style="{ left: tickX(t.pos, viewExtents) }">
+        <span class="xtick-mark" /><span class="xtick-lbl">{{ fmtTick(t.label) }}</span>
+      </span>
+      <span v-for="t in yTicks" :key="'y'+t.pos" class="ytick" :style="{ top: tickY(t.pos, viewExtents) }">
+        <span class="ytick-lbl">{{ fmtTick(t.label) }}</span><span class="ytick-mark" />
+      </span>
+      <span class="axis-x">{{ xLabel }}</span>
+      <span class="axis-y">{{ yLabel }}</span>
+      <div v-if="loading" class="panel-loading">…</div>
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* capture host for PNG export: the axis labels/ticks live in this padding (relative to .panel-plot,
+   at negative offsets), so exporting THIS element — not .panel-plot — includes the x/y axis names
+   instead of clipping them at the edge (#00061). */
+.plot-capture { position: relative; flex: 1; min-height: 218px; min-width: 0; display: flex; box-sizing: border-box;
+  padding: 18px 22px 50px 84px; }
+/* light theme for PDF export (dark theme is on-screen only): dark ink/border on the white ground */
+.plot-capture.cc-light { --cc-text: #111; --cc-text-dim: #555; --cc-border: #c9ccd1; }
+/* compact: tight chrome for small montage squares (gating-strategy) — smaller padding, no min-height,
+   axis names pulled in, tick labels hidden to avoid crowding */
+.plot-capture.compact { min-height: 0; padding: 10px 8px 20px 30px; }
+.plot-capture.compact .axis-x { bottom: -15px; font-size: 10px; }
+.plot-capture.compact .axis-y { left: -24px; font-size: 10px; }
+.plot-capture.compact .xtick-lbl, .plot-capture.compact .ytick-lbl { display: none; }
+/* min-width:0 so this flex-row item can shrink below the scatter canvas's intrinsic width. */
+.panel-plot { position: relative; flex: 1; min-height: 150px; min-width: 0; }
+.axisline { position: absolute; background: var(--cc-border); pointer-events: none; }
+.axisline-x { left: 0; right: 0; bottom: 0; height: 1px; }
+.axisline-y { left: 0; top: 0; bottom: 0; width: 1px; }
+.xtick { position: absolute; bottom: 0; transform: translate(-50%, 100%); display: flex; flex-direction: column; align-items: center; pointer-events: none; }
+.xtick-mark { width: 1px; height: 5px; background: var(--cc-text-dim); }
+.xtick-lbl { margin-top: 3px; font-size: 10px; color: var(--cc-text-dim); white-space: nowrap; }
+.ytick { position: absolute; left: 0; transform: translate(-100%, -50%); display: flex; align-items: center; pointer-events: none; }
+.ytick-mark { width: 5px; height: 1px; background: var(--cc-text-dim); }
+.ytick-lbl { margin-right: 3px; font-size: 10px; color: var(--cc-text-dim); white-space: nowrap; }
+.axis-x { position: absolute; bottom: -40px; left: 50%; transform: translateX(-50%); font-size: 13px; font-weight: 600; color: var(--cc-text); }
+/* vertical text via writing-mode (rotate's origin offsets by half the text width → overlap) */
+.axis-y { position: absolute; left: -66px; top: 50%; transform: translateY(-50%) rotate(180deg);
+  writing-mode: vertical-rl; font-size: 13px; font-weight: 600; color: var(--cc-text); }
+.panel-loading { position: absolute; top: 4px; right: 6px; font-size: 11px; color: var(--cc-text-dim); }
+</style>

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -1,0 +1,359 @@
+<!--
+  Gating-strategy (hierarchy) plot — an interactive VIEW for the Analysis canvas (registered in
+  interactiveViews.ts). READ-ONLY (project_analysis_canvas_readonly): it visualises an existing gating
+  scheme, never edits it. Ports the old R `.flowPlotGatedRaster`: walk the population tree, group each
+  parent's children by their gate's channel-pair, and for each group render the PARENT's cells as a
+  density scatter on those channels with the child gate outlines + "name  pct%" labels — a montage of
+  the whole gating strategy.
+
+  Reuse (feedback_use_existing_framework): each sub-panel is a read-only GateScatterCell (`mode='off'`)
+  — the SAME renderer as the Gate page — fed by the SAME stateless gating routes GatePlotPanel uses
+  (popmap / plotmeta / plotdata / stats). No second gate renderer, no store mutation.
+-->
+<script setup lang="ts">
+import { ref, computed, watch, useTemplateRef, onMounted, onUnmounted } from 'vue'
+import type { GateSpec, TransformSpec, PopNode, PopTree } from '../../stores/gating'
+import { orientGate } from '../../plots/gateGeometry'
+import { plotHostToImageURL } from '../../plots/export'
+import type { VisProps } from '../../plots/plot'
+import GateScatterCell from './GateScatterCell.vue'
+
+const props = defineProps<{
+  projectUid: string; imageUids: string[]; setUid: string | null
+  vis?: VisProps
+  state: { imageUid?: string; valueName?: string; popType?: string; rootPop?: string
+    renderMode?: 'points' | 'contour'; showHierarchy?: boolean }
+}>()
+
+// ── selectors (persisted in the panel state) ─────────────────────────────────────────────────────
+const imageUid = computed(() => (props.state.imageUid && props.imageUids.includes(props.state.imageUid))
+  ? props.state.imageUid : (props.imageUids[0] ?? ''))
+const popType = computed({ get: () => props.state.popType ?? 'flow', set: v => (props.state.popType = v) })
+const valueName = computed({ get: () => props.state.valueName ?? 'default', set: v => (props.state.valueName = v) })
+const rootPop = computed({ get: () => props.state.rootPop ?? 'root', set: v => (props.state.rootPop = v) })
+const renderMode = computed({ get: () => props.state.renderMode ?? 'points', set: v => (props.state.renderMode = v) })
+// DEFAULT: a single plot for the selected population (its defining gate). Toggling "show hierarchy"
+// walks the whole gating tree beneath the selected pop → the full montage (old .flowPlotGatedRaster).
+// Put a gating-strategy view in a 1×1 plate and turn this on to render the full strategy in one slot.
+const showHierarchy = computed({ get: () => props.state.showHierarchy ?? false, set: v => (props.state.showHierarchy = v) })
+// no size control — fit to the slot: the single plot fills it; the montage lays out responsive squares
+// that fit the slot width and wrap (grid columns set in CSS, so nothing to size manually).
+const single = computed(() => panelDefs.value.length === 1)
+const titleFor = (parentPath: string) => (parentPath === 'root' ? 'all events (root)' : parentPath)
+const setImageUid = (v: string) => (props.state.imageUid = v)
+
+// size + the hierarchy toggle live in a ⚙ popover (like the heatmap/state-plot panels) so the bar
+// never widens; close on an outside click.
+const optsOpen = ref(false)
+const optsRef = useTemplateRef<HTMLElement>('optsRef')
+function onDocClick(e: MouseEvent) { if (optsOpen.value && optsRef.value && !optsRef.value.contains(e.target as Node)) optsOpen.value = false }
+onMounted(() => document.addEventListener('mousedown', onDocClick))
+onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
+
+const valueNames = ref<string[]>([])
+// intensity columns + display names (aligned) → resolve raw axis keys (mean_intensity_2) to channel
+// names (CD4), mirroring the gating store's colLabel so axes read the same as on the Gate page.
+const channels = ref<string[]>([])
+const channelNames = ref<string[]>([])
+function colLabel(col: string): string {
+  const i = channels.value.indexOf(col)
+  return i >= 0 && channelNames.value[i] ? channelNames.value[i] : col
+}
+const tree = ref<PopTree | null>(null)
+const loading = ref(false)
+const err = ref('')
+
+// axis-transform → query params (mirrors GatePlotPanel.axisQ; logicle carries its shape)
+function axisQ(p: 'x' | 'y', ts: TransformSpec): string {
+  let q = `&${p}t=${ts.kind}`
+  if (ts.kind === 'logicle') q += `&${p}T=${ts.T ?? 262144}&${p}W=${ts.W ?? 0.5}&${p}M=${ts.M ?? 4.5}&${p}A=${ts.A ?? 0}`
+  return q
+}
+const idQ = () => `projectUid=${props.projectUid}&imageUid=${imageUid.value}&valueName=${encodeURIComponent(valueName.value)}&popType=${popType.value}`
+// x0=1&y0=1 → fixed whole-dataset axis per side, so the parent density + child gates align across panels
+function plotQ(pop: string, xc: string, yc: string, xt: TransformSpec, yt: TransformSpec) {
+  return `${idQ()}&x=${encodeURIComponent(xc)}&y=${encodeURIComponent(yc)}&pop=${encodeURIComponent(pop)}${axisQ('x', xt)}${axisQ('y', yt)}&x0=1&y0=1`
+}
+
+async function loadChannels() {
+  if (!props.projectUid || !imageUid.value) { valueNames.value = []; return }
+  try {
+    const d = await (await fetch(`/api/gating/channels?projectUid=${props.projectUid}&imageUid=${imageUid.value}&popType=${popType.value}`)).json()
+    valueNames.value = d.valueNames ?? []
+    channels.value = d.channels ?? []
+    channelNames.value = d.channelNames ?? []
+    if (valueNames.value.length && !valueNames.value.includes(valueName.value)) valueName.value = valueNames.value[0]
+  } catch { valueNames.value = []; channels.value = []; channelNames.value = [] }
+}
+async function loadTree() {
+  if (!props.projectUid || !imageUid.value) { tree.value = null; return }
+  try {
+    const d = await (await fetch(`/api/gating/popmap?${idQ()}`)).json() as { tree: PopTree }
+    tree.value = d.tree ?? null
+  } catch { tree.value = null }
+}
+
+// flat pop paths (for the "root population" selector)
+const flatPaths = computed<string[]>(() => {
+  const out: string[] = []
+  const walk = (nodes: PopNode[], parent: string) => {
+    for (const n of nodes) { const p = parent === 'root' ? `/${n.name}` : `${parent}/${n.name}`; out.push(p); walk(n.children ?? [], p) }
+  }
+  walk(tree.value?.populations ?? [], 'root')
+  return out
+})
+
+// ── build the panel defs: for each parent, group its gated children by gate channel-pair ──────────
+interface PanelDef { key: string; parentPath: string; parentName: string; xChan: string; yChan: string
+  xt: TransformSpec; yt: TransformSpec; children: { path: string; name: string; colour: string; gate: GateSpec }[] }
+const pairKey = (a: string, b: string) => [a, b].sort().join('~~')
+function childrenAt(root: string): { nodes: PopNode[]; name: string } {
+  if (root === 'root') return { nodes: tree.value?.populations ?? [], name: 'all events' }
+  let found: PopNode | null = null
+  const walk = (nodes: PopNode[], parent: string) => {
+    for (const n of nodes) { const p = parent === 'root' ? `/${n.name}` : `${parent}/${n.name}`; if (p === root) found = n; else walk(n.children ?? [], p) }
+  }
+  walk(tree.value?.populations ?? [], 'root')
+  const f = found as PopNode | null
+  return { nodes: f?.children ?? [], name: f?.name ?? root }
+}
+// one LEVEL: group a parent's directly-gated children by their gate channel-pair → one panel each
+function groupsAt(parentPath: string, parentName: string, nodes: PopNode[]): PanelDef[] {
+  const acc: PanelDef[] = []
+  const groups = new Map<string, PopNode[]>()
+  for (const n of nodes) if (n.gate) {
+    const k = pairKey(n.gate.x_channel, n.gate.y_channel)
+    ;(groups.get(k) ?? (groups.set(k, []), groups.get(k)!)).push(n)
+  }
+  for (const [k, group] of groups) {
+    const g0 = group[0].gate!
+    acc.push({
+      key: `${parentPath}::${k}`, parentPath, parentName,
+      xChan: g0.x_channel, yChan: g0.y_channel, xt: g0.x_transform, yt: g0.y_transform,
+      children: group.map(n => {
+        const path = parentPath === 'root' ? `/${n.name}` : `${parentPath}/${n.name}`
+        return { path, name: n.name, colour: n.colour, gate: orientGate(n.gate!, g0.x_channel, g0.y_channel) ?? n.gate! }
+      }),
+    })
+  }
+  return acc
+}
+// locate a node by path AND its parent context (for the single defining-gate plot)
+function nodeWithParent(target: string): { node: PopNode; parentPath: string; parentName: string } | null {
+  let res: { node: PopNode; parentPath: string; parentName: string } | null = null
+  const walk = (nodes: PopNode[], parentPath: string, parentName: string) => {
+    for (const n of nodes) {
+      const p = parentPath === 'root' ? `/${n.name}` : `${parentPath}/${n.name}`
+      if (p === target) res = { node: n, parentPath, parentName }
+      else walk(n.children ?? [], p, n.name)
+    }
+  }
+  walk(tree.value?.populations ?? [], 'root', 'all events')
+  return res
+}
+// FULL montage: recurse the tree beneath the selected pop, a panel per parent×channel-pair
+const hierarchyDefs = computed<PanelDef[]>(() => {
+  const acc: PanelDef[] = []
+  const collect = (parentPath: string, parentName: string, nodes: PopNode[]) => {
+    acc.push(...groupsAt(parentPath, parentName, nodes))
+    for (const n of nodes) {
+      const path = parentPath === 'root' ? `/${n.name}` : `${parentPath}/${n.name}`
+      collect(path, n.name, n.children ?? [])
+    }
+  }
+  const start = childrenAt(rootPop.value)
+  collect(rootPop.value, start.name, start.nodes)
+  return acc
+})
+// SINGLE plot: the plot that DEFINES the selected pop (its parent's density + this pop's own gate).
+// For root / an ungated pop, fall back to the first gated group directly beneath it.
+const singleDef = computed<PanelDef | null>(() => {
+  const rp = rootPop.value
+  if (rp !== 'root') {
+    const nw = nodeWithParent(rp)
+    if (nw?.node.gate) {
+      const g0 = nw.node.gate
+      return {
+        key: `single::${rp}`, parentPath: nw.parentPath, parentName: nw.parentName,
+        xChan: g0.x_channel, yChan: g0.y_channel, xt: g0.x_transform, yt: g0.y_transform,
+        children: [{ path: rp, name: nw.node.name, colour: nw.node.colour,
+                     gate: orientGate(g0, g0.x_channel, g0.y_channel) ?? g0 }],
+      }
+    }
+  }
+  const start = childrenAt(rp)
+  return groupsAt(rp, start.name, start.nodes)[0] ?? null
+})
+const panelDefs = computed<PanelDef[]>(() =>
+  showHierarchy.value ? hierarchyDefs.value : (singleDef.value ? [singleDef.value] : []))
+
+// ── fetch parent density + child stats per panel ─────────────────────────────────────────────────
+type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
+interface PanelData { points: Float32Array; extents: Ext; xTicks: { pos: number; label: string }[]
+  yTicks: { pos: number; label: string }[]; gates: { path: string; colour: string; gate: GateSpec; label: string }[] }
+const panelData = ref<Record<string, PanelData>>({})
+let loadTok = 0
+
+async function loadPanels() {
+  const defs = panelDefs.value
+  if (!defs.length) { panelData.value = {}; return }
+  const tok = ++loadTok
+  loading.value = true; err.value = ''
+  try {
+    const entries = await Promise.all(defs.map(async d => {
+      const q = plotQ(d.parentPath, d.xChan, d.yChan, d.xt, d.yt)
+      const meta = await (await fetch(`/api/gating/plotmeta?${q}`)).json() as {
+        xExtent: [number, number]; yExtent: [number, number]
+        xTicks: { pos: number; label: string }[]; yTicks: { pos: number; label: string }[] }
+      const points = new Float32Array(await (await fetch(`/api/gating/plotdata?${q}`)).arrayBuffer())
+      const gates = await Promise.all(d.children.map(async c => {
+        let label = c.name
+        try {
+          const s = await (await fetch(`/api/gating/stats?${idQ()}&pop=${encodeURIComponent(c.path)}`)).json() as { pctParent?: number }
+          // pctParent is ALREADY a percentage (backend pop_stats: 100 * cnt / pcnt) — don't ×100 again
+          if (typeof s.pctParent === 'number') label = `${c.name}  ${s.pctParent.toFixed(1)}%`
+        } catch { /* keep bare name */ }
+        return { path: c.path, colour: c.colour, gate: c.gate, label }
+      }))
+      const extents: Ext = { xMin: meta.xExtent[0], xMax: meta.xExtent[1], yMin: meta.yExtent[0], yMax: meta.yExtent[1] }
+      return [d.key, { points, extents, xTicks: meta.xTicks, yTicks: meta.yTicks, gates }] as const
+    }))
+    if (tok === loadTok) panelData.value = Object.fromEntries(entries)
+  } catch (e) {
+    if (tok === loadTok) { err.value = e instanceof Error ? e.message : String(e); panelData.value = {} }
+  } finally { if (tok === loadTok) loading.value = false }
+}
+
+watch([imageUid, popType], () => { loadChannels().then(loadTree) }, { immediate: true })
+watch([valueName], loadTree)
+watch(panelDefs, loadPanels, { immediate: true })
+
+// ── PDF export: a plot-only, LIGHT-theme image (no toolbar). Single plot → the one cell's hi-res
+// composite on white; montage → snapshot the grid on white with dark ink (`cc-light` flips the vars).
+const gsGridRef = useTemplateRef<HTMLElement>('gsGridRef')
+type CellExport = {
+  exportImage(bg?: string, light?: boolean): Promise<string | null>
+  hiRes(cv: HTMLCanvasElement, scale: number): Promise<CanvasImageSource | null>
+}
+const cellRefs = new Map<string, CellExport>()
+function setCellRef(key: string, el: unknown) { if (el) cellRefs.set(key, el as CellExport); else cellRefs.delete(key) }
+async function exportImage(): Promise<string | null> {
+  const defs = panelDefs.value
+  if (defs.length === 1) return (await cellRefs.get(defs[0].key)?.exportImage('#ffffff', true)) ?? null
+  // MONTAGE: capture the whole grid (titles + axes via the DOM overlay) but re-render each cell's canvases
+  // at export scale — a combined resolver routes each canvas to its owning cell's hiRes (else the whole
+  // montage would composite at screen resolution → soft).
+  const el = gsGridRef.value
+  if (!el) return null
+  const cells = [...cellRefs.values()]
+  const hiRes = async (cv: HTMLCanvasElement, scale: number) => {
+    for (const c of cells) { const r = await c.hiRes?.(cv, scale); if (r) return r }
+    return null
+  }
+  const scale = Math.min(8, Math.max(4, Math.ceil(2800 / (el.clientWidth || 500))))
+  el.classList.add('cc-light')
+  try { return await plotHostToImageURL(el, '#ffffff', { hiRes, scale }) } finally { el.classList.remove('cc-light') }
+}
+defineExpose({ exportImage })
+</script>
+
+<template>
+  <div class="gs-view">
+    <div class="gs-bar">
+      <select v-if="imageUids.length > 1" :value="imageUid" @change="setImageUid(($event.target as HTMLSelectElement).value)"
+              v-tooltip.bottom="'Image'">
+        <option v-for="u in imageUids" :key="u" :value="u">{{ u }}</option>
+      </select>
+      <select v-model="popType" v-tooltip.bottom="'Population type'">
+        <option value="flow">flow</option>
+        <option value="live">live</option>
+      </select>
+      <select v-if="valueNames.length" v-model="valueName" v-tooltip.bottom="'Segmentation'">
+        <option v-for="v in valueNames" :key="v" :value="v">{{ v }}</option>
+      </select>
+      <select v-model="rootPop" v-tooltip.bottom="'Start from this population'">
+        <option value="root">root</option>
+        <option v-for="p in flatPaths" :key="p" :value="p">{{ p }}</option>
+      </select>
+      <div class="seg" v-tooltip.bottom="'Render: points / density contour'">
+        <button :class="{ on: renderMode === 'points' }" @click="renderMode = 'points'"><i class="pi pi-circle-fill" /></button>
+        <button :class="{ on: renderMode === 'contour' }" @click="renderMode = 'contour'"><i class="pi pi-chart-line" /></button>
+      </div>
+      <div ref="optsRef" class="gs-opts">
+        <button class="gs-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+                v-tooltip.bottom="'Plot size & hierarchy'"><i class="pi pi-cog" /></button>
+        <div v-if="optsOpen" class="gs-pop">
+          <label class="gs-check"><input type="checkbox" :checked="showHierarchy"
+                 @change="showHierarchy = ($event.target as HTMLInputElement).checked" />
+            show gating hierarchy</label>
+        </div>
+      </div>
+    </div>
+
+    <div ref="gsGridRef" class="gs-grid" :class="{ single }">
+      <div v-if="err" class="gs-msg">{{ err }}</div>
+      <div v-else-if="!panelDefs.length" class="gs-msg">
+        No gate to show for “{{ rootPop }}”.
+        {{ showHierarchy ? 'No gated populations beneath it — draw gates on the Gate page first.'
+                         : 'Select a gated population, or draw gates on the Gate page first.' }}
+      </div>
+      <div v-for="d in panelDefs" :key="d.key" class="gs-cell">
+        <div class="gs-title" v-tooltip.top="`derived from ${titleFor(d.parentPath)}`">{{ titleFor(d.parentPath) }}</div>
+        <GateScatterCell v-if="panelData[d.key]" class="gs-plot" :ref="el => setCellRef(d.key, el)"
+                         :points="panelData[d.key].points" :extents="panelData[d.key].extents"
+                         :view-extents="panelData[d.key].extents"
+                         :x-ticks="panelData[d.key].xTicks" :y-ticks="panelData[d.key].yTicks"
+                         :gates="panelData[d.key].gates" :x-label="colLabel(d.xChan)" :y-label="colLabel(d.yChan)"
+                         :render-mode="renderMode" mode="off" :gate-labels="true" :compact="!single" :readonly="true" />
+        <div v-else class="gs-loading">…</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.gs-view { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+.gs-bar { display: flex; align-items: center; gap: 6px; padding: 6px 8px; flex-wrap: wrap; flex-shrink: 0;
+  border-bottom: 1px solid var(--cc-border); font-size: 12px; }
+.gs-bar select { font-size: 12px; max-width: 9rem; }
+/* fit to the slot — no size control. Montage: responsive squares that fill the slot width and wrap
+   (scroll if many). Single: one cell that fills the whole slot. */
+.gs-grid { flex: 1; min-height: 0; overflow-y: auto; padding: 6px; display: grid; gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); align-content: start; }
+.gs-grid.single { grid-template-columns: 1fr; grid-template-rows: 1fr; overflow: hidden; }
+/* light theme for PDF export: flip the ink/border vars so titles + axes read dark on white */
+.gs-grid.cc-light { --cc-text: #111; --cc-text-dim: #555; --cc-border: #c9ccd1; --cc-bg: #fff; --cc-surface-2: #f0f0f3; }
+.gs-cell { display: flex; flex-direction: column; min-height: 0; border: 1px solid var(--cc-border);
+  border-radius: 5px; overflow: hidden; background: var(--cc-bg); }
+/* montage: the plot area is SQUARE. Cap the width so a wide column doesn't make the square so TALL that
+   its bottom (the x-axis label) drops past the slot; centred when narrower than the column. */
+.gs-plot { flex: none; width: 100%; max-width: 320px; aspect-ratio: 1; margin: 0 auto; }
+/* single: keep the square aspect ratio but fit the slot — the largest square that fits the cell's
+   min(width, height − title), centred horizontally (title bar stays full-width). */
+.gs-grid.single .gs-cell { container-type: size; }
+/* min-height:0 overrides GateScatterCell's 218px floor so the square can shrink to fit a small slot */
+.gs-grid.single .gs-plot { flex: none; aspect-ratio: 1; min-height: 0; max-width: none;
+  width: min(100cqw, calc(100cqh - 26px)); margin: 0 auto; }
+/* ⚙ options popover (size + hierarchy toggle). margin-left:auto pins the gear to the far right of the
+   toolbar (even when it wraps to its own row), so the popover — anchored right:0 — always opens LEFTWARD
+   into the panel and is never clipped at the left edge. */
+.gs-opts { position: relative; display: inline-flex; margin-left: auto; }
+.gs-gear { background: var(--cc-surface-2); color: var(--cc-text-dim); border: 1px solid var(--cc-border);
+  border-radius: 5px; padding: 4px 8px; cursor: pointer; font-size: 12px; }
+.gs-gear.on { background: var(--cc-accent); color: #fff; border-color: var(--cc-accent); }
+/* opens leftward into the panel from the (right-pinned) gear; kept narrow so it fits a small slot */
+.gs-pop { position: absolute; top: calc(100% + 4px); right: 0; z-index: 20; width: 13rem;
+  display: flex; flex-direction: column; gap: 8px; padding: 10px; background: var(--cc-surface-1);
+  border: 1px solid var(--cc-border); border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,0.35); }
+.gs-check { display: flex; align-items: center; gap: 6px; color: var(--cc-text); font-size: 12px; }
+/* flex-shrink:0 so the title bar can never be squeezed to nothing by the plot in a short/constrained
+   cell (it's a flex-column child alongside the plot) */
+.gs-title { flex-shrink: 0; font-size: 11px; font-weight: 700; padding: 3px 6px; color: var(--cc-text-dim);
+  border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.gs-loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--cc-text-dim); }
+.gs-msg { grid-column: 1 / -1; padding: 16px; color: var(--cc-text-dim); font-size: 13px; }
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 4px 8px; cursor: pointer; font-size: 12px; }
+.seg button + button { border-left: 1px solid var(--cc-border); }
+.seg button.on { background: var(--cc-accent); color: #fff; }
+</style>

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -1,0 +1,222 @@
+<!--
+  Image / filmstrip slot for the Analysis canvas (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase D). One
+  slot holding N captioned images (a single image = a 1-cell strip) — for pipeline montages
+  (raw → denoised → segmented → tracked). Each cell's image is a napari CANVAS screenshot
+  (POST /api/napari/screenshot → PNG bytes → stored as a data URL in the slot state, so it persists and
+  embeds straight into the PDF). Orientation H/V; separators STRAIGHT (gap + rule) or ANGLED (clip-path
+  parallelograms — cheap because the slot stays rectangular and holds image-only content, decision 10).
+-->
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef, nextTick } from 'vue'
+import { elementToImageURL } from '../../plots/export'
+
+interface Cell { src?: string; caption?: string }
+const props = defineProps<{
+  projectUid: string; imageUids: string[]; setUid: string | null
+  state: { cells?: Cell[]; orientation?: 'h' | 'v'; separator?: 'straight' | 'angled'; sepAngle?: number; sepThick?: number; capSize?: number }
+}>()
+
+// seed defaults into the persisted state bag (the slot starts as {})
+if (!props.state.cells) props.state.cells = [{}]
+if (!props.state.orientation) props.state.orientation = 'h'
+if (!props.state.separator) props.state.separator = 'straight'
+
+const cells = computed(() => props.state.cells!)
+const orientation = computed({ get: () => props.state.orientation ?? 'h', set: v => (props.state.orientation = v) })
+const separator = computed({ get: () => props.state.separator ?? 'straight', set: v => (props.state.separator = v) })
+// angled separators: `skew` = the horizontal lean (angle), `thick` = the white gap width between frames
+const skew = computed({ get: () => props.state.sepAngle ?? 22, set: v => (props.state.sepAngle = v) })
+const thick = computed({ get: () => props.state.sepThick ?? 2, set: v => (props.state.sepThick = v) })
+// caption text size (px) — driven into the caption overlay via a CSS var
+const capSize = computed({ get: () => props.state.capSize ?? 13, set: v => (props.state.capSize = v) })
+// angled separators are horizontal-only (the clip leans across the row) — snap back to straight if the
+// strip is switched to vertical.
+watch(orientation, o => { if (o === 'v' && separator.value === 'angled') separator.value = 'straight' })
+
+// separator options (angle / width) live in a ⚙ popover (like the heatmap panel's options) so they
+// never widen the toolbar; close on an outside click.
+const optsOpen = ref(false)
+const optsRef = useTemplateRef<HTMLElement>('optsRef')
+function onDocClick(e: MouseEvent) { if (optsOpen.value && optsRef.value && !optsRef.value.contains(e.target as Node)) optsOpen.value = false }
+onMounted(() => document.addEventListener('mousedown', onDocClick))
+onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
+
+const capturing = ref(-1)
+const err = ref('')
+
+function toDataUrl(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf)
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return 'data:image/png;base64,' + btoa(bin)
+}
+
+// capture the current napari canvas into cell i
+async function capture(i: number) {
+  capturing.value = i
+  err.value = ''
+  try {
+    const res = await fetch('/api/napari/screenshot', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid: props.projectUid }),
+    })
+    if (!res.ok) { err.value = ((await res.json().catch(() => ({}))) as { error?: string }).error ?? 'Screenshot failed'; return }
+    cells.value[i].src = toDataUrl(await res.arrayBuffer())
+  } catch (e) { err.value = e instanceof Error ? e.message : String(e) }
+  finally { capturing.value = -1 }
+}
+function addCell() { cells.value.push({}) }
+function removeCell(i: number) { if (cells.value.length > 1) cells.value.splice(i, 1) }
+function setCaption(i: number, v: string) { cells.value[i].caption = v }
+
+// angled separators: clip each frame to a parallelogram leaning by `skew`; the WHITE strip background
+// shows through the `thick` gap between frames as the diagonal separator line. First/last frames keep
+// their outer edge square. Horizontal strip only (the common montage); vertical stays straight.
+function clipFor(i: number): string | undefined {
+  if (separator.value !== 'angled' || orientation.value !== 'h' || cells.value.length < 2) return undefined
+  const first = i === 0, last = i === cells.value.length - 1
+  const s = `${skew.value}px`
+  const tl = first ? '0' : s
+  const br = last ? '100%' : `calc(100% - ${s})`
+  return `polygon(${tl} 0, 100% 0, ${br} 100%, 0 100%)`
+}
+const stripStyle = computed(() => ({
+  '--cap-size': `${capSize.value}px`,
+  ...((separator.value === 'angled' && orientation.value === 'h')
+    ? { '--sk': `${skew.value}px`, '--sep-thick': `${thick.value}px` } : {}),
+}))
+
+// PDF export: just the STRIP (frames + captions), no toolbar/per-frame buttons. The `capturing` class
+// hides the in-frame controls; the strip is HTML + <img> (data URLs), so serialise via elementToImageURL.
+const stripRef = useTemplateRef<HTMLElement>('stripRef')
+const capturingStrip = ref(false)
+async function exportImage(): Promise<string | null> {
+  capturingStrip.value = true
+  await nextTick()
+  try { return await elementToImageURL(stripRef.value, 'png', '#ffffff') }
+  finally { capturingStrip.value = false }
+}
+defineExpose({ exportImage })
+</script>
+
+<template>
+  <div class="is-view">
+    <div class="is-bar">
+      <div class="seg" v-tooltip.bottom="'Strip direction'">
+        <button :class="{ on: orientation === 'h' }" @click="orientation = 'h'"><i class="pi pi-arrows-h" /></button>
+        <button :class="{ on: orientation === 'v' }" @click="orientation = 'v'"><i class="pi pi-arrows-v" /></button>
+      </div>
+      <div class="seg" v-tooltip.bottom="'Separator style'">
+        <button :class="{ on: separator === 'straight' }" @click="separator = 'straight'">straight</button>
+        <button :class="{ on: separator === 'angled' }" :disabled="orientation === 'v'"
+                @click="separator = 'angled'"
+                v-tooltip.bottom="orientation === 'v' ? 'Angled separators are horizontal-only' : ''">angled</button>
+      </div>
+      <div ref="optsRef" class="is-opts">
+        <button class="is-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+                v-tooltip.bottom="'Caption size & separator'"><i class="pi pi-cog" /></button>
+        <div v-if="optsOpen" class="is-pop">
+          <label class="is-slider">caption
+            <input type="range" min="8" max="28" :value="capSize" @input="capSize = +($event.target as HTMLInputElement).value" />
+            <span class="is-val">{{ capSize }}</span></label>
+          <template v-if="separator === 'angled' && orientation === 'h'">
+            <label class="is-slider">angle
+              <input type="range" min="0" max="80" :value="skew" @input="skew = +($event.target as HTMLInputElement).value" />
+              <span class="is-val">{{ skew }}</span></label>
+            <label class="is-slider">width
+              <input type="range" min="1" max="12" :value="thick" @input="thick = +($event.target as HTMLInputElement).value" />
+              <span class="is-val">{{ thick }}</span></label>
+          </template>
+        </div>
+      </div>
+      <button class="is-btn" @click="addCell" v-tooltip.bottom="'Add a frame'"><i class="pi pi-plus" /> frame</button>
+      <span v-if="err" class="is-err">{{ err }}</span>
+    </div>
+
+    <div ref="stripRef" class="is-strip" :class="[orientation === 'h' ? 'row' : 'col', separator, { capturing: capturingStrip }]" :style="stripStyle">
+      <div v-for="(c, i) in cells" :key="i" class="is-cell" :style="{ clipPath: clipFor(i) }">
+        <img v-if="c.src" :src="c.src" class="is-img" alt="napari screenshot" />
+        <button v-else class="is-capture" @click="capture(i)" :disabled="capturing === i"
+                v-tooltip.bottom="'Capture the current napari view'">
+          <i class="pi pi-camera" /> {{ capturing === i ? 'capturing…' : 'napari view' }}
+        </button>
+        <!-- caption: white centred text overlaid on the image (editable inline; plain text while
+             capturing since an <input>'s live value isn't cloned into the export) -->
+        <div class="is-cap">
+          <span v-if="capturingStrip" class="is-cap-text">{{ c.caption ?? '' }}</span>
+          <input v-else class="is-cap-input" :value="c.caption ?? ''" placeholder="caption…"
+                 @input="setCaption(i, ($event.target as HTMLInputElement).value)" />
+        </div>
+        <!-- per-frame actions (hidden while capturing) -->
+        <div v-if="!capturingStrip" class="is-actions">
+          <button v-if="c.src" class="is-mini" @click="capture(i)" v-tooltip.top="'Recapture'"><i class="pi pi-camera" /></button>
+          <button v-if="cells.length > 1" class="is-mini" @click="removeCell(i)" v-tooltip.top="'Remove frame'"><i class="pi pi-times" /></button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.is-view { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+/* angle/width live in a ⚙ popover (below), so the bar stays short and never wraps */
+.is-bar { display: flex; align-items: center; gap: 8px; padding: 6px 8px; flex-wrap: wrap; flex-shrink: 0;
+  border-bottom: 1px solid var(--cc-border); font-size: 12px; }
+.is-opts { position: relative; display: inline-flex; }
+.is-gear { display: inline-flex; align-items: center; justify-content: center; width: 1.7rem; height: 1.6rem;
+  border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-2); color: var(--cc-text-dim);
+  cursor: pointer; font-size: 0.72rem; }
+.is-gear:hover, .is-gear.on { color: var(--cc-text); border-color: #7c3aed; }
+.is-pop { position: absolute; top: calc(100% + 4px); left: 0; z-index: 30; display: flex; flex-direction: column; gap: 6px;
+  padding: 8px 10px; background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 6px;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.4); }
+.is-val { min-width: 1.2rem; text-align: right; font-weight: 700; color: var(--cc-text); }
+.is-err { color: #fca5a5; font-size: 11px; }
+.is-slider { display: inline-flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: 11px; }
+.is-slider input[type="range"] { width: 4.5rem; }
+.is-strip { flex: 1; min-height: 0; display: flex; padding: 6px; gap: 0; overflow: auto; }
+.is-strip.col { flex-direction: column; }
+/* straight: no box around each frame — just a thin rule BETWEEN frames */
+.is-strip.straight.row .is-cell + .is-cell { border-left: 1px solid var(--cc-border); }
+.is-strip.straight.col .is-cell + .is-cell { border-top: 1px solid var(--cc-border); }
+/* angled: frames overlap by (skew − thickness) so the white strip background shows through as a diagonal
+   line whose width is EXACTLY --sep-thick, independent of the angle (--sk). */
+/* padding:0 here — the base 6px padding + white bg would draw a white frame around the whole strip;
+   in angled mode white must ONLY show through the diagonal gaps between frames */
+.is-strip.angled.row { gap: 0; background: #fff; padding: 0; }
+.is-strip.angled.row .is-cell { border: none; border-radius: 0; background: transparent; }
+.is-strip.angled.row .is-cell + .is-cell { margin-left: calc(var(--sep-thick, 2px) - var(--sk, 22px)); }
+.is-cell { position: relative; flex: 1; min-width: 0; min-height: 120px; display: flex; flex-direction: column;
+  overflow: hidden; background: var(--cc-bg); }
+/* cover (not contain) so the frame fills edge-to-edge — no black letterbox "border" around the image */
+.is-img { flex: 1; width: 100%; object-fit: cover; min-height: 0; }
+.is-capture { flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px;
+  border: 1px dashed var(--cc-border); background: transparent; color: var(--cc-text-dim); cursor: pointer; font-size: 12px; }
+.is-capture:hover { color: var(--cc-text); border-color: #7c3aed; }
+/* caption overlay: white, centred, near the bottom of the image (legible via text-shadow) */
+.is-cap { position: absolute; left: 0; right: 0; bottom: 8px; display: flex; justify-content: center;
+  padding: 0 10px; pointer-events: none; }
+.is-cap-input, .is-cap-text { pointer-events: auto; max-width: 100%; text-align: center; color: #fff;
+  font-size: var(--cap-size, 13px); font-weight: 600; text-shadow: 0 1px 4px rgba(0,0,0,0.9); }
+.is-cap-input { width: 100%; background: transparent; border: none; border-radius: 3px; padding: 1px 4px; }
+.is-cap-input:focus { outline: none; background: rgba(0,0,0,0.35); }
+.is-cap-input::placeholder { color: rgba(255,255,255,0.55); font-weight: 400; }
+.is-cap-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* per-frame actions, top-right corner over the image */
+.is-actions { position: absolute; top: 4px; right: 4px; display: flex; gap: 4px; }
+.is-mini { width: 1.4rem; height: 1.4rem; display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid var(--cc-border); border-radius: 3px; background: rgba(0,0,0,0.45); color: #fff;
+  cursor: pointer; font-size: 0.6rem; }
+.is-mini:hover { background: rgba(0,0,0,0.7); }
+/* while capturing for the PDF: hide the per-frame buttons (and empty-frame capture prompts) so the
+   exported strip is just the images + captions */
+.is-strip.capturing .is-mini, .is-strip.capturing .is-capture { display: none; }
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 4px 8px; cursor: pointer; font-size: 11px; }
+.seg button + button { border-left: 1px solid var(--cc-border); }
+.seg button.on { background: var(--cc-accent); color: #fff; }
+.seg button:disabled { opacity: 0.4; cursor: not-allowed; }
+.is-btn { display: inline-flex; align-items: center; gap: 4px; background: var(--cc-surface-2); color: var(--cc-text-dim);
+  border: 1px solid var(--cc-border); border-radius: 4px; padding: 3px 8px; cursor: pointer; font-size: 11px; }
+.is-btn:hover { color: var(--cc-text); }
+</style>

--- a/frontend/src/components/plots/PlotChart.vue
+++ b/frontend/src/components/plots/PlotChart.vue
@@ -65,9 +65,21 @@ const hostBg = computed(() => (props.opts?.darkTheme ? '#1f2226' : 'white'))
 
 // expose image export to the host panel (shared helper — see plots/export.ts). SVG = native
 // serialisation (crisp); PNG = rasterise onto a 2× canvas over white.
-defineExpose({
-  toImageURL: (type: 'png' | 'svg') => svgToImageURL(svgOf(node as Element | null), type),
-})
+// `light` = build a one-off LIGHT-theme node (dark ink on white) for PDF export, without disturbing the
+// on-screen (dark-theme) chart — dark theme is only for webpage display. Legend/title overlays are HTML
+// (not in the SVG), so — as with the existing per-plot PNG export — they're omitted from the image.
+async function toImageURL(type: 'png' | 'svg', light = false): Promise<string | null> {
+  if (!light) return svgToImageURL(svgOf(node as Element | null), type)
+  if (!host.value) return null
+  if (!Plot) Plot = await import('@observablehq/plot')
+  const base = props.data ? buildPlotOptions(Plot, props.data, { ...props.opts, darkTheme: false }) as any : null   // eslint-disable-line @typescript-eslint/no-explicit-any
+  if (!base) return null
+  const w = Math.max(160, host.value.clientWidth || 320)
+  const h = Math.max(140, host.value.clientHeight || 260)
+  const off = Plot.plot({ ...base, width: w, height: h }) as SVGElement
+  return svgToImageURL(svgOf(off as unknown as Element), type)
+}
+defineExpose({ toImageURL })
 
 watch(() => [props.data, props.opts], render, { deep: true })
 onMounted(() => {

--- a/frontend/src/components/plots/ScatterGL.vue
+++ b/frontend/src/components/plots/ScatterGL.vue
@@ -174,7 +174,15 @@ async function render() {
   // and stay blank until some later event (changing a dropdown) forced a redraw. Cheap no-op when
   // the size is unchanged.
   resize()
+  await drawCurrent(1)
+}
+
+// draw the current encoding (density / category / flat). `pointMult` scales the point size — the export
+// path enlarges the backing store by `scale`, so points must grow by the same factor to keep the look.
+async function drawCurrent(pointMult = 1) {
+  if (!scatterplot) return
   const { x, y } = xy()
+  const ps = props.pointSize * pointMult
   if (props.colorMode === 'category' && x.length && (props.palette?.length ?? 0) > 0) {
     // colour-by-category (e.g. cluster on a UMAP): map each point's palette index → [0,1] so regl
     // picks pointColor[index]. The caller supplies one palette slot per category (incl. unclustered).
@@ -183,13 +191,13 @@ async function render() {
     const denom = Math.max(1, pal.length - 1)
     const v = new Float32Array(x.length)
     for (let i = 0; i < x.length; i++) v[i] = (cats[i] ?? 0) / denom
-    scatterplot.set({ colorBy: 'valueA', pointColor: pal, opacity: props.opacity, pointSize: props.pointSize })
+    scatterplot.set({ colorBy: 'valueA', pointColor: pal, opacity: props.opacity, pointSize: ps })
     await scatterplot.draw({ x, y, valueA: v })
   } else if (props.colorMode === 'density' && x.length) {
-    scatterplot.set({ colorBy: 'valueA', pointColor: RAMP, opacity: props.opacity, pointSize: props.pointSize })
+    scatterplot.set({ colorBy: 'valueA', pointColor: RAMP, opacity: props.opacity, pointSize: ps })
     await scatterplot.draw({ x, y, valueA: density() })
   } else {
-    scatterplot.set({ colorBy: null, pointColor: props.flatColor, opacity: props.opacity, pointSize: props.pointSize })
+    scatterplot.set({ colorBy: null, pointColor: props.flatColor, opacity: props.opacity, pointSize: ps })
     await scatterplot.draw({ x, y })
   }
 }
@@ -200,43 +208,36 @@ function resize() {
   scatterplot.set({ width: w, height: h, aspectRatio: aspect() })
 }
 
-// hi-res export: regl-scatterplot re-renders the point cloud at `scale`× (its on-screen backing
-// store is only CSS×DPR, so compositing the live canvas upscales → pixelated). Returns an offscreen
-// canvas at the higher resolution for the export compositor to draw crisply. See plots/export.ts.
-// We render on a TRANSPARENT ground (not the opaque backgroundColor) so the export is points-only —
-// it composites over the host's ground fill without a second opaque layer hiding the cloud, and
-// works the same for the gate plot (navy fill) and UMAP (themed fill). Falls back to null (→ the
-// compositor draws the live canvas) if the re-render fails, so points always appear.
+// hi-res export: enlarge the BACKING STORE by `scale`× and redraw, so the point cloud is captured at
+// high resolution (the on-screen backing is only CSS×DPR → compositing the live canvas upscales →
+// pixelated). We DON'T use regl's own `export({scale})`: it drops our custom `aspectRatio` on its
+// internal resize, so the fixed-camera gate scatter renders off-clip and returns a blank frame (hence
+// the old screen-res-snapshot fallback that looked soft). Instead we resize the canvas ourselves,
+// KEEPING aspectRatio, hold the on-screen DISPLAY size (so there's no visible jump), redraw on a
+// transparent ground (points-only → composites over the host fill), snapshot, then restore.
 async function exportCanvas(scale: number): Promise<HTMLCanvasElement | null> {
   if (!scatterplot || !canvasEl.value) return null
-  // Snapshot the current on-screen frame FIRST. regl-scatterplot blits its WebGL output into this 2D
-  // user canvas, so it always holds exactly what's on screen (points + background). This is the
-  // guaranteed fallback: `export()` can throw or blank (observed on the gate scatter) and leave the
-  // live canvas mid-resize, so we must copy it BEFORE calling export.
   const live = canvasEl.value
-  const snap = document.createElement('canvas'); snap.width = live.width; snap.height = live.height
-  snap.getContext('2d')?.drawImage(live, 0, 0)
+  const { w, h } = box()
+  // guaranteed fallback: the current on-screen frame (screen resolution)
+  const fallback = document.createElement('canvas'); fallback.width = live.width; fallback.height = live.height
+  fallback.getContext('2d')?.drawImage(live, 0, 0)
+  const cssW = live.style.width, cssH = live.style.height
   try {
-    // hi-res re-render on a transparent ground (composites over the host fill without a second opaque
-    // layer). Use it only if it actually painted something; otherwise fall through to the snapshot.
-    scatterplot.set({ backgroundColor: [0, 0, 0, 0] })
-    const data = await scatterplot.export({ scale }) as ImageData
-    scatterplot.set({ backgroundColor: props.backgroundColor })
-    if (data && data.width) {
-      let painted = false
-      for (let i = 3; i < data.data.length; i += 4 * 97) { if (data.data[i] !== 0) { painted = true; break } }
-      if (painted) {
-        const c = document.createElement('canvas'); c.width = data.width; c.height = data.height
-        const cx = c.getContext('2d')
-        if (cx) { cx.putImageData(data, 0, 0); return c }
-      }
-    }
+    scatterplot.set({ backgroundColor: [0, 0, 0, 0], width: Math.round(w * scale), height: Math.round(h * scale), aspectRatio: aspect() })
+    live.style.width = cssW || `${w}px`; live.style.height = cssH || `${h}px`   // keep the on-screen size
+    await drawCurrent(scale)   // redraw the same encoding, point size scaled to match the big backing
+    const snap = document.createElement('canvas'); snap.width = live.width; snap.height = live.height
+    snap.getContext('2d')?.drawImage(live, 0, 0)
+    return snap.width > fallback.width ? snap : fallback
   } catch {
-    // export() can leave the live canvas mid-resize — restore the on-screen render
-    scatterplot?.set({ backgroundColor: props.backgroundColor })
-    resize(); render()
+    return fallback
+  } finally {
+    // restore the on-screen render (size + opaque ground + point size)
+    scatterplot.set({ backgroundColor: props.backgroundColor, width: w, height: h, aspectRatio: aspect() })
+    live.style.width = cssW; live.style.height = cssH
+    render()
   }
-  return snap.width ? snap : null   // fallback: the pre-export on-screen frame (screen resolution)
 }
 defineExpose({ exportCanvas, getCanvas: () => canvasEl.value })
 

--- a/frontend/src/composables/useSummaryData.ts
+++ b/frontend/src/composables/useSummaryData.ts
@@ -1,0 +1,128 @@
+import { ref, computed, watch, onMounted, onUnmounted, type Ref } from 'vue'
+import { useWsStore } from '../stores/ws'
+import { useViewState } from './useViewState'
+import { tkey } from '../plots/series'
+import { defaultVis, type VisProps } from '../plots/plot'
+import type { PlotSpec, PlotSeries, SegmentationPops } from '../plots/types'
+
+// Data + shared view-state for a summary-plot surface — the part that is IDENTICAL whether the plots
+// float freely (SummaryCanvas, per-module) or sit in a grid (LayoutCanvas, /analysis). Extracted so the
+// two hosts share ONE implementation (see feedback_use_existing_framework): plot-spec registry,
+// populations-by-segmentation, image attributes + the compare cluster, and the canvas-level shared bag
+// (compare mode / scope / global eye-selection + vis / pool). The PANEL vs SLOT model stays in the host.
+//
+// `shared` is the per-canvas persisted bag (from useCanvasPanels for SummaryCanvas, from the layout
+// store for LayoutCanvas) — canvas-level options live in it via useViewState so they survive navigation.
+export function useSummaryData(opts: {
+  projectUid: Ref<string>
+  imageUids: Ref<string[]>
+  setUid: Ref<string | null>
+  module: string | null | undefined
+  shared: Ref<Record<string, unknown>>
+}) {
+  const { projectUid, imageUids, setUid, module } = opts
+  const ws = useWsStore()
+  const imageUid = computed(() => imageUids.value[0] ?? null)
+
+  const { compareMode, compareAttr, compareAttr2, scope, sel: gSel, vis: gVis, poolGroups } =
+    useViewState(opts.shared, {
+      compareMode: 'image' as 'image' | 'per_image' | 'summarised' | 'by_attr',
+      compareAttr: '' as string,
+      compareAttr2: '' as string,
+      scope: 'global' as 'global' | 'local',
+      sel: [] as string[],
+      vis: defaultVis() as VisProps,
+      poolGroups: false as boolean,
+    })
+
+  const canCompare = computed(() => !!setUid.value && imageUids.value.length > 1)
+  const crossImage = computed(() => compareMode.value !== 'image' && canCompare.value)
+  const panelSetUid = computed(() => crossImage.value ? setUid.value : null)
+  const panelImageUids = computed(() => crossImage.value ? imageUids.value : undefined)
+  const panelScope = computed<'per_image' | 'summarised'>(() =>
+    compareMode.value === 'summarised' ? 'summarised' : 'per_image')
+
+  // image attributes available across the set (for "by attribute" compare); the chosen one is sent as
+  // groupAttr so images sharing a value pool into one series labelled by the value.
+  const setAttrs = ref<{ name: string; values: string[] }[]>([])
+  async function loadAttrs() {
+    if (!setUid.value || !canCompare.value) { setAttrs.value = []; return }
+    const p = new URLSearchParams({ projectUid: projectUid.value, setUid: setUid.value })
+    if (imageUids.value.length) p.set('imageUids', imageUids.value.join(','))
+    try { setAttrs.value = (await (await fetch(`/api/plots/attrs?${p}`)).json()).attrs ?? [] }
+    catch { setAttrs.value = [] }
+  }
+  watch([compareMode, setAttrs, compareAttr], () => {
+    if (compareMode.value === 'by_attr' && !compareAttr.value && setAttrs.value.length)
+      compareAttr.value = setAttrs.value[0].name
+    if (compareAttr2.value && (compareAttr2.value === compareAttr.value
+        || !setAttrs.value.some(a => a.name === compareAttr2.value)))
+      compareAttr2.value = ''
+  })
+  const panelGroupAttr = computed<string[]>(() =>
+    compareMode.value === 'by_attr' && crossImage.value
+      ? [compareAttr.value, compareAttr2.value].filter(Boolean) : [])
+  const attrOptions2 = computed(() => setAttrs.value.filter(a => a.name !== compareAttr.value))
+
+  // available plot specs (per-module registry; null module = universal → all specs)
+  const specs = ref<PlotSpec[]>([])
+  const specById = computed(() => Object.fromEntries(specs.value.map(s => [s.id, s])))
+  const popType = computed(() => specs.value[0]?.dataSource.popType ?? 'live')
+  const granularity = computed(() => specs.value.some(s => s.dataSource.granularity === 'track') ? 'track' : 'cell')
+  async function loadSpecs() {
+    const q = module ? `?module=${encodeURIComponent(module)}` : ''
+    try { specs.value = await (await fetch(`/api/plots/definitions${q}`)).json() } catch { specs.value = [] }
+  }
+
+  // populations across the selected images, grouped by segmentation
+  const segPops = ref<SegmentationPops[]>([])
+  const popColors = computed(() => {
+    const m = new Map<string, string>()
+    for (const g of segPops.value) for (const p of g.populations) m.set(`${g.valueName}${p.path}`, p.colour)
+    return m
+  })
+  async function loadPops() {
+    if (!imageUid.value && !imageUids.value.length) { segPops.value = []; return }
+    const p = new URLSearchParams({ projectUid: projectUid.value, popType: popType.value, granularity: granularity.value })
+    if (setUid.value) { p.set('setUid', setUid.value); if (imageUids.value.length) p.set('imageUids', imageUids.value.join(',')) }
+    else if (imageUid.value) p.set('imageUid', imageUid.value)
+    try { segPops.value = await (await fetch(`/api/plots/populations?${p}`)).json() }
+    catch { segPops.value = [] }
+  }
+
+  // series colour = the POPULATION colour so a population reads identically across images
+  function seriesColor(s: PlotSeries): string { return popColors.value.get(s.pop) ?? '#7c93b8' }
+
+  // live updates: the server broadcasts gating:popmap after any gate mutation — refetch pops + bump a
+  // token so panels re-pull data (membership may change with no prop change). Prune vanished selections.
+  const reloadToken = ref(0)
+  function onPopmap(d: unknown) {
+    const m = d as { imageUid?: string }
+    if (m.imageUid && imageUids.value.length && !imageUids.value.includes(m.imageUid)) return
+    loadPops(); reloadToken.value++
+  }
+  // the set of currently-valid target keys (for pruning host selections)
+  const validSelKeys = computed(() => {
+    const exist = new Set<string>()
+    for (const g of segPops.value) for (const p of g.populations) exist.add(tkey(p.popType, g.valueName, p.path))
+    return exist
+  })
+
+  watch([() => imageUids.value.join(','), popType, setUid], () => { loadPops(); loadAttrs() })
+  // prune the selection to populations that still exist — but ONLY once we actually have populations.
+  // segPops is transiently [] during load / image-switch / a failed fetch; pruning then would wipe a
+  // restored selection (and it would save back empty). Guard so an empty segPops never clears gSel.
+  watch(segPops, () => { if (segPops.value.length) gSel.value = gSel.value.filter(k => validSelKeys.value.has(k)) })
+  onMounted(async () => { ws.on('gating:popmap', onPopmap); await loadSpecs(); await loadPops(); await loadAttrs() })
+  onUnmounted(() => ws.off('gating:popmap', onPopmap))
+
+  return {
+    // data
+    specs, specById, popType, granularity, segPops, popColors, setAttrs, seriesColor, reloadToken,
+    validSelKeys, loadSpecs, loadPops, loadAttrs,
+    // shared view-state
+    compareMode, compareAttr, compareAttr2, scope, gSel, gVis, poolGroups,
+    // compare-derived
+    canCompare, crossImage, panelSetUid, panelImageUids, panelScope, panelGroupAttr, attrOptions2,
+  }
+}

--- a/frontend/src/modules/AnalysisModule.vue
+++ b/frontend/src/modules/AnalysisModule.vue
@@ -1,25 +1,31 @@
 <!--
-  Universal "Analysis canvas" page (TODO #00036). The SAME summary-plot canvas as the per-module
-  pages, but with the MODULE FILTER OFF: `SummaryCanvas` mounted with no `module` prop offers EVERY
-  plot spec, so plots can be combined across modules / images / segmentations on one board. Pick one
-  OR MORE images from the active set (multi-select); the populations endpoint unions across the
-  selected images/segmentations.
+  Universal, multipage "Analysis canvas" page (TODO #00036 + docs/todo/ANALYSIS_CANVAS_PLAN.md). The
+  SAME summary-plot canvas as the per-module pages, but with the MODULE FILTER OFF: each board is a
+  `SummaryCanvas` mounted with no `module` prop, so it offers EVERY plot spec — plots can be combined
+  across modules / images / segmentations. `TabbedCanvas` wraps N independent boards (Phase A). Pick
+  one OR MORE images from the active set (multi-select, shared across boards); the populations endpoint
+  unions across the selected images/segmentations.
 
-  No TaskRunner (`#right`) — this page only visualises existing results, it doesn't run tasks. Image
-  selection + panel state persist under their own scopes (`analysis` for the selection, `summary:universal`
-  inside SummaryCanvas), independent of the per-module pages. See docs/UI.md → "Analysis-plot canvas".
+  No TaskRunner (`#right`) — this page only visualises existing results. Image selection persists under
+  the `analysis` scope; each board's panels under `analysis:{projectUid}:tab:{id}`. `TabbedCanvas` is
+  keyed by projectUid so a project switch remounts it. See docs/UI.md → "Analysis-plot canvas".
 -->
 <script setup lang="ts">
+import { computed } from 'vue'
 import ModuleLayout from '../components/ModuleLayout.vue'
 import CollapsibleSection from '../components/CollapsibleSection.vue'
-import SummaryCanvas from '../components/canvas/SummaryCanvas.vue'
+import TabbedCanvas from '../components/canvas/TabbedCanvas.vue'
+import { useProjectMetaStore } from '../stores/projectMeta'
+
+const meta = useProjectMetaStore()
+const projectUid = computed(() => meta.current?.uid ?? '')
 </script>
 
 <template>
   <ModuleLayout module="analysis" :show-attrs="true" :show-filter="true">
     <template #below-table="{ selectedUids }">
       <CollapsibleSection label="Plots" :max-height="'none'">
-        <SummaryCanvas :image-uids="selectedUids" />
+        <TabbedCanvas :key="projectUid" :image-uids="selectedUids" />
       </CollapsibleSection>
     </template>
   </ModuleLayout>

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -17,10 +17,10 @@ import { useGatingStore, isReservedPopName, type GateSpec, type TransformSpec } 
 import { useLogStore } from '../../stores/log'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
-import ScatterGL from '../../components/plots/ScatterGL.vue'
-import PlotLayers, { type PopLayer } from '../../components/plots/PlotLayers.vue'
-import GateOverlay from '../../components/plots/GateOverlay.vue'
-import { plotHostToImageURL, downloadDataUrl } from '../../plots/export'
+import GateScatterCell from '../../components/plots/GateScatterCell.vue'
+import type { PopLayer } from '../../components/plots/PlotLayers.vue'
+import { orientGate } from '../../plots/gateGeometry'
+import { downloadDataUrl } from '../../plots/export'
 
 const props = defineProps<{
   index: number; active: boolean; parent: string; highlight: string[]
@@ -74,30 +74,12 @@ function plotQ(pop: string) {
 }
 const baseQ = computed(() => plotQ(parent.value))
 
-// Orient a child's gate to the current plot axes. The gate matches if its two channels are the
-// plot's two channels in EITHER order (R: .flowMatchGatingParamsForPop, order-independent); when
-// swapped, transpose the coords so it draws correctly. Returns null if it's a different axis pair.
-function orientGate(gate: GateSpec, xc: string, yc: string): GateSpec | null {
-  if (gate.x_channel === xc && gate.y_channel === yc) return gate
-  if (gate.x_channel === yc && gate.y_channel === xc) {
-    const base = { ...gate, x_channel: xc, y_channel: yc, x_transform: gate.y_transform, y_transform: gate.x_transform }
-    return gate.kind === 'rectangle'
-      ? { ...base, x_min: gate.y_min, x_max: gate.y_max, y_min: gate.x_min, y_max: gate.x_max }
-      : { ...base, vertices: gate.vertices?.map(v => [v[1], v[0]] as [number, number]) }
-  }
-  return null
-}
-// child gates of this panel's parent that live on the current axis pair → outlines (for edit)
+// child gates of this panel's parent that live on the current axis pair → outlines (for edit).
+// orientGate is shared with the read-only gating-strategy plot (plots/gateGeometry.ts).
 const currentGates = computed(() =>
   g.flat.filter(p => p.parent === parent.value && p.gate)
         .map(p => ({ path: p.path, colour: p.colour, gate: orientGate(p.gate!, xChan.value, yChan.value) }))
         .filter((p): p is { path: string; colour: string; gate: GateSpec } => p.gate !== null))
-
-// base render look: density for plain points; dim/flat backdrop for contour or pop-colour modes
-const baseColorMode = computed<'density' | 'flat'>(() =>
-  renderMode.value === 'points' && !showPops.value ? 'density' : 'flat')
-const baseOpacity = computed(() => renderMode.value === 'contour' ? 0.22 : showPops.value ? 0.35 : 1)
-const basePointSize = computed(() => renderMode.value === 'contour' ? 2 : 3)
 
 async function fetchBuf(q: string): Promise<Float32Array> {
   const buf = await (await fetch(`/api/gating/plotdata?${q}`)).arrayBuffer()
@@ -176,40 +158,12 @@ async function onEdit(e: { path: string; gate: GateSpec }) {
   await g.setGate(e.path, e.gate)
 }
 
-// ticks positioned against the LIVE view extents so labels track pan/zoom
-const tickX = (pos: number) => `${((pos - viewExtents.value.xMin) / Math.max(1e-9, viewExtents.value.xMax - viewExtents.value.xMin)) * 100}%`
-const tickY = (pos: number) => `${(1 - (pos - viewExtents.value.yMin) / Math.max(1e-9, viewExtents.value.yMax - viewExtents.value.yMin)) * 100}%`
-// abbreviate big numbers (262144 → 262.1k) so axis labels don't crowd; leave small ones as-is
-function fmtTick(label: string): string {
-  const n = parseFloat(label)
-  if (!isFinite(n)) return label
-  const a = Math.abs(n), trim = (s: string) => s.replace(/\.0$/, '')
-  if (a >= 1e9) return trim((n / 1e9).toFixed(1)) + 'G'
-  if (a >= 1e6) return trim((n / 1e6).toFixed(1)) + 'M'
-  if (a >= 1e3) return trim((n / 1e3).toFixed(1)) + 'k'
-  return label
-}
-
-// export the plot area (WebGL scatter + contour/pop layers + gate overlay + axis ticks + labels) as a
-// PNG — composited via plots/export.ts (canvas pixels + HTML/canvas2D overlays). The capture host is
-// `.plot-capture` (which INCLUDES the axis-label margins), not `.panel-plot`, so the x/y axis names
-// aren't clipped off the bottom/left edge. The scatter is re-rendered hi-res so points stay crisp.
-const plotEl = useTemplateRef<HTMLElement>('plotEl')
-type LayerExport = { exportCanvas(scale: number): Promise<HTMLCanvasElement | null>; getCanvas(): HTMLCanvasElement | null }
-const scatterRef = useTemplateRef<LayerExport>('scatterRef')
-const layersRef = useTemplateRef<LayerExport>('layersRef')
-const overlayRef = useTemplateRef<LayerExport>('overlayRef')
-// each stacked canvas (WebGL scatter + canvas2D contours/gates) re-renders itself at export scale so
-// nothing is upscaled from the screen-DPR backing store; route each live canvas to its layer.
-const hiRes = async (cv: HTMLCanvasElement, scale: number) => {
-  for (const r of [scatterRef, layersRef, overlayRef]) {
-    if (cv === r.value?.getCanvas()) return (await r.value?.exportCanvas(scale)) ?? null
-  }
-  return null
-}
+// export the plot as PNG — GateScatterCell owns the composite (canvas pixels + HTML/canvas2D overlays,
+// each layer re-rendered hi-res); we just name the file.
+const cell = useTemplateRef<{ exportImage(bg?: string): Promise<string | null> }>('cell')
 function exportPng() {
   const stem = `gate_${xChan.value}_${yChan.value}`.replace(/[^\w.-]+/g, '_')
-  plotHostToImageURL(plotEl.value, '#0d0b1a', { hiRes }).then(url => url && downloadDataUrl(`${stem}.png`, url))
+  cell.value?.exportImage('#0d0b1a').then(url => url && downloadDataUrl(`${stem}.png`, url))
 }
 
 function ensureChannels() {
@@ -272,26 +226,13 @@ watch(hlVersion, loadPopLayers)
         <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to display; new gates are its children'">
         <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select></label>
     </div>
-    <div ref="plotEl" class="plot-capture">
-     <div class="panel-plot">
-      <ScatterGL ref="scatterRef" :points="points" :extents="extents" :color-mode="baseColorMode"
-                 :opacity="baseOpacity" :point-size="basePointSize" />
-      <PlotLayers ref="layersRef" :view-extents="viewExtents" :render-mode="renderMode" :base-points="points"
-                  :pop-layers="popLayers" :show-pops="showPops" :view-tick="viewTick" />
-      <GateOverlay ref="overlayRef" :extents="viewExtents" :mode="mode" :gates="currentGates" :view-tick="viewTick"
-                   :line-width="gateLineWidth" :show-labels="gateLabels"
-                   @draw="onDraw" @edit="onEdit" @cancel="mode = 'off'" />
-      <span class="axisline axisline-x" />
-      <span class="axisline axisline-y" />
-      <span v-for="t in xTicks" :key="'x'+t.pos" class="xtick" :style="{ left: tickX(t.pos) }">
-        <span class="xtick-mark" /><span class="xtick-lbl">{{ fmtTick(t.label) }}</span>
-      </span>
-      <span v-for="t in yTicks" :key="'y'+t.pos" class="ytick" :style="{ top: tickY(t.pos) }">
-        <span class="ytick-lbl">{{ fmtTick(t.label) }}</span><span class="ytick-mark" />
-      </span>
-      <span class="axis-x">{{ g.colLabel(xChan) }}</span>
-      <span class="axis-y">{{ g.colLabel(yChan) }}</span>
-      <div v-if="loading" class="panel-loading">…</div>
+    <GateScatterCell ref="cell" :points="points" :extents="extents" :view-extents="viewExtents"
+                     :x-ticks="xTicks" :y-ticks="yTicks" :gates="currentGates"
+                     :x-label="g.colLabel(xChan)" :y-label="g.colLabel(yChan)"
+                     :pop-layers="popLayers" :render-mode="renderMode" :show-pops="showPops"
+                     :mode="mode" :gate-line-width="gateLineWidth" :gate-labels="gateLabels"
+                     :view-tick="viewTick" :loading="loading"
+                     @draw="onDraw" @edit="onEdit" @cancel="mode = 'off'">
       <div v-if="pending" class="panel-name">
         <span>new {{ pending.kind }}</span>
         <input v-model="newName" placeholder="name…" autofocus
@@ -301,8 +242,7 @@ watch(hlVersion, loadPopLayers)
         <button class="cc-btn cc-btn-ghost" @click="pending = null">×</button>
         <span v-if="nameReserved" class="name-hint">names can't start with “_” (reserved for tracked / clustering)</span>
       </div>
-     </div>
-    </div>
+    </GateScatterCell>
   </CanvasPanel>
 </template>
 
@@ -331,33 +271,8 @@ watch(hlVersion, loadPopLayers)
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button.on { background: var(--cc-accent); color: #fff; }
 .cc-btn.on { border-color: var(--cc-accent); color: var(--cc-accent); }
-/* capture host for PNG export: the axis labels/ticks live in this padding (relative to .panel-plot,
-   at negative offsets), so exporting THIS element — not .panel-plot — includes the x/y axis names
-   instead of clipping them at the edge (#00061). The label-space that used to be .panel-plot's
-   margin is now this padding. min-height is modest so plot + padding + footer all fit inside the
-   default panel height without the panel's overflow:hidden clipping the bottom label. */
-.plot-capture { position: relative; flex: 1; min-height: 218px; min-width: 0; display: flex; box-sizing: border-box;
-  padding: 18px 22px 50px 84px; }
-/* min-width:0 so this flex-row item can shrink below the scatter canvas's intrinsic width — without
-   it the panel grows on resize-right but won't shrink back on resize-left. */
-.panel-plot { position: relative; flex: 1; min-height: 150px; min-width: 0; }
-.axisline { position: absolute; background: var(--cc-border); pointer-events: none; }
-.axisline-x { left: 0; right: 0; bottom: 0; height: 1px; }
-.axisline-y { left: 0; top: 0; bottom: 0; width: 1px; }
-/* x ticks: mark hangs below the baseline, label under it */
-.xtick { position: absolute; bottom: 0; transform: translate(-50%, 100%); display: flex; flex-direction: column; align-items: center; pointer-events: none; }
-.xtick-mark { width: 1px; height: 5px; background: var(--cc-text-dim); }
-.xtick-lbl { margin-top: 3px; font-size: 10px; color: var(--cc-text-dim); white-space: nowrap; }
-/* y ticks: label then mark, anchored so the mark touches the left axis */
-.ytick { position: absolute; left: 0; transform: translate(-100%, -50%); display: flex; align-items: center; pointer-events: none; }
-.ytick-mark { width: 5px; height: 1px; background: var(--cc-text-dim); }
-.ytick-lbl { margin-right: 3px; font-size: 10px; color: var(--cc-text-dim); white-space: nowrap; }
-.axis-x { position: absolute; bottom: -40px; left: 50%; transform: translateX(-50%); font-size: 13px; font-weight: 600; color: var(--cc-text); }
-/* vertical text via writing-mode (rotate's origin offsets by half the text width → overlap) */
-.axis-y { position: absolute; left: -66px; top: 50%; transform: translateY(-50%) rotate(180deg);
-  writing-mode: vertical-rl; font-size: 13px; font-weight: 600; color: var(--cc-text); }
 .gp-export { font-size: 12px; max-width: 7rem; }
-.panel-loading { position: absolute; top: 4px; right: 6px; font-size: 11px; color: var(--cc-text-dim); }
+/* the plot body (scatter/layers/gate + ticks/axes + PNG export) lives in GateScatterCell now. */
 .panel-name { position: absolute; top: 4px; left: 4px; display: flex; align-items: center; gap: 5px;
   background: var(--cc-surface-1); border: 1px solid var(--cc-accent); border-radius: 4px; padding: 4px 6px; font-size: 11px; }
 .panel-name input { background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-border); border-radius: 3px; padding: 1px 5px; width: 90px; }

--- a/frontend/src/plots/export.ts
+++ b/frontend/src/plots/export.ts
@@ -103,11 +103,13 @@ function loadImg(url: string): Promise<HTMLImageElement | null> {
 // is only CSS×DPR, so drawing the live canvas would upscale and pixelate). Resolver returns null →
 // composite the live canvas as-is (canvas2D overlays with no hi-res path).
 export async function plotHostToImageURL(host: HTMLElement | null, bg: string,
-  opts: { hiRes?: (cv: HTMLCanvasElement, scale: number) => Promise<CanvasImageSource | null> } = {}): Promise<string | null> {
+  opts: { hiRes?: (cv: HTMLCanvasElement, scale: number) => Promise<CanvasImageSource | null>; scale?: number } = {}): Promise<string | null> {
   if (!host) return null
   const w = host.clientWidth || host.offsetWidth, h = host.clientHeight || host.offsetHeight
   if (!w || !h) return null
-  const scale = RASTER_SCALE
+  // caller may force a higher scale (e.g. the flow/gate plot targets a fixed crisp resolution regardless
+  // of its on-screen size); both the WebGL re-render and the vector overlay rasterise at this scale.
+  const scale = opts.scale ?? RASTER_SCALE
   const c = document.createElement('canvas'); c.width = w * scale; c.height = h * scale
   const ctx = c.getContext('2d'); if (!ctx) return null
   ctx.scale(scale, scale)

--- a/frontend/src/plots/gateGeometry.ts
+++ b/frontend/src/plots/gateGeometry.ts
@@ -1,0 +1,18 @@
+import type { GateSpec } from '../stores/gating'
+
+// Orient a gate to a given plot axis pair. The gate matches if its two channels are the plot's two
+// channels in EITHER order (R: .flowMatchGatingParamsForPop, order-independent); when swapped,
+// transpose the coords so it draws correctly. Returns null if it's a different axis pair.
+//
+// Shared by GatePlotPanel (edit outlines) and the read-only gating-strategy plot — one implementation,
+// not two (see feedback_use_existing_framework).
+export function orientGate(gate: GateSpec, xc: string, yc: string): GateSpec | null {
+  if (gate.x_channel === xc && gate.y_channel === yc) return gate
+  if (gate.x_channel === yc && gate.y_channel === xc) {
+    const base = { ...gate, x_channel: xc, y_channel: yc, x_transform: gate.y_transform, y_transform: gate.x_transform }
+    return gate.kind === 'rectangle'
+      ? { ...base, x_min: gate.y_min, x_max: gate.y_max, y_min: gate.x_min, y_max: gate.x_max }
+      : { ...base, vertices: gate.vertices?.map(v => [v[1], v[0]] as [number, number]) }
+  }
+  return null
+}

--- a/frontend/src/plots/layoutTemplates.ts
+++ b/frontend/src/plots/layoutTemplates.ts
@@ -1,0 +1,66 @@
+// Layout templates for the Analysis canvas (docs/todo/ANALYSIS_CANVAS_PLAN.md, decisions 4/8/10).
+// One mechanism serves BOTH clean scientific grids AND rectangular "comic plates": a template is a
+// CSS-grid definition (cols × rows tracks) plus a grid-area string per slot. A uniform N×M is just the
+// generated case; comic plates are hand-defined span arrangements. Each tab picks a template; the page
+// renders one <div class="grid"> with `grid-template-columns/rows` and one cell per slot area.
+
+export interface LayoutTemplate {
+  id: string
+  label: string
+  cols: number
+  rows: number
+  // one CSS `grid-area` per slot: "rowStart / colStart / rowEnd / colEnd"
+  slots: string[]
+  // optional explicit track sizes (CSS `grid-template-rows/columns`) for non-uniform plates, e.g. a
+  // short header row. When absent, tracks are equal `repeat(n, minmax(0,1fr))`.
+  rowTracks?: string
+  colTracks?: string
+}
+
+// Uniform N×M — every cell 1×1, row-major.
+export function uniform(cols: number, rows: number): LayoutTemplate {
+  const slots: string[] = []
+  for (let r = 1; r <= rows; r++)
+    for (let c = 1; c <= cols; c++)
+      slots.push(`${r} / ${c} / ${r + 1} / ${c + 1}`)
+  return { id: `grid-${cols}x${rows}`, label: `${cols}×${rows}`, cols, rows, slots }
+}
+
+// Quick uniform presets shown as buttons alongside the free N×M inputs.
+export const UNIFORM_PRESETS: LayoutTemplate[] = [
+  uniform(1, 1), uniform(2, 1), uniform(1, 2), uniform(2, 2), uniform(3, 2), uniform(3, 3),
+]
+
+// Rectangular "comic plates": varied-size panels over a base grid (decision 8). Rectangular only —
+// angled panels are deferred; the filmstrip slot covers the angled-image use (decision 10).
+export const COMIC_PRESETS: LayoutTemplate[] = [
+  // wide left + narrow right (single row)
+  { id: 'wide-tall', label: '2 + 1', cols: 3, rows: 1,
+    slots: ['1 / 1 / 2 / 3', '1 / 3 / 2 / 4'] },
+  // wide feature on top + two beneath
+  { id: 'feature-2', label: 'Top + 2', cols: 2, rows: 2,
+    slots: ['1 / 1 / 2 / 3', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3'] },
+  // big square left + two stacked on the right
+  { id: 'big-2', label: 'Big + 2', cols: 3, rows: 2,
+    slots: ['1 / 1 / 3 / 3', '1 / 3 / 2 / 4', '2 / 3 / 3 / 4'] },
+  // wide feature on top + a row of three beneath
+  { id: 'feature-3', label: 'Feature + 3', cols: 3, rows: 2,
+    slots: ['1 / 1 / 2 / 4', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4'] },
+  // tall hero left + two small right + wide footer
+  { id: 'hero-3', label: 'Hero + 3', cols: 2, rows: 3,
+    slots: ['1 / 1 / 3 / 2', '1 / 2 / 2 / 3', '2 / 2 / 3 / 3', '3 / 1 / 4 / 3'] },
+  // tall sidebar left + three stacked on the right
+  { id: 'side-3', label: 'Side + 3', cols: 3, rows: 3,
+    slots: ['1 / 1 / 4 / 2', '1 / 2 / 2 / 4', '2 / 2 / 3 / 4', '3 / 2 / 4 / 4'] },
+  // large hero (2×2) with an L of five smaller panels
+  { id: 'hero-quad', label: 'Hero + 5', cols: 3, rows: 3,
+    slots: ['1 / 1 / 3 / 3', '1 / 3 / 2 / 4', '2 / 3 / 3 / 4', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4'] },
+  // wide header banner on top + two rows of three smaller slots (all rows equal height)
+  { id: 'header-2x3', label: 'Header + 2×3', cols: 3, rows: 3,
+    slots: ['1 / 1 / 2 / 4', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4'] },
+  // wide header banner on top + two rows of four smaller slots (all rows equal height)
+  { id: 'header-2x4', label: 'Header + 2×4', cols: 4, rows: 3,
+    slots: ['1 / 1 / 2 / 5', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '2 / 4 / 3 / 5', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4', '3 / 4 / 4 / 5'] },
+]
+
+export const ALL_PRESETS = [...UNIFORM_PRESETS, ...COMIC_PRESETS]

--- a/frontend/src/plots/pdf.ts
+++ b/frontend/src/plots/pdf.ts
@@ -1,0 +1,77 @@
+import { PDFDocument } from 'pdf-lib'
+import { downloadBlob } from './export'
+
+// Multipage PDF of the Analysis canvas: ONE page per tab, laid out as that tab's grid (each slot image
+// placed at its grid-area rectangle). Each summary plot's aggregated data can ride along as an embedded
+// CSV attachment (pdf-lib `attach`), so the figure + re-plottable data are one file
+// (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase E). Pure — the caller supplies captured slot PNGs + CSVs.
+
+// Each slot carries a NORMALISED rect (0..1) measured from the on-screen board, so the PDF reproduces
+// the real layout (spans, plates, row height, gaps) rather than a re-derived uniform grid.
+export interface PdfSlot { rect: { x: number; y: number; w: number; h: number }; png: string | null; csv?: string | null; name?: string }
+export interface PdfPage { title: string; aspect: number; slots: PdfSlot[] }
+
+// A4 in points (1pt = 1/72"): 210×297mm → 595.28 × 841.89. Each page picks the ORIENTATION that best
+// fits its board (wide board → landscape, tall board → portrait) so the sheet stays true A4 either way.
+// Tight margins — the board proportions (not padding) drive the spacing.
+const A4_SHORT = 595.28, A4_LONG = 841.89, MARGIN = 16, TITLE_H = 18, PAD = 2
+
+function dataUrlToBytes(dataUrl: string): Uint8Array {
+  const b64 = dataUrl.slice(dataUrl.indexOf(',') + 1)
+  const bin = atob(b64)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+const safe = (s: string) => s.replace(/[^\w.-]+/g, '_')
+
+export async function exportTabsToPdf(pages: PdfPage[], filename = 'analysis.pdf') {
+  const doc = await PDFDocument.create()
+  for (const page of pages) {
+    // A4, oriented to the board: wide (aspect ≥ 1) → landscape, tall → portrait
+    const landscape = (page.aspect || 1) >= 1
+    const PAGE_W = landscape ? A4_LONG : A4_SHORT
+    const PAGE_H = landscape ? A4_SHORT : A4_LONG
+    const p = doc.addPage([PAGE_W, PAGE_H])
+    p.drawText(page.title, { x: MARGIN, y: PAGE_H - MARGIN - 2, size: 11 })
+
+    // available area below the title, then fit the BOARD (preserving its aspect ratio) inside it and
+    // centre — so the whole layout scales as one unit and slot proportions match the screen.
+    const availW = PAGE_W - 2 * MARGIN
+    const availH = PAGE_H - 2 * MARGIN - TITLE_H
+    const aspect = page.aspect || (availW / availH)
+    let bw = availW, bh = bw / aspect
+    if (bh > availH) { bh = availH; bw = bh * aspect }
+    const boardLeft = MARGIN + (availW - bw) / 2
+    const boardTopFromTop = MARGIN + TITLE_H + (availH - bh) / 2   // distance from the PAGE TOP
+
+    for (const slot of page.slots) {
+      // slot rect within the board (top-origin), minus a hair of padding so neighbours don't touch
+      const sx = boardLeft + slot.rect.x * bw + PAD
+      const syTop = boardTopFromTop + slot.rect.y * bh + PAD
+      const w = slot.rect.w * bw - 2 * PAD
+      const h = slot.rect.h * bh - 2 * PAD
+
+      if (slot.png) {
+        try {
+          const img = await doc.embedPng(dataUrlToBytes(slot.png))
+          const s = Math.min(w / img.width, h / img.height)
+          const iw = img.width * s, ih = img.height * s
+          // centre the (aspect-preserved) image in its slot rect; PDF origin is bottom-left
+          const x = sx + (w - iw) / 2
+          const y = PAGE_H - (syTop + (h - ih) / 2) - ih
+          p.drawImage(img, { x, y, width: iw, height: ih })
+        } catch { /* skip an unembeddable image */ }
+      }
+      if (slot.csv) {
+        try {
+          await doc.attach(new TextEncoder().encode(slot.csv), safe(`${page.title}_${slot.name ?? 'plot'}.csv`),
+            { mimeType: 'text/csv', description: `Data — ${slot.name ?? 'plot'} (${page.title})` })
+        } catch { /* attachment optional */ }
+      }
+    }
+  }
+  const bytes = await doc.save()
+  downloadBlob(filename, new Blob([bytes as unknown as BlobPart], { type: 'application/pdf' }))
+}

--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -289,8 +289,11 @@ export function buildPlotOptions(Plot: PlotModule, r: PlotDataResponse, o: Build
   // a blank bound is filled from the data extent (so min-only or max-only works); +5% headroom on top.
   const ext = measureExtent(r)
   const uMin = parseFloat(o.yMin), uMax = parseFloat(o.yMax)
+  const hasUser = Number.isFinite(uMin) || Number.isFinite(uMax)
   let measDomain: number[] | null = null
   if (ext && isDist) {
+    // distribution charts (box/violin/strip/bar): the measure lives on the value axis, so we manage its
+    // full domain — include 0, +5% headroom, blank bound filled from the data extent.
     if (o.logScale) {
       const lo = Number.isFinite(uMin) && uMin > 0 ? uMin : ext.min
       const hi = Number.isFinite(uMax) ? uMax : ext.max
@@ -300,6 +303,13 @@ export function buildPlotOptions(Plot: PlotModule, r: PlotDataResponse, o: Build
       const hi = Number.isFinite(uMax) ? uMax : ext.max + (ext.max - lo) * 0.05
       if (hi > lo) measDomain = [lo, hi]
     }
+  } else if (hasUser && ext) {
+    // count/proportion charts (frequency, histogram, …) auto-scale their Y — but still HONOUR an explicit
+    // yMin/yMax (previously these were ignored). ext here is the value/count extent (series `value`), used
+    // only to fill a blank side; both sides given → used verbatim.
+    const lo = Number.isFinite(uMin) ? uMin : (o.nonNegative ? 0 : ext.min)
+    const hi = Number.isFinite(uMax) ? uMax : ext.max * 1.05
+    if (hi > lo) measDomain = [lo, hi]
   }
   opts[measAxis] = { ...(opts[measAxis] as object ?? {}), grid: o.grid,
                      ...(o.labY ? { label: o.labY } : {}), ...(measDomain ? { domain: measDomain } : {}) }

--- a/frontend/src/stores/analysisLayout.ts
+++ b/frontend/src/stores/analysisLayout.ts
@@ -1,0 +1,75 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { uniform, type LayoutTemplate } from '../plots/layoutTemplates'
+
+// Per-tab grid layout for the Analysis canvas (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase A2). Keyed by
+// the tab's canvas key (`analysis:tab:<id>`), parallel to `canvasPanels`/`analysisTabs`. Holds the
+// chosen template (cols/rows + per-slot grid-area) and each slot's CONTENT, plus the canvas-level
+// `shared` bag consumed by useSummaryData. In-memory (survives navigation, not reload); cleared
+// per-project from stores/project.ts. A slot's content is routed by `kind`:
+//   summary     → a SummaryPanel bound to a plot spec (ref = specId)
+//   interactive → an InteractivePanel view (ref = view key; Phase B)
+//   image       → a static PNG (napari screenshot; Phase D)
+//   filmstrip   → N captioned images with separators (Phase D)
+export interface SlotContent { kind: 'summary' | 'interactive' | 'image' | 'filmstrip'; ref: string; state: Record<string, unknown> }
+interface LayoutEntry {
+  cols: number; rows: number; slotAreas: string[]
+  rowTracks?: string; colTracks?: string   // non-uniform plates (e.g. a short header row)
+  rowHeight?: number                       // px per grid row (board-level slot-height slider); the board
+                                           // scrolls in the page if taller than the viewport
+  contents: (SlotContent | null)[]     // aligned 1:1 with slotAreas
+  activeIndex: number
+  shared: Record<string, unknown>      // canvas-level view-state for useSummaryData (compare/scope/sel/vis)
+}
+
+export const useAnalysisLayoutStore = defineStore('analysisLayout', () => {
+  const entries = ref<Record<string, LayoutEntry>>({})
+
+  function ensure(key: string): LayoutEntry {
+    if (!entries.value[key]) {
+      const t = uniform(2, 2)
+      entries.value[key] = { cols: t.cols, rows: t.rows, slotAreas: t.slots, contents: t.slots.map(() => null), activeIndex: 0, shared: {} }
+    }
+    return entries.value[key]
+  }
+
+  // Switch template, preserving slot CONTENTS by index (extra new slots empty; dropped slots discarded).
+  function applyTemplate(key: string, t: LayoutTemplate) {
+    const e = ensure(key)
+    const old = e.contents
+    e.cols = t.cols; e.rows = t.rows; e.slotAreas = t.slots
+    e.rowTracks = t.rowTracks; e.colTracks = t.colTracks   // undefined for uniform templates → clears any prior
+    e.contents = t.slots.map((_, i) => old[i] ?? null)
+    if (e.activeIndex >= e.contents.length) e.activeIndex = 0
+  }
+
+  function setContent(key: string, i: number, c: SlotContent | null) {
+    const e = ensure(key)
+    if (i >= 0 && i < e.contents.length) e.contents[i] = c
+  }
+  function setActive(key: string, i: number) {
+    const e = ensure(key)
+    if (i >= 0 && i < e.contents.length) e.activeIndex = i
+  }
+  // swap two slots' contents (drag-to-rearrange)
+  function swap(key: string, a: number, b: number) {
+    const e = ensure(key)
+    if (a === b || a < 0 || b < 0 || a >= e.contents.length || b >= e.contents.length) return
+    const t = e.contents[a]; e.contents[a] = e.contents[b]; e.contents[b] = t
+  }
+
+  function clear() { entries.value = {} }
+
+  // persistence with the project (analysisBoards.json): dump/restore the tab layouts for a project
+  // (all entries whose key starts with `analysis:<uid>:tab:`)
+  function serialize(prefix: string): Record<string, LayoutEntry> {
+    const out: Record<string, LayoutEntry> = {}
+    for (const [k, v] of Object.entries(entries.value)) if (k.startsWith(prefix)) out[k] = v
+    return out
+  }
+  function load(map: Record<string, LayoutEntry> | null | undefined) {
+    for (const [k, v] of Object.entries(map ?? {})) entries.value[k] = v
+  }
+
+  return { entries, ensure, applyTemplate, setContent, setActive, swap, clear, serialize, load }
+})

--- a/frontend/src/stores/analysisTabs.ts
+++ b/frontend/src/stores/analysisTabs.ts
@@ -1,0 +1,78 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+// Tab metadata for the multipage Analysis canvas (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase A). Each
+// "tab" is an independent board; its plots live in the `canvasPanels` store under the canvas key
+// `${groupKey}:tab:${id}` (so tabs reuse the whole existing SummaryCanvas persistence machinery —
+// this store only owns the tab LIST + names + which one is active).
+//
+// Keyed per group (`analysis:${projectUid}`) so boards are per-project. In-memory like `canvasPanels`
+// (survives navigation, not a full reload); cleared on project open/close from `stores/project.ts`.
+interface Tab { id: number; name: string }
+interface TabGroup { tabs: Tab[]; activeId: number; nextId: number }
+
+export const useAnalysisTabsStore = defineStore('analysisTabs', () => {
+  const entries = ref<Record<string, TabGroup>>({})
+
+  // Seed a first board so the canvas is never tab-less, and return the REACTIVE entry (re-read from
+  // `entries.value` — returning the local literal would hand back the raw, untracked object).
+  function ensure(groupKey: string): TabGroup {
+    if (!entries.value[groupKey]) entries.value[groupKey] = { tabs: [], activeId: 0, nextId: 0 }
+    const g = entries.value[groupKey]
+    if (g.tabs.length === 0) {
+      const id = ++g.nextId
+      g.tabs.push({ id, name: 'Board 1' })
+      g.activeId = id
+    }
+    return g
+  }
+
+  function addTab(groupKey: string, name?: string): number {
+    const g = ensure(groupKey)
+    const id = ++g.nextId
+    g.tabs.push({ id, name: name ?? `Board ${g.tabs.length + 1}` })
+    g.activeId = id
+    return id
+  }
+
+  function renameTab(groupKey: string, id: number, name: string) {
+    const t = entries.value[groupKey]?.tabs.find(x => x.id === id)
+    if (t) t.name = name.trim() || t.name
+  }
+
+  // Remove a tab; caller drops the tab's canvas panels (canvasPanels.drop) since this store doesn't
+  // know the canvas-key mapping. Keeps at least one board.
+  function removeTab(groupKey: string, id: number) {
+    const g = entries.value[groupKey]
+    if (!g || g.tabs.length <= 1) return
+    const idx = g.tabs.findIndex(t => t.id === id)
+    if (idx < 0) return
+    g.tabs.splice(idx, 1)
+    if (g.activeId === id) g.activeId = (g.tabs[idx] ?? g.tabs[idx - 1] ?? g.tabs[0]).id
+  }
+
+  function setActive(groupKey: string, id: number) {
+    const g = entries.value[groupKey]
+    if (g && g.tabs.some(t => t.id === id)) g.activeId = id
+  }
+
+  // Move the tab with `id` to a new index (drag-reorder in the tab bar).
+  function reorderTab(groupKey: string, id: number, toIndex: number) {
+    const g = entries.value[groupKey]
+    if (!g) return
+    const from = g.tabs.findIndex(t => t.id === id)
+    if (from < 0) return
+    const to = Math.max(0, Math.min(toIndex, g.tabs.length - 1))
+    if (from === to) return
+    const [t] = g.tabs.splice(from, 1)
+    g.tabs.splice(to, 0, t)
+  }
+
+  function clear() { entries.value = {} }
+
+  // persistence with the project (analysisBoards.json): dump/restore the tab group for a project
+  function serialize(groupKey: string): TabGroup | null { return entries.value[groupKey] ?? null }
+  function load(groupKey: string, g: TabGroup | null | undefined) { if (g) entries.value[groupKey] = g }
+
+  return { entries, ensure, addTab, renameTab, removeTab, setActive, reorderTab, clear, serialize, load }
+})

--- a/frontend/src/stores/canvasPanels.ts
+++ b/frontend/src/stores/canvasPanels.ts
@@ -25,7 +25,13 @@ export const useCanvasPanelsStore = defineStore('canvasPanels', () => {
   const getGeom = (k: string): PanelGeom | undefined => geom.value[k]
   const setGeom = (k: string, g: PanelGeom) => { geom.value[k] = g }
   const delGeom = (k: string) => { delete geom.value[k] }
+  // drop ONE canvas: its entry + every panel-geometry key prefixed `${key}:` (e.g. closing an
+  // Analysis-canvas tab, so its board doesn't linger in the store).
+  function drop(key: string) {
+    delete entries.value[key]
+    for (const k of Object.keys(geom.value)) if (k.startsWith(`${key}:`)) delete geom.value[k]
+  }
   // drop all canvases' panels + geometry (e.g. on project close, so stale plots don't carry over)
   function clear() { entries.value = {}; geom.value = {} }
-  return { entries, geom, ensure, getGeom, setGeom, delGeom, clear }
+  return { entries, geom, ensure, getGeom, setGeom, delGeom, drop, clear }
 })

--- a/frontend/src/stores/project.ts
+++ b/frontend/src/stores/project.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { useCanvasPanelsStore } from './canvasPanels'
+import { useAnalysisTabsStore } from './analysisTabs'
+import { useAnalysisLayoutStore } from './analysisLayout'
 
 export interface CciaImage {
   uid: string
@@ -49,6 +51,8 @@ export const useProjectStore = defineStore('project', () => {
     activeSetUid.value = sets.value[0]?.uid ?? null
     imageSelection.value = {}     // selections are per-project; don't carry across loads
     useCanvasPanelsStore().clear()   // open plots are per-project too
+    useAnalysisTabsStore().clear()   // …and the Analysis-canvas boards
+    useAnalysisLayoutStore().clear() // …and their grid layouts
   }
 
   function clear() {
@@ -57,6 +61,8 @@ export const useProjectStore = defineStore('project', () => {
     napariImageUid.value = null
     imageSelection.value = {}
     useCanvasPanelsStore().clear()
+    useAnalysisTabsStore().clear()
+    useAnalysisLayoutStore().clear()
   }
 
   function addSetFromApi(uid: string, name: string): CciaSet {

--- a/frontend/src/stores/projectMeta.ts
+++ b/frontend/src/stores/projectMeta.ts
@@ -2,6 +2,8 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { useLogStore } from './log'
 import { useProjectStore, type CciaSet } from './project'
+import { useAnalysisTabsStore } from './analysisTabs'
+import { useAnalysisLayoutStore } from './analysisLayout'
 
 export type ProjectType = 'static' | 'live' | 'flow'
 
@@ -69,11 +71,18 @@ export const useProjectMetaStore = defineStore('projectMeta', () => {
       const body = await res.json().catch(() => ({})) as {
         project?: ProjectRecord
         sets?: CciaSet[]
+        boards?: { tabs?: unknown; layouts?: Record<string, unknown> } | null
         error?: string
       }
       if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
       current.value = body.project!
-      projectStore.loadFromApi(body.sets ?? [])
+      projectStore.loadFromApi(body.sets ?? [])   // NB: clears the analysis stores — restore AFTER
+      // rehydrate the Analysis-canvas boards saved with the project (analysisBoards.json)
+      if (body.boards) {
+        const groupKey = `analysis:${body.project!.uid}`
+        useAnalysisTabsStore().load(groupKey, body.boards.tabs as never)
+        useAnalysisLayoutStore().load(body.boards.layouts as never)
+      }
       await fetchRecent()
       const nSets   = body.sets?.length ?? 0
       const nImages = body.sets?.reduce((n, s) => n + s.images.length, 0) ?? 0
@@ -93,10 +102,17 @@ export const useProjectMetaStore = defineStore('projectMeta', () => {
   async function saveProject(): Promise<void> {
     if (!current.value) return
     try {
+      // package the Analysis-canvas boards (tabs + per-tab grid layouts) for this project so they
+      // persist to analysisBoards.json alongside project.json
+      const groupKey = `analysis:${current.value.uid}`
+      const boards = {
+        tabs: useAnalysisTabsStore().serialize(groupKey),
+        layouts: useAnalysisLayoutStore().serialize(`${groupKey}:tab:`),
+      }
       const res = await fetch('/api/projects/save', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ uid: current.value.uid }),
+        body: JSON.stringify({ uid: current.value.uid, boards }),
       })
       const body = await res.json().catch(() => ({})) as { error?: string }
       if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)


### PR DESCRIPTION
## Analysis canvas — tabbed multi-board layout, gating strategy, filmstrip, PDF/CSV export

Implements the universal Analysis canvas (TODO #00036): a tabbed, multi-board surface that hosts every plot family in movable grid slots, with read-only gating visualisation and multipage PDF export.

### Layout & persistence
- Tabs + per-tab grid layout (`analysisTabs` / `analysisLayout` stores). Uniform N×M grids + comic "plate" presets; board-level slot-height slider.
- Persisted with the project under `settings/analysisBoards.json`. `chains/` also moved under `settings/` (with migration).

### Plots in slots
- Slots route to **summary** plots (`SummaryPanel`, docked) or **interactive** views (`InteractivePanel`): the gating-strategy montage and a napari-screenshot **filmstrip**. Shared canvas chrome gained a `docked` mode.
- **Read-only gating**: `GateScatterCell` extracted as the single scatter+gate renderer (reused by the Gate page *and* the analysis view); `GateOverlay` `readonly` guard; `orientGate` shared.
- **Gating-strategy view**: single defining-gate plot by default; ⚙ toggle for the full hierarchy montage; channel-name axes; fixed `pctParent` (was multiplied by 100 twice); square plot fit-to-slot (width-capped).
- **Filmstrip**: captioned napari screenshots (`/api/napari/screenshot`), straight/angled separators, white centred captions + caption-size slider.

### Export
- One **A4** page per board (orientation follows the board), laid out from the on-screen slot rects; **plot-only, light-theme** images (dark theme is on-screen only); per-plot **CSV attachments** + a standalone CSV button.
- Real **hi-res WebGL export**: resize the backing store keeping `aspectRatio` + redraw (regl's `export()` blanked on the fixed-camera gate scatter → screen-res fallback); applied to both single and montage.

### Fixes
- Selected populations were wiped by the prune watcher on a transient-empty `segPops` (load / image-switch) and then saved empty — guarded both the global and per-slot prunes.
- `useSummaryData` composable shared by `SummaryCanvas` + `LayoutCanvas`.

### Docs
- `OBJECTMODEL.md` / `API.md` / `UI.md` updated. `docs/todo/ANALYSIS_CANVAS_PLAN.md` parked plan incl. **Phase G** (cluster UMAP + heatmap via an active-slot-driven, per-family pop manager).

### Follow-ups (not in this PR)
- Phase G: cluster UMAP + heatmap in the canvas (own branch).
- `docs/ANALYSIS.md` (Phase F).
- Backend restart needed to activate `/api/napari/screenshot`, `settings/` board save/load, and `settings/chains` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)