### PR TITLE
feat(frontend): targeted task-refresh for plots + napari data-vs-imag…

### DIFF
--- a/api/src/sockets.jl
+++ b/api/src/sockets.jl
@@ -9,7 +9,11 @@ function ws_send(ws, msg)
 end
 
 ws_log(ws, task_id, line)              = ws_send(ws, (; type="task:log",      taskId=task_id, line=line))
-ws_status(ws, task_id, status, uid="") = ws_send(ws, (; type="task:status",   taskId=task_id, status=status, imageUid=uid))
+# `image_uids` carries ALL images a task touched — for a set/combined task, `uid` is just the
+# representative (first) member, so the frontend needs the full list to invalidate every member's plots
+# (task-refresh; see docs/todo/TASK_DATA_REFRESH_PLAN.md). Defaults empty → single-image tasks fall back
+# to `imageUid` on the frontend.
+ws_status(ws, task_id, status, uid=""; image_uids=String[]) = ws_send(ws, (; type="task:status", taskId=task_id, status=status, imageUid=uid, imageUids=image_uids))
 ws_result(ws, task_id, uid, meta)      = ws_send(ws, (; type="task:result",    taskId=task_id, imageUid=uid, meta=meta))
 
 function ws_progress(ws, task_id, fraction::Float64)
@@ -149,7 +153,9 @@ function handle_task_run(ws, data)
                                   final_status[] = rec.status
                               end)
             isnothing(result) || ws_result(ws, task_id, rep, result)
-            ws_status(ws, task_id, string(final_status[]), rep)
+            # a set task touched EVERY member — send the full list so the frontend invalidates all of
+            # their plots, not just the representative's (closes the non-rep-member gap).
+            ws_status(ws, task_id, string(final_status[]), rep; image_uids=[i.uid for i in imgs])
             return
         end
 

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -52,7 +52,8 @@ No `LayoutCanvas` change.
 ### `docked` — the chrome switch
 Every hosted plot reads `docked` (true in a board slot). Docked plots drop the chrome that only makes
 sense free-floating — the **reload** button and the per-plot **Export** dropdown — because the board
-re-fetches on context change and exports via PDF/CSV. `InteractivePanel` forwards `docked` to its view.
+re-fetches on context change and exports via PDF/CSV. (`SummaryPanel` + cluster panels take `docked`; a
+future interactive view that grows free-floating-only chrome would take it via `InteractivePanel` too.)
 
 ### Clustering — one run per board
 Cluster plots (UMAP + `CLUSTER_PANELS`) share **one clustering run per board**: board-level

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -195,6 +195,30 @@ They are reset on server restart (the `Ref`s are re-initialised). If napari is c
 
 ---
 
+## Reloading: data vs image
+
+**Reloading a shown image refreshes DATA only — never the image pyramid — unless the user ticks
+"reset".** Data reload = re-push the overlays via the existing endpoints (`show-labels`,
+`show-populations`, `show-tracks`, `colour-labels`), each of which re-reads from disk and **replaces its
+layer in place** (`_remove_layer` then add). The pyramid + camera stay. This is fully frontend-orchestrated
+(`ViewerPanel.reloadViewer()` → `pushAllOverlays()`); `POST /api/napari/open` is only for a *full* reopen.
+
+Who triggers what:
+- **Image-table eye** on the already-open image → `project.requestNapariReload()` → `ViewerPanel` reloads
+  data (full reopen only if reset). A *different* image → full `/api/napari/open`.
+- **Task finishes** (with the auto-update toggle on) → data reload (unless reset).
+- **`napariResetOnReload`** toggle (viewer panel, `pi-image`, default off) → reload reopens the whole
+  image. Needed when a task changed the *pixels* (drift/denoise). Mirrors the old R `viewerManager.R`
+  (reopen only on uID change / reset). See `docs/todo/TASK_DATA_REFRESH_PLAN.md`.
+
+Plot/data freshness elsewhere (not napari) rides `project.dataVersion` — a **per-image** version map
+bumped for the image a task touched (`ws.ts`, `task:status == 'done'`). Views watch
+`dataVersionFor(theirImages)` and refetch only when an image THEY show changed (targeted, not
+project-wide), which is why they no longer carry per-plot reload buttons. See
+`docs/todo/TASK_DATA_REFRESH_PLAN.md`.
+
+---
+
 ## 3D mode
 
 Setting `viewer.dims.ndisplay = 3` programmatically after `add_image` leaves the camera uninitialized for the 3D extent — the image is invisible until the user manually toggles (which calls `reset_view()` internally). Always follow with `viewer.reset_view()`:

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -318,10 +318,11 @@ host, it consumes the *same* registries + contract — do not re-wire plots per 
 - **Behaviour / summary pages** (`SummaryCanvas.vue`) and the board's summary slots both render every
   summary plot through one `SummaryPanel` driven by the server plot-spec registry
   (`GET /api/plots/definitions`) — already a single mechanism.
