### PR TITLE
Feat/analysis cluster plots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ See also:
 - [`docs/POPULATION.md`](docs/POPULATION.md) — population manager & gating: pop types, transforms, gating/{value_name}.json storage, pop_df unified accessor, gate↔track composition, membership access
 - [`docs/API.md`](docs/API.md) — HTTP/WS surface: routing conventions, binary responses, route index, gating routes (popmap/CRUD/plotdata/density/membership/stats)
 - [`docs/PLOTS.md`](docs/PLOTS.md) — summary-plot design: chart types × data source (one/multi/pooled) × measure type (numeric/categorical), encoding model, the agreed renderer spec
+- [`docs/ANALYSIS.md`](docs/ANALYSIS.md) — the Analysis board (`/analysis`): tabs + comic-plate layout + persistence keys, the registry-driven plot families (summary/interactive/cluster/image), the read-only cluster manager, the gating-strategy plot, and PDF/CSV export (light theme, shared hi-res raster path)
 - [`docs/FUTURE.md`](docs/FUTURE.md) — deliberately deferred optimisations (known-better alternatives set aside): what, why deferred, when to revisit
 - [`docs/ROADMAP.md`](docs/ROADMAP.md) — temporary forward goals: phases (behaviour/HMM → clustering → freeze v1.0 → packaging/distribution → self-update) + post-v1 backlog. Consult before starting a new phase.
 - [`docs/MILESTONES.md`](docs/MILESTONES.md) — durable, append-only ledger of what landed and how it was packaged (the counterpart to the throwaway roadmap). Add an entry at each freeze/release.
@@ -29,6 +30,7 @@ See also:
 | Layer boundaries, contracts, hidden invariants | `docs/ARCHITECTURE.md` |
 | Scheduler, resource pools, barriers, event bus | `docs/SCHEDULER.md` |
 | UI patterns, components, design tokens | `docs/UI.md` |
+| Analysis board: tabs/layout, plot-hosting registries, board export | `docs/ANALYSIS.md` |
 | Task JSON, registry, module pages, composite pattern | `docs/MODULES.md` |
 | Napari bridge, commands, OME-ZARR, contrast, layer props | `docs/NAPARI.md` |
 | Object model, ccid.json, versioned fields, disk layout | `docs/OBJECTMODEL.md` |

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -1,0 +1,94 @@
+# Analysis board
+
+The **Analysis board** (`/analysis`, `modules/AnalysisModule.vue`) is a free-form, multi-tab surface
+for composing plots from **every** module page onto one page — across images, segmentations and
+populations — for figure assembly and export. It is **read-only for the data model**: it visualises
+existing populations, gates, clusters and measures; it never mutates gate/population definitions
+(`memory: analysis_canvas_readonly`). Gate *drawing* stays on the gating page.
+
+Parked design + phase history: `docs/todo/ANALYSIS_CANVAS_PLAN.md`. Plot conventions: `docs/PLOTS.md`.
+The generic plot-integration contract (how a plot appears on this board without per-plot wiring):
+`docs/UI.md` → *Generic plot-integration interface*.
+
+## Model — tabs, layout, slots
+
+A board is one **tab**; a project has many. Three stores, each keyed per project/tab, keep the concerns
+separate:
+
+| Store | Owns | Key |
+|---|---|---|
+| `stores/analysisTabs.ts` | the tab **list** + names + active tab | group `analysis:${projectUid}` |
+| `stores/analysisLayout.ts` | each tab's **grid layout** (plate template, slot spans, per-slot content + `shared` bag) | `analysis:${projectUid}:tab:${id}` |
+| `stores/canvasPanels.ts` | reused only for the summary/interactive **panel machinery** under the same tab canvas key | `${groupKey}:tab:${id}` |
+
+All three are **in-memory** (survive navigation, not a full reload) and cleared on project open/close
+(`stores/project.ts`). Durable persistence is with the project: the whole board set is dumped to
+`{proj}/…/settings/analysisBoards.json` (opaque frontend JSON) on save and restored on open — see
+`api/src/routes.jl` (`api_projects_save` / project-open payload's `boards`). **Backend restart** is
+needed the first time this route is active (`api/` is not Revise-tracked; see `CLAUDE.md`).
+
+Each tab renders through `components/canvas/LayoutCanvas.vue`: a **comic-plate** grid (templates in
+`plots/layoutTemplates.ts` — header banners, splits, hero+N) whose slots each hold one plot. A slot's
+content is `{ kind, ref, state }`; the `⚙` popover tunes cols/rows/row-height. `TabbedCanvas.vue` wraps
+it with the tab bar + the PDF/CSV export buttons.
+
+## Plot families — one registry-driven mechanism
+
+Slots are filled from the **same registries the module pages use** — there is one way to host a plot,
+not one per surface (`docs/UI.md`). The `+ Plot` picker groups them:
+
+- **Summary** (server-aggregated, Observable Plot): the plot-spec registry (`GET /api/plots/definitions`),
+  rendered by one `SummaryPanel` → `PlotChart`. Identical to `SummaryCanvas` (behaviour/summary pages).
+- **Interactive** (WebGL/self-contained): `components/canvas/interactiveViews.ts` (`INTERACTIVE_VIEWS`),
+  hosted by the generic `InteractivePanel`. Members: **UMAP** (`UmapView`), **gating strategy**
+  (`GatingStrategyView`), **image/strip** (`ImageStripView`). Surface flags `clusterPage` / `analysisBoard`.
+- **Cluster panels** (summary-family, wrap `CanvasPanel`): `modules/cluster/clusterPanels.ts`
+  (`CLUSTER_PANELS`) — **heatmap**, **HMM states**, **HMM transitions**. Flags `analysisBoard` /
+  `trackOnly` / `needsCols`, plus a `props(ctx)` mapper. Rendered generically via `<component :is v-bind>`.
+
+Adding a plot to the board = write the component to the contract + one registry line + tick the flag.
+No `LayoutCanvas` change.
+
+### `docked` — the chrome switch
+Every hosted plot reads `docked` (true in a board slot). Docked plots drop the chrome that only makes
+sense free-floating — the **reload** button and the per-plot **Export** dropdown — because the board
+re-fetches on context change and exports via PDF/CSV. `InteractivePanel` forwards `docked` to its view.
+
+### Clustering — one run per board
+Cluster plots (UMAP + `CLUSTER_PANELS`) share **one clustering run per board**: board-level
+`clustPopType` + `clustSuffix` live in the tab's `shared` bag and drive the singleton gating store via
+`composables/useClusterContext.ts` (only when a cluster slot exists). The right rail swaps to a
+**read-only** `PopulationManager` (highlight/tick to colour, no add/delete/rename/recolour/reassign)
+that follows the active cluster slot with per-family global/local scope.
+
+### Gating strategy (read-only)
+`GatingStrategyView` renders the defining gate for a population (single plot) or the full hierarchy
+montage (⚙ toggle) from `popmap` + gate stats — the read-only counterpart of the gating page's
+`GatePlotPanel`. Ports the old R `plot_gating` lineage. **The gating page itself is intentionally NOT
+registry-hosted** (it is a write-capable gate-drawing workspace, the opposite of this contract).
+
+### Image / napari-screenshot slot
+`ImageStripView` shows an image filmstrip with a caption overlay (size slider in its ⚙). Napari-screenshot
+slots capture the live viewer via `/api/napari/screenshot` (backend restart to activate).
+
+## Export — PDF + CSV
+
+`TabbedCanvas` drives export; `LayoutCanvas.capturePage()` measures the on-screen grid so the PDF
+reproduces the layout exactly (spans, plates, gaps), and `plots/pdf.ts` lays out **exact A4** pages
+(per-board orientation) via `pdf-lib`.
+
+- **Light theme**: dark theme is on-screen only. Each plot exposes `exportImage()` → a plot-only
+  **light-theme** PNG (summary via `PlotChart.toImageURL(_, light)`; interactive/cluster via a
+  `forceLight`/`.cc-light` re-render). Chrome is excluded (the plot host is captured, not the slot).
+- **Hi-res raster**: WebGL scatters (UMAP, gating cell) would export soft at screen backing size. The
+  **shared** helpers `rasterExportScale` + `rasterPlotToImageURL` (`plots/export.ts`) target a fixed
+  ~2200px long side (scale 4–14×) and re-render the point cloud at that scale via each view's `hiRes`
+  resolver (`ScatterGL.exportCanvas`). One path for both the gating scatter and the cluster UMAP — do
+  not reinvent the scale math per plot.
+- **CSV**: each summary/cluster panel exposes `getCsv()` (the shown aggregated data); the standalone CSV
+  button collects them all (→ Prism).
+
+## Cross-references
+`docs/UI.md` (generic plot-integration contract, `docked`, canvas shell), `docs/PLOTS.md` (summary-plot
+spec), `docs/POPULATION.md` (pop_df, gate↔track, cluster pops), `docs/NAPARI.md` (screenshot),
+`docs/API.md` (`/api/plots/*`, project save/open), `docs/todo/ANALYSIS_CANVAS_PLAN.md` (design history).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -219,7 +219,7 @@ batch it rather than churn standalone.
 
 ## Fixed
 
-**#00036** — **Universal "Analysis canvas" page** (2026-07-01)
+**#00036** — **Universal "Analysis board" page** (2026-07-01)
 A standalone canvas at `/analysis` that hosts the SAME plot canvas as the per-module pages but with
 the **module filter off** — every plot spec is offerable, so plots can be combined across modules /
 images / segmentations on one board. Thin as anticipated: `SummaryCanvas` already supported the

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -281,6 +281,34 @@ graphics lib gives the cleaner publication look for pre-aggregated summaries. Ne
 job well, so we keep both. Never add or swap a charting library without updating this doc, `docs/PLOTS.md`,
 and the `cecelia-charting-decision` rationale.
 
+### Generic plot-integration interface (reuse across surfaces)
+
+A plot is defined **once** and appears on any surface — module page, **Analysis board**, and (future)
+the **chain whiteboard** (`docs/SCHEDULER.md`) — via a flag. **No per-plot host wiring.** This is how you
+"drop a plot onto the board" without touching `LayoutCanvas`/`ClusterPlots`.
+
+**The contract a plot component must honour:**
+- **Self-contained**: renders from a standard prop bag + persisted `state`, and **seeds its own defaults**
+  (e.g. `ClusterHeatmapPanel` seeds `features` from the run — never rely on the host to seed). Persist
+  every user-settable option in `state` (see "Persisting view state").
+- **Standard bag**: `projectUid, setUid, imageUids, vis, state` (+ for cluster plots `popType, suffix,
+  shownPops`; + panel chrome `index, active, docked, persistKey`).
+- **Export hooks** for the board's PDF/CSV: `exportImage()` → a plot-only **light-theme** PNG (dark theme
+  is on-screen only), and `getCsv()` → the shown data. (Interactive views may instead expose
+  `exportFormats`/`exportAs`.)
+
+**Two registries carry the surface "checkboxes":**
+- `components/canvas/interactiveViews.ts` — WebGL/interactive VIEWS (hosted by `InteractivePanel`), flags
+  `clusterPage` / `analysisBoard`.
+- `modules/cluster/clusterPanels.ts` — summary-family cluster PANELS (wrap `CanvasPanel`), flags
+  `analysisBoard` / `trackOnly` / `needsCols`, plus a `props(ctx)` mapper so the host binds panel-specific
+  props generically.
+
+**Hosts render from the registries**: each builds its `+Plot` picker by filtering on its own flag, and
+renders each slot with one generic `<component :is v-bind>`. Adding a plot to a surface = write the
+component to the contract + one registry line + tick the flag. When you add the chain-whiteboard as a
+host, it consumes the *same* registries + contract — do not re-wire plots per node.
+
 ---
 
 ## WS events — frontend side

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -309,6 +309,29 @@ renders each slot with one generic `<component :is v-bind>`. Adding a plot to a 
 component to the contract + one registry line + tick the flag. When you add the chain-whiteboard as a
 host, it consumes the *same* registries + contract — do not re-wire plots per node.
 