-- **`docked` is the contract's chrome switch.** A view/panel reads `docked` to hide anything that only
-  makes sense free-floating (the reload button, the per-plot Export dropdown) — the board re-fetches on
-  context change and exports via PDF/CSV, so that chrome would be redundant in a slot. `InteractivePanel`
-  forwards `docked` to its view for exactly this.
+- **`docked` is the contract's chrome switch.** A panel reads `docked` to hide anything that only makes
+  sense free-floating (e.g. the per-plot Export dropdown) — the board re-fetches on context change and
+  exports via PDF/CSV, so that chrome is redundant in a slot. `SummaryPanel` and the cluster panels use
+  it; `InteractivePanel` can forward it to a view that needs it (none do today — plots stay fresh via
+  `useDataRefresh`, so there are no per-plot reload buttons to hide).
 
 **Exception — the gating page (`gate/GatingPlots.vue`) is intentionally NOT registry-hosted.** It is a
 single, *write-capable* gate-drawing workspace (`GatePlotPanel` draws/edits gates), not a multi-type
@@ -349,9 +350,36 @@ onUnmounted(() => {
 })
 ```
 
-For task results, the `task:result` message updates `img.filepaths[valueName]` in the Pinia project store automatically (handled in `ws.ts`). Panels that react to new results should `watch` the relevant image store field.
+For task results, the `task:result` message updates `img.filepaths[valueName]` in the Pinia project store automatically (handled in `ws.ts`). Panels that need to re-fetch when a task changes data should use **`useDataRefresh`** (see *Data freshness* below), not a hand-rolled watch.
 
 Full WS message-type reference is in `ARCHITECTURE.md`.
+
+---
+
+## Data freshness — task-refresh (no per-plot reload buttons)
+
+A task can rewrite data **in place** (same `value_name` / clustering `suffix`), so `img.filepaths`
+doesn't change and a plot keyed on it never re-fetches. Rather than give every plot a manual reload
+button, plots auto-refresh off a **targeted, per-image version signal**:
+
+- `stores/project.ts` holds `dataVersion: Record<imageUid, number>`. On a successful task (`ws.ts`,
+  `task:status == 'done'`) it bumps the touched image(s) — `bumpDataVersion(uid)`. A **set/combined**
+  task reports all its members in the status message's `imageUids` (the backend sends the member list,
+  not just the representative — see `api/src/sockets.jl`), so every member is bumped.
+- Plots subscribe with the **one primitive**, `composables/useDataRefresh.ts`:
+  ```ts
+  useDataRefresh(() => props.imageUids, load)   // refetch only when a task touches one of THESE images
+  ```
+  It watches `project.dataVersionFor(theirImages)` and calls the reload fn only when an image *that plot
+  shows* changed — never on unrelated tasks. Used by `useSummaryData`, `UmapView`, the cluster panels
+  (heatmap / HMM) and `GatingStrategyView`. **Do not** re-import the store and hand-weave a `dataVersion`
+  watch in a new plot — call `useDataRefresh`.
+- Gated by the global **`autoRefreshOnTask`** setting (Settings → Interface, on by default). Because
+  `useDataRefresh` is the single chokepoint, that one toggle governs every plot; off → plots refresh on
+  the next navigation / input change instead.
+
+This mirrors the older gate path (`gating:popmap` → `reloadToken`) and the old R app's success-time
+`retrieveState`. The **napari viewer** refresh is a separate, data-vs-image path — see `docs/NAPARI.md`.
 
 ---
 

--- a/docs/todo/TASK_DATA_REFRESH_PLAN.md
+++ b/docs/todo/TASK_DATA_REFRESH_PLAN.md
@@ -1,0 +1,90 @@
+# Task-completion data refresh + napari data-vs-image reload
+
+**Goal.** When a task finishes, dependent views should refresh **without** per-plot "reload" buttons,
+and the napari viewer should reload **data (overlays) only** — never the (expensive) image pyramid —
+unless the user explicitly asks to reset. Kills the "weird reload buttons" on plots.
+
+**Reference (not a hard rule):** the old R app — `taskManager.R` (reload state on success +
+`input$taskUpdateImage` gating only the viewer image reload) and `viewerManager.R::openImage` (always
+reloads DATA; only reopens the IMAGE when a different uID is shown or a reset/reload flag is set). See
+`old-R-shiny-version/inst/app/modules/managers/{taskManager,viewerManager}.R`.
+
+Principle both parts share: **data reload ≠ image reload.** Data is cheap (an HTTP refetch / overlay
+re-push) → always automatic. The image reload (napari pyramid) is heavy → opt-in.
+
+---
+
+## Part A — Auto-refresh plots + pop manager on task success (remove per-plot buttons)
+
+Today: `task:result` (`stores/ws.ts`) does targeted patches (`filepaths`, dims, channels). A plot only
+refetches when a prop it keys on changes — so a task that overwrites data **in place** (same
+`value_name`/clustering `suffix`, unchanged `filepaths`) leaves the plot stale → hence the manual
+reload buttons (cluster heatmap/UMAP/HMM; tooltip literally "after re-running clustering at the same
+suffix"). Gating already solved this: `gating:popmap` → `useSummaryData.onPopmap()` bumps a
+`reloadToken` → panels refetch. Generalise that.
+
+**Design**
+- `stores/project.ts`: add `dataVersion: Record<string, number>` (keyed by object uID) + `bumpData(uid)`.
+- `stores/ws.ts` `task:result`: **only on success**, `bumpData(uid)`. Resolve uID type — image vs set/node
+  (the exact `taskManager.R` TODO): a set/combined task bumps every member image (or a set-level key that
+  set-pooled plots watch). A failed/cancelled task must NOT bump.
+- Consumers watch the version of the object(s) they show and refetch — the `reloadToken` shape, now fed
+  by task success too: summary panels, cluster UMAP/heatmap/HMM, gating-strategy, the pop manager
+  (pop list / stats). This is the `retrieveState(invalidate=FALSE)` equivalent.
+- **Remove the per-plot reload buttons** (cluster panels + `UmapView`) — they're already `v-if="!docked"`;
+  now delete them outright. No global/board button needed (R had none).
+
+**Open Q:** is a single global `dataVersion++` (refetch everything) acceptable for v1, or scope by uID
+from the start? Lean scoped-by-uID (mirrors `onPopmap`'s imageUid guard + `gating.ts` per-pop version).
+
+---
+
+## Part B — Napari: reload data only; reset toggle for the image
+
+Today: every viewer refresh path (`onValueNameChange`, `onTaskResult`, `onTaskStatus`, the eye) calls
+`openInNapari` → `POST /api/napari/open` → the bridge does `layers.clear()` + reopens the pyramid
+(`napari/napari_bridge.py::open_image`). So reloading DATA needlessly reopens the IMAGE.
+
+**Design**
+- New `reloadViewer(reset)` in `ViewerPanel.vue`:
+  - **image reopen** (`openInNapari`) only when `reset` **OR** the requested uID ≠ the shown uID
+    (`projectStore.napariImageUid`) **OR** nothing shown. (viewerManager.R's condition.)
+  - else **data-only**: re-push the visible overlays via the existing endpoints — `show-populations`,
+    `show-tracks`, `show-labels` (+ new label layers without a reopen), `colour-labels` (this is exactly
+    what `onNapariOpened` does minus the image open; factor it out and reuse).
+- New setting `napariResetOnReload` (default **false**; same localStorage pattern as `napariUpdateImage`)
+  + a **"reset" toggle** button in the viewer panel, next to the existing auto-update toggle. Tooltip:
+  "Reset: reopen the image (not just data) on reload — needed when a task changed the image pixels
+  (drift/denoise)."
+- Rewire the eye / value-name-change / task handlers to `reloadViewer(napariResetOnReload)`.
+- `napariUpdateImage` (existing, R's `taskUpdateImage`) stays as the *task→viewer* gate; `reset` decides
+  data-vs-image for whatever reload does fire.
+
+**Note:** image-pixel-changing tasks (cleanup/drift/denoise) genuinely need a pyramid reload — that's the
+`reset` toggle's job. Segmentation/tracking/gating/clustering are data-only → default (reset off).
+
+---
+
+## Build order — BOTH LANDED (pending review)
+1. **Part B (done):** `napariResetOnReload` setting (`pi-image` toggle, default off) +
+   `ViewerPanel.reloadViewer()`/`pushAllOverlays()` + `project.napariReloadTick`/`requestNapariReload`;
+   image-table eye on the open image + task-completion now data-only unless reset. Pure frontend
+   (endpoints re-read + replace layers), no bridge change / server restart. Documented in `docs/NAPARI.md`.
+2. **Part A (done):** `project.dataVersion` — a **per-image version map** — + `bumpDataVersion(uid)`,
+   bumped in `ws.ts` on `task:status == 'done'` for every image the task touched (success only). Plots
+   subscribe via the **`useDataRefresh(imageUids, onRefresh)` composable** (the one primitive of the
+   framework — watches `dataVersionFor(theirImages)`), so a plot refetches ONLY when an image IT shows
+   changed and no plot imports the store or hand-weaves a watch: `useSummaryData` (loadPops + reloadToken),
+   `UmapView`, `ClusterHeatmapPanel`, `ClusterHmm{States,Transitions}Panel`, `GatingStrategyView`. Per-plot
+   reload buttons removed.
+   Set-scope gap **closed**: `api/src/sockets.jl` now sends the full member list (`imageUids`) on the
+   set-task terminal status (not just `rep`), and `ws.ts` bumps every one — so a non-rep member's
+   single-image plot refreshes too. (Backend change → server restart to take effect.)
+
+Decoration: viewer panel gained a small `pi-circle-fill` dot marking the population/overlay toggle group
+(matches the colour-by dot).
+
+## Docs to update when built
+`docs/NAPARI.md` (data-vs-image reload + reset), `docs/UI.md` (task-refresh reactivity; buttons removed),
+`docs/API.md` (if any endpoint gains a flag), `docs/ARCHITECTURE.md` (task:result as an invalidation
+signal). Promote the durable parts; delete this plan when done.

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -179,6 +179,9 @@ async function doDelete() {
 async function openInNapari(imageUid: string) {
   const projectUid = projectMeta.current?.uid
   if (!projectUid) return
+  // clicking the eye on the ALREADY-open image = reload it. Delegate to ViewerPanel (it owns the
+  // overlay logic), which reloads DATA only unless the user ticked reset — no needless pyramid reopen.
+  if (project.napariImageUid === imageUid) { project.requestNapariReload(); return }
   napariLoading.value = new Set([...napariLoading.value, imageUid])
   const autoProps = settings.napariAutoSaveLayerProps
   try {

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -321,12 +321,16 @@ function onTaskStatus(data: Record<string, unknown>) {
   if (String(data.status ?? '') !== 'done') return
   const napariUid = projectStore.napariImageUid
   if (!napariUid || String(data.imageUid ?? '') !== napariUid) return
-  openInNapari(selectedValueName.value)
+  reloadViewer()   // data-only unless the user ticked reset (task changed pixels → reopen)
 }
 
-function onNapariOpened() {
-  // everything runs in nextTick so the napariImage-derived state (labelNames, visibleLabels) has
-  // settled before we push overlays — the labels early-return must NOT skip the pop/track overlays.
+// Re-push ALL of the image's DATA overlays (labels + colour-by + population/track points/ribbons),
+// each re-read from disk by its endpoint (show-labels/show-populations/show-tracks all replace their
+// layer in place). This is the "reload data" path — it touches NO image pyramid. Shared by the open
+// handler (after a full reopen) and reloadViewer's data-only branch.
+function pushAllOverlays() {
+  // run in nextTick so the napariImage-derived state (labelNames, visibleLabels) has settled before we
+  // push overlays — the labels early-return must NOT skip the pop/track overlays.
   nextTick(() => {
     if (hasLabels.value) {
       const toShow = Object.fromEntries(
@@ -358,6 +362,17 @@ function onNapariOpened() {
   })
 }
 
+function onNapariOpened() { pushAllOverlays() }
+
+// Refresh the SHOWN image. Data-only by default (re-push overlays, re-read from disk — the pyramid and
+// camera stay); only reopen the whole image when the user ticked reset, or nothing is shown yet. This
+// is what the eye (on the already-open image) and finished tasks call, so a plain reload no longer
+// yanks the image out from under the user (mirrors viewerManager.R: reopen only on reset / uID change).
+function reloadViewer() {
+  if (settings.napariResetOnReload || !projectStore.napariImageUid) openInNapari(selectedValueName.value)
+  else pushAllOverlays()
+}
+
 function onTaskResult(data: Record<string, unknown>) {
   const imageUid = String(data.imageUid ?? '')
   if (!imageUid || imageUid !== projectStore.napariImageUid) return
@@ -366,7 +381,7 @@ function onTaskResult(data: Record<string, unknown>) {
   const addedValueName = meta.valueName as string | undefined
   if (addedValueName) {
     selectedValueName.value = addedValueName
-    if (settings.napariUpdateImage) openInNapari(addedValueName)
+    if (settings.napariUpdateImage) reloadViewer()   // data-only unless reset
   }
 
   const labelValueName = meta.labelValueName as string | undefined
@@ -385,6 +400,9 @@ function onTaskResult(data: Record<string, unknown>) {
     })
   }
 }
+
+// the image-table eye, clicked on the ALREADY-open image, asks us to reload it (data-only unless reset)
+watch(() => projectStore.napariReloadTick, () => reloadViewer())
 
 onMounted(() => {
   ws.on('napari:opened', onNapariOpened)
@@ -451,8 +469,14 @@ onUnmounted(() => {
       <button
         class="opt-btn" :class="{ active: settings.napariUpdateImage }"
         @click="settings.napariUpdateImage = !settings.napariUpdateImage"
-        v-tooltip.bottom="'Auto-update: reload image in Napari whenever a task finishes on that image'"
+        v-tooltip.bottom="'Auto-update: refresh Napari whenever a task finishes on that image'"
       ><i class="pi pi-refresh" /></button>
+
+      <button
+        class="opt-btn" :class="{ active: settings.napariResetOnReload }"
+        @click="settings.napariResetOnReload = !settings.napariResetOnReload"
+        v-tooltip.bottom="'Reset on reload: reopen the whole image (not just data) when reloading — needed when a task changed the image pixels (drift/denoise). Off = reload data only.'"
+      ><i class="pi pi-image" /></button>
 
       <button
         class="opt-btn" :class="{ active: settings.napariAutoSaveLayerProps }"
@@ -474,8 +498,12 @@ onUnmounted(() => {
 
       <!-- Populations sub-menu: one toggle per pop type, shown as coloured centroid points in napari
            (layers namespaced by pop type, so they coexist). Distinct from the Tracks-ribbon toggle. -->
-      <template v-if="napariImage">
-        <span class="opt-sep" aria-hidden="true" />
+      <!-- population / overlay toggles: their OWN line (flex row break), led by a decorative dot at the
+           left — a distinct control group from the image-open options above, aligned with the
+           label/track-prop rows and the colour-by row below. -->
+      <div v-if="napariImage" class="opt-group">
+        <i class="pi pi-circle-fill opt-deco"
+           v-tooltip.bottom="'Toggles for the population types to show'" />
         <button
           v-for="pt in POP_TYPES" :key="pt.key"
           class="opt-btn" :class="{ active: settings.popVisible(pt.key) }"
@@ -494,7 +522,7 @@ onUnmounted(() => {
           @click="toggleTrackclust"
           v-tooltip.bottom="settings.popVisible('trackclust') ? 'Hide track-cluster ribbons' : 'Show track-cluster populations as ribbons'"
         ><i class="pi pi-sitemap" /></button>
-      </template>
+      </div>
       <!-- colour tracks + labels by an obs column (e.g. HMM state); '' = default colouring -->
       <span
         v-if="napariImage && obsCols.length" class="opt-colourby-wrap"
@@ -620,5 +648,22 @@ onUnmounted(() => {
   margin: 0.1rem 0.15rem;
   background: var(--cc-border);
   flex-shrink: 0;
+}
+/* population/overlay toggles on their own line (breaks the flex row), led by the dot at the left —
+   aligned with the label/track-prop rows above and the colour-by row below */
+.opt-group {
+  flex: 1 0 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+/* dot marking that group — matches the colour-by dot (.opt-colourby-wrap .pi): same colour + size, and
+   carries a tooltip. Non-interactive (no click), but hoverable so the tooltip shows. */
+.opt-deco {
+  color: var(--cc-text-dim);
+  font-size: 0.72rem;
+  margin-left: 0.05rem;
+  flex-shrink: 0;
+  cursor: default;
 }
 </style>

--- a/frontend/src/components/canvas/InteractivePanel.vue
+++ b/frontend/src/components/canvas/InteractivePanel.vue
@@ -39,9 +39,7 @@ defineExpose({ exportImage })
   <CanvasPanel :index="index" :active="active" :arrange="arrange" :persist-key="persistKey" :docked="docked"
                :title="entry?.label ?? view"
                @activate="emit('activate', $event)" @remove="emit('remove')">
-    <!-- `docked` is forwarded to the view so it can drop its own chrome (reload/controls) in a grid
-         slot — part of the generic contract, same as SummaryPanel/cluster panels. -->
-    <component v-if="entry" :is="entry.component" ref="viewRef" v-bind="context" :state="state" :docked="docked" />
+    <component v-if="entry" :is="entry.component" ref="viewRef" v-bind="context" :state="state" />
     <div v-else class="ip-missing">Unknown interactive plot “{{ view }}”.</div>
     <template v-if="duplicable || exportFormats.length" #footer>
       <button v-if="duplicable" class="ip-iconbtn" type="button" @click="emit('duplicate')"

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -13,6 +13,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, useTemplateRef, onMounted, onUnmounted } from 'vue'
 import type { GateSpec, TransformSpec, PopNode, PopTree } from '../../stores/gating'
+import { useDataRefresh } from '../../composables/useDataRefresh'
 import { orientGate } from '../../plots/gateGeometry'
 import { plotHostToImageURL } from '../../plots/export'
 import type { VisProps } from '../../plots/plot'
@@ -226,6 +227,8 @@ async function loadPanels() {
 
 watch([imageUid, popType], () => { loadChannels().then(loadTree) }, { immediate: true })
 watch([valueName], loadTree)
+// a task finishing on THIS image → gates/stats may have changed; reload the tree (cascades to panels)
+useDataRefresh(() => [imageUid.value], () => { loadChannels().then(loadTree) })
 watch(panelDefs, loadPanels, { immediate: true })
 
 // ── PDF export: a plot-only, LIGHT-theme image (no toolbar). Single plot → the one cell's hi-res

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -16,6 +16,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, nextTick, useTemplateRef } from 'vue'
 import { useLogStore } from '../../stores/log'
+import { useDataRefresh } from '../../composables/useDataRefresh'
 import ScatterGL from './ScatterGL.vue'
 import { plotHostToImageURL, rasterPlotToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
 import type { VisProps } from '../../plots/plot'
@@ -28,7 +29,6 @@ const props = defineProps<{
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
   vis?: VisProps                 // canvas plot styling — here we honour the dark-theme knob
   state: { labels?: boolean }
-  docked?: boolean               // hosted in a grid slot (Analysis board) → drop the reload button
 }>()
 const log = useLogStore()
 const labels = computed({ get: () => props.state.labels !== false, set: v => (props.state.labels = v) })
@@ -169,6 +169,7 @@ async function load() {
 }
 
 watch([() => props.projectUid, () => props.imageUids.join(','), () => props.popType, () => props.suffix], load)
+useDataRefresh(() => props.imageUids, load)   // refetch when a task finishes on one of THESE images
 // highlight a pop / tick clusters → recolour from cached codes (no refetch)
 watch(() => JSON.stringify((props.shownPops ?? []).map(p => [p.colour, p.clusterIds])), recolour)
 onMounted(load)
@@ -208,8 +209,6 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
     <div class="uv-ctrl">
       <button class="cc-btn cc-btn-ghost" :class="{ on: labels }" @click="labels = !labels"
               v-tooltip.bottom="'Toggle cluster-number labels'"><i class="pi pi-tag" /> #</button>
-      <button v-if="!docked" class="cc-btn cc-btn-ghost" @click="load"
-              v-tooltip.bottom="'Reload (e.g. after re-running clustering at the same suffix)'"><i class="pi pi-refresh" /></button>
       <span class="uv-spacer" />
       <span v-if="total" class="uv-count">{{ total.toLocaleString() }} {{ unit }} · {{ legend.length }} clusters</span>
     </div>

--- a/frontend/src/composables/useDataRefresh.ts
+++ b/frontend/src/composables/useDataRefresh.ts
@@ -1,0 +1,19 @@
+import { watch } from 'vue'
+import { useProjectStore } from '../stores/project'
+import { useSettingsStore } from '../stores/settings'
+
+// The one primitive of the task-refresh framework: "refetch when a task finishes on one of THESE
+// images." A plot passes the images it shows + its reload fn; this watches the per-image data version
+// (project.dataVersion, bumped in ws.ts on `task:status == 'done'` for the touched image) and calls
+// `onRefresh` only when one of those images changed — targeted, not project-wide. This is what replaced
+// the per-plot reload buttons; every plot uses it the same way instead of importing the store and
+// weaving `dataVersionFor` into its own watch. See docs/todo/TASK_DATA_REFRESH_PLAN.md.
+//
+// Gated by the global `autoRefreshOnTask` setting (on by default): when off, a finished task doesn't
+// pull plots out from under the user — they refresh on the next navigation / input change instead. This
+// is the ONE chokepoint, so the setting governs every plot at once.
+export function useDataRefresh(imageUids: () => string[], onRefresh: () => void) {
+  const project = useProjectStore()
+  const settings = useSettingsStore()
+  watch(() => project.dataVersionFor(imageUids()), () => { if (settings.autoRefreshOnTask) onRefresh() })
+}

--- a/frontend/src/composables/useSummaryData.ts
+++ b/frontend/src/composables/useSummaryData.ts
@@ -1,5 +1,6 @@
 import { ref, computed, watch, onMounted, onUnmounted, type Ref } from 'vue'
 import { useWsStore } from '../stores/ws'
+import { useDataRefresh } from './useDataRefresh'
 import { useViewState } from './useViewState'
 import { tkey } from '../plots/series'
 import { defaultVis, type VisProps } from '../plots/plot'
@@ -101,6 +102,9 @@ export function useSummaryData(opts: {
     if (m.imageUid && imageUids.value.length && !imageUids.value.includes(m.imageUid)) return
     loadPops(); reloadToken.value++
   }
+  // a task finishing on one of THESE images → refetch (pop list may have new pops; data may have
+  // changed in place). Same mechanism as the gate popmap above; targeted per-image via useDataRefresh.
+  useDataRefresh(() => imageUids.value, () => { loadPops(); reloadToken.value++ })
   // the set of currently-valid target keys (for pruning host selections)
   const validSelKeys = computed(() => {
     const exist = new Set<string>()

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -133,6 +133,13 @@ onMounted(checkUpdates)
           <span class="toggle-label">Auto-follow running tasks in task manager</span>
         </label>
       </div>
+
+      <div class="field">
+        <label class="toggle-row" v-tooltip.right="'Keep plots in sync with your data: when a task finishes, any plot or population list showing the affected image(s) reloads on its own. Turn off to keep plots steady while you work — they update next time you open or change them.'">
+          <input type="checkbox" v-model="settings.autoRefreshOnTask" />
+          <span class="toggle-label">Auto-refresh plots when tasks finish</span>
+        </label>
+      </div>
     </section>
 
     <!-- ── Software updates ────────────────────────────────────────────── -->

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -11,6 +11,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, useTemplateRef } from 'vue'
 import { useLogStore } from '../../stores/log'
+import { useDataRefresh } from '../../composables/useDataRefresh'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import PlotChart from '../../components/plots/PlotChart.vue'
@@ -100,6 +101,7 @@ async function load() {
 watch([() => props.projectUid, () => props.imageUids.join(','), () => props.setUid, () => props.popType,
        () => props.suffix, () => features.value.join(','),
        () => JSON.stringify((props.shownPops ?? []).map(p => [p.path, p.clusterIds]))], load)
+useDataRefresh(() => props.imageUids, load)   // refetch when a task finishes on one of THESE images
 onMounted(load)
 // self-seed: default to the run's full feature set once known (don't clobber a user pick / an empty
 // pick the user made). Makes the panel work out-of-the-box on any host (no host-side seeding needed).
@@ -128,8 +130,6 @@ defineExpose({ exportImage, getCsv })
           <p v-if="!featureOptions.length" class="feat-empty">No recorded features — re-run clustering, or this run predates feature tracking.</p>
         </div>
       </details>
-      <button v-if="!docked" class="cc-btn cc-btn-ghost" @click="load"
-              v-tooltip.bottom="'Reload (e.g. after re-running clustering at the same suffix)'"><i class="pi pi-refresh" /></button>
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel / the HMM panels -->
     <template #footer>

--- a/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
@@ -15,6 +15,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef, nextTick } from 'vue'
 import { useLogStore } from '../../stores/log'
+import { useDataRefresh } from '../../composables/useDataRefresh'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import { defaultVis, paletteRange, type VisProps } from '../../plots/plot'
 import { elementToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
@@ -146,6 +147,7 @@ function exportAs(kind: string) {
 
 watch([() => props.projectUid, () => props.imageUids.join(','), () => props.setUid, () => props.suffix,
        () => measure.value, () => JSON.stringify(props.shownPops.map(p => [p.path, p.clusterIds]))], load)
+useDataRefresh(() => props.imageUids, load)   // refetch when a task finishes on one of THESE images
 // styling is render-only (no refetch) — re-render when the vis bag changes
 watch(v, render, { deep: true })
 onMounted(() => {
@@ -174,7 +176,6 @@ defineExpose({ exportImage, getCsv })
               v-tooltip.bottom="'Which HMM measure to show'">
         <option v-for="c in hmmCols" :key="c" :value="c">{{ shortName(c) }}</option>
       </select>
-      <button v-if="!docked" class="cc-btn cc-btn-ghost" @click="load" v-tooltip.bottom="'Reload'"><i class="pi pi-refresh" /></button>
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel -->
     <template #footer>

--- a/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
@@ -15,6 +15,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef, nextTick } from 'vue'
 import { useLogStore } from '../../stores/log'
+import { useDataRefresh } from '../../composables/useDataRefresh'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import { defaultVis, type VisProps } from '../../plots/plot'
 import { elementToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
@@ -153,6 +154,7 @@ function exportAs(kind: string) {
 
 watch([() => props.projectUid, () => props.imageUids.join(','), () => props.setUid, () => props.suffix,
        () => measure.value, () => JSON.stringify(props.shownPops.map(p => [p.path, p.clusterIds]))], load)
+useDataRefresh(() => props.imageUids, load)   // refetch when a task finishes on one of THESE images
 // styling is render-only (no refetch) — re-render when the vis bag changes
 watch(v, render, { deep: true })
 onMounted(() => {
@@ -181,7 +183,6 @@ defineExpose({ exportImage, getCsv })
               v-tooltip.bottom="'Which HMM measure to show'">
         <option v-for="c in hmmCols" :key="c" :value="c">{{ shortName(c) }}</option>
       </select>
-      <button v-if="!docked" class="cc-btn cc-btn-ghost" @click="load" v-tooltip.bottom="'Reload'"><i class="pi pi-refresh" /></button>
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel -->
     <template #footer>

--- a/frontend/src/stores/project.ts
+++ b/frontend/src/stores/project.ts
@@ -30,6 +30,26 @@ export const useProjectStore = defineStore('project', () => {
   const sets = ref<CciaSet[]>([])
   const activeSetUid = ref<string | null>(null)
   const napariImageUid = ref<string | null>(null)
+  // Reload signal for the napari viewer: bumped by anything asking to refresh the SHOWN image (the
+  // image-table eye clicked on the already-open image). ViewerPanel owns the overlay logic, so it
+  // watches this tick and decides data-only vs full reopen (see settings.napariResetOnReload).
+  const napariReloadTick = ref(0)
+  const requestNapariReload = () => { napariReloadTick.value++ }
+  // Data freshness — TARGETED per-image invalidation. A finished task (ws `task:status` == 'done')
+  // bumps only the image(s) it touched; a plot watches `dataVersionFor(itsImages)` and refetches ONLY
+  // when one of the images IT shows changed — not on every task in the project. This replaces the
+  // per-plot reload buttons without the Shiny-style "invalidate the world". Set-scope tasks report one
+  // representative member uid (see api/src/sockets.jl), so set plots — which watch all their member
+  // images incl. the rep — still refresh; a non-rep member's single-image plot is the one gap (rare).
+  // See docs/todo/TASK_DATA_REFRESH_PLAN.md.
+  const dataVersion = ref<Record<string, number>>({})
+  const bumpDataVersion = (imageUid: string) => {
+    if (imageUid) dataVersion.value[imageUid] = (dataVersion.value[imageUid] ?? 0) + 1
+  }
+  // combined version for a set of images — reactive (reads the per-uid counters), so a plot can
+  // `watch(() => dataVersionFor(itsImageUids), refetch)` and only fire when one of them bumps.
+  const dataVersionFor = (uids: string[]): number =>
+    uids.reduce((sum, u) => sum + (dataVersion.value[u] ?? 0), 0)
 
   // Remembered per-page image selection (the run-table checkboxes), keyed by `${scope}|${setUid}`
   // so it survives navigating away from a module page and back. `scope` is the module name (so a
@@ -50,6 +70,7 @@ export const useProjectStore = defineStore('project', () => {
     sets.value = apiSets
     activeSetUid.value = sets.value[0]?.uid ?? null
     imageSelection.value = {}     // selections are per-project; don't carry across loads
+    dataVersion.value = {}        // per-image versions are per-project too (uids don't cross projects)
     useCanvasPanelsStore().clear()   // open plots are per-project too
     useAnalysisTabsStore().clear()   // …and the Analysis-canvas boards
     useAnalysisLayoutStore().clear() // …and their grid layouts
@@ -60,6 +81,7 @@ export const useProjectStore = defineStore('project', () => {
     activeSetUid.value = null
     napariImageUid.value = null
     imageSelection.value = {}
+    dataVersion.value = {}
     useCanvasPanelsStore().clear()
     useAnalysisTabsStore().clear()
     useAnalysisLayoutStore().clear()
@@ -158,5 +180,5 @@ export const useProjectStore = defineStore('project', () => {
     }
   }
 
-  return { sets, activeSetUid, napariImageUid, activeSet, getImageSelection, setImageSelection, loadFromApi, clear, addSetFromApi, deleteSet, addImages, addImagesFromApi, deleteImage, updateImageStatus, updateImageMeta, addAttrKey, removeAttrKey, setAttrValues, removeLabelSet }
+  return { sets, activeSetUid, napariImageUid, napariReloadTick, requestNapariReload, dataVersion, bumpDataVersion, dataVersionFor, activeSet, getImageSelection, setImageSelection, loadFromApi, clear, addSetFromApi, deleteSet, addImages, addImagesFromApi, deleteImage, updateImageStatus, updateImageMeta, addAttrKey, removeAttrKey, setAttrValues, removeLabelSet }
 })

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -6,8 +6,22 @@ export const useSettingsStore = defineStore('settings', () => {
     localStorage.getItem('cc.taskListAutoFollow') !== 'false'  // default true
   )
 
+  // Auto-refresh plots + pop lists when a task finishes successfully (the per-image task-refresh; see
+  // composables/useDataRefresh). On by default; users who find plots refetching under them distracting
+  // can turn it off (they then refresh on the next navigation / input change).
+  const autoRefreshOnTask = ref(
+    localStorage.getItem('cc.autoRefreshOnTask') !== 'false'   // default true
+  )
+
   const napariUpdateImage = ref(
     localStorage.getItem('cc.napariUpdateImage') === 'true'    // default false
+  )
+
+  // Reload behaviour: reloading a shown image (the eye / a finished task) refreshes DATA only
+  // (labels + population/track overlays, re-read from disk) — NOT the image pyramid. Tick "reset" to
+  // reopen the image too (needed when a task changed the pixels: drift/denoise). Default false.
+  const napariResetOnReload = ref(
+    localStorage.getItem('cc.napariResetOnReload') === 'true'  // default false
   )
 
   const napariAutoSaveLayerProps = ref(
@@ -95,7 +109,9 @@ export const useSettingsStore = defineStore('settings', () => {
   }
 
   watch(taskListAutoFollow,       v => localStorage.setItem('cc.taskListAutoFollow',       String(v)))
+  watch(autoRefreshOnTask,        v => localStorage.setItem('cc.autoRefreshOnTask',        String(v)))
   watch(napariUpdateImage,        v => localStorage.setItem('cc.napariUpdateImage',        String(v)))
+  watch(napariResetOnReload,      v => localStorage.setItem('cc.napariResetOnReload',      String(v)))
   watch(napariAutoSaveLayerProps, v => localStorage.setItem('cc.napariAutoSaveLayerProps', String(v)))
   watch(napariShow3D,             v => localStorage.setItem('cc.napariShow3D',             String(v)))
   watch(napariAsDask,             v => localStorage.setItem('cc.napariAsDask',             String(v)))
@@ -107,5 +123,5 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(sidebarCollapsed,         v => localStorage.setItem('cc.sidebarCollapsed',         String(v)))
   watch(rightPanelCollapsed,      v => localStorage.setItem('cc.rightPanelCollapsed',      String(v)))
 
-  return { taskListAutoFollow, napariUpdateImage, napariAutoSaveLayerProps, napariShow3D, napariAsDask, napariPointSize, napariShowPopulations, napariShowTracks, napariShowGatedTracks, napariColourBy, sidebarCollapsed, rightPanelCollapsed, popVisible, setPopVisible, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility }
+  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, napariResetOnReload, napariAutoSaveLayerProps, napariShow3D, napariAsDask, napariPointSize, napariShowPopulations, napariShowTracks, napariShowGatedTracks, napariColourBy, sidebarCollapsed, rightPanelCollapsed, popVisible, setPopVisible, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility }
 })

--- a/frontend/src/stores/ws.ts
+++ b/frontend/src/stores/ws.ts
@@ -98,6 +98,16 @@ export const useWsStore = defineStore('ws', () => {
               useProjectStore().updateImageStatus(imageUid, status as any)
             }
           }
+          // successful completion → the touched image(s)' data on disk may have changed (in place, same
+          // value_name/suffix → no filepath change to react to). Bump each image's data version so only
+          // the plots showing them refetch (targeted, not project-wide). A set/combined task sends the
+          // full member list in `imageUids` (else fall back to the single `imageUid`) so EVERY member is
+          // invalidated, not just the representative. Replaces the reload buttons.
+          if (status === 'done') {
+            const uids = Array.isArray(data.imageUids) && data.imageUids.length
+              ? (data.imageUids as string[]) : (imageUid ? [imageUid] : [])
+            for (const u of uids) useProjectStore().bumpDataVersion(u)
+          }
         }
       }
 


### PR DESCRIPTION
## Targeted task-refresh for plots + napari data-vs-image reload

Refreshes dependent views when a task finishes — **without** per-plot reload buttons — and stops the
napari eye reload from needlessly reopening the image.

### Plots — targeted, per-image
- `project.dataVersion` is a **per-image version map**; `ws.ts` bumps the touched image(s) on
  `task:status == 'done'`. A **set/combined** task now reports its full member list (`api/src/sockets.jl`
  sends `imageUids`, not just the representative) so every member is invalidated — not just the rep.
- New composable **`useDataRefresh(imageUids, onRefresh)`** — the one primitive: watches
  `dataVersionFor(itsImages)` and refetches only when an image *that plot shows* changed. Used by
  `useSummaryData`, `UmapView`, the cluster heatmap + HMM panels, and `GatingStrategyView`.
- Per-plot reload buttons removed. Gated by a global setting **`autoRefreshOnTask`** (Settings →
  Interface, on by default) — one chokepoint governs every plot.

### Napari — data vs image
- `reloadViewer()` re-pushes overlays (labels/pops/tracks, re-read and replaced in place) and leaves the
  image pyramid + camera; only reopens on the new **`napariResetOnReload`** toggle or a different image.
  The image-table eye on the open image + task completion route through it. Pure frontend, no bridge change.

### Cleanup / misc
- Removed dead `docked` (UmapView + the InteractivePanel forward) left from the deleted reload button.
- `dataVersion` reset on project open/close.
- Viewer panel: population toggles on their own line, led by a group dot (matches the colour-by dot, with tooltip).
- Docs: promoted to `docs/UI.md` ("Data freshness — task-refresh") + `docs/NAPARI.md` (data-vs-image reload).

### Before merge
- ⚠️ **Server restart** — the `api/src/sockets.jl` change (set-task member list) isn't Revise-tracked.
- Not yet exercised at runtime: verify a finished task refreshes only the right plots, the toggle turns it
  off, and the napari eye reloads data without reopening the image (reset toggle reopens it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)