+**One mechanism across every surface — no per-page divergence.** The module page and the board host the
+*same* components the *same* way; there is not "the cluster page's way" and "the board's way":
+- **Cluster page** (`ClusterPlots.vue`) and **Analysis board** (`LayoutCanvas.vue`) both discover plots
+  from `INTERACTIVE_VIEWS` + `CLUSTER_PANELS` and render them with the identical generic
+  `<component :is v-bind>` (see each file's `clusterPanelProps`). Panel chrome differs only by `docked`
+  (a grid slot drops its own reload/controls/export; a floating panel keeps them).
+- **Behaviour / summary pages** (`SummaryCanvas.vue`) and the board's summary slots both render every
+  summary plot through one `SummaryPanel` driven by the server plot-spec registry
+  (`GET /api/plots/definitions`) — already a single mechanism.
+- **`docked` is the contract's chrome switch.** A view/panel reads `docked` to hide anything that only
+  makes sense free-floating (the reload button, the per-plot Export dropdown) — the board re-fetches on
+  context change and exports via PDF/CSV, so that chrome would be redundant in a slot. `InteractivePanel`
+  forwards `docked` to its view for exactly this.
+
+**Exception — the gating page (`gate/GatingPlots.vue`) is intentionally NOT registry-hosted.** It is a
+single, *write-capable* gate-drawing workspace (`GatePlotPanel` draws/edits gates), not a multi-type
+read-only plot host — the opposite of the board contract. The board hosts gating **read-only** via
+`GatingStrategyView` (an interactive-registry view, `analysisBoard: true`). Don't try to fold the
+gate-drawing surface into the registry.
+
+See **`docs/ANALYSIS.md`** for the Analysis board itself (tabs, comic-plate layout, persistence keys,
+the read-only cluster manager, and PDF/CSV export incl. the shared hi-res raster path).
+
 ---
 
 ## WS events — frontend side
@@ -547,7 +570,7 @@ aggregation is a PACKAGE function, the route is thin, rendering is frontend-only
   the host just re-renders with the new size. Exposes `toImageURL('png'|'svg')` — SVG serialises the
   node (native), PNG rasterises it at the DPR-aware `EXPORT_SCALE`. The summaries equivalent of `ScatterGL` for the big point
   clouds.
-The universal **Analysis canvas** (`/analysis`, `AnalysisModule.vue`) is **multipage**: `TabbedCanvas`
+The universal **Analysis board** (`/analysis`, `AnalysisModule.vue`) is **multipage**: `TabbedCanvas`
 wraps N independent boards, each a `SummaryCanvas` with no `module` prop (→ all plot specs). The tab
 LIST (names/order/active) lives in the `analysisTabs` store; each board's plots persist in
 `canvasPanels` under the canvas key `analysis:{projectUid}:tab:{id}` — i.e. tabs reuse the whole
@@ -561,7 +584,7 @@ multipage feature (interactive plots in the universal canvas, gating-strategy pl
 `docs/todo/ANALYSIS_CANVAS_PLAN.md`.
 
 These canvas components are **generic** (`components/canvas/`, NOT under a module) so every module
-page — and the Analysis canvas — reuses them unchanged:
+page — and the Analysis board — reuses them unchanged:
 - **`components/canvas/SummaryPanel.vue`** — one summary plot, wrapping `CanvasPanel`. Layout: the
   **controls row** (`#actions`) holds a **measure dropdown** (from the spec's `measureOptions`) and a
   **chart-type dropdown** (from `chartTypes`, shown when >1); the secondary options — **Split by**
@@ -591,13 +614,13 @@ page — and the Analysis canvas — reuses them unchanged:
   block (rendered when the host passes a `vis` bag). Both `SeriesPicker` and `PopulationManager` wrap
   it — the differing population LIST is the default slot; host-specific controls (the gating manager's
   gate/viewer options) go in the `#options` slot. Slotted rows keep their own component's scoped CSS;
-  the shell owns only the chrome. One place for the chrome → the universal analysis canvas reuses it.
+  the shell owns only the chrome. One place for the chrome → the universal analysis board reuses it.
 - **`components/canvas/PlotOptions.vue`** — the **shared** `VisProps` styling controls (collapsible
   Layout / Points / Colours / Labels sub-sections; props `vis`, emits `update:vis`). Embedded by BOTH
   `SeriesPicker` (summary canvas) and `PopulationManager` (gating / cluster canvas), so the styling
   knobs live in ONE place. `PopulationManager` renders it only when the host passes a `vis` bag (the
   cluster canvas does; the gate canvas doesn't) — the "add plot styling to the pop manager" keyword.
-  The universal Analysis canvas (`/analysis`) gets the same controls for free.
+  The universal Analysis board (`/analysis`) gets the same controls for free.
 - **`plots/export.ts`** — the **shared** plot-export plumbing (`svgToImageURL` PNG/SVG rasterise,
   `svgOf`, `downloadDataUrl`/`downloadBlob`, `rowsToCsv`, and `elementToImageURL`). Used by
   `PlotChart.toImageURL` AND the bespoke cluster panels, so a plot that renders its own `<svg>` exports

--- a/docs/todo/ANALYSIS_CANVAS_PLAN.md
+++ b/docs/todo/ANALYSIS_CANVAS_PLAN.md
@@ -346,13 +346,12 @@ board run-picker; right rail swaps to a **read-only** `PopulationManager` for cl
 only, no add/delete/rename/recolour/cluster-reassignment). Registry gained a `clusterPage` flag so
 `gatingStrategy`/`filmstrip` no longer leak into the Cluster module's +Plot picker (they're analysis-only).
 
-Remaining ("all plots from all module pages"):
-- **HMM state + HMM transition plots** (`ClusterHmmStatesPanel` / `ClusterHmmTransitionsPanel`,
-  trackclust-only) as analysis slots — same docked-panel pattern as the cluster heatmap, fed the board
-  cluster context (`hmmStateCols` / `hmmTransitionCols` from `useClusterContext`, `shownPops`, `suffix`).
-  Offer them in the "Clustering" picker group only when `clustPopType === 'trackclust'` and the cols exist.
-- Hi-res UMAP PDF export (expose `exportImage`/`hiRes` from `UmapView` like `GateScatterCell`; today it
-  falls back to a screen-res DOM snapshot).
+Remaining ("all plots from all module pages") — **DONE**:
+- **HMM state + HMM transition plots** landed as analysis slots (docked-panel pattern, board cluster
+  context, offered in the "Clustering" picker only for `trackclust` runs with the cols).
+- **Hi-res UMAP PDF export** landed: `UmapView.exportImage()` forces a light theme and uses the shared
+  `rasterPlotToImageURL` helper (fixed ~2200px long side, WebGL re-render at scale) — same crisp path as
+  `GateScatterCell`; no more screen-res DOM-snapshot fallback (which also leaked chrome + dark theme).
 
 #### Generic plot-integration interface (the goal — no per-plot host wiring)
 
@@ -380,6 +379,16 @@ Landed: `clusterPanels.ts` registry (heatmap + HMM states/transitions) with `ana
 cluster plot GENERICALLY (`<component :is v-bind>` from the registry, picker from the flag) — no per-plot
 branch. Panels conform to the contract: `docked`, self-seed (heatmap features), `exportImage()` (light) +
 `getCsv()`. Interface documented in `docs/UI.md` ("Generic plot-integration interface").
-Cleanup (defer): render the **Cluster module page** (`ClusterPlots`) from the same registry too (it still
-hard-codes heatmap/hmm branches + a `hmm-states`↔`hmmStates` kind-name mismatch — align keys, mind
-persisted panel kinds). Chain-whiteboard host consumes the same registries when built.
+Landed (cleanup done): the **Cluster module page** (`ClusterPlots`) now renders cluster panels from the
+SAME `CLUSTER_PANELS` registry via one generic `<component :is v-bind="clusterPanelProps(p)">` (no more
+hard-coded heatmap/hmm branches); picker built from the registry flags; legacy persisted kinds migrated
+(`hmm-states`→`hmmStates`, `hmm-transitions`→`hmmTransitions`). `SummaryCanvas` was already registry-driven
+(server plot-spec registry → one `SummaryPanel`), so behaviour/summary pages already matched. The **gating
+page** stays out by design (write-capable gate-drawing surface; the board hosts read-only `GatingStrategyView`
+via the interactive registry) — documented as the explicit exception in `docs/UI.md`.
+`docked` is the contract's chrome switch: views/panels drop reload + per-plot export in a grid slot;
+`InteractivePanel` forwards `docked` to its view (fixed the lingering UMAP/heatmap/HMM reload buttons).
+Hi-res export unified: `plots/export.ts` gained `rasterExportScale` + `rasterPlotToImageURL` (one crisp
+fixed-~2200px-long-side path), shared by the gating scatter (`GateScatterCell`) and the cluster UMAP
+(`UmapView`) — fixed the low-res / dark-theme / chrome-in-PDF UMAP export. Chain-whiteboard host consumes
+the same registries + helpers when built.

--- a/docs/todo/ANALYSIS_CANVAS_PLAN.md
+++ b/docs/todo/ANALYSIS_CANVAS_PLAN.md
@@ -353,3 +353,33 @@ Remaining ("all plots from all module pages"):
   Offer them in the "Clustering" picker group only when `clustPopType === 'trackclust'` and the cols exist.
 - Hi-res UMAP PDF export (expose `exportImage`/`hiRes` from `UmapView` like `GateScatterCell`; today it
   falls back to a screen-res DOM snapshot).
+
+#### Generic plot-integration interface (the goal — no per-plot host wiring)
+
+A plot is defined ONCE and appears on any surface (cluster module page, analysis board, future
+whiteboard) via a flag — no bespoke host branch. The contract:
+
+1. **Component** is self-contained: renders from a standard prop bag + `state`, seeds its OWN defaults
+   (e.g. the heatmap seeds features from the run — never rely on the host to seed), and exposes
+   `exportImage()` (plot-only, light) + `getCsv()` for the board's PDF/CSV export.
+2. **Registry entry** declares WHERE it shows (the "checkboxes"): interactive WebGL views in
+   `interactiveViews.ts` (`clusterPage` / `analysisBoard` flags); summary-family cluster panels in
+   `clusterPanels.ts` (`analysisBoard`, `trackOnly`, `needsCols`, and a `props(ctx)` mapper so the host
+   binds panel-specific props generically).
+3. **Hosts render from the registry**: the +Plot picker filters by the surface flag; each slot is a
+   single generic `<component :is v-bind>` — no per-plot code in `LayoutCanvas` / `ClusterPlots`.
+
+Convergence work (rejig existing plots to the contract): make the cluster heatmap + HMM panels
+self-seed + expose `exportImage`/`getCsv` + accept the common bag; render both the cluster page and the
+board from the registries; then adding a plot = write the component + one registry line + tick the
+surface flag. Document in docs/UI.md (Interactive plots / cluster panels) + docs/MODULES.md.
+
+#### Generic integration — landed + cleanup
+Landed: `clusterPanels.ts` registry (heatmap + HMM states/transitions) with `analysisBoard`/`trackOnly`/
+`needsCols`/`props(ctx)`; `interactiveViews.ts` gained `analysisBoard`. The Analysis board renders every
+cluster plot GENERICALLY (`<component :is v-bind>` from the registry, picker from the flag) — no per-plot
+branch. Panels conform to the contract: `docked`, self-seed (heatmap features), `exportImage()` (light) +
+`getCsv()`. Interface documented in `docs/UI.md` ("Generic plot-integration interface").
+Cleanup (defer): render the **Cluster module page** (`ClusterPlots`) from the same registry too (it still
+hard-codes heatmap/hmm branches + a `hmm-states`↔`hmmStates` kind-name mismatch — align keys, mind
+persisted panel kinds). Chain-whiteboard host consumes the same registries when built.

--- a/docs/todo/ANALYSIS_CANVAS_PLAN.md
+++ b/docs/todo/ANALYSIS_CANVAS_PLAN.md
@@ -338,3 +338,18 @@ Consequences (keeps model C working for clusters):
   global summary selection across summary slots; local = active slot.
 - `useClusterContext(projectUid,imageUids,popType,suffix)` extracted from `ClusterPlots` (run list +
   features + clusterIds/members + validUids + gating-store drive + `shownPopsFor`), reused by both.
+
+#### Phase G progress + remaining
+
+Landed: `useClusterContext`; **cluster UMAP** + **cluster heatmap** as analysis slots (one run per board;
+board run-picker; right rail swaps to a **read-only** `PopulationManager` for cluster slots — highlight
+only, no add/delete/rename/recolour/cluster-reassignment). Registry gained a `clusterPage` flag so
+`gatingStrategy`/`filmstrip` no longer leak into the Cluster module's +Plot picker (they're analysis-only).
+
+Remaining ("all plots from all module pages"):
+- **HMM state + HMM transition plots** (`ClusterHmmStatesPanel` / `ClusterHmmTransitionsPanel`,
+  trackclust-only) as analysis slots — same docked-panel pattern as the cluster heatmap, fed the board
+  cluster context (`hmmStateCols` / `hmmTransitionCols` from `useClusterContext`, `shownPops`, `suffix`).
+  Offer them in the "Clustering" picker group only when `clustPopType === 'trackclust'` and the cols exist.
+- Hi-res UMAP PDF export (expose `exportImage`/`hiRes` from `UmapView` like `GateScatterCell`; today it
+  falls back to a screen-res DOM snapshot).

--- a/docs/todo/ANALYSIS_CANVAS_PLAN.md
+++ b/docs/todo/ANALYSIS_CANVAS_PLAN.md
@@ -320,3 +320,21 @@ pops it can't consume. (`useSummaryData`'s current single global `sel` becomes t
 5. **No regression to summary toggling** — flow/live becomes one family; existing `useSummaryData`
    `gSel`/`toggleTarget` behaviour must be preserved exactly.
 6. **Active-slot edge cases** — empty / `noPicker` active slot → neutral picker state; sane default target.
+
+#### DECISION: one cluster run per board (resolves the singleton-store snag)
+
+Investigation found cluster pops live in the **singleton `useGatingStore`** (loaded via
+`g.selectImage(uid, vn, popType)`) and are toggled through **`PopulationManager`** (tickable cluster IDs),
+not `SeriesPicker`. The store holds ONE active (popType, suffix) at a time — so independent per-slot
+cluster runs can't coexist. **Decision (Dom): enforce a single cluster run per board.**
+
+Consequences (keeps model C working for clusters):
+- The board carries a **board-level cluster context**: `clustPopType` + `clustSuffix`, stored in the
+  layout entry; a small run-picker shows in the board bar once a cluster slot exists. All cluster slots
+  on the board share it, so the singleton store is driven once (via `useClusterContext`).
+- Right-rail manager swaps by ACTIVE slot family: `SeriesPicker` for summary slots, **`PopulationManager`
+  (cluster mode)** for cluster slots — both already exist, no fork.
+- Per-family scope holds: global cluster highlight is shared across the board's cluster slots (same run);
+  global summary selection across summary slots; local = active slot.
+- `useClusterContext(projectUid,imageUids,popType,suffix)` extracted from `ClusterPlots` (run list +
+  features + clusterIds/members + validUids + gating-store drive + `shownPopsFor`), reused by both.

--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -42,5 +42,5 @@ If it fits in a paragraph and needs no design, it's a `docs/TODO.md` item, not a
 
 - `CLUSTERING_PLAN.md` — Leiden clustering (cells + tracks), GPU/RAPIDS parked. Cited from
   `pixi.toml`, `clustering_utils.py`, `clustPops`/`clustTracks` `cluster.jl`, `docs/SHIPPING.md`.
-- `ANALYSIS_CANVAS_PLAN.md` — multipage tabbed analysis canvas + gating-strategy plot + PDF export
+- `ANALYSIS_CANVAS_PLAN.md` — multipage tabbed analysis board + gating-strategy plot + PDF export
   (branch `feat/multipage-analysis-canvas`).

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -46,7 +46,7 @@ const groups: { heading: string; items: NavItem[] }[] = [
       { to: '/clust-cells',  label: 'Cluster cells',  icon: 'pi-palette', tip: 'Leiden cluster cells (intensities + morphology), then define populations from clusters.', requiresProject: true },
       { to: '/clust-tracks', label: 'Cluster tracks', icon: 'pi-sitemap',      tip: 'Leiden cluster tracks (motility + HMM/behaviour), then define populations from clusters.', requiresProject: true },
       { to: '/spatial', label: 'Spatial', icon: 'pi-map',          tip: 'Spatial neighbourhood and proximity analysis.', disabled: true, soon: true },
-      { to: '/analysis', label: 'Analysis canvas', icon: 'pi-clone', tip: 'Free-form canvas combining plots across modules, images and segmentations.', requiresProject: true },
+      { to: '/analysis', label: 'Analysis board', icon: 'pi-clone', tip: 'Free-form canvas combining plots across modules, images and segmentations.', requiresProject: true },
     ],
   },
   {

--- a/frontend/src/components/canvas/InteractivePanel.vue
+++ b/frontend/src/components/canvas/InteractivePanel.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
   context: Record<string, unknown>
   state: Record<string, unknown>
   duplicable?: boolean            // show a footer Duplicate button (host wires @duplicate)
-  docked?: boolean                // fill a grid slot (Analysis canvas) instead of free-floating
+  docked?: boolean                // fill a grid slot (Analysis board) instead of free-floating
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
 const entry = computed(() => INTERACTIVE_VIEWS[props.view])
@@ -39,7 +39,9 @@ defineExpose({ exportImage })
   <CanvasPanel :index="index" :active="active" :arrange="arrange" :persist-key="persistKey" :docked="docked"
                :title="entry?.label ?? view"
                @activate="emit('activate', $event)" @remove="emit('remove')">
-    <component v-if="entry" :is="entry.component" ref="viewRef" v-bind="context" :state="state" />
+    <!-- `docked` is forwarded to the view so it can drop its own chrome (reload/controls) in a grid
+         slot — part of the generic contract, same as SummaryPanel/cluster panels. -->
+    <component v-if="entry" :is="entry.component" ref="viewRef" v-bind="context" :state="state" :docked="docked" />
     <div v-else class="ip-missing">Unknown interactive plot “{{ view }}”.</div>
     <template v-if="duplicable || exportFormats.length" #footer>
       <button v-if="duplicable" class="ip-iconbtn" type="button" @click="emit('duplicate')"

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -28,7 +28,7 @@ import InteractivePanel from './InteractivePanel.vue'
 import { INTERACTIVE_VIEWS } from './interactiveViews'
 import SeriesPicker from './SeriesPicker.vue'
 import PopulationManager from './PopulationManager.vue'
-import ClusterHeatmapPanel from '../../modules/cluster/ClusterHeatmapPanel.vue'
+import { CLUSTER_PANELS, isClusterPanel } from '../../modules/cluster/clusterPanels'
 
 const props = defineProps<{ imageUids: string[]; module?: string | null; canvasKey: string }>()
 
@@ -79,17 +79,24 @@ const st = (c: SlotContent): PState => c.state as PState
 // self-contained interactive views (read their own context / pops)
 const ANALYSIS_VIEWS = ['gatingStrategy']
 const interactiveOptions = computed(() => ANALYSIS_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
-// CLUSTERING views — one clustering run per board (see useClusterContext / ANALYSIS_CANVAS_PLAN Phase G):
-// fed the board cluster context, and the right rail shows the cluster PopulationManager when one is active.
-// `umap` is a registered interactive view; `clusterHeatmap` is a docked ClusterHeatmapPanel (rendered by
-// a dedicated slot branch, not InteractivePanel). Both belong to the board's single cluster run.
-const CLUSTER_VIEWS = ['umap', 'clusterHeatmap']
-const clusterOptions = computed(() => [
-  ...CLUSTER_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })),
-  { key: 'clusterHeatmap', label: 'Cluster heatmap' },
-])
-const isClusterSlot = (c: SlotContent | null): boolean => !!c && c.kind === 'interactive' && CLUSTER_VIEWS.includes(c.ref)
-const isClusterHeatmap = (c: SlotContent | null): boolean => !!c && c.kind === 'interactive' && c.ref === 'clusterHeatmap'
+// CLUSTERING plots — one clustering run per board (see useClusterContext / ANALYSIS_CANVAS_PLAN Phase G):
+// the interactive UMAP (INTERACTIVE_VIEWS) + the cluster panels (CLUSTER_PANELS registry). Discovered
+// GENERICALLY via each registry's `analysisBoard` flag — no per-plot wiring here. A cluster slot is any
+// interactive slot whose ref is `umap` OR a registered cluster panel.
+const isClusterSlot = (c: SlotContent | null): boolean =>
+  !!c && c.kind === 'interactive' && (c.ref === 'umap' || isClusterPanel(c.ref))
+const clusterOptions = computed(() => {
+  const out: { key: string; label: string }[] = []
+  if (INTERACTIVE_VIEWS.umap?.analysisBoard) out.push({ key: 'umap', label: INTERACTIVE_VIEWS.umap.label })
+  for (const [key, def] of Object.entries(CLUSTER_PANELS)) {
+    if (!def.analysisBoard) continue
+    if (def.trackOnly && clustPopType.value !== 'trackclust') continue          // HMM = track runs only
+    if (def.needsCols === 'hmmState' && !clustHmmStateCols.value.length) continue
+    if (def.needsCols === 'hmmTransition' && !clustHmmTransitionCols.value.length) continue
+    out.push({ key, label: def.label })
+  }
+  return out
+})
 // image-content views (napari screenshot slots) — grouped separately in the picker
 const IMAGE_VIEWS = ['filmstrip']
 const imageOptions = computed(() => IMAGE_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
@@ -100,7 +107,8 @@ function addPlot(i: number, val: string) {
   const sep = val.indexOf(':'); const kind = val.slice(0, sep); const ref = val.slice(sep + 1)
   if (kind === 'summary') layout.setContent(props.canvasKey, i, { kind: 'summary', ref, state: { specId: ref, sel: [], vis: defaultVis() } })
   else if (kind === 'interactive') {
-    const state = ref === 'umap' ? { labels: true, hl: [] } : ref === 'clusterHeatmap' ? { features: [], hl: [] } : {}
+    // cluster slots carry a `hl` (highlight) bag; panels self-seed the rest (e.g. heatmap features)
+    const state = ref === 'umap' ? { labels: true, hl: [] } : isClusterPanel(ref) ? { hl: [] } : {}
     layout.setContent(props.canvasKey, i, { kind: 'interactive', ref, state })
   }
   layout.setActive(props.canvasKey, i)
@@ -155,7 +163,8 @@ const clustSuffix = computed<string>({
   get: () => (entry.value.shared.clustSuffix as string) ?? 'default',
   set: v => (entry.value.shared.clustSuffix = v) })
 const { suffixes: clustSuffixes, clusterIds: clustClusterIds, validUids: clustValidUids,
-        featureOptions: clustFeatureOptions, nameMap: clustNameMap, shownPopsFor } =
+        featureOptions: clustFeatureOptions, nameMap: clustNameMap,
+        hmmStateCols: clustHmmStateCols, hmmTransitionCols: clustHmmTransitionCols, shownPopsFor } =
   useClusterContext({ projectUid, imageUids: computed(() => props.imageUids),
                       popType: clustPopType, suffix: clustSuffix, enabled: hasClusterSlot })
 
@@ -182,6 +191,22 @@ function ctxFor(c: SlotContent) {
   return { projectUid: projectUid.value, imageUids: props.imageUids, setUid: setUid.value, vis: panelVis(c) }
 }
 
+// props for a cluster PANEL slot (CLUSTER_PANELS): the common bag + the panel-specific props its registry
+// entry maps from the shared cluster context — so the slot renders with one generic <component v-bind>.
+function clusterPanelProps(i: number) {
+  const c = entry.value.contents[i]!
+  const ctx = { featureOptions: clustFeatureOptions.value, nameMap: clustNameMap.value,
+                hmmStateCols: clustHmmStateCols.value, hmmTransitionCols: clustHmmTransitionCols.value }
+  return {
+    index: i, active: i === entry.value.activeIndex, arrange: null, docked: true,
+    projectUid: projectUid.value, setUid: setUid.value, imageUids: clustValidUids.value,
+    popType: clustPopType.value, suffix: clustSuffix.value,
+    shownPops: shownPopsFor(panelClustHl(c)), vis: panelVis(c), state: c.state,
+    persistKey: `${props.canvasKey}:slot:${i}`,
+    ...(CLUSTER_PANELS[c.ref].props?.(ctx) ?? {}),
+  }
+}
+
 // prune vanished pops from every slot's local selection (the composable prunes the global one). Guard on
 // a non-empty segPops — it's transiently [] during load/image-switch, and pruning then would wipe (and
 // then persist-empty) a restored per-slot selection.
@@ -195,7 +220,7 @@ const gridRef = useTemplateRef<HTMLElement>('gridRef')
 const capturing = ref(false)
 function labelFor(c: SlotContent): string {
   if (c.kind === 'summary') return specById.value[c.ref]?.label ?? c.ref
-  if (isClusterHeatmap(c)) return 'Cluster heatmap'
+  if (isClusterPanel(c.ref)) return CLUSTER_PANELS[c.ref].label
   return INTERACTIVE_VIEWS[c.ref]?.label ?? c.ref
 }
 // panel instances by slot index, so we can ask each for a PLOT-ONLY, LIGHT-theme image (no chrome) and
@@ -227,7 +252,7 @@ async function capturePage() {
       // (e.g. filmstrip/image slots, which are already screenshots) with the chrome hidden.
       // summary + cluster-heatmap panels expose exportImage()/getCsv() (summaryRefs); other interactive
       // views expose exportImage() (interactiveRefs); anything else → white-ground DOM snapshot.
-      const summaryLike = c.kind === 'summary' || isClusterHeatmap(c)
+      const summaryLike = c.kind === 'summary' || isClusterPanel(c.ref)
       let png: string | null = null
       if (summaryLike) png = await summaryRefs.get(i)?.exportImage() ?? null
       else if (c.kind === 'interactive') png = await interactiveRefs.get(i)?.exportImage?.() ?? null
@@ -246,7 +271,7 @@ function collectCsvs(): { name: string; csv: string | null }[] {
   const out: { name: string; csv: string | null }[] = []
   for (let i = 0; i < entry.value.contents.length; i++) {
     const c = entry.value.contents[i]
-    if (c && (c.kind === 'summary' || isClusterHeatmap(c))) out.push({ name: labelFor(c), csv: summaryRefs.get(i)?.getCsv() ?? null })
+    if (c && (c.kind === 'summary' || isClusterPanel(c.ref))) out.push({ name: labelFor(c), csv: summaryRefs.get(i)?.getCsv() ?? null })
   }
   return out
 }
@@ -359,17 +384,12 @@ defineExpose({ capturePage, collectCsvs })
                           :vis="panelVis(entry.contents[i]!)" :ui="entry.contents[i]!.state" :collapse-series="poolGroups"
                           :reload-token="reloadToken" :persist-key="`${canvasKey}:slot:${i}`"
                           @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)" />
-            <!-- cluster heatmap (docked ClusterHeatmapPanel; board's single cluster run) -->
-            <ClusterHeatmapPanel v-else-if="isClusterHeatmap(entry.contents[i])"
-                          :ref="el => setSummaryRef(i, el)"
-                          :index="i" :active="i === entry.activeIndex" :docked="true" :arrange="null"
-                          :project-uid="projectUid" :set-uid="setUid" :image-uids="clustValidUids"
-                          :pop-type="clustPopType" :suffix="clustSuffix"
-                          :feature-options="clustFeatureOptions" :name-map="clustNameMap"
-                          :shown-pops="shownPopsFor(panelClustHl(entry.contents[i]!))"
-                          :vis="panelVis(entry.contents[i]!)" :state="entry.contents[i]!.state"
-                          :persist-key="`${canvasKey}:slot:${i}`"
-                          @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)" />
+            <!-- cluster PANEL (heatmap / HMM …) — rendered GENERICALLY from the CLUSTER_PANELS registry
+                 (docked, board's single cluster run); no per-plot branch -->
+            <component v-else-if="entry.contents[i] && isClusterPanel(entry.contents[i]!.ref)"
+                       :is="CLUSTER_PANELS[entry.contents[i]!.ref].component" :ref="(el: unknown) => setSummaryRef(i, el)"
+                       v-bind="clusterPanelProps(i)"
+                       @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)" />
             <!-- interactive plot (UMAP / gating-strategy / …) -->
             <InteractivePanel v-else-if="entry.contents[i]?.kind === 'interactive' && INTERACTIVE_VIEWS[entry.contents[i]!.ref]"
                               :ref="el => setInteractiveRef(i, el)"

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -12,7 +12,7 @@
   under this tab's `canvasKey`; the parent (TabbedCanvas) :keys us by it so a tab switch rebinds.
 -->
 <script setup lang="ts">
-import { computed, watch, ref, useTemplateRef } from 'vue'
+import { computed, watch, ref, useTemplateRef, onMounted, onUnmounted } from 'vue'
 import { plotHostToImageURL } from '../../plots/export'
 import { useProjectStore } from '../../stores/project'
 import { useProjectMetaStore } from '../../stores/projectMeta'
@@ -28,6 +28,7 @@ import InteractivePanel from './InteractivePanel.vue'
 import { INTERACTIVE_VIEWS } from './interactiveViews'
 import SeriesPicker from './SeriesPicker.vue'
 import PopulationManager from './PopulationManager.vue'
+import ClusterHeatmapPanel from '../../modules/cluster/ClusterHeatmapPanel.vue'
 
 const props = defineProps<{ imageUids: string[]; module?: string | null; canvasKey: string }>()
 
@@ -47,6 +48,13 @@ const entry = computed(() => layout.entries[props.canvasKey])
 // board-level slot height: rows share a fixed total height (rowHeight × rows); the board scrolls in the
 // page if it's taller than the viewport. Default 320px/row.
 const rowHeight = computed({ get: () => entry.value.rowHeight ?? 320, set: v => (entry.value.rowHeight = v) })
+
+// grid size + height controls live in a ⚙ popover so the board bar doesn't crowd; close on outside click
+const optsOpen = ref(false)
+const optsRef = useTemplateRef<HTMLElement>('optsRef')
+function onDocClick(e: MouseEvent) { if (optsOpen.value && optsRef.value && !optsRef.value.contains(e.target as Node)) optsOpen.value = false }
+onMounted(() => document.addEventListener('mousedown', onDocClick))
+onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
 const gridStyle = computed(() => ({
   gridTemplateColumns: entry.value.colTracks ?? `repeat(${entry.value.cols}, minmax(0, 1fr))`,
   gridTemplateRows: entry.value.rowTracks ?? `repeat(${entry.value.rows}, minmax(0, 1fr))`,
@@ -73,9 +81,15 @@ const ANALYSIS_VIEWS = ['gatingStrategy']
 const interactiveOptions = computed(() => ANALYSIS_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
 // CLUSTERING views — one clustering run per board (see useClusterContext / ANALYSIS_CANVAS_PLAN Phase G):
 // fed the board cluster context, and the right rail shows the cluster PopulationManager when one is active.
-const CLUSTER_VIEWS = ['umap']
-const clusterOptions = computed(() => CLUSTER_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
+// `umap` is a registered interactive view; `clusterHeatmap` is a docked ClusterHeatmapPanel (rendered by
+// a dedicated slot branch, not InteractivePanel). Both belong to the board's single cluster run.
+const CLUSTER_VIEWS = ['umap', 'clusterHeatmap']
+const clusterOptions = computed(() => [
+  ...CLUSTER_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })),
+  { key: 'clusterHeatmap', label: 'Cluster heatmap' },
+])
 const isClusterSlot = (c: SlotContent | null): boolean => !!c && c.kind === 'interactive' && CLUSTER_VIEWS.includes(c.ref)
+const isClusterHeatmap = (c: SlotContent | null): boolean => !!c && c.kind === 'interactive' && c.ref === 'clusterHeatmap'
 // image-content views (napari screenshot slots) — grouped separately in the picker
 const IMAGE_VIEWS = ['filmstrip']
 const imageOptions = computed(() => IMAGE_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
@@ -85,7 +99,10 @@ function addPlot(i: number, val: string) {
   if (!val) return
   const sep = val.indexOf(':'); const kind = val.slice(0, sep); const ref = val.slice(sep + 1)
   if (kind === 'summary') layout.setContent(props.canvasKey, i, { kind: 'summary', ref, state: { specId: ref, sel: [], vis: defaultVis() } })
-  else if (kind === 'interactive') layout.setContent(props.canvasKey, i, { kind: 'interactive', ref, state: CLUSTER_VIEWS.includes(ref) ? { labels: true, hl: [] } : {} })
+  else if (kind === 'interactive') {
+    const state = ref === 'umap' ? { labels: true, hl: [] } : ref === 'clusterHeatmap' ? { features: [], hl: [] } : {}
+    layout.setContent(props.canvasKey, i, { kind: 'interactive', ref, state })
+  }
   layout.setActive(props.canvasKey, i)
 }
 function clearSlot(i: number) { layout.setContent(props.canvasKey, i, null) }
@@ -137,7 +154,8 @@ const clustPopType = computed<'clust' | 'trackclust'>({
 const clustSuffix = computed<string>({
   get: () => (entry.value.shared.clustSuffix as string) ?? 'default',
   set: v => (entry.value.shared.clustSuffix = v) })
-const { suffixes: clustSuffixes, clusterIds: clustClusterIds, validUids: clustValidUids, shownPopsFor } =
+const { suffixes: clustSuffixes, clusterIds: clustClusterIds, validUids: clustValidUids,
+        featureOptions: clustFeatureOptions, nameMap: clustNameMap, shownPopsFor } =
   useClusterContext({ projectUid, imageUids: computed(() => props.imageUids),
                       popType: clustPopType, suffix: clustSuffix, enabled: hasClusterSlot })
 
@@ -176,7 +194,9 @@ watch(segPops, () => {
 const gridRef = useTemplateRef<HTMLElement>('gridRef')
 const capturing = ref(false)
 function labelFor(c: SlotContent): string {
-  return c.kind === 'summary' ? (specById.value[c.ref]?.label ?? c.ref) : (INTERACTIVE_VIEWS[c.ref]?.label ?? c.ref)
+  if (c.kind === 'summary') return specById.value[c.ref]?.label ?? c.ref
+  if (isClusterHeatmap(c)) return 'Cluster heatmap'
+  return INTERACTIVE_VIEWS[c.ref]?.label ?? c.ref
 }
 // panel instances by slot index, so we can ask each for a PLOT-ONLY, LIGHT-theme image (no chrome) and
 // pull the summary plot's aggregated CSV. Both panel types expose exportImage(); summary also getCsv().
@@ -205,11 +225,14 @@ async function capturePage() {
       if (!c || !el) continue
       // prefer the panel's plot-only light-theme export; fall back to a white-ground DOM snapshot
       // (e.g. filmstrip/image slots, which are already screenshots) with the chrome hidden.
+      // summary + cluster-heatmap panels expose exportImage()/getCsv() (summaryRefs); other interactive
+      // views expose exportImage() (interactiveRefs); anything else → white-ground DOM snapshot.
+      const summaryLike = c.kind === 'summary' || isClusterHeatmap(c)
       let png: string | null = null
-      if (c.kind === 'summary') png = await summaryRefs.get(i)?.exportImage() ?? null
+      if (summaryLike) png = await summaryRefs.get(i)?.exportImage() ?? null
       else if (c.kind === 'interactive') png = await interactiveRefs.get(i)?.exportImage?.() ?? null
       if (!png) png = await plotHostToImageURL(el, '#ffffff')
-      const csv = c.kind === 'summary' ? (summaryRefs.get(i)?.getCsv() ?? null) : null
+      const csv = summaryLike ? (summaryRefs.get(i)?.getCsv() ?? null) : null
       const sr = el.getBoundingClientRect()
       const rect = { x: (sr.left - gr.left) / gr.width, y: (sr.top - gr.top) / gr.height,
                      w: sr.width / gr.width, h: sr.height / gr.height }
@@ -223,7 +246,7 @@ function collectCsvs(): { name: string; csv: string | null }[] {
   const out: { name: string; csv: string | null }[] = []
   for (let i = 0; i < entry.value.contents.length; i++) {
     const c = entry.value.contents[i]
-    if (c?.kind === 'summary') out.push({ name: labelFor(c), csv: summaryRefs.get(i)?.getCsv() ?? null })
+    if (c && (c.kind === 'summary' || isClusterHeatmap(c))) out.push({ name: labelFor(c), csv: summaryRefs.get(i)?.getCsv() ?? null })
   }
   return out
 }
@@ -246,20 +269,24 @@ defineExpose({ capturePage, collectCsvs })
               {{ t.label }}
             </button>
           </div>
-          <div class="lc-nm" v-tooltip.bottom="'Custom uniform grid'">
-            <span class="lc-lbl">cols</span>
-            <input type="range" min="1" max="6" :value="entry.cols"
-                   @input="layout.applyTemplate(canvasKey, uniform(+($event.target as HTMLInputElement).value, entry.rows))" />
-            <span class="lc-val">{{ entry.cols }}</span>
-            <span class="lc-lbl">rows</span>
-            <input type="range" min="1" max="6" :value="entry.rows"
-                   @input="layout.applyTemplate(canvasKey, uniform(entry.cols, +($event.target as HTMLInputElement).value))" />
-            <span class="lc-val">{{ entry.rows }}</span>
-          </div>
-          <div class="lc-nm" v-tooltip.bottom="'Slot height (applies to all slots on the board)'">
-            <span class="lc-lbl">height</span>
-            <input type="range" min="160" max="720" step="10" :value="rowHeight"
-                   @input="rowHeight = +($event.target as HTMLInputElement).value" />
+          <!-- custom grid size + slot height, tucked into a ⚙ popover to keep the bar tidy -->
+          <div ref="optsRef" class="lc-opts">
+            <button class="lc-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+                    v-tooltip.bottom="'Grid size & slot height'"><i class="pi pi-sliders-h" /></button>
+            <div v-if="optsOpen" class="lc-pop">
+              <label class="lc-pop-row"><span>cols</span>
+                <input type="range" min="1" max="6" :value="entry.cols"
+                       @input="layout.applyTemplate(canvasKey, uniform(+($event.target as HTMLInputElement).value, entry.rows))" />
+                <span class="lc-val">{{ entry.cols }}</span></label>
+              <label class="lc-pop-row"><span>rows</span>
+                <input type="range" min="1" max="6" :value="entry.rows"
+                       @input="layout.applyTemplate(canvasKey, uniform(entry.cols, +($event.target as HTMLInputElement).value))" />
+                <span class="lc-val">{{ entry.rows }}</span></label>
+              <label class="lc-pop-row"><span>height</span>
+                <input type="range" min="160" max="720" step="10" :value="rowHeight"
+                       @input="rowHeight = +($event.target as HTMLInputElement).value" />
+                <span class="lc-val">{{ rowHeight }}</span></label>
+            </div>
           </div>
           <!-- clustering run: ONE per board (drives all cluster slots + the cluster pop manager) -->
           <div v-if="hasClusterSlot" class="lc-clust" v-tooltip.bottom="'Clustering run shown by this board’s cluster plots'">
@@ -332,6 +359,17 @@ defineExpose({ capturePage, collectCsvs })
                           :vis="panelVis(entry.contents[i]!)" :ui="entry.contents[i]!.state" :collapse-series="poolGroups"
                           :reload-token="reloadToken" :persist-key="`${canvasKey}:slot:${i}`"
                           @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)" />
+            <!-- cluster heatmap (docked ClusterHeatmapPanel; board's single cluster run) -->
+            <ClusterHeatmapPanel v-else-if="isClusterHeatmap(entry.contents[i])"
+                          :ref="el => setSummaryRef(i, el)"
+                          :index="i" :active="i === entry.activeIndex" :docked="true" :arrange="null"
+                          :project-uid="projectUid" :set-uid="setUid" :image-uids="clustValidUids"
+                          :pop-type="clustPopType" :suffix="clustSuffix"
+                          :feature-options="clustFeatureOptions" :name-map="clustNameMap"
+                          :shown-pops="shownPopsFor(panelClustHl(entry.contents[i]!))"
+                          :vis="panelVis(entry.contents[i]!)" :state="entry.contents[i]!.state"
+                          :persist-key="`${canvasKey}:slot:${i}`"
+                          @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)" />
             <!-- interactive plot (UMAP / gating-strategy / …) -->
             <InteractivePanel v-else-if="entry.contents[i]?.kind === 'interactive' && INTERACTIVE_VIEWS[entry.contents[i]!.ref]"
                               :ref="el => setInteractiveRef(i, el)"
@@ -365,7 +403,7 @@ defineExpose({ capturePage, collectCsvs })
         <!-- docked pop manager (control, not content — excluded from PDF). Follows the ACTIVE slot:
              cluster PopulationManager for a cluster slot, else the summary SeriesPicker. -->
         <div class="lc-rail">
-          <PopulationManager v-if="activeIsCluster" :docked="true"
+          <PopulationManager v-if="activeIsCluster" :docked="true" :readonly="true"
                              :selected="''" :highlighted="activeClustHl" :scope="scope"
                              :line-width="1" :gate-labels="false" :axis-from-zero="false"
                              :pop-type="clustPopType" :cluster-ids="clustClusterIds[clustSuffix] ?? []"
@@ -394,6 +432,18 @@ defineExpose({ capturePage, collectCsvs })
 .lc-clust { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim);
   padding: 2px 8px; border: 1px solid var(--cc-border); border-radius: 6px; }
 .lc-clust select { font-size: 11px; }
+/* ⚙ grid-size / height popover */
+.lc-opts { position: relative; display: inline-flex; }
+.lc-gear { display: inline-flex; align-items: center; justify-content: center; width: 1.7rem; height: 1.6rem;
+  border: 1px solid var(--cc-border); border-radius: 5px; background: var(--cc-surface-2); color: var(--cc-text-dim);
+  cursor: pointer; font-size: 0.72rem; }
+.lc-gear:hover, .lc-gear.on { color: var(--cc-text); border-color: #7c3aed; }
+.lc-pop { position: absolute; top: calc(100% + 4px); left: 0; z-index: 20; min-width: 13rem;
+  display: flex; flex-direction: column; gap: 8px; padding: 10px; background: var(--cc-surface-1);
+  border: 1px solid var(--cc-border); border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,0.35); }
+.lc-pop-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--cc-text-dim); }
+.lc-pop-row span:first-child { width: 3rem; }
+.lc-pop-row input[type="range"] { flex: 1; }
 .lc-val { min-width: 0.9rem; text-align: center; font-weight: 700; color: var(--cc-text); }
 .seg-wrap { flex-wrap: wrap; }
 /* wrapped seg buttons keep separators between rows too */

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -18,6 +18,7 @@ import { useProjectStore } from '../../stores/project'
 import { useProjectMetaStore } from '../../stores/projectMeta'
 import { useAnalysisLayoutStore, type SlotContent } from '../../stores/analysisLayout'
 import { useSummaryData } from '../../composables/useSummaryData'
+import { useClusterContext } from '../../composables/useClusterContext'
 import { tkey, parseTkey } from '../../plots/series'
 import { defaultVis, type VisProps } from '../../plots/plot'
 import { UNIFORM_PRESETS, COMIC_PRESETS, uniform } from '../../plots/layoutTemplates'
@@ -26,6 +27,7 @@ import SummaryPanel from './SummaryPanel.vue'
 import InteractivePanel from './InteractivePanel.vue'
 import { INTERACTIVE_VIEWS } from './interactiveViews'
 import SeriesPicker from './SeriesPicker.vue'
+import PopulationManager from './PopulationManager.vue'
 
 const props = defineProps<{ imageUids: string[]; module?: string | null; canvasKey: string }>()
 
@@ -66,10 +68,14 @@ const activeContent = computed<SlotContent | null>(() => entry.value.contents[en
 type PState = { sel: string[]; vis: VisProps; [k: string]: unknown }
 const st = (c: SlotContent): PState => c.state as PState
 
-// interactive views offerable here today (self-contained context). UMAP / cluster heatmap need
-// per-slot clustering context (a suffix picker) — a follow-up; only list the analysis-ready ones.
+// self-contained interactive views (read their own context / pops)
 const ANALYSIS_VIEWS = ['gatingStrategy']
 const interactiveOptions = computed(() => ANALYSIS_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
+// CLUSTERING views — one clustering run per board (see useClusterContext / ANALYSIS_CANVAS_PLAN Phase G):
+// fed the board cluster context, and the right rail shows the cluster PopulationManager when one is active.
+const CLUSTER_VIEWS = ['umap']
+const clusterOptions = computed(() => CLUSTER_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
+const isClusterSlot = (c: SlotContent | null): boolean => !!c && c.kind === 'interactive' && CLUSTER_VIEWS.includes(c.ref)
 // image-content views (napari screenshot slots) — grouped separately in the picker
 const IMAGE_VIEWS = ['filmstrip']
 const imageOptions = computed(() => IMAGE_VIEWS.filter(k => k in INTERACTIVE_VIEWS).map(k => ({ key: k, label: INTERACTIVE_VIEWS[k].label })))
@@ -79,13 +85,10 @@ function addPlot(i: number, val: string) {
   if (!val) return
   const sep = val.indexOf(':'); const kind = val.slice(0, sep); const ref = val.slice(sep + 1)
   if (kind === 'summary') layout.setContent(props.canvasKey, i, { kind: 'summary', ref, state: { specId: ref, sel: [], vis: defaultVis() } })
-  else if (kind === 'interactive') layout.setContent(props.canvasKey, i, { kind: 'interactive', ref, state: {} })
+  else if (kind === 'interactive') layout.setContent(props.canvasKey, i, { kind: 'interactive', ref, state: CLUSTER_VIEWS.includes(ref) ? { labels: true, hl: [] } : {} })
   layout.setActive(props.canvasKey, i)
 }
 function clearSlot(i: number) { layout.setContent(props.canvasKey, i, null) }
-
-// generic context handed to an interactive view in a slot (self-contained views read what they need)
-const ctxFor = () => ({ projectUid: projectUid.value, imageUids: props.imageUids, setUid: setUid.value, vis: activeVis.value })
 
 // duplicate a slot's plot into the NEXT EMPTY slot (deep-copy its state so you can tweak one thing);
 // no-op if the grid is full.
@@ -124,6 +127,42 @@ function setVis(patch: Partial<VisProps>) {
   else if (activeContent.value) st(activeContent.value).vis = { ...(st(activeContent.value).vis ?? defaultVis()), ...patch }
 }
 const panelSeries = (c: SlotContent): SeriesTarget[] => panelSel(c).map(parseTkey)
+
+// ── cluster context: ONE clustering run per board (board-level popType + suffix in the shared bag) so
+// the singleton gating store is driven unambiguously; only active when a cluster slot exists. ─────────
+const hasClusterSlot = computed(() => entry.value.contents.some(isClusterSlot))
+const clustPopType = computed<'clust' | 'trackclust'>({
+  get: () => (entry.value.shared.clustPopType as 'clust' | 'trackclust') ?? 'clust',
+  set: v => (entry.value.shared.clustPopType = v) })
+const clustSuffix = computed<string>({
+  get: () => (entry.value.shared.clustSuffix as string) ?? 'default',
+  set: v => (entry.value.shared.clustSuffix = v) })
+const { suffixes: clustSuffixes, clusterIds: clustClusterIds, validUids: clustValidUids, shownPopsFor } =
+  useClusterContext({ projectUid, imageUids: computed(() => props.imageUids),
+                      popType: clustPopType, suffix: clustSuffix, enabled: hasClusterSlot })
+
+// cluster HIGHLIGHT — global (shared, one run per board) or per-slot (local), same scope as summary
+const clustHl = computed<string[]>({ get: () => (entry.value.shared.clustHl as string[]) ?? [], set: v => (entry.value.shared.clustHl = v) })
+const clustHlOf = (c: SlotContent): string[] => (st(c).hl as string[]) ?? []
+const panelClustHl = (c: SlotContent) => scope.value === 'global' ? clustHl.value : clustHlOf(c)
+const activeClustHl = computed(() => scope.value === 'global' ? clustHl.value
+  : (activeContent.value ? clustHlOf(activeContent.value) : []))
+const activeIsCluster = computed(() => isClusterSlot(activeContent.value))
+function toggleClustHl(path: string) {
+  if (scope.value === 'global') clustHl.value = toggle(clustHl.value, path)
+  else if (activeContent.value) st(activeContent.value).hl = toggle(clustHlOf(activeContent.value), path)
+}
+
+// context handed to an interactive slot: cluster views get the board cluster run + shown pops; the
+// self-contained views (gating strategy, filmstrip) just get the image/project context.
+function ctxFor(c: SlotContent) {
+  if (isClusterSlot(c)) return {
+    projectUid: projectUid.value, imageUids: clustValidUids.value, setUid: setUid.value,
+    popType: clustPopType.value, suffix: clustSuffix.value,
+    shownPops: shownPopsFor(panelClustHl(c)), vis: panelVis(c),
+  }
+  return { projectUid: projectUid.value, imageUids: props.imageUids, setUid: setUid.value, vis: panelVis(c) }
+}
 
 // prune vanished pops from every slot's local selection (the composable prunes the global one). Guard on
 // a non-empty segPops — it's transiently [] during load/image-switch, and pruning then would wipe (and
@@ -222,6 +261,18 @@ defineExpose({ capturePage, collectCsvs })
             <input type="range" min="160" max="720" step="10" :value="rowHeight"
                    @input="rowHeight = +($event.target as HTMLInputElement).value" />
           </div>
+          <!-- clustering run: ONE per board (drives all cluster slots + the cluster pop manager) -->
+          <div v-if="hasClusterSlot" class="lc-clust" v-tooltip.bottom="'Clustering run shown by this board’s cluster plots'">
+            <span class="lc-lbl">cluster</span>
+            <select v-model="clustPopType">
+              <option value="clust">cells</option>
+              <option value="trackclust">tracks</option>
+            </select>
+            <select v-model="clustSuffix">
+              <option v-if="!clustSuffixes.length" :value="clustSuffix">{{ clustSuffix }}</option>
+              <option v-for="s in clustSuffixes" :key="s" :value="s">{{ s }}</option>
+            </select>
+          </div>
           <!-- compare + pool sit at the right of the layout row -->
           <div class="lc-right">
             <div v-if="canCompare" class="lc-compare"
@@ -285,7 +336,7 @@ defineExpose({ capturePage, collectCsvs })
             <InteractivePanel v-else-if="entry.contents[i]?.kind === 'interactive' && INTERACTIVE_VIEWS[entry.contents[i]!.ref]"
                               :ref="el => setInteractiveRef(i, el)"
                               :index="i" :active="i === entry.activeIndex" :docked="true"
-                              :view="entry.contents[i]!.ref" :context="ctxFor()" :state="entry.contents[i]!.state"
+                              :view="entry.contents[i]!.ref" :context="ctxFor(entry.contents[i]!)" :state="entry.contents[i]!.state"
                               :duplicable="true" :persist-key="`${canvasKey}:slot:${i}`"
                               @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)" />
             <!-- empty slot: add a plot (summary spec or interactive view) -->
@@ -299,6 +350,9 @@ defineExpose({ capturePage, collectCsvs })
                 <optgroup v-if="interactiveOptions.length" label="Interactive">
                   <option v-for="v in interactiveOptions" :key="v.key" :value="`interactive:${v.key}`">{{ v.label }}</option>
                 </optgroup>
+                <optgroup v-if="clusterOptions.length" label="Clustering">
+                  <option v-for="v in clusterOptions" :key="v.key" :value="`interactive:${v.key}`">{{ v.label }}</option>
+                </optgroup>
                 <optgroup v-if="imageOptions.length" label="Image">
                   <option v-for="v in imageOptions" :key="v.key" :value="`interactive:${v.key}`">{{ v.label }}</option>
                 </optgroup>
@@ -308,9 +362,16 @@ defineExpose({ capturePage, collectCsvs })
           </div>
         </div>
 
-        <!-- docked pop picker (control, not content — excluded from PDF) -->
+        <!-- docked pop manager (control, not content — excluded from PDF). Follows the ACTIVE slot:
+             cluster PopulationManager for a cluster slot, else the summary SeriesPicker. -->
         <div class="lc-rail">
-          <SeriesPicker :groups="segPops" :selected="activeSel" :scope="scope" :vis="activeVis" :docked="true"
+          <PopulationManager v-if="activeIsCluster" :docked="true"
+                             :selected="''" :highlighted="activeClustHl" :scope="scope"
+                             :line-width="1" :gate-labels="false" :axis-from-zero="false"
+                             :pop-type="clustPopType" :cluster-ids="clustClusterIds[clustSuffix] ?? []"
+                             :suffix="clustSuffix" :vis="activeVis"
+                             @update:scope="scope = $event" @update:vis="setVis" @toggle-highlight="toggleClustHl" />
+          <SeriesPicker v-else :groups="segPops" :selected="activeSel" :scope="scope" :vis="activeVis" :docked="true"
                         @toggle="toggleTarget" @update:scope="scope = $event" @update:vis="setVis" />
         </div>
       </div>
@@ -330,6 +391,9 @@ defineExpose({ capturePage, collectCsvs })
 .lc-sep { width: 1px; height: 1.4rem; background: var(--cc-border); }
 .lc-nm { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .lc-nm input[type="range"] { width: 5rem; }
+.lc-clust { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim);
+  padding: 2px 8px; border: 1px solid var(--cc-border); border-radius: 6px; }
+.lc-clust select { font-size: 11px; }
 .lc-val { min-width: 0.9rem; text-align: center; font-weight: 700; color: var(--cc-text); }
 .seg-wrap { flex-wrap: wrap; }
 /* wrapped seg buttons keep separators between rows too */

--- a/frontend/src/components/canvas/PlotOptions.vue
+++ b/frontend/src/components/canvas/PlotOptions.vue
@@ -3,7 +3,7 @@
   Layout / Points / Colours / Labels sub-sections ported from the old R plotCharts adjustments.
   Presentational only: reads `vis`, emits `update:vis` patches. Embedded by SeriesPicker (summary
   canvas) and PopulationManager (gating / cluster canvas) so the styling UI lives in ONE place — the
-  same knobs everywhere, and the future universal analysis canvas gets them for free.
+  same knobs everywhere, and the future universal analysis board gets them for free.
 
   `sections` optionally restricts which sub-sections show (e.g. a plot family with no raw points hides
   Points). Default = all four.

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -34,7 +34,7 @@ const props = withDefaults(defineProps<{
   // OPTIONAL plot-styling block: when a host canvas passes `vis`, the shared PlotOptions styling
   // controls render below the gate options (same knobs as the summary SeriesPicker). Omit → no block.
   vis?: VisProps
-  docked?: boolean                 // fill a docked rail (Analysis canvas) instead of floating
+  docked?: boolean                 // fill a docked rail (Analysis board) instead of floating
   readonly?: boolean               // read-only surface (Analysis board): highlight only — no add / delete /
                                    // rename / recolour / cluster reassignment (project_analysis_canvas_readonly)
 }>(), { popType: 'flow', clusterIds: () => [], suffix: 'default', vis: undefined, docked: false, readonly: false })

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -35,7 +35,9 @@ const props = withDefaults(defineProps<{
   // controls render below the gate options (same knobs as the summary SeriesPicker). Omit → no block.
   vis?: VisProps
   docked?: boolean                 // fill a docked rail (Analysis canvas) instead of floating
-}>(), { popType: 'flow', clusterIds: () => [], suffix: 'default', vis: undefined, docked: false })
+  readonly?: boolean               // read-only surface (Analysis board): highlight only — no add / delete /
+                                   // rename / recolour / cluster reassignment (project_analysis_canvas_readonly)
+}>(), { popType: 'flow', clusterIds: () => [], suffix: 'default', vis: undefined, docked: false, readonly: false })
 const emit = defineEmits<{
   'update:selected': [string]
   'update:scope': ['global' | 'local']
@@ -113,7 +115,7 @@ async function addClusterPopulation() {
                         @update:scope="emit('update:scope', $event)" @update:vis="emit('update:vis', $event)">
     <!-- ── population list (default slot) ── -->
       <!-- cluster mode: pops are made here (no gate to draw), then clusters ticked into them -->
-      <div v-if="clusterMode" class="pm-add">
+      <div v-if="clusterMode && !readonly" class="pm-add">
         <button class="pm-add-btn" @click="addClusterPopulation"
                 v-tooltip.bottom="'Create a population, then tick cluster IDs into it'">
           <i class="pi pi-plus" /> Add population
@@ -130,12 +132,12 @@ async function addClusterPopulation() {
              @click="pick(p)">
           <i v-if="p.transient" class="pi pi-map-marker pm-napari"
              v-tooltip.left="'Cells selected in napari (temporary)'" :style="{ color: p.colour }" />
-          <input v-else type="color" class="pm-swatch" :value="p.colour"
-                 v-tooltip.left="'Colour'"
+          <input v-else type="color" class="pm-swatch" :value="p.colour" :disabled="readonly"
+                 v-tooltip.left="readonly ? '' : 'Colour'"
                  @click.stop @change="g.updatePop(p.path, { colour: ($event.target as HTMLInputElement).value })" />
 
           <span v-if="editing !== p.path" class="pm-name"
-                @dblclick.stop="p.transient || beginRename(p)">{{ p.name }}</span>
+                @dblclick.stop="!readonly && !p.transient && beginRename(p)">{{ p.name }}</span>
           <input v-else class="pm-rename" v-model="editName" autofocus
                  @keyup.enter="commitRename(p)" @blur="commitRename(p)" @click.stop />
 
@@ -154,7 +156,7 @@ async function addClusterPopulation() {
                   @click.stop="toggleNapari(p)">
             <i class="pi pi-images" />
           </button>
-          <button v-if="!p.transient" class="pm-icon danger" v-tooltip.left="'Delete population'"
+          <button v-if="!p.transient && !readonly" class="pm-icon danger" v-tooltip.left="'Delete population'"
                   @click.stop="g.deletePop(p.path)">
             <i class="pi pi-trash" />
           </button>
@@ -171,10 +173,10 @@ async function addClusterPopulation() {
         <div v-if="clusterMode && p.filter" class="pm-clusters"
              :style="{ paddingLeft: 22 + p.depth * 14 + 'px' }">
           <button v-for="id in props.clusterIds" :key="id" class="pm-chip"
-                  :class="{ on: popClusterIds(p).includes(id) }"
+                  :class="{ on: popClusterIds(p).includes(id), ro: readonly }" :disabled="readonly"
                   :style="popClusterIds(p).includes(id) ? { background: p.colour, borderColor: p.colour, color: '#111' } : {}"
                   v-tooltip.bottom="clusterOwner(id) && clusterOwner(id)?.path !== p.path ? `In “${clusterOwner(id)?.name}”` : ''"
-                  @click.stop="toggleCluster(p, id)">{{ id }}</button>
+                  @click.stop="!readonly && toggleCluster(p, id)">{{ id }}</button>
           <span v-if="!props.clusterIds.length" class="pm-chip-empty">no clusters at this suffix</span>
         </div>
       </template>
@@ -268,6 +270,10 @@ async function addClusterPopulation() {
   color: var(--cc-text-dim); cursor: pointer; font-variant-numeric: tabular-nums; transition: background 0.1s, color 0.1s, border-color 0.1s; }
 .pm-chip:hover { border-color: #7c3aed; color: var(--cc-text); }
 .pm-chip.on { font-weight: 700; }
+/* read-only (Analysis board): chips show assignment but aren't clickable */
+.pm-chip.ro { cursor: default; }
+.pm-chip.ro:hover { border-color: var(--cc-border); color: var(--cc-text-dim); }
+.pm-chip.ro.on:hover { color: #111; }
 .pm-chip-empty { font-size: 10px; color: var(--cc-text-dim); font-style: italic; }
 
 /* segmented toggle (axis option in the #options slot; the shell owns the footer scope toggle) */

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -34,7 +34,8 @@ const props = withDefaults(defineProps<{
   // OPTIONAL plot-styling block: when a host canvas passes `vis`, the shared PlotOptions styling
   // controls render below the gate options (same knobs as the summary SeriesPicker). Omit → no block.
   vis?: VisProps
-}>(), { popType: 'flow', clusterIds: () => [], suffix: 'default', vis: undefined })
+  docked?: boolean                 // fill a docked rail (Analysis canvas) instead of floating
+}>(), { popType: 'flow', clusterIds: () => [], suffix: 'default', vis: undefined, docked: false })
 const emit = defineEmits<{
   'update:selected': [string]
   'update:scope': ['global' | 'local']
@@ -108,7 +109,7 @@ async function addClusterPopulation() {
 </script>
 
 <template>
-  <PopulationPanelShell :count="g.flat.length" :scope="scope" :vis="vis"
+  <PopulationPanelShell :count="g.flat.length" :scope="scope" :vis="vis" :docked="docked"
                         @update:scope="emit('update:scope', $event)" @update:vis="emit('update:vis', $event)">
     <!-- ── population list (default slot) ── -->
       <!-- cluster mode: pops are made here (no gate to draw), then clusters ticked into them -->

--- a/frontend/src/components/canvas/PopulationPanelShell.vue
+++ b/frontend/src/components/canvas/PopulationPanelShell.vue
@@ -5,7 +5,7 @@
   the draggable header (icon · title · count · collapse), the global/local scope footer, and the
   optional shared `PlotOptions` styling block. The differing bit — the population LIST — is the
   default slot; a host with its own extra controls (the gating manager's gate/viewer options) uses the
-  `#options` slot. One place for the chrome so the future universal analysis canvas reuses it too.
+  `#options` slot. One place for the chrome so the future universal analysis board reuses it too.
 -->
 <script setup lang="ts">
 import { ref, onMounted, useTemplateRef } from 'vue'

--- a/frontend/src/components/canvas/SeriesPicker.vue
+++ b/frontend/src/components/canvas/SeriesPicker.vue
@@ -21,7 +21,7 @@ const props = defineProps<{
   selected: string[]                  // selected target keys (tkey), in the current scope
   scope: 'global' | 'local'
   vis: VisProps                       // visual properties for the current scope
-  docked?: boolean                    // render in a fixed rail (Analysis canvas) instead of floating
+  docked?: boolean                    // render in a fixed rail (Analysis board) instead of floating
 }>()
 const emit = defineEmits<{
   toggle: [valueName: string, pop: string, popType: string]

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -26,7 +26,7 @@ import { defaultVis, type VisProps } from '../../plots/plot'
 import type { SeriesTarget, ChartType } from '../../plots/types'
 
 // `canvasKey` OPTIONALLY overrides the persistence namespace (default `summary:{module|universal}`).
-// The tabbed Analysis canvas passes `analysis:{projectUid}:tab:{id}` per tab so each board persists
+// The tabbed Analysis board passes `analysis:{projectUid}:tab:{id}` per tab so each board persists
 // independently; parents that switch the key MUST also `:key` this component by it so setup re-runs.
 const props = defineProps<{ imageUids: string[]; module?: string | null; canvasKey?: string }>()
 const ckey = props.canvasKey ?? `summary:${props.module ?? 'universal'}`

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -35,7 +35,7 @@ const props = defineProps<{
   collapseSeries?: boolean             // pool across pops & images → series by the groupBy level only
   reloadToken?: number                 // bumped by the host to force a refetch (live gate updates)
   persistKey?: string                  // CanvasPanel geometry persistence key
-  docked?: boolean                     // fill a grid slot (Analysis canvas) instead of free-floating
+  docked?: boolean                     // fill a grid slot (Analysis board) instead of free-floating
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
 const plotRef = useTemplateRef<{ toImageURL(t: 'png' | 'svg', light?: boolean): Promise<string | null> }>('plotRef')

--- a/frontend/src/components/canvas/interactiveViews.ts
+++ b/frontend/src/components/canvas/interactiveViews.ts
@@ -15,10 +15,12 @@ import ImageStripView from '../plots/ImageStripView.vue'
 export interface InteractiveView {
   label: string
   component: Component
+  clusterPage?: boolean   // offered on the Cluster module page's +Plot picker (UMAP only). gatingStrategy
+                          // and filmstrip are Analysis-canvas-only, so they must NOT leak into it.
 }
 
 export const INTERACTIVE_VIEWS: Record<string, InteractiveView> = {
-  umap: { label: 'UMAP', component: UmapView },
+  umap: { label: 'UMAP', component: UmapView, clusterPage: true },
   gatingStrategy: { label: 'Gating strategy', component: GatingStrategyView },
   filmstrip: { label: 'Image / strip', component: ImageStripView },
 }

--- a/frontend/src/components/canvas/interactiveViews.ts
+++ b/frontend/src/components/canvas/interactiveViews.ts
@@ -15,14 +15,16 @@ import ImageStripView from '../plots/ImageStripView.vue'
 export interface InteractiveView {
   label: string
   component: Component
-  clusterPage?: boolean   // offered on the Cluster module page's +Plot picker (UMAP only). gatingStrategy
-                          // and filmstrip are Analysis-canvas-only, so they must NOT leak into it.
+  clusterPage?: boolean     // offered on the Cluster module page's +Plot picker (UMAP only)
+  analysisBoard?: boolean   // offered on the Analysis board's +Plot picker
 }
 
+// `clusterPage` / `analysisBoard` are the surface "checkboxes": each host builds its picker by filtering
+// on its own flag, so a view appears on a surface with no host-side wiring (see docs/UI.md).
 export const INTERACTIVE_VIEWS: Record<string, InteractiveView> = {
-  umap: { label: 'UMAP', component: UmapView, clusterPage: true },
-  gatingStrategy: { label: 'Gating strategy', component: GatingStrategyView },
-  filmstrip: { label: 'Image / strip', component: ImageStripView },
+  umap: { label: 'UMAP', component: UmapView, clusterPage: true, analysisBoard: true },
+  gatingStrategy: { label: 'Gating strategy', component: GatingStrategyView, analysisBoard: true },
+  filmstrip: { label: 'Image / strip', component: ImageStripView, analysisBoard: true },
 }
 
 export const isInteractiveView = (key: string): boolean => key in INTERACTIVE_VIEWS

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -2,7 +2,7 @@
   The shared scatter+gate PLOT BODY: a WebGL scatter (ScatterGL) + contour/population layer
   (PlotLayers) + canvas2D gate layer (GateOverlay), with axis lines/ticks/labels and PNG export. This
   is the ONE gate-scatter renderer — extracted from GatePlotPanel so the read-only gating-strategy plot
-  (Analysis canvas) reuses it instead of forking a second one (feedback_use_existing_framework).
+  (Analysis board) reuses it instead of forking a second one (feedback_use_existing_framework).
 
   It renders whatever it's given: the host owns data fetching, axis selection, and gate state. Interactive
   use (Gate page) passes `mode` = rectangle/polygon and handles @draw/@edit; read-only use (Analysis
@@ -18,7 +18,7 @@ import type { GateSpec } from '../../stores/gating'
 import ScatterGL from './ScatterGL.vue'
 import PlotLayers, { type PopLayer } from './PlotLayers.vue'
 import GateOverlay from './GateOverlay.vue'
-import { plotHostToImageURL } from '../../plots/export'
+import { rasterPlotToImageURL } from '../../plots/export'
 
 type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
 
@@ -40,7 +40,7 @@ withDefaults(defineProps<{
   viewTick?: number
   loading?: boolean
   compact?: boolean                              // tight chrome for small montage panels (gating strategy)
-  readonly?: boolean                             // static gates — no move/resize (read-only Analysis canvas)
+  readonly?: boolean                             // static gates — no move/resize (read-only Analysis board)
 }>(), {
   gates: () => [], popLayers: () => [], renderMode: 'points', showPops: false,
   mode: 'off', gateLineWidth: 1.5, gateLabels: false, viewTick: 0, loading: false, compact: false, readonly: false,
@@ -75,16 +75,13 @@ const hiRes = async (cv: HTMLCanvasElement, scale: number) => {
   return null
 }
 // `light` = flip the ink/border vars (via .cc-light) so ticks/axis names read dark on a white ground —
-// used by the PDF export (dark theme is only for on-screen display).
-// The flow scatter is a RASTER, so its export sharpness is set by the scale relative to the on-screen
-// size. A small on-screen plot exports soft — so aim for a fixed ~2200px long side (scale bounded 4–14×)
-// regardless of slot size; regl scales point size with it, keeping the look constant but crisp.
+// used by the PDF export (dark theme is only for on-screen display). The crisp fixed-resolution raster
+// export (aim for a ~2200px long side so a small slot doesn't export soft) is the SHARED helper
+// rasterPlotToImageURL — the same path the cluster UMAP uses.
 async function exportImage(bg = '#0d0b1a', light = false): Promise<string | null> {
   const el = hostEl.value
   if (light) el?.classList.add('cc-light')
-  const px = el ? Math.max(el.clientWidth, el.clientHeight) : 0
-  const scale = px ? Math.min(14, Math.max(4, Math.ceil(2200 / px))) : undefined
-  try { return await plotHostToImageURL(el, bg, { hiRes, scale }) }
+  try { return await rasterPlotToImageURL(el, bg, hiRes) }
   finally { if (light) el?.classList.remove('cc-light') }
 }
 // `hiRes` is exposed so a host that captures a LARGER element containing several of these cells (the

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -1,5 +1,5 @@
 <!--
-  Gating-strategy (hierarchy) plot — an interactive VIEW for the Analysis canvas (registered in
+  Gating-strategy (hierarchy) plot — an interactive VIEW for the Analysis board (registered in
   interactiveViews.ts). READ-ONLY (project_analysis_canvas_readonly): it visualises an existing gating
   scheme, never edits it. Ports the old R `.flowPlotGatedRaster`: walk the population tree, group each
   parent's children by their gate's channel-pair, and for each group render the PARENT's cells as a

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -1,5 +1,5 @@
 <!--
-  Image / filmstrip slot for the Analysis canvas (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase D). One
+  Image / filmstrip slot for the Analysis board (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase D). One
   slot holding N captioned images (a single image = a 1-cell strip) — for pipeline montages
   (raw → denoised → segmented → tracked). Each cell's image is a napari CANVAS screenshot
   (POST /api/napari/screenshot → PNG bytes → stored as a data URL in the slot state, so it persists and

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -14,10 +14,10 @@
   the panel's persisted per-panel options bag (here just `labels`).
 -->
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, useTemplateRef } from 'vue'
+import { ref, computed, watch, onMounted, nextTick, useTemplateRef } from 'vue'
 import { useLogStore } from '../../stores/log'
 import ScatterGL from './ScatterGL.vue'
-import { plotHostToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
+import { plotHostToImageURL, rasterPlotToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
 import type { VisProps } from '../../plots/plot'
 
 const props = defineProps<{
@@ -28,13 +28,25 @@ const props = defineProps<{
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
   vis?: VisProps                 // canvas plot styling — here we honour the dark-theme knob
   state: { labels?: boolean }
+  docked?: boolean               // hosted in a grid slot (Analysis board) → drop the reload button
 }>()
 const log = useLogStore()
 const labels = computed({ get: () => props.state.labels !== false, set: v => (props.state.labels = v) })
 const unit = computed(() => (props.popType === 'trackclust' ? 'tracks' : 'cells'))
 
-// dark-theme knob (default dark, like the summary plots): drives the scatter ground + label chip.
-const dark = computed(() => props.vis?.darkTheme !== false)
+// `forceLight` flips to a light render for the board's PDF export (dark theme is on-screen only) —
+// like the cluster panels. It re-themes the OVERLAYS (label chips, legend ink) + the composite ground,
+// but deliberately NOT the WebGL scatter's own background (see `scatterGround`).
+const forceLight = ref(false)
+// On-screen scatter ground — the WebGL layer's background. Deliberately independent of `forceLight`:
+// changing ScatterGL's background prop fires an async re-render that races `exportCanvas` and snapshots
+// a BLANK point cloud. The export goes light via the composite `bg` arg + transparent host instead
+// (exactly like the gating cell, which never re-grounds its scatter for export).
+const screenDark = computed(() => props.vis?.darkTheme !== false)
+const scatterGround = computed(() => (screenDark.value ? '#0d0b1a' : '#ffffff'))
+// dark-theme knob (default dark): drives the label chip / legend ink AND the composite ground used as
+// the PNG background (points are drawn transparent, so this fill IS the exported ground).
+const dark = computed(() => !forceLight.value && screenDark.value)
 const ground = computed(() => (dark.value ? '#0d0b1a' : '#ffffff'))
 // label chip + legend ink follow the theme so they stay legible on the exported ground (a light
 // ground with the app's light legend ink was invisible — #00061 follow-up).
@@ -179,7 +191,16 @@ function exportAs(kind: string) {
     downloadBlob(`${stem}.csv`, new Blob([rowsToCsv(rows)], { type: 'text/csv' }))
   }
 }
-defineExpose({ exportFormats: ['png', 'csv'], exportAs })
+// board export (surfaced by InteractivePanel.exportImage → the PDF): a plot-only, LIGHT-theme, HI-RES
+// PNG via the SHARED raster-export helper (rasterPlotToImageURL — the same crisp fixed-resolution path
+// as the gating scatter, GateScatterCell.exportImage), with the theme forced light so it reads on white.
+async function exportImage(): Promise<string | null> {
+  forceLight.value = true
+  await nextTick()   // let the ground + label/legend ink flip to light before we rasterize the host
+  try { return await rasterPlotToImageURL(plotEl.value, ground.value, hiRes) }
+  finally { forceLight.value = false }
+}
+defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
 </script>
 
 <template>
@@ -187,17 +208,20 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs })
     <div class="uv-ctrl">
       <button class="cc-btn cc-btn-ghost" :class="{ on: labels }" @click="labels = !labels"
               v-tooltip.bottom="'Toggle cluster-number labels'"><i class="pi pi-tag" /> #</button>
-      <button class="cc-btn cc-btn-ghost" @click="load"
+      <button v-if="!docked" class="cc-btn cc-btn-ghost" @click="load"
               v-tooltip.bottom="'Reload (e.g. after re-running clustering at the same suffix)'"><i class="pi pi-refresh" /></button>
       <span class="uv-spacer" />
       <span v-if="total" class="uv-count">{{ total.toLocaleString() }} {{ unit }} · {{ legend.length }} clusters</span>
     </div>
     <div ref="plotEl" class="uv-body">
-      <div class="uv-plot" :style="{ background: ground }">
+      <!-- during export the inner ground MUST be transparent, else the overlay pass (host→SVG) paints
+           this opaque div OVER the transparent hi-res points (the points-missing bug). On-screen it
+           carries the scatter ground for the letterbox margins. -->
+      <div class="uv-plot" :style="{ background: forceLight ? 'transparent' : scatterGround }">
         <template v-if="points && points.length">
           <ScatterGL ref="scatterRef" :points="points" :extents="extents" color-mode="category"
                      :categories="categories" :palette="palette" :point-size="4" :opacity="0.9"
-                     :background-color="ground" />
+                     :background-color="scatterGround" />
           <span v-for="c in centroids" v-show="labels" :key="c.label" class="uv-label"
                 :style="{ left: lx(c.x), top: ly(c.y), ...labelStyle }">{{ c.label }}</span>
         </template>

--- a/frontend/src/composables/useClusterContext.ts
+++ b/frontend/src/composables/useClusterContext.ts
@@ -1,0 +1,99 @@
+// Shared CLUSTER context — the run list, per-run feature/cluster metadata, valid-image resolution, the
+// gating-store drive that loads a run's pop tree set-wide, and highlight→shownPops resolution. Extracted
+// from ClusterPlots so the Analysis canvas can host the cluster UMAP/heatmap without a divergent
+// re-implementation (feedback_use_existing_framework). Both callers own the `suffix` ref (page-level on
+// the cluster module; board-level on the analysis canvas — one run per board) and pass it in.
+//
+// NB: cluster pops live in the SINGLETON useGatingStore (loaded via g.selectImage(uid, vn, popType)); it
+// holds one (popType, suffix) at a time. That's why the analysis canvas enforces ONE cluster run per
+// board — so this context drives the store once, unambiguously.
+import { ref, computed, watch, type Ref } from 'vue'
+import { useGatingStore } from '../stores/gating'
+import { useLogStore } from '../stores/log'
+
+export interface ShownPop { path: string; name: string; colour: string; clusterIds: number[] }
+
+export function useClusterContext(opts: {
+  projectUid: Ref<string>
+  imageUids: Ref<string[]>
+  popType: Ref<'clust' | 'trackclust'>
+  suffix: Ref<string>
+}) {
+  const g = useGatingStore()
+  const log = useLogStore()
+  const { projectUid, imageUids, popType, suffix } = opts
+
+  // per-suffix feature list each run actually used (interpretive columns), from the channels endpoint's
+  // clusterFeatures sidecar; fall back to markers/motility if a run predates feature tracking.
+  const clusterFeatures = ref<Record<string, string[]>>({})
+  const featureFallback = ref<string[]>([])
+  const nameMap = ref<Record<string, string>>({})     // raw channel column → display name
+  const clusterIds = ref<Record<string, number[]>>({})     // per-suffix tickable cluster universe
+  const clusterMembers = ref<Record<string, string[]>>({}) // per-suffix uids the run clustered together
+  const resolvedVn = ref('default')                    // segmentation value_name the channels resolved to
+  const hmmStateCols = ref<string[]>([])               // live.cell.hmm.state.<name>
+  const hmmTransitionCols = ref<string[]>([])          // live.cell.hmm.transitions.<name>
+  const suffixes = ref<string[]>([])
+
+  // HMM behaviour columns are categorical-behaviour features → the dedicated HMM plots, NOT the heatmap.
+  const HMM_RE = /live\.cell\.hmm\.(state|transitions)\b/
+  const allFeatures = computed<string[]>(() => clusterFeatures.value[suffix.value] ?? featureFallback.value)
+  const featureOptions = computed<string[]>(() => allFeatures.value.filter(f => !HMM_RE.test(f)))
+
+  async function loadFeatures() {
+    if (!projectUid.value || !imageUids.value[0]) { clusterFeatures.value = {}; featureFallback.value = []; return }
+    const q = new URLSearchParams({ projectUid: projectUid.value, imageUid: imageUids.value[0], popType: popType.value })
+    try {
+      const r = await fetch(`/api/gating/channels?${q}`)
+      if (!r.ok) { clusterFeatures.value = {}; featureFallback.value = []; return }
+      const d = await r.json()
+      clusterFeatures.value = d.clusterFeatures ?? {}
+      clusterIds.value = d.clusterIds ?? {}
+      clusterMembers.value = d.clusterMembers ?? {}
+      resolvedVn.value = d.valueName ?? 'default'
+      featureFallback.value = popType.value === 'trackclust' ? (d.columns ?? []) : (d.channels ?? [])
+      const chans: string[] = d.channels ?? [], names: string[] = d.channelNames ?? []
+      nameMap.value = Object.fromEntries(chans.map((c, i) => [c, names[i] ?? c]))
+      const obs: string[] = d.cellObsMeasures ?? []
+      hmmStateCols.value = obs.filter(c => c.startsWith('live.cell.hmm.state.'))
+      hmmTransitionCols.value = obs.filter(c => c.startsWith('live.cell.hmm.transitions.'))
+      suffixes.value = d.clusterSuffixes ?? []
+      if (suffixes.value.length && !suffixes.value.includes(suffix.value)) suffix.value = suffixes.value[0]
+    } catch (e) {
+      log.error(`Cluster features: ${e instanceof Error ? e.message : String(e)}`, { source: 'cluster' })
+      clusterFeatures.value = {}; featureFallback.value = []
+    }
+  }
+
+  // Cluster pops only apply to images IN THE RUN (carry clusters.{suffix} — the recorded `partOf`).
+  const runMembers = computed<string[]>(() => clusterMembers.value[suffix.value] ?? [])
+  const validUids = computed<string[]>(() =>
+    runMembers.value.length ? imageUids.value.filter(u => runMembers.value.includes(u)) : imageUids.value)
+  const strayUids = computed<string[]>(() =>
+    runMembers.value.length ? imageUids.value.filter(u => !runMembers.value.includes(u)) : [])
+  const missingUids = computed<string[]>(() =>
+    runMembers.value.filter(u => !imageUids.value.includes(u)))
+
+  // resolve a highlight set (pop paths) to shown populations (colour + owned cluster IDs) via the store
+  const shownPopsFor = (hl: string[]): ShownPop[] => g.flat
+    .filter(p => hl.includes(p.path))
+    .map(p => ({ path: p.path, name: p.name, colour: p.colour,
+                 clusterIds: Array.isArray(p.filter?.values) ? (p.filter!.values as unknown[]).map(Number) : [] }))
+
+  // drive the (shared, pop_type-agnostic) gating store for the pop tree: primary = first valid image,
+  // the rest mirror every mutation so cluster pops land set-wide. Re-sync on selection/suffix change.
+  watch([validUids, suffix, popType, projectUid], () => {
+    if (!projectUid.value || !validUids.value.length) return
+    g.selectImage(validUids.value[0], resolvedVn.value, popType.value).then(() => {
+      g.mirrorUids = validUids.value.slice(1)
+    })
+  }, { immediate: true })
+  // reload the run/feature metadata when the image set / project / popType changes
+  watch([projectUid, () => imageUids.value.join(','), popType], loadFeatures, { immediate: true })
+
+  return {
+    suffixes, clusterFeatures, featureFallback, nameMap, clusterIds, clusterMembers, resolvedVn,
+    hmmStateCols, hmmTransitionCols, allFeatures, featureOptions,
+    runMembers, validUids, strayUids, missingUids, loadFeatures, shownPopsFor,
+  }
+}

--- a/frontend/src/composables/useClusterContext.ts
+++ b/frontend/src/composables/useClusterContext.ts
@@ -18,10 +18,14 @@ export function useClusterContext(opts: {
   imageUids: Ref<string[]>
   popType: Ref<'clust' | 'trackclust'>
   suffix: Ref<string>
+  // gate the singleton-store drive + feature load (the Analysis canvas only wants this when a cluster
+  // slot exists; the cluster module leaves it on). Defaults to always-on.
+  enabled?: Ref<boolean>
 }) {
   const g = useGatingStore()
   const log = useLogStore()
   const { projectUid, imageUids, popType, suffix } = opts
+  const enabled = opts.enabled ?? computed(() => true)
 
   // per-suffix feature list each run actually used (interpretive columns), from the channels endpoint's
   // clusterFeatures sidecar; fall back to markers/motility if a run predates feature tracking.
@@ -41,6 +45,7 @@ export function useClusterContext(opts: {
   const featureOptions = computed<string[]>(() => allFeatures.value.filter(f => !HMM_RE.test(f)))
 
   async function loadFeatures() {
+    if (!enabled.value) return
     if (!projectUid.value || !imageUids.value[0]) { clusterFeatures.value = {}; featureFallback.value = []; return }
     const q = new URLSearchParams({ projectUid: projectUid.value, imageUid: imageUids.value[0], popType: popType.value })
     try {
@@ -82,14 +87,14 @@ export function useClusterContext(opts: {
 
   // drive the (shared, pop_type-agnostic) gating store for the pop tree: primary = first valid image,
   // the rest mirror every mutation so cluster pops land set-wide. Re-sync on selection/suffix change.
-  watch([validUids, suffix, popType, projectUid], () => {
-    if (!projectUid.value || !validUids.value.length) return
+  watch([validUids, suffix, popType, projectUid, enabled], () => {
+    if (!enabled.value || !projectUid.value || !validUids.value.length) return
     g.selectImage(validUids.value[0], resolvedVn.value, popType.value).then(() => {
       g.mirrorUids = validUids.value.slice(1)
     })
   }, { immediate: true })
-  // reload the run/feature metadata when the image set / project / popType changes
-  watch([projectUid, () => imageUids.value.join(','), popType], loadFeatures, { immediate: true })
+  // reload the run/feature metadata when the image set / project / popType changes (or on enable)
+  watch([projectUid, () => imageUids.value.join(','), popType, enabled], loadFeatures, { immediate: true })
 
   return {
     suffixes, clusterFeatures, featureFallback, nameMap, clusterIds, clusterMembers, resolvedVn,

--- a/frontend/src/composables/useClusterContext.ts
+++ b/frontend/src/composables/useClusterContext.ts
@@ -1,11 +1,11 @@
 // Shared CLUSTER context — the run list, per-run feature/cluster metadata, valid-image resolution, the
 // gating-store drive that loads a run's pop tree set-wide, and highlight→shownPops resolution. Extracted
-// from ClusterPlots so the Analysis canvas can host the cluster UMAP/heatmap without a divergent
+// from ClusterPlots so the Analysis board can host the cluster UMAP/heatmap without a divergent
 // re-implementation (feedback_use_existing_framework). Both callers own the `suffix` ref (page-level on
-// the cluster module; board-level on the analysis canvas — one run per board) and pass it in.
+// the cluster module; board-level on the analysis board — one run per board) and pass it in.
 //
 // NB: cluster pops live in the SINGLETON useGatingStore (loaded via g.selectImage(uid, vn, popType)); it
-// holds one (popType, suffix) at a time. That's why the analysis canvas enforces ONE cluster run per
+// holds one (popType, suffix) at a time. That's why the analysis board enforces ONE cluster run per
 // board — so this context drives the store once, unambiguously.
 import { ref, computed, watch, type Ref } from 'vue'
 import { useGatingStore } from '../stores/gating'
@@ -18,7 +18,7 @@ export function useClusterContext(opts: {
   imageUids: Ref<string[]>
   popType: Ref<'clust' | 'trackclust'>
   suffix: Ref<string>
-  // gate the singleton-store drive + feature load (the Analysis canvas only wants this when a cluster
+  // gate the singleton-store drive + feature load (the Analysis board only wants this when a cluster
   // slot exists; the cluster module leaves it on). Defaults to always-on.
   enabled?: Ref<boolean>
 }) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -38,7 +38,7 @@ const router = createRouter({
     { path: '/behaviour', component: BehaviourModule, meta: { label: 'Behaviour' } },
     { path: '/clust-cells',  component: ClusterCellsModule,  meta: { label: 'Cluster cells' } },
     { path: '/clust-tracks', component: ClusterTracksModule, meta: { label: 'Cluster tracks' } },
-    { path: '/analysis',  component: AnalysisModule,   meta: { label: 'Analysis canvas' } },
+    { path: '/analysis',  component: AnalysisModule,   meta: { label: 'Analysis board' } },
     { path: '/tasks',     component: TasksModule,     meta: { label: 'Tasks' } },
     { path: '/chain',     component: ChainModule,     meta: { label: 'Whiteboard' } },
     { path: '/settings',  component: SettingsModule,  meta: { label: 'Settings' } },

--- a/frontend/src/modules/AnalysisModule.vue
+++ b/frontend/src/modules/AnalysisModule.vue
@@ -1,5 +1,5 @@
 <!--
-  Universal, multipage "Analysis canvas" page (TODO #00036 + docs/todo/ANALYSIS_CANVAS_PLAN.md). The
+  Universal, multipage "Analysis board" page (TODO #00036 + docs/todo/ANALYSIS_CANVAS_PLAN.md). The
   SAME summary-plot canvas as the per-module pages, but with the MODULE FILTER OFF: each board is a
   `SummaryCanvas` mounted with no `module` prop, so it offers EVERY plot spec — plots can be combined
   across modules / images / segmentations. `TabbedCanvas` wraps N independent boards (Phase A). Pick

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -29,10 +29,11 @@ const props = defineProps<{
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
   vis?: VisProps                 // canvas plot styling (dark-theme etc.) — see ClusterPlots panelVis
   state: { features?: string[] }
+  docked?: boolean               // fill a grid slot (Analysis canvas) instead of free-floating
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
 const log = useLogStore()
-const plotRef = useTemplateRef<{ toImageURL(t: 'png' | 'svg'): Promise<string | null> }>('plotRef')
+const plotRef = useTemplateRef<{ toImageURL(t: 'png' | 'svg', light?: boolean): Promise<string | null> }>('plotRef')
 
 // export the shown heatmap: CSV (the aggregated cells) or PNG/SVG (the rendered chart) — like SummaryPanel
 function exportAs(kind: string) {
@@ -100,11 +101,16 @@ watch([() => props.projectUid, () => props.imageUids.join(','), () => props.setU
        () => props.suffix, () => features.value.join(','),
        () => JSON.stringify((props.shownPops ?? []).map(p => [p.path, p.clusterIds]))], load)
 onMounted(load)
+
+// docked (Analysis canvas) export: plot-only LIGHT-theme PNG + the shown cells as CSV (like SummaryPanel)
+async function exportImage(): Promise<string | null> { return (await plotRef.value?.toImageURL('png', true)) ?? null }
+function getCsv(): string | null { return heatmap.value ? plotDataToCsv(heatmap.value) : null }
+defineExpose({ exportImage, getCsv })
 </script>
 
 <template>
   <CanvasPanel :index="index" :active="active" :arrange="arrange" :persist-key="persistKey" title="Heatmap"
-               @activate="emit('activate', $event)" @remove="emit('remove')">
+               :docked="docked" @activate="emit('activate', $event)" @remove="emit('remove')">
     <template #actions>
       <details class="feat">
         <summary v-tooltip.bottom="'Features (rows) — the measures this clustering run used'">
@@ -124,7 +130,8 @@ onMounted(load)
     <template #footer>
       <button class="hm-iconbtn" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same features) to tweak one thing'"><i class="pi pi-copy" /></button>
-      <select class="hm-export" v-tooltip.top="'Export the shown plot'" :disabled="!heatmap"
+      <!-- per-plot export dropped in a docked slot (the board exports to PDF); kept when floating -->
+      <select v-if="!docked" class="hm-export" v-tooltip.top="'Export the shown plot'" :disabled="!heatmap"
               @change="exportAs(($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
         <option value="">⤓ Export</option>
         <option value="csv">Data (CSV)</option>

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
   vis?: VisProps                 // canvas plot styling (dark-theme etc.) — see ClusterPlots panelVis
   state: { features?: string[] }
-  docked?: boolean               // fill a grid slot (Analysis canvas) instead of free-floating
+  docked?: boolean               // fill a grid slot (Analysis board) instead of free-floating
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
 const log = useLogStore()
@@ -107,7 +107,7 @@ watch(() => props.featureOptions, opts => {
   if (opts.length && props.state.features === undefined) props.state.features = [...opts]
 }, { immediate: true })
 
-// docked (Analysis canvas) export: plot-only LIGHT-theme PNG + the shown cells as CSV (like SummaryPanel)
+// docked (Analysis board) export: plot-only LIGHT-theme PNG + the shown cells as CSV (like SummaryPanel)
 async function exportImage(): Promise<string | null> { return (await plotRef.value?.toImageURL('png', true)) ?? null }
 function getCsv(): string | null { return heatmap.value ? plotDataToCsv(heatmap.value) : null }
 defineExpose({ exportImage, getCsv })
@@ -128,7 +128,7 @@ defineExpose({ exportImage, getCsv })
           <p v-if="!featureOptions.length" class="feat-empty">No recorded features — re-run clustering, or this run predates feature tracking.</p>
         </div>
       </details>
-      <button class="cc-btn cc-btn-ghost" @click="load"
+      <button v-if="!docked" class="cc-btn cc-btn-ghost" @click="load"
               v-tooltip.bottom="'Reload (e.g. after re-running clustering at the same suffix)'"><i class="pi pi-refresh" /></button>
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel / the HMM panels -->

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -101,6 +101,11 @@ watch([() => props.projectUid, () => props.imageUids.join(','), () => props.setU
        () => props.suffix, () => features.value.join(','),
        () => JSON.stringify((props.shownPops ?? []).map(p => [p.path, p.clusterIds]))], load)
 onMounted(load)
+// self-seed: default to the run's full feature set once known (don't clobber a user pick / an empty
+// pick the user made). Makes the panel work out-of-the-box on any host (no host-side seeding needed).
+watch(() => props.featureOptions, opts => {
+  if (opts.length && props.state.features === undefined) props.state.features = [...opts]
+}, { immediate: true })
 
 // docked (Analysis canvas) export: plot-only LIGHT-theme PNG + the shown cells as CSV (like SummaryPanel)
 async function exportImage(): Promise<string | null> { return (await plotRef.value?.toImageURL('png', true)) ?? null }

--- a/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
@@ -174,7 +174,7 @@ defineExpose({ exportImage, getCsv })
               v-tooltip.bottom="'Which HMM measure to show'">
         <option v-for="c in hmmCols" :key="c" :value="c">{{ shortName(c) }}</option>
       </select>
-      <button class="cc-btn cc-btn-ghost" @click="load" v-tooltip.bottom="'Reload'"><i class="pi pi-refresh" /></button>
+      <button v-if="!docked" class="cc-btn cc-btn-ghost" @click="load" v-tooltip.bottom="'Reload'"><i class="pi pi-refresh" /></button>
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel -->
     <template #footer>

--- a/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
@@ -13,7 +13,7 @@
   of the generic stacked bar (x = group, fill = state) — not worth a new shared chart type.
 -->
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef, nextTick } from 'vue'
 import { useLogStore } from '../../stores/log'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import { defaultVis, paletteRange, type VisProps } from '../../plots/plot'
@@ -29,6 +29,7 @@ const props = defineProps<{
   hmmCols: string[]                       // live.cell.hmm.state.<measure>
   vis?: VisProps                          // plot styling (from the pop manager, global/local scope)
   state: { measure?: string }
+  docked?: boolean                        // fill a grid slot (Analysis board) instead of free-floating
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
 const log = useLogStore()
@@ -49,8 +50,11 @@ let node: (HTMLElement | SVGElement) | null = null
 let legendNode: HTMLElement | null = null
 let titleNode: HTMLElement | null = null
 let ro: ResizeObserver | null = null
-// host background follows the dark-theme flag (no white border around a dark plot), like PlotChart
-const hostBg = computed(() => (v.value.darkTheme ? '#1f2226' : 'white'))
+// `forceLight` flips to a light render for the board's PDF export (dark theme is on-screen only)
+const forceLight = ref(false)
+const effDark = computed(() => forceLight.value ? false : v.value.darkTheme)
+// host background follows the effective dark-theme flag (no white border around a dark plot)
+const hostBg = computed(() => (effDark.value ? '#1f2226' : 'white'))
 // reactive so the empty-state / host v-show re-evaluate when data arrives (a bare array does not).
 const rows = ref<{ group: string; state: string; freq: number }[]>([])
 const cats = ref<string[]>([])           // HMM state levels, in order (for the colour domain)
@@ -104,8 +108,8 @@ async function render() {
   const w = Math.max(200, host.value.clientWidth || 360)
   const h = Math.max(160, host.value.clientHeight || 260)
   const o = v.value
-  const fg = o.darkTheme ? '#e6e6e6' : '#111'
-  const bg = o.darkTheme ? '#1f2226' : 'white'
+  const fg = effDark.value ? '#e6e6e6' : '#111'
+  const bg = effDark.value ? '#1f2226' : 'white'
   // palette knob → explicit colours for the state levels; 'standard' (null) keeps a categorical scheme
   const domain = cats.value.map(c => `state ${c}`)
   const range = paletteRange(o, domain.length)
@@ -149,11 +153,22 @@ onMounted(() => {
   if (host.value && typeof ResizeObserver !== 'undefined') { ro = new ResizeObserver(() => render()); ro.observe(host.value) }
 })
 onBeforeUnmount(() => { ro?.disconnect(); ro = null; node?.remove(); node = null; legendNode?.remove(); legendNode = null; titleNode?.remove(); titleNode = null })
+
+// board export: a plot-only LIGHT re-render → PNG, and the shown rows as CSV (generic panel contract)
+async function exportImage(): Promise<string | null> {
+  forceLight.value = true
+  await nextTick(); await render()
+  const url = await elementToImageURL(host.value, 'png', '#ffffff')
+  forceLight.value = false; await render()
+  return url
+}
+function getCsv(): string | null { return rows.value.length ? rowsToCsv(rows.value) : null }
+defineExpose({ exportImage, getCsv })
 </script>
 
 <template>
   <CanvasPanel :index="index" :active="active" :arrange="arrange" :persist-key="persistKey" title="HMM states"
-               @activate="emit('activate', $event)" @remove="emit('remove')">
+               :docked="docked" @activate="emit('activate', $event)" @remove="emit('remove')">
     <template #actions>
       <select v-if="hmmCols.length > 1" v-model="measure" class="cc-sel"
               v-tooltip.bottom="'Which HMM measure to show'">
@@ -165,7 +180,7 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null; node?.remove(); node = null
     <template #footer>
       <button class="hmm-iconbtn" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same settings) to tweak one thing'"><i class="pi pi-copy" /></button>
-      <select class="hmm-export" v-tooltip.top="'Export the shown plot'" :disabled="!rows.length"
+      <select v-if="!docked" class="hmm-export" v-tooltip.top="'Export the shown plot'" :disabled="!rows.length"
               @change="exportAs(($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
         <option value="">⤓ Export</option>
         <option value="csv">Data (CSV)</option>

--- a/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
@@ -181,7 +181,7 @@ defineExpose({ exportImage, getCsv })
               v-tooltip.bottom="'Which HMM measure to show'">
         <option v-for="c in hmmCols" :key="c" :value="c">{{ shortName(c) }}</option>
       </select>
-      <button class="cc-btn cc-btn-ghost" @click="load" v-tooltip.bottom="'Reload'"><i class="pi pi-refresh" /></button>
+      <button v-if="!docked" class="cc-btn cc-btn-ghost" @click="load" v-tooltip.bottom="'Reload'"><i class="pi pi-refresh" /></button>
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel -->
     <template #footer>

--- a/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
@@ -13,7 +13,7 @@
   on the first "_" and rendered as a faceted dot grid (self-contained Observable Plot).
 -->
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef, nextTick } from 'vue'
 import { useLogStore } from '../../stores/log'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import { defaultVis, type VisProps } from '../../plots/plot'
@@ -29,6 +29,7 @@ const props = defineProps<{
   hmmCols: string[]                       // live.cell.hmm.transitions.<measure>
   vis?: VisProps                          // plot styling (from the pop manager, global/local scope)
   state: { measure?: string }
+  docked?: boolean                        // fill a grid slot (Analysis board) instead of free-floating
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
 const log = useLogStore()
@@ -49,8 +50,10 @@ let node: (HTMLElement | SVGElement) | null = null
 let legendNode: HTMLElement | null = null
 let titleNode: HTMLElement | null = null
 let ro: ResizeObserver | null = null
-// host background follows the dark-theme flag (no white border around a dark plot), like PlotChart
-const hostBg = computed(() => (v.value.darkTheme ? '#1f2226' : 'white'))
+// `forceLight` flips to a light render for the board's PDF export (dark theme is on-screen only)
+const forceLight = ref(false)
+const effDark = computed(() => forceLight.value ? false : v.value.darkTheme)
+const hostBg = computed(() => (effDark.value ? '#1f2226' : 'white'))
 // reactive so the empty-state / host v-show re-evaluate when data arrives (a bare array does not).
 const rows = ref<{ group: string; from: string; to: string; freq: number }[]>([])
 
@@ -105,8 +108,8 @@ async function render() {
   const w = Math.max(220, host.value.clientWidth || 380)
   const h = Math.max(180, host.value.clientHeight || 280)
   const o = v.value
-  const fg = o.darkTheme ? '#e6e6e6' : '#111'
-  const bg = o.darkTheme ? '#1f2226' : 'white'
+  const fg = effDark.value ? '#e6e6e6' : '#111'
+  const bg = effDark.value ? '#1f2226' : 'white'
   const hi = Math.max(1e-9, ...rows.value.map(r => r.freq))
   const colorScale = { scheme: 'YlOrRd', label: 'freq', domain: [0, hi] }
   // The continuous colour ramp is placed as a VERTICAL bar in the right margin (not a top overlay) so
@@ -157,11 +160,22 @@ onMounted(() => {
   if (host.value && typeof ResizeObserver !== 'undefined') { ro = new ResizeObserver(() => render()); ro.observe(host.value) }
 })
 onBeforeUnmount(() => { ro?.disconnect(); ro = null; node?.remove(); node = null; legendNode?.remove(); legendNode = null; titleNode?.remove(); titleNode = null })
+
+// board export: a plot-only LIGHT re-render → PNG, and the shown rows as CSV (generic panel contract)
+async function exportImage(): Promise<string | null> {
+  forceLight.value = true
+  await nextTick(); await render()
+  const url = await elementToImageURL(host.value, 'png', '#ffffff')
+  forceLight.value = false; await render()
+  return url
+}
+function getCsv(): string | null { return rows.value.length ? rowsToCsv(rows.value) : null }
+defineExpose({ exportImage, getCsv })
 </script>
 
 <template>
   <CanvasPanel :index="index" :active="active" :arrange="arrange" :persist-key="persistKey" title="HMM transitions"
-               @activate="emit('activate', $event)" @remove="emit('remove')">
+               :docked="docked" @activate="emit('activate', $event)" @remove="emit('remove')">
     <template #actions>
       <select v-if="hmmCols.length > 1" v-model="measure" class="cc-sel"
               v-tooltip.bottom="'Which HMM measure to show'">
@@ -173,7 +187,7 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null; node?.remove(); node = null
     <template #footer>
       <button class="hmm-iconbtn" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same settings) to tweak one thing'"><i class="pi pi-copy" /></button>
-      <select class="hmm-export" v-tooltip.top="'Export the shown plot'" :disabled="!rows.length"
+      <select v-if="!docked" class="hmm-export" v-tooltip.top="'Export the shown plot'" :disabled="!rows.length"
               @change="exportAs(($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
         <option value="">⤓ Export</option>
         <option value="csv">Data (CSV)</option>

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -3,10 +3,12 @@
   (Cluster cells, popType="clust") and track clustering (Cluster tracks, popType="trackclust"). Built
   on the shared canvas shell (useCanvasPanels + CanvasPanel; docs/UI.md), like gating/summary.
 
-  Plots come in two families, both added from the one "+ Plot" picker and routed by family:
-   • INTERACTIVE (registry `INTERACTIVE_VIEWS`, e.g. UMAP) → generic InteractivePanel. Adding another
-     interactive plot = a new view component + one registry line; no change here.
-   • SUMMARY (server-aggregated, PlotChart) → here the cluster heatmap (ClusterHeatmapPanel).
+  Plots come in two families, both added from the one "+ Plot" picker and rendered GENERICALLY from
+  their registry — the SAME mechanism the Analysis board uses (see LayoutCanvas), so there is one way
+  to host a plot, not one per surface:
+   • INTERACTIVE (registry `INTERACTIVE_VIEWS`, e.g. UMAP) → generic InteractivePanel.
+   • CLUSTER PANELS (registry `CLUSTER_PANELS`, e.g. heatmap, HMM behaviour) → generic <component :is>.
+  Adding a cluster plot = a new component (to the contract) + one registry line; no change here.
 
   Page-level: the clustering-run (suffix) dropdown — you view one run at a time, like picking a
   segmentation. Clustering is set-scope, so plots pool across the selected images (shared UMAP space +
@@ -17,14 +19,12 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { useProjectMetaStore } from '../../stores/projectMeta'
 import { useProjectStore } from '../../stores/project'
 import { useGatingStore } from '../../stores/gating'
-import { useCanvasPanels } from '../../composables/useCanvasPanels'
+import { useCanvasPanels, type CanvasItem } from '../../composables/useCanvasPanels'
 import { useViewState } from '../../composables/useViewState'
 import { useClusterContext } from '../../composables/useClusterContext'
 import InteractivePanel from '../../components/canvas/InteractivePanel.vue'
 import { INTERACTIVE_VIEWS, isInteractiveView } from '../../components/canvas/interactiveViews'
-import ClusterHeatmapPanel from './ClusterHeatmapPanel.vue'
-import ClusterHmmStatesPanel from './ClusterHmmStatesPanel.vue'
-import ClusterHmmTransitionsPanel from './ClusterHmmTransitionsPanel.vue'
+import { CLUSTER_PANELS, isClusterPanel } from './clusterPanels'
 import PopulationManager from '../../components/canvas/PopulationManager.vue'
 import { defaultVis, type VisProps } from '../../plots/plot'
 
@@ -45,10 +45,18 @@ const projectUid = computed(() => meta.current?.uid ?? '')
 const setUid = computed(() => project.activeSetUid)
 
 const canvasRef = ref<HTMLElement | null>(null)
+// NB: no `features: []` default — leave it undefined so the heatmap panel self-seeds its features
+// from the run (its seed watch only fires when `features === undefined`, to avoid clobbering a
+// deliberate empty pick). Seeding `[]` here silently blocked that → heatmap never rendered on the page.
 const { panels, activeId, shared, add, remove, arrangeGrid, arrangeCascade } =
-  useCanvasPanels<ClusterPanelState>(canvasRef, () => ({ kind: 'umap', features: [], labels: true, hl: [] }),
+  useCanvasPanels<ClusterPanelState>(canvasRef, () => ({ kind: 'umap', labels: true, hl: [] }),
     `clust:${props.popType}`)
 const activePanel = computed(() => panels.value.find(p => p.id === activeId.value) ?? null)
+
+// migrate persisted panel kinds to the CLUSTER_PANELS registry keys (legacy hyphenated → camelCase),
+// so old canvases keep working now that the page renders panels generically from the registry.
+const KIND_ALIASES: Record<string, string> = { 'hmm-states': 'hmmStates', 'hmm-transitions': 'hmmTransitions' }
+for (const p of panels.value) { const a = KIND_ALIASES[p.state.kind]; if (a) p.state.kind = a }
 
 // suffix is PAGE-LEVEL (you view one clustering run at a time, like picking a segmentation).
 // Highlighting the eye shows a pop on the UMAP (its colour, other clusters greyed) + breaks the
@@ -59,7 +67,7 @@ const { suffix, highlighted, scope, vis: gVis } = useViewState(shared, {
   vis: defaultVis() as VisProps })
 
 // run list + per-run features/cluster metadata + valid-image resolution + the gating-store drive +
-// highlight→shownPops resolution (shared with the Analysis canvas via useClusterContext).
+// highlight→shownPops resolution (shared with the Analysis board via useClusterContext).
 const {
   suffixes, nameMap, clusterIds, featureOptions, hmmStateCols, hmmTransitionCols,
   runMembers, validUids, strayUids, missingUids, shownPopsFor,
@@ -106,14 +114,18 @@ watch(() => g.flat.map(p => p.path).join('\n'), () => {
   for (const p of panels.value) if (p.state.hl) p.state.hl = p.state.hl.filter(x => exist.has(x))
 })
 
-// plot types in the "+ Plot" picker: every registered interactive view + the summary heatmap, plus
-// (track clustering only, when HMM columns exist) the HMM state / transition behaviour plots.
+// plot types in the "+ Plot" picker, discovered from the SAME two registries the Analysis board uses
+// (no per-plot wiring): cluster-page interactive views (UMAP) + the CLUSTER_PANELS (heatmap, and — for
+// track clustering with the right obs columns — the HMM behaviour plots).
 const plotTypes = computed(() => [
-  // only cluster-page interactive views (UMAP) — gatingStrategy/filmstrip are Analysis-canvas-only
+  // only cluster-page interactive views (UMAP) — gatingStrategy/filmstrip are Analysis-board-only
   ...Object.entries(INTERACTIVE_VIEWS).filter(([, v]) => v.clusterPage).map(([kind, v]) => ({ kind, label: v.label })),
-  { kind: 'heatmap', label: 'Heatmap' },
-  ...(props.popType === 'trackclust' && hmmStateCols.value.length ? [{ kind: 'hmm-states', label: 'HMM states' }] : []),
-  ...(props.popType === 'trackclust' && hmmTransitionCols.value.length ? [{ kind: 'hmm-transitions', label: 'HMM transitions' }] : []),
+  ...Object.entries(CLUSTER_PANELS).filter(([, def]) => {
+    if (def.trackOnly && props.popType !== 'trackclust') return false
+    if (def.needsCols === 'hmmState' && !hmmStateCols.value.length) return false
+    if (def.needsCols === 'hmmTransition' && !hmmTransitionCols.value.length) return false
+    return true
+  }).map(([kind, def]) => ({ kind, label: def.label })),
 ])
 function addKind(kind: string) {
   const id = add()
@@ -125,11 +137,20 @@ function addKind(kind: string) {
 const nameOf = (uid: string) =>
   project.activeSet()?.images.find(i => i.uid === uid)?.name ?? uid
 
-// default a heatmap panel's features to the run's full feature set once known (don't clobber a pick)
-watch([featureOptions, () => panels.value.length], () => {
-  if (!featureOptions.value.length) return
-  for (const p of panels.value) if (p.state.kind === 'heatmap' && !(p.state.features?.length)) p.state.features = [...featureOptions.value]
-})
+// props for a cluster PANEL (CLUSTER_PANELS): the common bag + the registry entry's panel-specific
+// props mapped from the shared cluster context — so the page renders every cluster panel with one
+// generic <component v-bind>, exactly like the Analysis board (LayoutCanvas.clusterPanelProps). Panels
+// self-seed their own defaults (e.g. heatmap features), so no host-side seeding is needed.
+function clusterPanelProps(p: CanvasItem<ClusterPanelState>) {
+  const ctx = { featureOptions: featureOptions.value, nameMap: nameMap.value,
+                hmmStateCols: hmmStateCols.value, hmmTransitionCols: hmmTransitionCols.value }
+  return {
+    projectUid: projectUid.value, setUid: setUid.value, imageUids: validUids.value,
+    popType: props.popType, suffix: suffix.value,
+    shownPops: shownPopsFor(panelHL(p.state)), vis: panelVis(p.state), state: p.state,
+    ...(CLUSTER_PANELS[p.state.kind].props?.(ctx) ?? {}),
+  }
+}
 
 // the generic context an interactive view receives, per panel (so LOCAL scope can show different
 // pops per panel). Plots run on the run-MEMBER images (validUids), not the raw selection — a cluster
@@ -209,26 +230,12 @@ onMounted(() => {
                             :context="ctxFor(p.state)" :state="p.state" :duplicable="true"
                             :persist-key="`clust:${popType}:${p.id}`"
                             @activate="activeId = p.id" @remove="remove(p.id)" @duplicate="duplicatePanel(p.state)" />
-          <!-- summary (heatmap) -->
-          <ClusterHeatmapPanel v-else-if="p.state.kind === 'heatmap'" :index="i" :arrange="p.arrange"
-                            :active="p.id === activeId" :project-uid="projectUid" :set-uid="setUid"
-                            :image-uids="validUids" :pop-type="popType" :suffix="suffix"
-                            :feature-options="featureOptions" :name-map="nameMap" :shown-pops="shownPopsFor(panelHL(p.state))"
-                            :vis="panelVis(p.state)" :state="p.state"
-                            :persist-key="`clust:${popType}:${p.id}`"
-                            @activate="activeId = p.id" @remove="remove(p.id)" @duplicate="duplicatePanel(p.state)" />
-          <!-- HMM behaviour plots (track clustering) -->
-          <ClusterHmmStatesPanel v-else-if="p.state.kind === 'hmm-states'" :index="i" :arrange="p.arrange"
-                            :active="p.id === activeId" :project-uid="projectUid" :set-uid="setUid"
-                            :image-uids="validUids" :suffix="suffix" :hmm-cols="hmmStateCols"
-                            :shown-pops="shownPopsFor(panelHL(p.state))" :vis="panelVis(p.state)" :state="p.state"
-                            :persist-key="`clust:${popType}:${p.id}`"
-                            @activate="activeId = p.id" @remove="remove(p.id)" @duplicate="duplicatePanel(p.state)" />
-          <ClusterHmmTransitionsPanel v-else-if="p.state.kind === 'hmm-transitions'" :index="i" :arrange="p.arrange"
-                            :active="p.id === activeId" :project-uid="projectUid" :set-uid="setUid"
-                            :image-uids="validUids" :suffix="suffix" :hmm-cols="hmmTransitionCols"
-                            :shown-pops="shownPopsFor(panelHL(p.state))" :vis="panelVis(p.state)" :state="p.state"
-                            :persist-key="`clust:${popType}:${p.id}`"
+          <!-- cluster panels (heatmap / HMM behaviour) → GENERIC render from the CLUSTER_PANELS
+               registry — the SAME mechanism the Analysis board uses (LayoutCanvas). Adding a cluster
+               plot is one registry line; no per-plot branch here. -->
+          <component v-else-if="isClusterPanel(p.state.kind)" :is="CLUSTER_PANELS[p.state.kind].component"
+                            :index="i" :arrange="p.arrange" :active="p.id === activeId"
+                            v-bind="clusterPanelProps(p)" :persist-key="`clust:${popType}:${p.id}`"
                             @activate="activeId = p.id" @remove="remove(p.id)" @duplicate="duplicatePanel(p.state)" />
         </template>
       </div>

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -19,7 +19,7 @@ import { useProjectStore } from '../../stores/project'
 import { useGatingStore } from '../../stores/gating'
 import { useCanvasPanels } from '../../composables/useCanvasPanels'
 import { useViewState } from '../../composables/useViewState'
-import { useLogStore } from '../../stores/log'
+import { useClusterContext } from '../../composables/useClusterContext'
 import InteractivePanel from '../../components/canvas/InteractivePanel.vue'
 import { INTERACTIVE_VIEWS, isInteractiveView } from '../../components/canvas/interactiveViews'
 import ClusterHeatmapPanel from './ClusterHeatmapPanel.vue'
@@ -41,7 +41,6 @@ const props = defineProps<{
 const meta = useProjectMetaStore()
 const project = useProjectStore()
 const g = useGatingStore()
-const log = useLogStore()
 const projectUid = computed(() => meta.current?.uid ?? '')
 const setUid = computed(() => project.activeSetUid)
 
@@ -58,7 +57,16 @@ const activePanel = computed(() => panels.value.find(p => p.id === activeId.valu
 const { suffix, highlighted, scope, vis: gVis } = useViewState(shared, {
   suffix: 'default', highlighted: [] as string[], scope: 'global' as 'global' | 'local',
   vis: defaultVis() as VisProps })
-const suffixes = ref<string[]>([])
+
+// run list + per-run features/cluster metadata + valid-image resolution + the gating-store drive +
+// highlight→shownPops resolution (shared with the Analysis canvas via useClusterContext).
+const {
+  suffixes, nameMap, clusterIds, featureOptions, hmmStateCols, hmmTransitionCols,
+  runMembers, validUids, strayUids, missingUids, shownPopsFor,
+} = useClusterContext({
+  projectUid, imageUids: computed(() => props.imageUids),
+  popType: computed(() => props.popType), suffix,
+})
 
 const toggle = (arr: string[], v: string) => arr.includes(v) ? arr.filter(x => x !== v) : [...arr, v]
 function toggleHighlight(path: string) {
@@ -91,12 +99,6 @@ function duplicatePanel(s: ClusterPanelState) {
   activeId.value = id
 }
 
-// resolve a highlight set to shown populations (colour + owned cluster IDs) against the store tree
-const shownPopsFor = (hl: string[]) => g.flat
-  .filter(p => hl.includes(p.path))
-  .map(p => ({ path: p.path, name: p.name, colour: p.colour,
-               clusterIds: Array.isArray(p.filter?.values) ? (p.filter!.values as unknown[]).map(Number) : [] }))
-
 // drop stale highlights (global + each panel's local) as pops are deleted/renamed
 watch(() => g.flat.map(p => p.path).join('\n'), () => {
   const exist = new Set(g.flat.map(p => p.path))
@@ -119,82 +121,14 @@ function addKind(kind: string) {
   activeId.value = id
 }
 
-// per-suffix feature list each run actually used (clusters' interpretive columns), from the channels
-// endpoint's clusterFeatures sidecar; fall back to markers/motility if a run predates feature
-// tracking. RAW column names — the matrix selects by raw name and we relabel channels via nameMap.
-const clusterFeatures = ref<Record<string, string[]>>({})
-const featureFallback = ref<string[]>([])
-const nameMap = ref<Record<string, string>>({})   // raw channel column → display name
-// HMM behaviour columns (state / transition frequencies) are categorical-behaviour features — they
-// belong in the dedicated HMM plot types, NOT the numeric heatmap (they don't render there). Keep
-// them out of the heatmap's feature options.
-const HMM_RE = /live\.cell\.hmm\.(state|transitions)\b/
-const allFeatures = computed<string[]>(() => clusterFeatures.value[suffix.value] ?? featureFallback.value)
-const featureOptions = computed<string[]>(() => allFeatures.value.filter(f => !HMM_RE.test(f)))
-// per-suffix: the tickable cluster IDs (universe) and the uIDs the run clustered together (partOf)
-const clusterIds = ref<Record<string, number[]>>({})
-const clusterMembers = ref<Record<string, string[]>>({})
-const resolvedVn = ref('default')                  // segmentation value_name the channels resolved to
-// HMM behaviour cell-obs columns → the dedicated HMM plot types (track clustering only).
-const hmmStateCols = ref<string[]>([])             // live.cell.hmm.state.<name>
-const hmmTransitionCols = ref<string[]>([])        // live.cell.hmm.transitions.<name>
-
-async function loadFeatures() {
-  if (!projectUid.value || !props.imageUids[0]) { clusterFeatures.value = {}; featureFallback.value = []; return }
-  const q = new URLSearchParams({ projectUid: projectUid.value, imageUid: props.imageUids[0], popType: props.popType })
-  try {
-    const r = await fetch(`/api/gating/channels?${q}`)
-    if (!r.ok) { clusterFeatures.value = {}; featureFallback.value = []; return }
-    const d = await r.json()
-    clusterFeatures.value = d.clusterFeatures ?? {}
-    clusterIds.value = d.clusterIds ?? {}
-    clusterMembers.value = d.clusterMembers ?? {}
-    resolvedVn.value = d.valueName ?? 'default'
-    featureFallback.value = props.popType === 'trackclust' ? (d.columns ?? []) : (d.channels ?? [])
-    // raw channel column → display name (matrix aggregates by raw; heatmap relabels for display)
-    const chans: string[] = d.channels ?? [], names: string[] = d.channelNames ?? []
-    nameMap.value = Object.fromEntries(chans.map((c, i) => [c, names[i] ?? c]))
-    // HMM behaviour columns (track branch cellObsMeasures) → the HMM plot types
-    const obs: string[] = d.cellObsMeasures ?? []
-    hmmStateCols.value = obs.filter(c => c.startsWith('live.cell.hmm.state.'))
-    hmmTransitionCols.value = obs.filter(c => c.startsWith('live.cell.hmm.transitions.'))
-    // discovered cluster runs → page-level suffix dropdown; self-heal if the stored one is gone
-    suffixes.value = d.clusterSuffixes ?? []
-    if (suffixes.value.length && !suffixes.value.includes(suffix.value)) suffix.value = suffixes.value[0]
-  } catch (e) {
-    log.error(`Cluster features: ${e instanceof Error ? e.message : String(e)}`, { source: 'cluster' })
-    clusterFeatures.value = {}; featureFallback.value = []
-  }
-}
-
-// Cluster pops can only be defined for images IN THE RUN (those carrying clusters.{suffix} — the
-// recorded `partOf`). Restrict writes to that subset; surface the mismatch so the user can fix the
-// selection. If a run predates partOf recording (empty members), don't block — treat all selected.
-const runMembers = computed<string[]>(() => clusterMembers.value[suffix.value] ?? [])
-const validUids = computed<string[]>(() =>
-  runMembers.value.length ? props.imageUids.filter(u => runMembers.value.includes(u)) : props.imageUids)
-const strayUids = computed<string[]>(() =>
-  runMembers.value.length ? props.imageUids.filter(u => !runMembers.value.includes(u)) : [])
-const missingUids = computed<string[]>(() =>
-  runMembers.value.filter(u => !props.imageUids.includes(u)))
 const nameOf = (uid: string) =>
   project.activeSet()?.images.find(i => i.uid === uid)?.name ?? uid
-
-// drive the (shared, pop_type-agnostic) gating store for the pop tree: primary = first valid image,
-// the rest mirror every mutation so cluster pops land set-wide. Re-sync on selection/suffix change.
-watch([validUids, suffix, () => props.popType, projectUid], () => {
-  if (!projectUid.value || !validUids.value.length) return
-  g.selectImage(validUids.value[0], resolvedVn.value, props.popType).then(() => {
-    g.mirrorUids = validUids.value.slice(1)
-  })
-}, { immediate: true })
 
 // default a heatmap panel's features to the run's full feature set once known (don't clobber a pick)
 watch([featureOptions, () => panels.value.length], () => {
   if (!featureOptions.value.length) return
   for (const p of panels.value) if (p.state.kind === 'heatmap' && !(p.state.features?.length)) p.state.features = [...featureOptions.value]
 })
-watch([projectUid, () => props.imageUids.join(','), () => props.popType], loadFeatures)
 
 // the generic context an interactive view receives, per panel (so LOCAL scope can show different
 // pops per panel). Plots run on the run-MEMBER images (validUids), not the raw selection — a cluster
@@ -210,7 +144,6 @@ const ctxFor = (s: ClusterPanelState) => ({
 const selectedPop = ref('')
 
 onMounted(() => {
-  loadFeatures()
   // seed a UMAP + a heatmap ONLY when this canvas is empty (panels persist per `clust:${popType}`
   // across navigation — an unconditional add() would stack more on every remount).
   if (panels.value.length === 0) { addKind('umap'); addKind('heatmap') }

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -109,7 +109,8 @@ watch(() => g.flat.map(p => p.path).join('\n'), () => {
 // plot types in the "+ Plot" picker: every registered interactive view + the summary heatmap, plus
 // (track clustering only, when HMM columns exist) the HMM state / transition behaviour plots.
 const plotTypes = computed(() => [
-  ...Object.entries(INTERACTIVE_VIEWS).map(([kind, v]) => ({ kind, label: v.label })),
+  // only cluster-page interactive views (UMAP) — gatingStrategy/filmstrip are Analysis-canvas-only
+  ...Object.entries(INTERACTIVE_VIEWS).filter(([, v]) => v.clusterPage).map(([kind, v]) => ({ kind, label: v.label })),
   { kind: 'heatmap', label: 'Heatmap' },
   ...(props.popType === 'trackclust' && hmmStateCols.value.length ? [{ kind: 'hmm-states', label: 'HMM states' }] : []),
   ...(props.popType === 'trackclust' && hmmTransitionCols.value.length ? [{ kind: 'hmm-transitions', label: 'HMM transitions' }] : []),

--- a/frontend/src/modules/cluster/clusterPanels.ts
+++ b/frontend/src/modules/cluster/clusterPanels.ts
@@ -1,0 +1,46 @@
+import type { Component } from 'vue'
+import ClusterHeatmapPanel from './ClusterHeatmapPanel.vue'
+import ClusterHmmStatesPanel from './ClusterHmmStatesPanel.vue'
+import ClusterHmmTransitionsPanel from './ClusterHmmTransitionsPanel.vue'
+
+// Registry of CLUSTER "panel" plots — the summary-family cluster plots that wrap CanvasPanel themselves
+// (heatmap, HMM behaviour), as opposed to the interactive WebGL views in interactiveViews.ts (UMAP).
+// This is the ONE place both the Cluster module page and the Analysis board discover them, so adding a
+// cluster plot is a single registry line — no per-plot host wiring. Each entry declares:
+//   • how it appears (label, trackOnly, needsCols) and WHERE (`analysisBoard` — the "put it on the board"
+//     checkbox the whole design hinges on), and
+//   • `props(ctx)` — the panel-specific props mapped from the shared cluster context, so the host can
+//     render every panel with one generic `<component :is v-bind>` (no per-panel prop knowledge).
+// Every panel must accept the common bag (index/active/docked/projectUid/setUid/imageUids/popType/suffix/
+// shownPops/vis/state/persistKey) and expose exportImage()/getCsv() for the board's PDF/CSV export.
+export interface ClusterCtx {
+  featureOptions: string[]
+  nameMap: Record<string, string>
+  hmmStateCols: string[]
+  hmmTransitionCols: string[]
+}
+export interface ClusterPanelDef {
+  label: string
+  component: Component
+  trackOnly?: boolean                        // trackclust runs only (HMM behaviour plots)
+  needsCols?: 'hmmState' | 'hmmTransition'   // only offer when the run has these obs columns
+  analysisBoard?: boolean                    // ALSO offered on the Analysis board (not just the cluster page)
+  props?: (ctx: ClusterCtx) => Record<string, unknown>   // panel-specific props from the shared context
+}
+
+export const CLUSTER_PANELS: Record<string, ClusterPanelDef> = {
+  heatmap: {
+    label: 'Cluster heatmap', component: ClusterHeatmapPanel, analysisBoard: true,
+    props: ctx => ({ featureOptions: ctx.featureOptions, nameMap: ctx.nameMap }),
+  },
+  hmmStates: {
+    label: 'HMM states', component: ClusterHmmStatesPanel, trackOnly: true, needsCols: 'hmmState',
+    analysisBoard: true, props: ctx => ({ hmmCols: ctx.hmmStateCols }),
+  },
+  hmmTransitions: {
+    label: 'HMM transitions', component: ClusterHmmTransitionsPanel, trackOnly: true, needsCols: 'hmmTransition',
+    analysisBoard: true, props: ctx => ({ hmmCols: ctx.hmmTransitionCols }),
+  },
+}
+
+export const isClusterPanel = (kind: string): boolean => kind in CLUSTER_PANELS

--- a/frontend/src/plots/export.ts
+++ b/frontend/src/plots/export.ts
@@ -125,6 +125,22 @@ export async function plotHostToImageURL(host: HTMLElement | null, bg: string,
   return c.toDataURL('image/png')
 }
 
+// Export a WebGL/raster plot host (a regl point cloud + HTML/SVG overlays) at a CRISP FIXED
+// resolution, regardless of its on-screen size. A raster plot drawn at its screen backing store
+// exports soft on a small slot; instead we aim for a fixed ~`targetPx` long side (scale bounded
+// 4–14×) and let the `hiRes` resolver re-render the point cloud at that scale — regl scales the point
+// size with it, so the look stays constant but sharp. This is the ONE hi-res path shared by the gating
+// scatter (GateScatterCell) and the cluster UMAP (UmapView); don't reinvent the scale math per plot.
+export function rasterExportScale(host: HTMLElement | null, targetPx = 2200): number | undefined {
+  const px = host ? Math.max(host.clientWidth, host.clientHeight) : 0
+  return px ? Math.min(14, Math.max(4, Math.ceil(targetPx / px))) : undefined
+}
+export async function rasterPlotToImageURL(host: HTMLElement | null, bg: string,
+  hiRes: (cv: HTMLCanvasElement, scale: number) => Promise<CanvasImageSource | null>,
+  targetPx = 2200): Promise<string | null> {
+  return plotHostToImageURL(host, bg, { hiRes, scale: rasterExportScale(host, targetPx) })
+}
+
 // find the <svg> in a rendered node (Observable Plot returns a <figure> wrapper when it has a legend)
 export function svgOf(node: Element | null): SVGSVGElement | null {
   if (!node) return null

--- a/frontend/src/plots/layoutTemplates.ts
+++ b/frontend/src/plots/layoutTemplates.ts
@@ -46,6 +46,9 @@ export const COMIC_PRESETS: LayoutTemplate[] = [
   // wide feature on top + a row of three beneath
   { id: 'feature-3', label: 'Feature + 3', cols: 3, rows: 2,
     slots: ['1 / 1 / 2 / 4', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4'] },
+  // wide feature on top + a row of four beneath
+  { id: 'feature-4', label: 'Top + 4', cols: 4, rows: 2,
+    slots: ['1 / 1 / 2 / 5', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '2 / 4 / 3 / 5'] },
   // tall hero left + two small right + wide footer
   { id: 'hero-3', label: 'Hero + 3', cols: 2, rows: 3,
     slots: ['1 / 1 / 3 / 2', '1 / 2 / 2 / 3', '2 / 2 / 3 / 3', '3 / 1 / 4 / 3'] },

--- a/frontend/src/plots/layoutTemplates.ts
+++ b/frontend/src/plots/layoutTemplates.ts
@@ -1,4 +1,4 @@
-// Layout templates for the Analysis canvas (docs/todo/ANALYSIS_CANVAS_PLAN.md, decisions 4/8/10).
+// Layout templates for the Analysis board (docs/todo/ANALYSIS_CANVAS_PLAN.md, decisions 4/8/10).
 // One mechanism serves BOTH clean scientific grids AND rectangular "comic plates": a template is a
 // CSS-grid definition (cols × rows tracks) plus a grid-area string per slot. A uniform N×M is just the
 // generated case; comic plates are hand-defined span arrangements. Each tab picks a template; the page

--- a/frontend/src/plots/layoutTemplates.ts
+++ b/frontend/src/plots/layoutTemplates.ts
@@ -33,37 +33,39 @@ export const UNIFORM_PRESETS: LayoutTemplate[] = [
 
 // Rectangular "comic plates": varied-size panels over a base grid (decision 8). Rectangular only —
 // angled panels are deferred; the filmstrip slot covers the angled-image use (decision 10).
+// Ordered into families so the picker reads as two tidy rows:
+//   ROW 1 — a wide FEATURE + small panels: split, big-left, and "top banner + N".
+//   ROW 2 — HEADER banner + a grid, and tall HERO / SIDEBAR layouts.
 export const COMIC_PRESETS: LayoutTemplate[] = [
+  // ── Row 1: feature + small panels ─────────────────────────────────────────
   // wide left + narrow right (single row)
   { id: 'wide-tall', label: '2 + 1', cols: 3, rows: 1,
     slots: ['1 / 1 / 2 / 3', '1 / 3 / 2 / 4'] },
-  // wide feature on top + two beneath
-  { id: 'feature-2', label: 'Top + 2', cols: 2, rows: 2,
-    slots: ['1 / 1 / 2 / 3', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3'] },
   // big square left + two stacked on the right
   { id: 'big-2', label: 'Big + 2', cols: 3, rows: 2,
     slots: ['1 / 1 / 3 / 3', '1 / 3 / 2 / 4', '2 / 3 / 3 / 4'] },
-  // wide feature on top + a row of three beneath
-  { id: 'feature-3', label: 'Feature + 3', cols: 3, rows: 2,
+  // wide feature on top + a row of two / three / four beneath (progressive family)
+  { id: 'feature-2', label: 'Top + 2', cols: 2, rows: 2,
+    slots: ['1 / 1 / 2 / 3', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3'] },
+  { id: 'feature-3', label: 'Top + 3', cols: 3, rows: 2,
     slots: ['1 / 1 / 2 / 4', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4'] },
-  // wide feature on top + a row of four beneath
   { id: 'feature-4', label: 'Top + 4', cols: 4, rows: 2,
     slots: ['1 / 1 / 2 / 5', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '2 / 4 / 3 / 5'] },
+  // ── Row 2: header banner + grid, and hero / sidebar ───────────────────────
+  // wide header banner on top + two rows of three / four smaller slots (all rows equal height)
+  { id: 'header-2x3', label: 'Header + 2×3', cols: 3, rows: 3,
+    slots: ['1 / 1 / 2 / 4', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4'] },
+  { id: 'header-2x4', label: 'Header + 2×4', cols: 4, rows: 3,
+    slots: ['1 / 1 / 2 / 5', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '2 / 4 / 3 / 5', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4', '3 / 4 / 4 / 5'] },
   // tall hero left + two small right + wide footer
   { id: 'hero-3', label: 'Hero + 3', cols: 2, rows: 3,
     slots: ['1 / 1 / 3 / 2', '1 / 2 / 2 / 3', '2 / 2 / 3 / 3', '3 / 1 / 4 / 3'] },
-  // tall sidebar left + three stacked on the right
-  { id: 'side-3', label: 'Side + 3', cols: 3, rows: 3,
-    slots: ['1 / 1 / 4 / 2', '1 / 2 / 2 / 4', '2 / 2 / 3 / 4', '3 / 2 / 4 / 4'] },
   // large hero (2×2) with an L of five smaller panels
   { id: 'hero-quad', label: 'Hero + 5', cols: 3, rows: 3,
     slots: ['1 / 1 / 3 / 3', '1 / 3 / 2 / 4', '2 / 3 / 3 / 4', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4'] },
-  // wide header banner on top + two rows of three smaller slots (all rows equal height)
-  { id: 'header-2x3', label: 'Header + 2×3', cols: 3, rows: 3,
-    slots: ['1 / 1 / 2 / 4', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4'] },
-  // wide header banner on top + two rows of four smaller slots (all rows equal height)
-  { id: 'header-2x4', label: 'Header + 2×4', cols: 4, rows: 3,
-    slots: ['1 / 1 / 2 / 5', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '2 / 4 / 3 / 5', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4', '3 / 4 / 4 / 5'] },
+  // tall sidebar left + three stacked on the right
+  { id: 'side-3', label: 'Side + 3', cols: 3, rows: 3,
+    slots: ['1 / 1 / 4 / 2', '1 / 2 / 2 / 4', '2 / 2 / 3 / 4', '3 / 2 / 4 / 4'] },
 ]
 
 export const ALL_PRESETS = [...UNIFORM_PRESETS, ...COMIC_PRESETS]

--- a/frontend/src/plots/pdf.ts
+++ b/frontend/src/plots/pdf.ts
@@ -1,7 +1,7 @@
 import { PDFDocument } from 'pdf-lib'
 import { downloadBlob } from './export'
 
-// Multipage PDF of the Analysis canvas: ONE page per tab, laid out as that tab's grid (each slot image
+// Multipage PDF of the Analysis board: ONE page per tab, laid out as that tab's grid (each slot image
 // placed at its grid-area rectangle). Each summary plot's aggregated data can ride along as an embedded
 // CSV attachment (pdf-lib `attach`), so the figure + re-plottable data are one file
 // (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase E). Pure — the caller supplies captured slot PNGs + CSVs.

--- a/frontend/src/stores/analysisLayout.ts
+++ b/frontend/src/stores/analysisLayout.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { uniform, type LayoutTemplate } from '../plots/layoutTemplates'
 
-// Per-tab grid layout for the Analysis canvas (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase A2). Keyed by
+// Per-tab grid layout for the Analysis board (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase A2). Keyed by
 // the tab's canvas key (`analysis:tab:<id>`), parallel to `canvasPanels`/`analysisTabs`. Holds the
 // chosen template (cols/rows + per-slot grid-area) and each slot's CONTENT, plus the canvas-level
 // `shared` bag consumed by useSummaryData. In-memory (survives navigation, not reload); cleared

--- a/frontend/src/stores/analysisTabs.ts
+++ b/frontend/src/stores/analysisTabs.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-// Tab metadata for the multipage Analysis canvas (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase A). Each
+// Tab metadata for the multipage Analysis board (docs/todo/ANALYSIS_CANVAS_PLAN.md, Phase A). Each
 // "tab" is an independent board; its plots live in the `canvasPanels` store under the canvas key
 // `${groupKey}:tab:${id}` (so tabs reuse the whole existing SummaryCanvas persistence machinery —
 // this store only owns the tab LIST + names + which one is active).


### PR DESCRIPTION
## Cluster plots on the Analysis board + one generic plot-hosting mechanism

Hosts every clustering plot on the Analysis board, then makes **all module pages host plots the same
way** (registry-driven, no per-plot host wiring) and unifies the hi-res export path. Read-only: never
mutates gate/population/cluster definitions.

### Analysis board — clustering plots (Phase G)
- **UMAP**, **cluster heatmap**, **HMM states**, **HMM transitions** as board slots.
- **One clustering run per board**: board-level popType+suffix drive the singleton gating store via
  `useClusterContext` (only when a cluster slot exists); right rail swaps to a **read-only**
  `PopulationManager` (highlight/tick only — no add/delete/rename/recolour/reassign) with per-family scope.

### One mechanism across surfaces (no per-plot wiring)
- Two registries carry the surface flags: `interactiveViews.ts` (`clusterPage`/`analysisBoard`) and
  `clusterPanels.ts` (`analysisBoard`/`trackOnly`/`needsCols` + `props(ctx)`).
- **Cluster module page** de-duped to render from `CLUSTER_PANELS` via one generic `<component :is v-bind>`
  — identical to the board; picker built from registry flags; legacy panel kinds migrated.
- **Behaviour/summary pages** already registry-driven (server plot-spec registry → one `SummaryPanel`).
- **Gating page** stays out by design (write-capable gate-drawing); board hosts it read-only via
  `GatingStrategyView`. Documented as the explicit exception.
- `docked` is the chrome switch: docked plots drop reload + per-plot export; `InteractivePanel` forwards it.

### Export
- Shared `rasterExportScale` + `rasterPlotToImageURL` (`plots/export.ts`) — one crisp ~2200px-long-side
  path used by both the gating scatter and the cluster UMAP.
- **UMAP PDF fixed**: light-theme hi-res `exportImage()`; ScatterGL ground decoupled from the export theme
  (no racing re-render); host transparent during export so the overlay pass no longer paints over the
  hi-res points (points-missing bug, previously masked dark-over-dark).
- **Heatmap-on-module-page fixed**: dropped the `features: []` default so the panel self-seeds.

### Rename + docs
- "Analysis canvas" → "Analysis board" across labels + comments (persistence keys/store ids untouched).
- New `docs/ANALYSIS.md`; registered in `CLAUDE.md` doc table; cross-referenced from `docs/UI.md`.

### Verify before merge
- UMAP → PDF renders points on white with dark legend/labels.
- HMM states/transitions → PDF; heatmap renders on the cluster module page.
- **Backend restart** needed to activate `settings/analysisBoards.json` persistence + `/api/napari/screenshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)