### PR TITLE
feat(import): physical-size/timing metadata review, edit, and resync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,63 +192,28 @@ Do not add a `useGPU` param to task JSON or Julia handlers.
 
 ## Windows compatibility
 
-All code must run on Linux, macOS, and Windows. Key differences:
+All code must run on Linux, macOS, and Windows. Each of these has already caused a real bug —
+use the named helper, don't re-derive the platform branch inline:
 
-### Python venv layout
-| Platform | Path inside `.venv` |
-|----------|----------------------|
-| Linux / macOS | `bin/python3` |
-| Windows | `Scripts\python.exe` |
+- **Python venv path** differs (`bin/python3` vs `Scripts\python.exe`) — always branch on
+  `Sys.iswindows()`, never hardcode one.
+- **bioformats2raw binary name** — use `bioformats2raw_bin()` in `config.jl`, don't hardcode
+  `.bat` vs no-extension.
+- **Process killing** — use `_kill_tree(pid)` in `api/src/sockets.jl`; never write
+  `kill`/`pgrep`/`taskkill` inline. (`Base.Process` has no `.pid` field — `_kill_tree` already
+  handles getting the OS pid via libuv.) Never `taskkill /IM julia.exe` — it kills every Julia
+  process on the machine, which is why `stop`/`stop-backend`/`stop-napari` kill by **listening
+  port** instead of process name.
+- **`proc.exitcode == 0` doesn't mean success on cancel** — libuv sets it to 0 for signal-killed
+  processes too. Always check `proc.termsignal == 0` as well (see *Task system* below).
+- **Directory size** — use `_dir_bytes(path)` in `app/src/utils.jl`, not a hardcoded `du`/`walkdir`.
+- **Path separators** — always `joinpath()`, never string-concatenate paths.
+- **`[PROGRESS]` line endings** — `eachline()` already strips `\r\n` on Windows, no special-casing
+  needed.
 
-Always branch in Julia:
-```julia
-const MY_PYTHON = Sys.iswindows() ?
-    joinpath(root, ".venv", "Scripts", "python.exe") :
-    joinpath(root, ".venv", "bin", "python3")
-```
-
-### bioformats2raw binary name
-```julia
-Sys.iswindows() ? "bioformats2raw.bat" : "bioformats2raw"
-```
-`bioformats2raw_bin()` in `config.jl` already handles this — don't hardcode the name.
-
-### Process killing
-Use `_kill_tree(pid)` in `api/src/sockets.jl`. Never write `kill`/`pgrep`/`pkill` inline.
-- Unix: recursive `pgrep -P` + `kill -TERM`
-- Windows: `taskkill /F /T /PID` (whole subtree, one shot)
-
-`Base.Process` has no `.pid` field — get the OS PID via libuv:
-```julia
-pid = Int(ccall(:uv_process_get_pid, Cint, (Ptr{Cvoid},), proc.handle))
-```
-
-**`proc.exitcode` is 0 for signal-killed processes.** libuv stores the signal in `proc.termsignal`. Always check both:
-```julia
-ok = proc.exitcode == 0 && proc.termsignal == 0
-```
-Each task's inline subprocess loop does this check (see `tasks/importImages/omezarr.jl`, `tasks/cleanupImages/cellpose_correct.jl`).
-
-### Directory size
-Use `_dir_bytes(path)` in `app/src/utils.jl`:
-- Unix: `du -sb` · Windows: `walkdir + filesize`
-
-### Stopping processes
-The `stop` / `stop-backend` / `stop-napari` pixi tasks kill by **listening port** (`lsof` on unix,
-`Get-NetTCPConnection` on Windows), not by process name — name-matching self-matches the task's own
-shell and was orphaning the napari bridge. Never use `taskkill /IM julia.exe` — it kills all Julia
-processes on the machine.
-
-### Run templates (pixi tasks)
-Launcher logic lives in `pixi.toml` tasks (`pixi run <task>`: `dev`/`prod`/`frontend`/`build`/`napari`/
-`stop`), not shell scripts. Tasks are cross-platform via the deno task shell; for OS-specific commands
-(e.g. killing by port) add a `[target.<platform>.tasks]` override instead of a separate script.
-
-### Path separators
-Always use `joinpath()` in Julia. Never concatenate paths with `/`.
-
-### `[PROGRESS]` line endings
-`eachline()` strips `\r\n` on Windows — the regex `^\[PROGRESS\] (\d+)/(\d+)$` is safe as-is.
+Launcher logic for all of the above lives in `pixi.toml` tasks (`dev`/`prod`/`frontend`/`napari`/
+`stop`), not shell scripts — add a `[target.<platform>.tasks]` override for OS-specific commands
+rather than a separate script.
 
 ---
 
@@ -375,13 +340,10 @@ OME-ZARR pyramids. Document any fixture you add in `test-data/README.md`.
   verb, extend the owner's function (`import DataFrames: transform`) rather than exporting your own.
 
 ### HTTP.jl v2 WebSocket
-- Use `HTTP.listen(handle_stream, host, port)` — NOT `HTTP.serve`. `HTTP.serve` is the high-level request→response API; `HTTP.listen` is the stream API that supports WS upgrades.
-- Stream handler signature: `handle_stream(stream::HTTP.Stream)` — access request via `req = stream.message`
-- WS upgrade check: `HTTP.WebSockets.isupgrade(req)` then `HTTP.WebSockets.upgrade(handle_ws, stream; check_origin=(req, origin)->true)`
-- HTTP responses in stream handler: `HTTP.setstatus(stream, N)` + `HTTP.setheader(stream, k=>v)` + `HTTP.startwrite(stream)` + `write(stream, body)` — do NOT return an `HTTP.Response` object
-- Read POST body before writing: `body_bytes = read(stream)` — call this before any `HTTP.setstatus` / `HTTP.startwrite`
-- `check_origin = (req, origin) -> true` required in dev (Vite proxy sends a different origin)
-- WS message loop: `while true; msg = HTTP.WebSockets.receive(ws); ...` — not `for msg in ws`
+Use `HTTP.listen`, not `HTTP.serve` — the latter is request→response only and doesn't support
+WS upgrades. Full stream-handler/WS-upgrade/response conventions are in
+[`docs/API.md`](docs/API.md) → *HTTP.jl v2 conventions* — read that before touching
+`api/src/server.jl` or `api/src/sockets.jl`.
 
 ---
 
@@ -436,6 +398,16 @@ if omezarr is True and 'multiscales' not in zgroup.attrs:
 ```
 Never assume one format — always detect.
 
+**Exception, and a trap:** `read_ome_metadata` (`app/src/tasks/importImages/omezarr.jl`) does **not**
+do this detection — it hardcodes the bioformats2raw nested layout (`zarr/0/.zattrs`), because it
+only ever needs to read the *original import's* calibration metadata (`PhysicalSize*`,
+`TimeIncrement*`). Downstream processed variants (drift/AF-correct, cellpose-correct) write the
+flat layout and carry **no** OME calibration at all — no `unit` on axes, no OME-XML sidecar — so
+pointing this reader at whichever zarr is currently `active` silently returns nothing (this bit
+`resync_ome_meta!` once: it originally read `img_filepath(img)` and quietly no-opped on any image
+with a processed variant active). Any caller of `read_ome_metadata` must resolve
+`img_filepath(img, VERSIONED_DEFAULT_VAL)` — the `"default"` zarr — never the active one.
+
 ---
 
 ## Versioned variable pattern (ccid.json)
@@ -459,15 +431,5 @@ Without this, `get(dict, "default", nothing)` returns `nothing` silently even wh
 
 ## Input definition — param type reference
 
-| type | widget | extra fields |
-|------|--------|-------------|
-| `int` / `float` + min/max | slider | `min`, `max`, `step` |
-| `bool` | checkbox | — |
-| `text` | text input | — |
-| `select` | dropdown | `options: [{label, value}]`, `multiple` |
-| `channelSelection` | channel picker (from image metadata) | `multiple` |
-| `valueNameSelection` | segmentation name picker | `field` |
-| `popSelection` | population picker | `multiple`, `includeRoot` |
-| `labelPropsSelection` | label property picker | `multiple` |
-| `group` | repeatable block | `repeatable`, `sortable`, `params` |
-| `section` | collapsible box | `collapsed`, `params` |
+Full widget-type reference (every type, extra fields, JSON examples) lives in
+[`docs/MODULES.md`](docs/MODULES.md) — don't duplicate it here.

--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -615,6 +615,95 @@ function api_images_channelnames(body_bytes::Vector{UInt8})
     200, JSON3.write((; ok=true))
 end
 
+# Generic bulk merge into an image's `meta` dict — one endpoint for any meta field (physical
+# size/unit, time interval, …) rather than a one-off route per field. `values` maps
+# uid → partial dict of meta keys to merge in (same shape idea as api_images_attr_set, but the
+# per-uid value is itself a dict instead of a scalar).
+function api_images_meta_set(body_bytes::Vector{UInt8})
+    proj_dir, data, err = _parse_meta_request(body_bytes)
+    isnothing(proj_dir) && return 400, JSON3.write((; error=err))
+    project_uid = String(get(data, :projectUid, ""))
+    values_raw  = get(data, :values, nothing)
+    isnothing(values_raw) && return 400, JSON3.write((; error="values required"))
+
+    for (image_uid, fields_raw) in values_raw
+        fields = Dict{String,Any}(String(k) => v for (k, v) in fields_raw)
+        _mutate_images!(project_uid, [String(image_uid)]) do img
+            for (k, v) in fields
+                # a JSON `null` deletes the key (e.g. clearing a stale PhysicalSizeZ_raw marker
+                # once a trusted value replaces an auto-corrected one) rather than setting it
+                isnothing(v) ? delete!(img.meta, k) : (img.meta[k] = v)
+            end
+        end
+
+        # Also correct the two metadata copies napari actually reads — the NGFF `.zattrs` scale
+        # (spatial rendering, incl. the 3D view) and the OME-XML `<Pixels>` attributes (the
+        # timestamp overlay's `TimeIncrement` — napari reads this file UNCONDITIONALLY, with no
+        # `.zattrs` fallback, unlike spatial scale). Without both, a physical-size fix only changes
+        # ccid.json's display copy and napari keeps showing the old value / "t = N".
+        axis_updates = Dict{String,Float64}()
+        for (key, axis) in (("PhysicalSizeX", "x"), ("PhysicalSizeY", "y"),
+                            ("PhysicalSizeZ", "z"), ("TimeIncrement", "t"))
+            v = get(fields, key, nothing)
+            v isa Real && (axis_updates[axis] = Float64(v))
+        end
+
+        xml_attrs = Dict{String,String}()
+        spatial_unit_raw = get(fields, "PhysicalSizeUnit", nothing)
+        ome_spatial_unit = spatial_unit_raw isa AbstractString ?
+            ome_xml_unit_name(spatial_unit_raw) : nothing
+        for (key, unit_key) in (("PhysicalSizeX", "PhysicalSizeXUnit"), ("PhysicalSizeY", "PhysicalSizeYUnit"),
+                                ("PhysicalSizeZ", "PhysicalSizeZUnit"))
+            v = get(fields, key, nothing)
+            if v isa Real
+                xml_attrs[key] = string(Float64(v))
+                isnothing(ome_spatial_unit) || (xml_attrs[unit_key] = ome_spatial_unit)
+            end
+        end
+        tv = get(fields, "TimeIncrement", nothing)
+        if tv isa Real
+            xml_attrs["TimeIncrement"] = string(Float64(tv))
+            tu = get(fields, "TimeIncrementUnit", nothing)
+            tu isa AbstractString && (xml_attrs["TimeIncrementUnit"] = ome_xml_unit_name(tu))
+        end
+
+        if !isempty(axis_updates) || !isempty(xml_attrs)
+            img = init_object(project_uid, String(image_uid))
+            if img isa CciaImage
+                zarr_path = img_filepath(img)
+                if !isnothing(zarr_path) && isdir(zarr_path)
+                    isempty(axis_updates) || update_ome_scale!(zarr_path, axis_updates)
+                    isempty(xml_attrs)    || update_ome_xml_pixels!(zarr_path, xml_attrs)
+                end
+            end
+        end
+    end
+    200, JSON3.write((; ok=true))
+end
+
+# Backfill physical-size/timing meta for images imported before this metadata was tracked (or
+# whose ccid.json lost these fields) — re-derives them from the already-converted OME-ZARR (same
+# reader ImportOmezarr uses) without touching the original source file or re-running
+# bioformats2raw. Returns the refreshed payload per uid so the frontend can drop the warning icon
+# immediately, no page reload needed.
+function api_images_meta_resync(body_bytes::Vector{UInt8})
+    proj_dir, data, err = _parse_meta_request(body_bytes)
+    isnothing(proj_dir) && return 400, JSON3.write((; error=err))
+    project_uid = String(get(data, :projectUid, ""))
+    image_uids  = [String(u) for u in get(data, :imageUids, [])]
+    isempty(image_uids) && return 400, JSON3.write((; error="imageUids required"))
+
+    images = Dict{String,Any}()
+    for uid in image_uids
+        img = init_object(project_uid, uid)
+        img isa CciaImage || continue
+        resync_ome_meta!(img)
+        reloaded = init_object(project_uid, uid)
+        reloaded isa CciaImage && (images[uid] = _image_payload(reloaded))
+    end
+    200, JSON3.write((; ok=true, images=images))
+end
+
 # ── Internal helpers ──────────────────────────────────────────────────────────
 # Project listing reads project.json directly (lightweight discovery, no object
 # graph). Image/set payloads are sourced from the model (CciaImage/CciaSet) so
@@ -647,6 +736,17 @@ function _meta_int(meta::AbstractDict, key::String)
     v isa Integer ? v : tryparse(Int, string(v))
 end
 
+function _meta_float(meta::AbstractDict, key::String)
+    v = get(meta, key, nothing)
+    isnothing(v) && return nothing
+    v isa Real ? Float64(v) : tryparse(Float64, string(v))
+end
+
+function _meta_str(meta::AbstractDict, key::String)
+    v = get(meta, key, nothing)
+    isnothing(v) ? nothing : string(v)
+end
+
 # Frontend-shaped payload for one image, sourced from the model. Response shaping
 # (camelCase, field selection) is the API's job; data access goes through CciaImage
 # so ccid.json parsing has a single home.
@@ -667,6 +767,19 @@ function _image_payload(img::CciaImage)
         sizeC           = _meta_int(img.meta, "SizeC"),
         sizeT           = _meta_int(img.meta, "SizeT"),
         sizeZ           = _meta_int(img.meta, "SizeZ"),
+        # Raw/nullable — NOT img_physical_sizes' 1.0-default-for-computation fallback. The UI
+        # needs to tell "genuinely missing" apart from "explicitly confirmed 1.0".
+        physicalSizeX     = _meta_float(img.meta, "PhysicalSizeX"),
+        physicalSizeY     = _meta_float(img.meta, "PhysicalSizeY"),
+        physicalSizeZ     = _meta_float(img.meta, "PhysicalSizeZ"),
+        physicalSizeUnit  = _meta_str(img.meta, "PhysicalSizeUnit"),
+        # set when the ImageJ-TIFF Z-spacing auto-fix overrode bioformats2raw's value at import
+        # (see omezarr.jl) — the corrected number is still only as good as the source file's own
+        # ImageJ tag, so the frontend keeps flagging it for the user to confirm, not just silently
+        # trusting it because the ratio now looks plausible.
+        physicalSizeZCorrected = haskey(img.meta, "PhysicalSizeZ_raw"),
+        timeIncrement     = _meta_float(img.meta, "TimeIncrement"),
+        timeIncrementUnit = _meta_str(img.meta, "TimeIncrementUnit"),
         channelNames    = isnothing(ch) ? String[] : ch,
         filepath        = active_fn,
         activeValueName = active_vn,

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -174,6 +174,10 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_images_attr_set(body_bytes)
         elseif path == "/api/images/channelnames"
             api_images_channelnames(body_bytes)
+        elseif path == "/api/images/meta/set"
+            api_images_meta_set(body_bytes)
+        elseif path == "/api/images/meta/resync"
+            api_images_meta_resync(body_bytes)
         elseif path == "/api/images/labels/delete"
             api_images_delete_labels(body_bytes)
         elseif path == "/api/chains/save"

--- a/app/py/tasks/importImages/read_imagej_physical_size_run.py
+++ b/app/py/tasks/importImages/read_imagej_physical_size_run.py
@@ -1,0 +1,73 @@
+"""
+Independently re-derive PhysicalSizeZ from a source TIFF's ImageJ metadata.
+
+bioformats2raw correctly converts X/Y pixel size to micrometers (via the standard TIFF
+XResolution/YResolution + ResolutionUnit tags) but does not apply the same conversion to Z (from
+ImageJ's own `spacing` tag) when the file's calibration unit isn't already micron — it writes the
+raw, unconverted `spacing` value straight into PhysicalSizeZ. ImageJ's ImageDescription tag carries
+`unit` + `spacing` directly, so we can recompute the correct micrometer value ourselves without
+touching bioformats2raw. Called by the Julia ImportOmezarr task handler, only for TIFF sources.
+
+Parameter contract (JSON written by Julia):
+  imPath     - absolute path to the ORIGINAL source file (pre-conversion)
+  resultPath - absolute path to write the result JSON to
+
+Result JSON: {"PhysicalSizeZ": <float, µm>, "sourceUnit": <str>} or {} if there was nothing
+usable to correct (not a TIFF, no ImageJ metadata, no `spacing`, or unit already micron).
+"""
+
+import json
+
+import tifffile
+
+import py.utils.script_utils as script_utils
+
+# ImageJ calibration unit → micrometers
+_UNIT_TO_MICRON = {
+    'micron': 1.0, 'microns': 1.0, 'um': 1.0, 'µm': 1.0, 'micrometer': 1.0,
+    'nm': 1e-3, 'nanometer': 1e-3,
+    'mm': 1e3, 'millimeter': 1e3,
+    'cm': 1e4, 'centimeter': 1e4,
+    'inch': 25400.0, 'inches': 25400.0,
+}
+
+
+def run(params):
+    log = script_utils.get_logfile_utils(params)
+
+    im_path     = params['imPath']
+    result_path = params['resultPath']
+    result = {}
+
+    try:
+        with tifffile.TiffFile(im_path) as tif:
+            meta = tif.imagej_metadata
+    except Exception as e:
+        meta = None
+        log.log(f'>> not a readable TIFF, skipping ImageJ Z-spacing check: {e}')
+
+    if meta:
+        unit    = str(meta.get('unit', '')).lower()
+        spacing = meta.get('spacing')
+        factor  = _UNIT_TO_MICRON.get(unit)
+
+        if spacing is not None and factor is not None and unit not in ('micron', 'microns', 'um', 'µm', 'micrometer'):
+            result = {'PhysicalSizeZ': float(spacing) * factor, 'sourceUnit': unit}
+            log.log(f'>> ImageJ spacing={spacing} unit={unit} -> PhysicalSizeZ={result["PhysicalSizeZ"]} um')
+        elif spacing is not None and factor is None:
+            log.log(f'>> ImageJ unit "{unit}" has no known micron conversion, skipping')
+
+    with open(result_path, 'w') as f:
+        json.dump(result, f)
+
+
+def main():
+    params = script_utils.script_params()
+    if params is None:
+        print('[ERROR] No params file provided (--params missing or not found)', flush=True)
+        raise SystemExit(1)
+    run(params)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -58,7 +58,8 @@ export CciaTask
 export validate_params, ParamValidationError
 export _task_from_fun_name, task_scope
 export TestImageTask, TestSetTask, IncrementalPlotTask
-export ImportOmezarr, read_ome_metadata
+export ImportOmezarr, read_ome_metadata, update_ome_scale!, update_ome_xml_pixels!, ome_xml_unit_name
+export resync_ome_meta!
 export RemoveImage
 export CellposeCorrect
 export CellposeSegment

--- a/app/src/tasks/importImages/omezarr.jl
+++ b/app/src/tasks/importImages/omezarr.jl
@@ -3,6 +3,36 @@ using JSON3
 # ── OME-ZARR metadata reader ──────────────────────────────────────────────────
 
 """
+Fallback for the time interval when there's no top-level NGFF `t`-axis scale: many OME-XML
+sources (including ones bioformats2raw converts) carry no single `TimeIncrement` on `Pixels`,
+only a per-`Plane` `DeltaT` — the interval between frames at `TheZ="0" TheT="1"`. Scrapes
+bioformats2raw's `OME/METADATA.ome.xml` sidecar with a plain regex (ports the same idea as the old
+R `cciaImage.R::omeXMLTimelapseInfo` crutch; no XML dependency, see `image.jl` header note).
+Returns the interval in seconds, or `nothing` if the file/tag isn't there.
+"""
+function _delta_t_fallback(zarr_path::String)::Union{Float64,Nothing}
+    xml_file = joinpath(zarr_path, "OME", "METADATA.ome.xml")
+    isfile(xml_file) || return nothing
+    try
+        xml = read(xml_file, String)
+        for m in eachmatch(r"<Plane\b[^>]*?/>", xml)
+            tag = m.match
+            occursin(r"TheZ=\"0\"", tag) || continue
+            occursin(r"TheT=\"1\"", tag) || continue
+            dm = match(r"DeltaT=\"([-\d.eE+]+)\"", tag)
+            isnothing(dm) && continue
+            value = parse(Float64, dm.captures[1])
+            um    = match(r"DeltaTUnit=\"([a-zA-Z]+)\"", tag)
+            unit  = isnothing(um) ? "s" : lowercase(um.captures[1])
+            return unit == "ms" ? value / 1000 : (unit == "min" ? value * 60 : value)
+        end
+    catch e
+        @warn "Could not read OME-XML for DeltaT fallback" zarr_path exception = e
+    end
+    nothing
+end
+
+"""
 Read OME-ZARR metadata (axes, shape, channel names, physical pixel sizes) produced by
 bioformats2raw. bioformats2raw wraps arrays in a series group: multiscales in zarr/0/.zattrs.
 Returns a flat Dict with keys SizeC, SizeT, SizeZ, optionally channel_names, and the physical
@@ -20,7 +50,9 @@ function read_ome_metadata(zarr_path::String)::Dict{String,Any}
         (isnothing(multiscales) || isempty(multiscales)) && return result
         ms = first(multiscales)
 
-        axes       = [lowercase(string(get(ax, :name, ""))) for ax in get(ms, :axes, [])]
+        ax_list    = get(ms, :axes, [])
+        axes       = [lowercase(string(get(ax, :name, ""))) for ax in ax_list]
+        ax_units   = [haskey(ax, :unit) ? string(ax[:unit]) : nothing for ax in ax_list]
         datasets   = get(ms, :datasets, [])
         level_path = isempty(datasets) ? "0" : string(get(first(datasets), :path, "0"))
 
@@ -59,7 +91,37 @@ function read_ome_metadata(zarr_path::String)::Dict{String,Any}
                 isnothing(xi) || (result["PhysicalSizeX"] = scale[xi])
                 isnothing(yi) || (result["PhysicalSizeY"] = scale[yi])
                 isnothing(zi) || (result["PhysicalSizeZ"] = scale[zi])
-                isnothing(ti) || (result["TimeIncrement"] = scale[ti])
+
+                # spatial axes share one calibration unit in practice; take the first present
+                spatial_unit = nothing
+                for i in (xi, yi, zi)
+                    if !isnothing(i) && !isnothing(ax_units[i])
+                        spatial_unit = ax_units[i]
+                        break
+                    end
+                end
+                isnothing(spatial_unit) || (result["PhysicalSizeUnit"] = spatial_unit)
+
+                # bioformats2raw always writes a t-axis scale (defaulting to 1.0) even when it has
+                # no real timing for the file — but it only attaches a `unit` to the t axis when it
+                # actually found one. A unit-less t scale is a placeholder, not a reading: trusting
+                # it verbatim produced a bogus "TimeIncrement": 1.0 for files with no real interval
+                # (and skipped the DeltaT fallback below, since 1.0 isn't the "missing" sentinel).
+                if !isnothing(ti) && !isnothing(ax_units[ti])
+                    result["TimeIncrement"]     = scale[ti]
+                    result["TimeIncrementUnit"] = ax_units[ti]
+                end
+            end
+        end
+
+        # per-plane DeltaT fallback — only when there's genuinely a timelapse and the top-level
+        # scale-t gave nothing usable (missing or zero)
+        size_t = get(result, "SizeT", 1)
+        if size_t > 1 && get(result, "TimeIncrement", 0.0) == 0.0
+            fallback = _delta_t_fallback(zarr_path)
+            if !isnothing(fallback)
+                result["TimeIncrement"]     = fallback
+                result["TimeIncrementUnit"] = "second"
             end
         end
     catch e
@@ -67,6 +129,116 @@ function read_ome_metadata(zarr_path::String)::Dict{String,Any}
     end
 
     result
+end
+
+"""
+Propagate a physical-size/timing correction into the OME-ZARR's OWN `.zattrs` NGFF scale — the
+actual value napari (and any other zarr-reading consumer) uses for spatial calibration and
+rendering. The metadata editor (`api_images_meta_set`) only wrote `ccid.json`'s `meta` dict (the
+API/display copy); that left the zarr itself uncorrected, so napari kept showing the old (wrong)
+spacing even after the editor said it was fixed. `updates` maps axis name ("x"/"y"/"z"/"t") to its
+new value AT LEVEL 0; every pyramid level's scale for that axis is rescaled by the same ratio
+(new/old), so a level-dependent downsampling factor (x/y shrink per level; z/t normally don't) is
+preserved rather than clobbered with one flat value.
+"""
+function update_ome_scale!(zarr_path::String, updates::Dict{String,Float64})
+    isempty(updates) && return
+    zattrs_file = joinpath(zarr_path, "0", ".zattrs")
+    isfile(zattrs_file) || return
+    try
+        raw = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(zattrs_file, String)))
+        multiscales = get(raw, "multiscales", nothing)
+        (isnothing(multiscales) || isempty(multiscales)) && return
+        ms = Dict{String,Any}(String(k) => v for (k, v) in first(multiscales))
+
+        axes     = [lowercase(string(get(ax, :name, ""))) for ax in get(ms, "axes", [])]
+        datasets = get(ms, "datasets", [])
+        isempty(datasets) && return
+
+        level0 = Dict{String,Any}(String(k) => v for (k, v) in first(datasets))
+        level0_scale = nothing
+        for ct in get(level0, "coordinateTransformations", [])
+            string(get(ct, :type, "")) == "scale" &&
+                (level0_scale = collect(Float64, get(ct, :scale, [])))
+        end
+        isnothing(level0_scale) && return
+
+        ratios = Dict{Int,Float64}()
+        for (axis_name, new_val) in updates
+            idx = findfirst(==(axis_name), axes)
+            isnothing(idx) && continue
+            old_val = level0_scale[idx]
+            old_val == 0 && continue
+            ratios[idx] = new_val / old_val
+        end
+        isempty(ratios) && return
+
+        new_datasets = map(datasets) do d
+            dd = Dict{String,Any}(String(k) => v for (k, v) in d)
+            cts = get(dd, "coordinateTransformations", [])
+            new_cts = map(cts) do ct
+                ctd = Dict{String,Any}(String(k) => v for (k, v) in ct)
+                if string(get(ctd, "type", "")) == "scale"
+                    scale = collect(Float64, get(ctd, "scale", []))
+                    for (idx, r) in ratios
+                        scale[idx] *= r
+                    end
+                    ctd["scale"] = scale
+                end
+                ctd
+            end
+            dd["coordinateTransformations"] = new_cts
+            dd
+        end
+        ms["datasets"]        = new_datasets
+        multiscales_new       = [ms; multiscales[2:end]...]
+        raw["multiscales"]    = multiscales_new
+        open(zattrs_file, "w") do io; JSON3.write(io, raw); end
+    catch e
+        @warn "Could not update OME-ZARR scale metadata" zarr_path exception = e
+    end
+end
+
+# NGFF unit names (what the frontend/ccid.json use) → OME-XML's unit abbreviations
+const _OME_XML_UNIT = Dict(
+    "micrometer" => "µm", "nanometer" => "nm", "millimeter" => "mm",
+    "second" => "s", "minute" => "min",
+)
+
+"""Map an NGFF unit name (e.g. `"micrometer"`) to its OME-XML abbreviation (`"µm"`), or pass the
+value through unchanged if it's not one of the known NGFF names (e.g. already an abbreviation)."""
+ome_xml_unit_name(ngff_unit::AbstractString)::String = get(_OME_XML_UNIT, ngff_unit, ngff_unit)
+
+"""
+Patch `OME/METADATA.ome.xml`'s `<Pixels>` attributes directly (regex text edit — no XML
+dependency, see `image.jl` header note). This is a THIRD, separate metadata location from
+`.zattrs`: napari's `_read_time_increment` (`napari_bridge.py`) reads `TimeIncrement` from here
+UNCONDITIONALLY, with no NGFF/`.zattrs` fallback the way spatial scale has — so correcting
+`.zattrs` alone (`update_ome_scale!`) fixes the 3D view but leaves the timestamp overlay showing
+the raw frame index ("t = N") because this file still has the old/absent value. `attrs` maps the
+OME attribute name (e.g. `"TimeIncrement"`, `"PhysicalSizeZ"`) to its new string value; an
+existing attribute is replaced, a missing one is inserted.
+"""
+function update_ome_xml_pixels!(zarr_path::String, attrs::Dict{String,String})
+    isempty(attrs) && return
+    xml_file = joinpath(zarr_path, "OME", "METADATA.ome.xml")
+    isfile(xml_file) || return
+    try
+        xml = read(xml_file, String)
+        m = match(r"<Pixels\b[^>]*>", xml)
+        isnothing(m) && return
+        tag = m.match
+        for (k, v) in attrs
+            attr_re = Regex(k * "=\"[^\"]*\"")
+            tag = occursin(attr_re, tag) ?
+                replace(tag, attr_re => "$k=\"$v\"") :
+                replace(tag, "<Pixels " => "<Pixels $k=\"$v\" "; count = 1)
+        end
+        new_xml = replace(xml, m.match => tag; count = 1)
+        open(xml_file, "w") do io; write(io, new_xml); end
+    catch e
+        @warn "Could not update OME-XML Pixels attributes" zarr_path exception = e
+    end
 end
 
 # ── ccid.json helpers ─────────────────────────────────────────────────────────
@@ -82,6 +254,17 @@ function _update_image_status!(img::CciaImage, status::String)
     end
 end
 
+# Keys `read_ome_metadata` is the sole, authoritative source for. Cleared unconditionally before
+# merging so a re-import always reflects exactly what THIS read found — never a zombie value
+# left over from some earlier (possibly much older, possibly buggy) import that this run's
+# zarr_meta simply doesn't happen to produce again (e.g. TimeIncrement staying missing is a real,
+# meaningful "we found nothing" that a plain additive merge would otherwise mask forever).
+const _OME_DERIVED_META_KEYS = (
+    "SizeC", "SizeT", "SizeZ",
+    "PhysicalSizeX", "PhysicalSizeY", "PhysicalSizeZ", "PhysicalSizeUnit", "PhysicalSizeZ_raw",
+    "TimeIncrement", "TimeIncrementUnit",
+)
+
 function _merge_zarr_meta_into_ccid!(img::CciaImage, zarr_meta::Dict;
                                       zarr_filename::Union{String,Nothing} = nothing,
                                       value_name::String = VERSIONED_DEFAULT_VAL)
@@ -90,6 +273,9 @@ function _merge_zarr_meta_into_ccid!(img::CciaImage, zarr_meta::Dict;
     try
         raw = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(ccid, String)))
         m   = Dict{String,Any}(String(k) => v for (k, v) in get(raw, "meta", Dict()))
+        for k in _OME_DERIVED_META_KEYS
+            delete!(m, k)
+        end
         for (k, v) in zarr_meta
             if k == "channel_names"
                 versioned_set_field!(raw, "imChannelNames", collect(String, v))
@@ -104,6 +290,33 @@ function _merge_zarr_meta_into_ccid!(img::CciaImage, zarr_meta::Dict;
     catch e
         @warn "Could not update image metadata" exception = e
     end
+end
+
+"""
+Backfill an already-imported image's physical-size/timing `meta` fields by re-reading them from
+its OME-ZARR — the same reader `ImportOmezarr` uses at import time — WITHOUT re-running
+bioformats2raw. For images converted before this metadata was tracked (or whose `meta` predates
+the `PhysicalSizeUnit`/`TimeIncrementUnit` fields), the zarr itself is already correct; only
+`ccid.json`'s `meta` dict is stale/missing these keys. Safe and idempotent to call on an image
+that's already up to date — it just re-derives the same values a fresh import would produce.
+
+Deliberately reads the `VERSIONED_DEFAULT_VAL` ("default") zarr — the original bioformats2raw
+output — rather than whichever version is currently `active`. Downstream tasks (drift/AF
+correction, cellpose correction) write their own zarr with a plain NGFF layout that has no `unit`
+on its axes and no OME-XML sidecar with calibration; `read_ome_metadata` only understands the
+bioformats2raw nested-series layout, so pointing this at an `active` post-processing output
+silently found nothing. Physical size/timing are acquisition properties anyway — unaffected by
+which processed variant happens to be active for viewing.
+
+Returns `false` (no-op) when the default zarr path is missing or has no usable metadata.
+"""
+function resync_ome_meta!(img::CciaImage)::Bool
+    zarr_path = img_filepath(img, VERSIONED_DEFAULT_VAL)
+    (isnothing(zarr_path) || !isdir(zarr_path)) && return false
+    zarr_meta = read_ome_metadata(zarr_path)
+    isempty(zarr_meta) && return false
+    _merge_zarr_meta_into_ccid!(img, zarr_meta)
+    true
 end
 
 # ── Task ──────────────────────────────────────────────────────────────────────
@@ -172,6 +385,36 @@ function _run_task(task::ImportOmezarr, img::CciaImage, params::Dict{String,Any}
     on_log("[INFO] Conversion complete.")
 
     zarr_meta = read_ome_metadata(zarr_out)
+
+    # ImageJ-sourced TIFFs: bioformats2raw applies the source's calibration-unit conversion
+    # correctly for X/Y but not for Z, so a non-micron unit (e.g. an ImageJ file saved with
+    # unit=inch) leaves PhysicalSizeZ wildly wrong. Re-derive it ourselves from the original
+    # file's ImageJ tags rather than trust bioformats2raw's raw value — only for TIFF sources,
+    # cheap extension check first so every import doesn't pay for a Python subprocess.
+    if endswith(lowercase(src_path), ".tif") || endswith(lowercase(src_path), ".tiff")
+        run_dir     = task_run_dir(img._dir)
+        result_file = joinpath(run_dir, "read_imagej_physical_size.$(string(rand(UInt32); base = 16)).result.json")
+        ok_z = run_py("tasks/importImages/read_imagej_physical_size_run.py",
+            (; imPath = src_path, resultPath = result_file), run_dir;
+            on_log = on_log)
+        if ok_z && isfile(result_file)
+            try
+                corrected = JSON3.read(read(result_file, String))
+                if haskey(corrected, :PhysicalSizeZ)
+                    raw_z = get(zarr_meta, "PhysicalSizeZ", nothing)
+                    new_z = Float64(corrected[:PhysicalSizeZ])
+                    on_log("[INFO] Corrected Z spacing from source ImageJ metadata (unit=$(get(corrected, :sourceUnit, "?"))): $raw_z -> $new_z um")
+                    isnothing(raw_z) || (zarr_meta["PhysicalSizeZ_raw"] = raw_z)
+                    zarr_meta["PhysicalSizeZ"] = new_z
+                end
+            catch e
+                @warn "Could not read ImageJ physical-size result" exception = e
+            finally
+                rm(result_file; force = true)
+            end
+        end
+    end
+
     _update_image_status!(img, "done")
     _merge_zarr_meta_into_ccid!(img, zarr_meta;
                                 zarr_filename = basename(zarr_out),

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,6 +22,22 @@ that resolve objects and call package functions.
 - **WS broadcast**: `broadcast_ws(Dict(...))` pushes JSON to all connected clients
   (`stores/ws.ts` dispatches by `type`). See WS message reference in `ARCHITECTURE.md`.
 
+### HTTP.jl v2 conventions
+
+- Use `HTTP.listen(handle_stream, host, port)` — **not** `HTTP.serve`. `HTTP.serve` is the
+  high-level request→response API; `HTTP.listen` is the stream API that supports WS upgrades.
+- Stream handler signature: `handle_stream(stream::HTTP.Stream)` — access the request via
+  `req = stream.message`.
+- WS upgrade check: `HTTP.WebSockets.isupgrade(req)` then
+  `HTTP.WebSockets.upgrade(handle_ws, stream; check_origin=(req, origin)->true)`.
+  `check_origin = (req, origin) -> true` is required in dev — the Vite proxy sends a different
+  origin.
+- HTTP responses in a stream handler: `HTTP.setstatus(stream, N)` + `HTTP.setheader(stream, k=>v)`
+  + `HTTP.startwrite(stream)` + `write(stream, body)` — do **not** return an `HTTP.Response` object.
+- Read the POST body before writing a response: `body_bytes = read(stream)`, before any
+  `HTTP.setstatus` / `HTTP.startwrite`.
+- WS message loop: `while true; msg = HTTP.WebSockets.receive(ws); ...` — not `for msg in ws`.
+
 ## Route index
 
 | Method | Path | Purpose |
@@ -30,6 +46,8 @@ that resolve objects and call package functions.
 | GET | `/api/projects`, POST `/api/projects/{list,create,load,save,rename}` | project CRUD |
 | POST | `/api/sets/{create,delete}` | set CRUD |
 | GET | `/api/images/meta`, POST `/api/images/{register,delete,channelnames,labels/delete}`, `/api/images/attr/{create,delete,set}` | image CRUD/metadata |
+| POST | `/api/images/meta/set` | `{projectUid, values: {uid: {<meta keys>}}}` — generic bulk merge into an image's `meta` dict (physical size/unit, time interval, or any future field) via `_mutate_images!`, same shape idea as `attr/set` but the per-uid value is a partial dict instead of a scalar. Add new `meta` fields here, not a new one-off route. |
+| POST | `/api/images/meta/resync` | `{projectUid, imageUids: [...]}` — backfills physical-size/timing `meta` for images imported before that metadata was tracked, by re-reading the `"default"` (original bioformats2raw) zarr — never the active version, see CLAUDE.md → *OME-ZARR dual-format* — via `resync_ome_meta!`/`read_ome_metadata`. No re-import, no source-file access. Returns `{ok, images: {uid: <full image payload>}}` so the frontend can drop the warning icon immediately. |
 | GET | `/api/fs/list`, `/api/pools`, `/api/tasks/definitions` | filesystem, pools, task specs |
 | GET | `/api/chains`, `/api/chains/get`, POST `/api/chains/{save,delete}` | chain templates |
 | GET | `/api/napari/status`, POST `/api/napari/{open,close,restart,show-labels,show-populations,start-selection,stop-selection,event}` | napari bridge + gating linked brushing |

--- a/docs/OBJECTMODEL.md
+++ b/docs/OBJECTMODEL.md
@@ -117,7 +117,7 @@ Written by `save!(proj::CciaProject)`. Runtime fields (`root`, `_sets`) are not 
 | `labels` | versioned dict | Paths to label zarrs inside `1/{uid}/data/` |
 | `label_props` | versioned dict | Paths to label property files |
 | `attr` | flat dict | User-defined string metadata (used for filtering) |
-| `meta` | free dict | OME metadata extracted at import: `SizeC`, `SizeZ`, `SizeX`, `SizeY`, etc. |
+| `meta` | free dict | OME metadata extracted at import: `SizeC`, `SizeZ`, `SizeX`, `SizeY`, `PhysicalSizeX/Y/Z` (µm/px), `PhysicalSizeUnit`, `TimeIncrement` (seconds/frame), `TimeIncrementUnit`, etc. Physical-size/timing keys are absent (not defaulted) when the source file carried no usable value — the API surfaces them raw/nullable so the frontend can tell "genuinely missing" apart from "confirmed 0/1"; see the metadata-editor warning icon in `docs/UI.md`. `PhysicalSizeZ_raw` is set alongside a corrected `PhysicalSizeZ` when the importer's ImageJ-TIFF Z-spacing auto-fix overrides bioformats2raw's value (see `app/src/tasks/importImages/omezarr.jl`). Images imported before these keys existed can be backfilled without a re-import via `resync_ome_meta!`/`POST /api/images/meta/resync`, which re-reads them from the `"default"` (original bioformats2raw) zarr — deliberately not whichever version is currently `active`, since processed variants (drift/cellpose-correct) carry no OME calibration metadata at all; see `CLAUDE.md` → *OME-ZARR dual-format*. |
 
 `_dir` (the absolute path to `1/{uid}/`) is runtime-only and never written to disk.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -61,6 +61,27 @@ select; (b) a resampling step that emits overlapping sub-tracks as first-class r
 per-image frame-interval normalisation so cross-rate comparison needs no manual skip. Settle the
 storage/UX before building. Not urgent.
 
+**#00063** 🔹 needs-input — **Vendor-specific OME metadata quirks: Olympus/Imaris timelapse interval, MACSIMA channel names**
+> **Needs you:** a real `.oir` (Olympus), `.ims` (Imaris), or MACSIMA-exported file to verify
+> against — the regex/XPath ports below are untested without one.
+
+The old R `cciaImage.R` has two more format-specific metadata fallbacks beyond the plain OME
+`TimeIncrement`/per-plane `DeltaT` case (that one *is* being ported — see the physical-size/
+time-interval metadata work referencing `bioformats2raw`'s `OME/METADATA.ome.xml`):
+- **`omeXMLTimelapseInfo`** (`cciaImage.R:405-516`) dispatches on the original file extension:
+  `.oir` reads a `TIMELAPSE` `StructuredAnnotations` node and pulls the interval from a specific
+  axis-step annotation (falling back to per-plane `DeltaT` if that's zero); `.ims` reads a
+  `Time_Step`/`Time_Interval_[s]` annotation node. Neither shape is standard OME XML.
+- **`omeXMLChannels`** (`cciaImage.R:336-364`) tries `StructuredAnnotations//MapAnnotation` "Dye"
+  labels first (MACSIMA-specific), falling back to standard `Channel` `Name` attributes only if
+  that's empty.
+Both would read from the same `OME/METADATA.ome.xml` bioformats2raw already writes. Deferred
+rather than blind-ported because there's no fixture to confirm the regex/XPath shapes still match
+current bioformats2raw output. When a real file surfaces: port the R logic into the import task's
+OME-XML fallback chain (time: after the plain-`DeltaT` fallback; channels: only when standard
+`Channel.Name` is missing/generic), log clearly when a vendor path fires, and add the file as a
+fixture per #00014.
+
 **#00037** — **Whiteboard plot integration** (deferred)
 Plot nodes in the chain whiteboard (`ChainModule.vue`). A collapsible **"Plots"** box is already in
 the palette (under "Module functions") with a "coming soon" placeholder. Notes:
@@ -218,6 +239,40 @@ batch it rather than churn standalone.
 ---
 
 ## Fixed
+
+**#00065** — **Task-manager "cancel all" + per-project task-list scoping; resync silently no-op'd against processed variants** (2026-07-03)
+Three related fixes to today's real-data testing round. (1) Added a "cancel all" button next to
+"clear finished" in the module Tasks sidebar — cancels every running/queued task for that
+module+project via the same per-task `task:cancel`/`chain:cancel` path, deduping chain runs. (2)
+`TaskList.vue` showed a previous project's (e.g. cancelled) tasks after switching projects —
+`useTaskStore().forModule()`/`clearFinished()` only filtered by module, not project. Added an
+optional `projectUid` filter, threaded through `TaskList`/`TaskRunner`/`ImageTable`; the global
+`/tasks` manager intentionally keeps the unscoped cross-project view. (3) The new
+"resync flagged from file" button (see #00064) silently did nothing on images with a processed
+variant (drift/cellpose-correct) active — `resync_ome_meta!` read `img_filepath(img)` (whatever's
+`active`), but those outputs use the flat NGFF layout with no axis `unit` and no OME-XML sidecar,
+which `read_ome_metadata` (Julia; unlike the Python `zarr_utils.py` reader) doesn't detect at all —
+it only understands the bioformats2raw nested layout. Fixed by always resolving the `"default"`
+(original import) zarr instead — physical size/timing are acquisition properties, unaffected by
+downstream correction tasks anyway. See CLAUDE.md → *OME-ZARR dual-format*.
+
+**#00064** — **Physical-size & timing metadata: review, edit, and per-image warnings** (2026-07-03)
+Root-caused a napari bug on a real 3D timecourse: collapsed Z-spacing and "t = n" instead of real
+time. Two independent causes — `bioformats2raw` converts a source TIFF's non-micron calibration
+unit (e.g. ImageJ `unit=inch`) correctly for X/Y but not Z, and this file had no genuine time
+interval anywhere in its metadata. Since auto-detection can never cover every vendor quirk, built a
+full review/edit system instead of a point fix: an ImageJ-tag Z-spacing auto-correction at import
+(`read_imagej_physical_size_run.py`), an OME-XML per-plane `DeltaT` fallback (ports the old R
+`omeXMLTimelapseInfo` crutch), raw/nullable `PhysicalSizeX/Y/Z`/`PhysicalSizeUnit`/`TimeIncrement`/
+`TimeIncrementUnit` in the image payload, a warning icon + `PhysicalSizeDialog.vue` modal (Apply /
+Copy-to-selected / Fill-flagged, mixed-value detection) reachable from every module's image table,
+and `POST /api/images/meta/set` which keeps all three metadata copies in sync — `ccid.json`,
+the OME-ZARR's own `.zattrs` NGFF scale, and `OME/METADATA.ome.xml`'s `<Pixels>` attributes (napari
+reads `TimeIncrement` from the XML unconditionally, with no `.zattrs` fallback). Also added
+`resync_ome_meta!`/`POST /api/images/meta/resync` + a table header button to backfill these fields
+for images imported before this metadata was tracked at all, without a re-import. Deferred
+vendor-specific quirks (Olympus/Imaris timelapse annotations, MACSIMA channel-name metadata) to
+**#00063**. See `docs/OBJECTMODEL.md`, `docs/API.md`, `docs/UI.md`.
 
 **#00036** — **Universal "Analysis board" page** (2026-07-01)
 A standalone canvas at `/analysis` that hosts the SAME plot canvas as the per-module pages but with

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -224,6 +224,43 @@ Both default expanded and persist across sessions/navigation.
 
 Emits `selectionChange(uids: string[])`. `ModuleLayout` handles this internally.
 
+**Metadata warning icon.** A row shows a `pi-exclamation-triangle` next to the image name when
+`metadataWarning(img)` (`frontend/src/lib/imageMetadataWarnings.ts` — the single source of truth,
+shared with `PhysicalSizeDialog`'s inline warning so the two never disagree) flags missing/suspect
+physical size or time-interval metadata. This includes `physicalSizeZCorrected` (the import-time
+ImageJ-TIFF Z-spacing auto-fix, `omezarr.jl`) — an auto-corrected value stays flagged for human
+confirmation even when it now looks plausible, since the source tag it was derived from (the
+file's own ImageJ `spacing`/`unit`) isn't independently verifiable and has been observed to be a
+placeholder rather than a real per-slice calibration on real data. Clicking the icon opens
+`PhysicalSizeDialog.vue` right there (own local `physSizeDialogUid` ref — no page navigation),
+focused on that image with the current checkbox selection carried in as the target set for
+Apply/Fill-flagged. Shown on every module page — the icon isn't gated behind `showAttrs`/`module`.
+
+**Physical size & timing editor** (`frontend/src/components/PhysicalSizeDialog.vue`) is a modal,
+not a sidebar section — the first version crammed six fields + long explanatory paragraphs into
+the 280px `MetadataPanel` sidebar and was unreadable. Follows the `ProjectPanel.vue` hand-rolled
+modal shell (`.pp-overlay`/`.pp-modal` — no PrimeVue Dialog). Explanatory text lives in tooltips
+(the header's `pi-info-circle`, per-field labels, button tooltips), not inline paragraphs.
+Actions all write only the toggled fields (X/Y/Z/Δt chips — untick what's already correct so a fix
+to one axis doesn't also rewrite ones that are fine): **Apply** (to the selection it was opened
+with, or just the focused image if none), **Copy to selected** (the other selected images),
+**Fill flagged** (only the *other* selected images that currently show a warning — the
+batch-fix-from-a-known-good-reference workflow). Also reachable via an "Open editor" button in
+`MetadataPanel`'s sidebar (no specific image clicked — focuses the first selected/set image)
+alongside a flagged-count badge for the set.
+
+**Name-column header buttons** (`ImageTable.vue`, next to "Name"): a `pi-exclamation-triangle`
+toggle to select/deselect every currently-flagged image in one click (`selectFlagged`, amber when
+active, shown on every module page), and a `pi-sync` **"Resync flagged from file"** button
+(`resyncFlagged` → `POST /api/images/meta/resync`), shown only on `module === 'metadata' | 'import'`
+(same gating as the page-icon "open editor" button), for images that were imported *before*
+physical-size/timing `meta` was tracked at all. Their OME-ZARR is already correct, so this
+re-derives `meta` straight from the `"default"` (original bioformats2raw) zarr, deliberately never
+whichever version is currently `active` — drift/cellpose-correct outputs carry no OME calibration
+metadata at all, see CLAUDE.md → *OME-ZARR dual-format* — rather than asking the user to type
+known-good values back in or re-import. Both header buttons operate on `flaggedUids`, not the
+checkbox selection.
+
 ---
 
 ## TaskRunner component
@@ -247,6 +284,18 @@ selects the pool matching the task def's `resource_pool` field. The chosen pool 
 `poolName` in the `task:run` WS message, which `handle_task_run` in `sockets.jl` passes to
 `run_task` as the `pool_name` override kwarg. The old concurrent-task slider
 (`task:setLimit` / `tasksLimit`) has been removed entirely.
+
+**Task list scoping.** `useTaskStore().forModule(module, projectUid?)` and `clearFinished(module,
+projectUid?)` take an optional `projectUid` — `TaskList.vue`/`TaskRunner.vue` always pass the
+current project's uid so switching projects doesn't leave a previous project's (e.g. cancelled)
+tasks visible in the module sidebar. The global `/tasks` manager (`TasksModule.vue`) intentionally
+omits it — that page is the cross-project view. `TaskEntry.projectUid` is what makes the filter
+possible; it's stamped on every entry at `add()`/`addFromChainEvent()`.
+
+**Cancel all** — a `pi-times-circle` button next to "Clear finished" in the Tasks section header,
+shown only when the current module+project has running/queued tasks. Cancels every one of them via
+the same per-task path as the individual cancel button (`task:cancel`/`chain:cancel` over WS,
+deduping so a multi-node chain run only sends one `chain:cancel`).
 
 ---
 

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -5,6 +5,8 @@ import { useProjectMetaStore } from '../stores/projectMeta'
 import { useLogStore } from '../stores/log'
 import { useTaskStore, type TaskStatus } from '../stores/tasks'
 import { useSettingsStore } from '../stores/settings'
+import { metadataWarning } from '../lib/imageMetadataWarnings'
+import PhysicalSizeDialog from './PhysicalSizeDialog.vue'
 
 const props = defineProps<{
   setUid: string
@@ -22,6 +24,24 @@ const projectMeta = useProjectMetaStore()
 const log         = useLogStore()
 const taskStore   = useTaskStore()
 const settings    = useSettingsStore()
+
+// opens right where you are — no page navigation needed
+const physSizeDialogUid = ref<string | null>(null)
+
+// Two distinct affordances, kept visually separate: the warning (any module, always visible when
+// flagged) sits in front of the name where it's impossible to miss; the neutral "open editor" icon
+// lives after the name alongside the other row-hover actions (copy UID) on every row — flagged or
+// not — on the pages where reviewing/propagating physical size is a primary task, so a known-good
+// image can be opened deliberately and used as the Copy/Fill-flagged reference.
+function warnIconFor(img: CciaImage): { tip: string } | null {
+  const w = metadataWarning(img)
+  return w ? { tip: w.short } : null
+}
+function pageIconFor(): { tip: string } | null {
+  if (props.module === 'metadata' || props.module === 'import')
+    return { tip: 'View or edit physical size & timing' }
+  return null
+}
 
 // ── Selection ─────────────────────────────────────────────────────────────────
 
@@ -130,6 +150,57 @@ function toggleAll() {
   commit()
 }
 
+// Quick way to batch-fix physical-size/timing warnings: select every flagged image in one click,
+// then open a clean reference image's dialog and Copy/Fill flagged onto exactly this selection.
+const flaggedUids = computed(() => images.value.filter(i => metadataWarning(i)).map(i => i.uid))
+// "Active" = the current selection IS exactly the flagged set — drives both the toggle behaviour
+// and the icon colour (gray = not applied, amber = applied).
+const flaggedActive = computed(() =>
+  flaggedUids.value.length > 0 &&
+  selected.value.size === flaggedUids.value.length &&
+  flaggedUids.value.every(u => selected.value.has(u))
+)
+function selectFlagged() {
+  selected.value = flaggedActive.value ? new Set() : new Set(flaggedUids.value)
+  commit()
+}
+
+// For images imported before physical-size/timing metadata was tracked in ccid.json (or whose
+// meta lost these fields): the OME-ZARR itself is already correct, so re-derive `meta` straight
+// from it (same reader the importer uses) instead of asking the user to re-import or type values
+// back in by hand.
+const resyncing = ref(false)
+async function resyncFlagged() {
+  const uids = flaggedUids.value
+  const projectUid = projectMeta.current?.uid
+  if (!uids.length || !projectUid || resyncing.value) return
+  resyncing.value = true
+  try {
+    const res = await fetch('/api/images/meta/resync', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid, imageUids: uids }),
+    })
+    const body = await res.json().catch(() => ({})) as { ok?: boolean; images?: Record<string, Partial<CciaImage>>; error?: string }
+    if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
+    for (const [uid, img] of Object.entries(body.images ?? {})) {
+      project.updateImageMeta(uid, {
+        physicalSizeX: img.physicalSizeX,
+        physicalSizeY: img.physicalSizeY,
+        physicalSizeZ: img.physicalSizeZ,
+        physicalSizeUnit: img.physicalSizeUnit,
+        physicalSizeZCorrected: img.physicalSizeZCorrected,
+        timeIncrement: img.timeIncrement,
+        timeIncrementUnit: img.timeIncrementUnit,
+      })
+    }
+    log.info(`Re-read physical size & timing from file for ${uids.length} image(s).`, { source: 'import' })
+  } catch (e) {
+    log.error(`Failed to resync metadata: ${e instanceof Error ? e.message : String(e)}`, { source: 'import' })
+  } finally {
+    resyncing.value = false
+  }
+}
+
 function toggle(uid: string) {
   if (props.singleSelect) {
     // radio-style: clicking selects only this image (clicking the selected one clears it)
@@ -214,7 +285,7 @@ async function openInNapari(imageUid: string) {
 
 function imageModuleStatus(img: CciaImage): TaskStatus | 'pending' | null {
   if (!props.module) return null
-  const t = taskStore.forModule(props.module).find(t => t.imageUid === img.uid)
+  const t = taskStore.forModule(props.module, projectMeta.current?.uid).find(t => t.imageUid === img.uid)
   if (t) return t.status
   if (props.module === 'import') {
     const s = img.status as string
@@ -339,6 +410,17 @@ onUnmounted(stopResize)
         <!-- resizable: name -->
         <th class="col-resize" :style="{ width: colW('name'), minWidth: colW('name') }">
           Name
+          <button v-if="!singleSelect && flaggedUids.length" class="select-flagged-btn"
+            :class="{ active: flaggedActive }" @click.stop="selectFlagged"
+            v-tooltip.bottom="flaggedActive ? 'Deselect flagged images' : `Select all ${flaggedUids.length} flagged image(s)`">
+            <i class="pi pi-exclamation-triangle" />
+          </button>
+          <button v-if="flaggedUids.length && (module === 'metadata' || module === 'import')"
+            class="select-flagged-btn" :disabled="resyncing"
+            @click.stop="resyncFlagged"
+            v-tooltip.bottom="`Re-read physical size & timing from file for all ${flaggedUids.length} flagged image(s) — use if they were imported before this check existed and are actually fine.`">
+            <i :class="['pi', resyncing ? 'pi-spin pi-spinner' : 'pi-sync']" />
+          </button>
           <div class="resize-handle" @mousedown.stop.prevent="startResize('name', $event)" />
         </th>
 
@@ -403,13 +485,23 @@ onUnmounted(stopResize)
         </td>
 
         <td class="col-resize td-name">
-          <span class="cell-text" v-tooltip.right="img.filepath ?? img.name">{{ img.name }}</span>
-          <span class="uid-row">
-            <span class="img-uid">{{ img.uid }}</span>
-            <button class="uid-copy" @click.stop="copyUid(img.uid)"
+          <span class="name-row">
+            <button v-if="warnIconFor(img)" class="warn-icon-btn" @click.stop="physSizeDialogUid = img.uid"
+              v-tooltip.right="warnIconFor(img)!.tip">
+              <i class="pi pi-exclamation-triangle" />
+            </button>
+            <span class="cell-text" v-tooltip.right="img.filepath ?? img.name">{{ img.name }}</span>
+            <button v-if="pageIconFor()" class="row-icon-btn" @click.stop="physSizeDialogUid = img.uid"
+              v-tooltip.right="pageIconFor()!.tip">
+              <i class="pi pi-file-edit" />
+            </button>
+            <button class="row-icon-btn" @click.stop="copyUid(img.uid)"
               v-tooltip.right="copiedUid === img.uid ? 'Copied!' : 'Copy UID to clipboard'">
               <i :class="copiedUid === img.uid ? 'pi pi-check' : 'pi pi-copy'" />
             </button>
+          </span>
+          <span class="uid-row">
+            <span class="img-uid">{{ img.uid }}</span>
           </span>
         </td>
 
@@ -463,6 +555,10 @@ onUnmounted(stopResize)
       </tr>
     </tbody>
   </table>
+
+  <PhysicalSizeDialog v-if="physSizeDialogUid"
+    :set-uid="setUid" :focus-uid="physSizeDialogUid" :selected-uids="[...selected]"
+    @close="physSizeDialogUid = null" />
 </template>
 
 <style scoped>
@@ -502,6 +598,16 @@ onUnmounted(stopResize)
   white-space: nowrap;
   overflow: hidden;
 }
+
+.select-flagged-btn {
+  background: none; border: none; cursor: pointer;
+  color: var(--cc-text-dim); font-size: 0.72rem; padding: 0.1rem 0.3rem;
+  margin-left: 0.3rem; border-radius: 0.2rem; vertical-align: middle;
+}
+.select-flagged-btn:hover { color: var(--cc-text); background: var(--cc-surface-2); }
+.select-flagged-btn.active { color: #fbbf24; }
+.select-flagged-btn.active:hover { color: #fcd34d; }
+.select-flagged-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .image-row { border-bottom: 1px solid var(--cc-border); cursor: pointer; transition: background 0.08s; }
 .image-row:hover { background: var(--cc-surface-1); }
@@ -556,6 +662,26 @@ th:hover .resize-handle::after { opacity: 1; }
 
 .td-name .cell-text { color: var(--cc-text); }
 
+.name-row { display: flex; align-items: center; gap: 0.3rem; min-width: 0; }
+.name-row .cell-text { flex: 1; min-width: 0; }
+
+/* always visible when flagged — impossible-to-miss, sits in front of the name */
+.warn-icon-btn {
+  flex-shrink: 0; background: none; border: none; cursor: pointer;
+  color: #fbbf24; font-size: 0.75rem; padding: 0.1rem; line-height: 1;
+}
+.warn-icon-btn:hover { color: #fcd34d; }
+
+/* row-hover actions after the name: the "open editor" page icon + copy-UID — same look, one class */
+.row-icon-btn {
+  flex-shrink: 0; background: none; border: none; cursor: pointer;
+  color: var(--cc-text-dim); font-size: 0.72rem; padding: 0.1rem 0.2rem;
+  border-radius: 0.2rem; line-height: 1;
+  opacity: 0; transition: opacity 0.1s, color 0.1s, background 0.1s;
+}
+.image-row:hover .row-icon-btn { opacity: 1; }
+.row-icon-btn:hover { color: var(--cc-text); background: var(--cc-surface-2); }
+
 /* editable attribute cell: click to edit; subtle hover affordance */
 .attr-cell { cursor: text; border-radius: 3px; padding: 0 2px; }
 .attr-cell:hover { background: var(--cc-surface-2); outline: 1px dashed var(--cc-border); }
@@ -579,21 +705,6 @@ th:hover .resize-handle::after { opacity: 1; }
   flex: 1;
   min-width: 0;
 }
-.uid-copy {
-  flex-shrink: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--cc-text-dim);
-  font-size: 0.65rem;
-  padding: 0.1rem 0.2rem;
-  border-radius: 0.2rem;
-  line-height: 1;
-  opacity: 0;
-  transition: opacity 0.1s;
-}
-tr:hover .uid-copy { opacity: 1; }
-.uid-copy:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 
 .dim { color: var(--cc-text-dim); }
 

--- a/frontend/src/components/PhysicalSizeDialog.vue
+++ b/frontend/src/components/PhysicalSizeDialog.vue
@@ -1,0 +1,409 @@
+<!--
+  Physical size & timing editor — a focused modal (not squeezed into the metadata sidebar) for
+  viewing/fixing an image's voxel size and frame interval. Opens from the ImageTable warning icon
+  (docs/UI.md) or the Metadata module page. Shell copied from ProjectPanel.vue's overlay/modal
+  pattern (the one hand-rolled modal convention in this codebase — no PrimeVue Dialog).
+  Explanatory text lives in tooltips, not inline paragraphs — see feedback from testing.
+-->
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useProjectStore, type CciaImage } from '../stores/project'
+import { useProjectMetaStore } from '../stores/projectMeta'
+import { useLogStore } from '../stores/log'
+import { metadataWarning, flaggedFields, type PhysField as WarnField } from '../lib/imageMetadataWarnings'
+
+const props = defineProps<{
+  setUid: string
+  focusUid: string          // the image this dialog was opened for — seeds the form
+  selectedUids: string[]    // checkbox selection at time of opening (may be empty or just [focusUid])
+}>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const project     = useProjectStore()
+const projectMeta = useProjectMetaStore()
+const log         = useLogStore()
+
+const setImages = computed(() => project.sets.find(s => s.uid === props.setUid)?.images ?? [])
+const focusedImg = computed(() => setImages.value.find(i => i.uid === props.focusUid) ?? null)
+const focusedWarning = computed(() => focusedImg.value ? metadataWarning(focusedImg.value) : null)
+
+// Always includes — and leads with — the focused image (the one whose icon was actually
+// clicked), regardless of whether it happens to be checked: opening an image's own editor must
+// always be able to write back to that image. Any other checked images ride along as additional
+// Apply targets; "Copy to selected" / "Fill flagged" are the explicit wide-reaching actions.
+const targetUids = computed(() => [...new Set([props.focusUid, ...props.selectedUids])])
+
+// Union of flags across the WHOLE target set, not just the focused image — drives the toggle
+// chips (both their default state and their highlight): select a batch flagged for Z + Δt only,
+// open a clean reference, and only Z/Δt light up — X/Y were never in question for anyone involved.
+const targetFlags = computed<Set<WarnField>>(() => {
+  const flags = new Set<WarnField>()
+  for (const uid of targetUids.value) {
+    const img = setImages.value.find(i => i.uid === uid)
+    if (img) for (const f of flaggedFields(img)) flags.add(f)
+  }
+  return flags
+})
+
+type PhysField = 'physicalSizeX' | 'physicalSizeY' | 'physicalSizeZ' | 'timeIncrement'
+function fieldValues(field: PhysField): (number | null | undefined)[] {
+  return targetUids.value.map(uid => setImages.value.find(i => i.uid === uid)?.[field])
+}
+// Real files from "the same acquisition settings" still differ by tiny rounding amounts (e.g.
+// 0.5964274525755702 vs 0.5960001239680258, ~0.07% apart — independent per-file resolution-tag
+// rounding), so exact equality flagged every real dataset as "mixed". A relative tolerance treats
+// that noise as equal while still catching genuinely different values (e.g. Z = 3.0 vs 0.6).
+function valuesEqual(a: number | null, b: number | null): boolean {
+  if (a === null || b === null) return a === b
+  if (a === b) return true
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b), 1e-12) < 1e-3
+}
+function isMixed(field: PhysField): boolean {
+  const vals = fieldValues(field)
+  const first = vals[0] ?? null
+  return !vals.every(v => valuesEqual(v ?? null, first))
+}
+
+const physX     = ref<number | null>(null)
+const physY     = ref<number | null>(null)
+const physZ     = ref<number | null>(null)
+const physUnit  = ref('micrometer')
+const timeInc   = ref<number | null>(null)
+const timeUnit  = ref('second')
+
+// Which fields Apply / Copy to selected / Fill flagged actually write — e.g. only Z was wrong,
+// leave X/Y alone even though the form shows their (correct) values too.
+const includeX = ref(true)
+const includeY = ref(true)
+const includeZ = ref(true)
+const includeT = ref(true)
+
+function reseed() {
+  // Always show the FOCUSED image's own real value — never blank it out just because other
+  // selected images disagree (that made the value you're trying to copy invisible/unusable).
+  // "Mixed" is now a passive highlight on the field (see isMixed in the template), not something
+  // that hides the number.
+  const seed = (field: PhysField) => focusedImg.value?.[field] ?? null
+  physX.value    = seed('physicalSizeX')
+  physY.value    = seed('physicalSizeY')
+  physZ.value    = seed('physicalSizeZ')
+  timeInc.value  = seed('timeIncrement')
+  physUnit.value = focusedImg.value?.physicalSizeUnit ?? 'micrometer'
+  timeUnit.value = focusedImg.value?.timeIncrementUnit ?? 'second'
+
+  // Default to only fields flagged somewhere in the target set (see targetFlags) — e.g. select a
+  // batch flagged for Z + Δt only, open a clean reference image: only Z/Δt default on, so
+  // Copy/Fill flagged fixes exactly what's broken without also overwriting X/Y that were fine.
+  includeX.value = targetFlags.value.has('x')
+  includeY.value = targetFlags.value.has('y')
+  includeZ.value = targetFlags.value.has('z')
+  includeT.value = targetFlags.value.has('t')
+}
+watch(targetUids, reseed, { immediate: true })
+
+// A PhysicalSizeZ written here is either a human confirming/entering it, or copied from a
+// trusted reference — either way it's no longer "auto-corrected, unverified", so clear that
+// stale marker (api_images_meta_set treats a null value as "delete this key").
+function withZFlagCleared(fields: Record<string, unknown>): Record<string, unknown> {
+  return 'PhysicalSizeZ' in fields ? { ...fields, PhysicalSizeZ_raw: null } : fields
+}
+function zFlagPatch(fields: Record<string, unknown>): Record<string, unknown> {
+  return 'PhysicalSizeZ' in fields ? { physicalSizeZCorrected: false } : {}
+}
+
+function currentFields(): Record<string, unknown> {
+  const fields: Record<string, unknown> = {}
+  if (includeX.value && physX.value != null)   fields.PhysicalSizeX     = physX.value
+  if (includeY.value && physY.value != null)   fields.PhysicalSizeY     = physY.value
+  if (includeZ.value && physZ.value != null)   fields.PhysicalSizeZ     = physZ.value
+  if ((includeX.value || includeY.value || includeZ.value) && physUnit.value)
+    fields.PhysicalSizeUnit = physUnit.value
+  if (includeT.value && timeInc.value != null) fields.TimeIncrement     = timeInc.value
+  if (includeT.value && timeUnit.value)        fields.TimeIncrementUnit = timeUnit.value
+  return fields
+}
+function referenceFields(img: CciaImage): Record<string, unknown> {
+  const fields: Record<string, unknown> = {}
+  if (includeX.value && img.physicalSizeX != null)     fields.PhysicalSizeX     = img.physicalSizeX
+  if (includeY.value && img.physicalSizeY != null)     fields.PhysicalSizeY     = img.physicalSizeY
+  if (includeZ.value && img.physicalSizeZ != null)     fields.PhysicalSizeZ     = img.physicalSizeZ
+  if ((includeX.value || includeY.value || includeZ.value) && img.physicalSizeUnit)
+    fields.PhysicalSizeUnit = img.physicalSizeUnit
+  if (includeT.value && img.timeIncrement != null)     fields.TimeIncrement     = img.timeIncrement
+  if (includeT.value && img.timeIncrementUnit)         fields.TimeIncrementUnit = img.timeIncrementUnit
+  return fields
+}
+// Only copies keys actually present in `fields` (i.e. actually sent to the backend) into the
+// local store patch. `Object.assign` in updateImageMeta would otherwise happily write
+// `physicalSizeX: undefined` for a toggled-off field, wiping out that image's real stored value
+// client-side even though the backend was never asked to touch it (this is exactly what produced
+// the bogus "mixed" X/Y highlight after copying only Z/Δt — X/Y silently went to undefined).
+function patchFrom(fields: Record<string, unknown>): Record<string, unknown> {
+  const patch: Record<string, unknown> = { ...zFlagPatch(fields) }
+  if ('PhysicalSizeX' in fields)     patch.physicalSizeX     = fields.PhysicalSizeX
+  if ('PhysicalSizeY' in fields)     patch.physicalSizeY     = fields.PhysicalSizeY
+  if ('PhysicalSizeZ' in fields)     patch.physicalSizeZ     = fields.PhysicalSizeZ
+  if ('PhysicalSizeUnit' in fields)  patch.physicalSizeUnit  = fields.PhysicalSizeUnit
+  if ('TimeIncrement' in fields)     patch.timeIncrement     = fields.TimeIncrement
+  if ('TimeIncrementUnit' in fields) patch.timeIncrementUnit = fields.TimeIncrementUnit
+  return patch
+}
+
+async function pushFieldsTo(fields: Record<string, unknown>, uids: string[]): Promise<boolean> {
+  const projectUid = projectMeta.current?.uid
+  if (!projectUid || !uids.length) return false
+  const withCleared = withZFlagCleared(fields)
+  const values: Record<string, Record<string, unknown>> = {}
+  for (const u of uids) values[u] = withCleared
+  const res = await fetch('/api/images/meta/set', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ projectUid, values }),
+  })
+  const body = await res.json().catch(() => ({})) as { error?: string }
+  if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
+  return true
+}
+
+const saving = ref(false)
+async function apply() {
+  const fields = currentFields()
+  if (!Object.keys(fields).length) return
+  saving.value = true
+  try {
+    await pushFieldsTo(fields, targetUids.value)
+    const patch = patchFrom(withZFlagCleared(fields))
+    for (const uid of targetUids.value) project.updateImageMeta(uid, patch)
+    log.info(`Updated physical size/timing for ${targetUids.value.length} image(s).`, { source: 'metadata' })
+    emit('close')
+  } catch (e) {
+    log.error(e instanceof Error ? e.message : String(e), { source: 'metadata' })
+  } finally {
+    saving.value = false
+  }
+}
+
+const copying = ref(false)
+async function copyToSelected() {
+  const img = focusedImg.value
+  if (!img) return
+  const fields = referenceFields(img)
+  if (!Object.keys(fields).length) { log.warn('No values to copy yet.', { source: 'metadata' }); return }
+  const uids = targetUids.value.filter(u => u !== img.uid)
+  if (!uids.length) { log.warn('Select at least one other image first.', { source: 'metadata' }); return }
+  copying.value = true
+  try {
+    await pushFieldsTo(fields, uids)
+    const patch = patchFrom(withZFlagCleared(fields))
+    for (const u of uids) project.updateImageMeta(u, patch)
+    log.info(`Copied to ${uids.length} selected image(s).`, { source: 'metadata' })
+  } catch (e) {
+    log.error(e instanceof Error ? e.message : String(e), { source: 'metadata' })
+  } finally {
+    copying.value = false
+  }
+}
+
+const propagating = ref(false)
+async function fillFlagged() {
+  const img = focusedImg.value
+  if (!img) return
+  const fields = referenceFields(img)
+  if (!Object.keys(fields).length) { log.warn('No values to copy yet.', { source: 'metadata' }); return }
+  const targets = props.selectedUids
+    .filter(uid => uid !== img.uid)
+    .map(uid => setImages.value.find(i => i.uid === uid))
+    .filter((i): i is CciaImage => !!i && metadataWarning(i) !== null)
+  if (!targets.length) { log.warn('No other selected images are flagged.', { source: 'metadata' }); return }
+  propagating.value = true
+  try {
+    await pushFieldsTo(fields, targets.map(t => t.uid))
+    const patch = patchFrom(withZFlagCleared(fields))
+    for (const t of targets) project.updateImageMeta(t.uid, patch)
+    log.info(`Filled ${targets.length} flagged image(s) from "${img.name}".`, { source: 'metadata' })
+  } catch (e) {
+    log.error(e instanceof Error ? e.message : String(e), { source: 'metadata' })
+  } finally {
+    propagating.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="pp-overlay" @click.self="emit('close')">
+    <div class="pp-modal">
+
+      <div class="pp-header">
+        <span class="pp-title">
+          <i class="pi pi-ruler" /> Physical size &amp; timing
+          <i class="pi pi-info-circle info-dot"
+             v-tooltip.bottom="'Read from the file at import when possible. A flagged value means we couldn\'t find it, or it looked unusual — check Fiji (Image ▸ Properties) or your acquisition settings.'" />
+        </span>
+        <button class="pp-close" @click="emit('close')" v-tooltip.left="'Close'">
+          <i class="pi pi-times" />
+        </button>
+      </div>
+
+      <div class="pp-body pp-form">
+        <p v-if="focusedImg" class="focus-name">{{ focusedImg.name }}</p>
+
+        <p v-if="focusedWarning" class="warn-line" v-tooltip.bottom="focusedWarning.long">
+          <i class="pi pi-exclamation-triangle" /> {{ focusedWarning.short }}
+        </p>
+
+        <div class="toggle-row" v-tooltip.bottom="'Which fields Apply / Copy / Fill flagged write — untick what\'s already correct.'">
+          <label class="toggle-chip" :class="{ on: includeX, warn: targetFlags.has('x') }"><input type="checkbox" v-model="includeX" />X</label>
+          <label class="toggle-chip" :class="{ on: includeY, warn: targetFlags.has('y') }"><input type="checkbox" v-model="includeY" />Y</label>
+          <label class="toggle-chip" :class="{ on: includeZ, warn: targetFlags.has('z') }"><input type="checkbox" v-model="includeZ" />Z</label>
+          <label class="toggle-chip" :class="{ on: includeT, warn: targetFlags.has('t') }"><input type="checkbox" v-model="includeT" />Δt</label>
+        </div>
+
+        <div class="dims-row" :class="{ excluded: !includeX && !includeY && !includeZ }">
+          <label class="dim-label" v-tooltip.bottom="'Pixel size in X'">X</label>
+          <input class="field-input" :class="{ warn: targetFlags.has('x'), mixed: isMixed('physicalSizeX') }"
+            type="number" step="any" v-model.number="physX" :disabled="!includeX" placeholder="—"
+            v-tooltip.bottom="isMixed('physicalSizeX') ? 'Other selected images have a different X — this is just ' + focusedImg?.name + '\'s.' : null" />
+          <label class="dim-label" v-tooltip.bottom="'Pixel size in Y'">Y</label>
+          <input class="field-input" :class="{ warn: targetFlags.has('y'), mixed: isMixed('physicalSizeY') }"
+            type="number" step="any" v-model.number="physY" :disabled="!includeY" placeholder="—"
+            v-tooltip.bottom="isMixed('physicalSizeY') ? 'Other selected images have a different Y — this is just ' + focusedImg?.name + '\'s.' : null" />
+          <label class="dim-label" v-tooltip.bottom="'Voxel depth — the Z step'">Z</label>
+          <input class="field-input" :class="{ warn: targetFlags.has('z'), mixed: isMixed('physicalSizeZ') }"
+            type="number" step="any" v-model.number="physZ" :disabled="!includeZ" placeholder="—"
+            v-tooltip.bottom="isMixed('physicalSizeZ') ? 'Other selected images have a different Z — this is just ' + focusedImg?.name + '\'s.' : null" />
+          <select class="field-input unit-input" v-model="physUnit" v-tooltip.bottom="'Unit for X/Y/Z'">
+            <option value="micrometer">µm</option>
+            <option value="nanometer">nm</option>
+            <option value="millimeter">mm</option>
+          </select>
+        </div>
+
+        <div class="dims-row" :class="{ excluded: !includeT }">
+          <label class="dim-label" v-tooltip.bottom="'Time between frames'">Δt</label>
+          <input class="field-input" :class="{ warn: targetFlags.has('t'), mixed: isMixed('timeIncrement') }"
+            type="number" step="any" v-model.number="timeInc" :disabled="!includeT" placeholder="—"
+            v-tooltip.bottom="isMixed('timeIncrement') ? 'Other selected images have a different Δt — this is just ' + focusedImg?.name + '\'s.' : null" />
+          <select class="field-input unit-input" v-model="timeUnit" v-tooltip.bottom="'Unit for the frame interval'">
+            <option value="second">s</option>
+            <option value="minute">min</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="pp-footer">
+        <button class="btn-ghost btn-sm" :disabled="propagating" @click="fillFlagged"
+          v-tooltip.top="'Fill this image\'s values into the OTHER selected images that are flagged — same-session acquisitions usually match exactly.'">
+          <i v-if="propagating" class="pi pi-spin pi-cog" /><i v-else class="pi pi-share-alt" />
+          Fill flagged
+        </button>
+        <button class="btn-ghost btn-sm" :disabled="copying" @click="copyToSelected"
+          v-tooltip.top="'Copy this image\'s values to the other selected images.'">
+          <i v-if="copying" class="pi pi-spin pi-cog" /><i v-else class="pi pi-copy" />
+          Copy to selected
+        </button>
+        <span class="footer-spacer" />
+        <button class="btn-ghost btn-sm" @click="emit('close')">Cancel</button>
+        <button class="btn-primary btn-sm" :disabled="saving" @click="apply"
+          v-tooltip.top="`Apply to ${targetUids.length} image(s). Doesn't retroactively recompute derived measures (e.g. track speed).`">
+          <i v-if="saving" class="pi pi-spin pi-cog" /><i v-else class="pi pi-check" />
+          Apply
+        </button>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.pp-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.65);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 500;
+}
+.pp-modal {
+  background: var(--cc-surface-1);
+  border: 1px solid var(--cc-border);
+  border-radius: 0.6rem;
+  width: 480px;
+  max-width: 96vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 24px 48px rgba(0,0,0,0.5);
+}
+
+.pp-header {
+  display: flex; align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--cc-border);
+  flex-shrink: 0;
+}
+.pp-title { flex: 1; font-size: 0.9rem; font-weight: 600; color: var(--cc-text); display: flex; gap: 0.45rem; align-items: center; }
+.info-dot { font-size: 0.72rem; color: var(--cc-text-dim); cursor: default; }
+.pp-close {
+  background: none; border: none; cursor: pointer;
+  color: var(--cc-text-dim); font-size: 0.8rem;
+  padding: 0.2rem 0.4rem; border-radius: 0.25rem;
+}
+.pp-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
+
+.pp-body { flex: 1; overflow-y: auto; }
+.pp-form { padding: 1rem 1.25rem; display: flex; flex-direction: column; gap: 0.75rem; }
+
+.focus-name { margin: 0; font-size: 0.82rem; font-weight: 600; color: var(--cc-text); }
+
+.warn-line {
+  display: flex; align-items: center; gap: 0.4rem; margin: 0;
+  font-size: 0.78rem; color: #fcd34d;
+  background: #7c2d1244; border: 1px solid #92400e55;
+  border-radius: 0.3rem; padding: 0.35rem 0.55rem; cursor: help;
+}
+
+.toggle-row { display: flex; gap: 0.35rem; }
+.toggle-chip {
+  display: flex; align-items: center; gap: 0.25rem;
+  font-size: 0.72rem; font-weight: 600;
+  padding: 0.15rem 0.5rem; border-radius: 999px;
+  border: 1px solid var(--cc-border); background: var(--cc-surface-2);
+  color: var(--cc-text-dim); cursor: pointer;
+}
+.toggle-chip input { display: none; }
+.toggle-chip.on { border-color: var(--cc-accent); color: var(--cc-accent); background: #a78bfa14; }
+.toggle-chip.warn { border-color: #f59e0b88; }
+.toggle-chip.warn.on { border-color: #f59e0b; color: #fbbf24; background: #7c2d1233; }
+
+.dims-row { display: flex; align-items: center; gap: 0.4rem; transition: opacity 0.1s; }
+.dims-row.excluded { opacity: 0.4; }
+.dim-label {
+  flex-shrink: 0; width: 1.2rem; text-align: right;
+  font-size: 0.75rem; font-weight: 600; color: var(--cc-text-dim);
+}
+.field-input { flex: 1; min-width: 0; }
+.field-input.warn { border-color: #f59e0b !important; background: #7c2d1222; }
+.field-input.mixed { border: 1px dashed #60a5fa !important; background: #1e3a5f55; cursor: help; }
+.unit-input { flex: 0 0 4.2rem; }
+
+.pp-footer {
+  display: flex; align-items: center; gap: 0.4rem;
+  padding: 0.65rem 1rem;
+  border-top: 1px solid var(--cc-border);
+  background: var(--cc-surface-1);
+  flex-shrink: 0;
+}
+.footer-spacer { flex: 1; }
+
+.btn-sm {
+  display: flex; align-items: center; gap: 0.3rem;
+  font-size: 0.78rem; font-weight: 500;
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.35rem; border: 1px solid transparent;
+  cursor: pointer; white-space: nowrap;
+}
+.btn-ghost { background: var(--cc-surface-2); border-color: var(--cc-border); color: var(--cc-text-dim); }
+.btn-ghost:hover:not(:disabled) { color: var(--cc-text); }
+.btn-ghost:disabled { opacity: 0.4; cursor: not-allowed; }
+.btn-primary { background: var(--cc-accent); color: #fff; }
+.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
+.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+</style>

--- a/frontend/src/lib/imageMetadataWarnings.ts
+++ b/frontend/src/lib/imageMetadataWarnings.ts
@@ -1,0 +1,120 @@
+// Single source of truth for "this image's physical metadata looks missing/suspect" — used by
+// the ImageTable row icon (short tooltip), and PhysicalSizeDialog (long hint + per-field
+// highlight), so all three surfaces never disagree about the same image.
+import type { CciaImage } from '../stores/project'
+
+export interface MetadataWarning {
+  short: string
+  long: string
+}
+
+export type PhysField = 'x' | 'y' | 'z' | 't'
+
+interface FieldIssue extends MetadataWarning {
+  field: PhysField
+}
+
+// Generous sane band for Z-step vs XY pixel size. Real acquisitions vary widely, but a ratio
+// outside this range is far more likely to be a unit-conversion bug (e.g. an ImageJ TIFF saved
+// with a non-micron calibration unit) than a real voxel geometry.
+const Z_RATIO_MIN = 0.02
+const Z_RATIO_MAX = 50
+
+function fieldIssues(img: CciaImage): FieldIssue[] {
+  const issues: FieldIssue[] = []
+  const sizeZ = img.sizeZ ?? 1
+  const sizeT = img.sizeT ?? 1
+
+  if (sizeZ > 1 && (img.physicalSizeZ === null || img.physicalSizeZ === undefined)) {
+    issues.push({
+      field: 'z',
+      short: 'Z spacing unknown — click to fill in',
+      long: 'No Z step size was found for this image. Check your acquisition software’s ' +
+        'metadata or open the file in Fiji (Image ▸ Properties) to find the voxel depth, ' +
+        'then enter it below.',
+    })
+  } else if (img.physicalSizeZCorrected) {
+    // Auto-corrected at import from the source file's own ImageJ tag (bioformats2raw's raw value
+    // was even more obviously wrong) — but that tag isn't independently verifiable from the data
+    // alone, so this ALWAYS stays flagged for a human to confirm, even when the corrected ratio
+    // now looks plausible.
+    issues.push({
+      field: 'z',
+      short: 'Z spacing auto-corrected — click to verify',
+      long: 'This Z step was auto-corrected from the source file’s own ImageJ tag ' +
+        '(the file’s calibration unit wasn’t micrometers). That tag may not be a real ' +
+        'per-slice measurement, so please confirm it against Fiji (Image ▸ Properties) or ' +
+        'your acquisition settings before trusting it.',
+    })
+  } else if (img.physicalSizeZ != null && img.physicalSizeX != null && img.physicalSizeX > 0) {
+    const ratio = img.physicalSizeZ / img.physicalSizeX
+    if (ratio < Z_RATIO_MIN || ratio > Z_RATIO_MAX) {
+      issues.push({
+        field: 'z',
+        short: 'Z spacing looks unusual — click to review',
+        long: 'The Z step looks unusually small or large compared to the pixel size in X/Y. ' +
+          'This can happen when the original file’s calibration unit wasn’t ' +
+          'micrometers — e.g. an ImageJ TIFF saved with unit = inch instead of micron. ' +
+          'Open the original file in Fiji (Image ▸ Properties) to check the real voxel ' +
+          'depth, then correct it below.',
+      })
+    }
+  }
+
+  if (sizeT > 1 && (img.timeIncrement === null || img.timeIncrement === undefined)) {
+    issues.push({
+      field: 't',
+      short: 'Frame interval unknown — click to fill in',
+      long: 'No frame interval was found in this file’s metadata. This is common for plain ' +
+        'TIFF stacks without hyperstack timing info. If you know the interval from your ' +
+        'acquisition settings, enter it below.',
+    })
+  } else if (img.timeIncrement != null && !img.timeIncrementUnit) {
+    // A number with no known unit is exactly as untrustworthy as no number — don't let it pass
+    // silently just because a value is present.
+    issues.push({
+      field: 't',
+      short: 'Frame interval has no unit — click to review',
+      long: 'A frame interval is recorded but its unit (seconds/minutes) is unknown, so the ' +
+        'number can\'t be trusted as-is. Confirm it against your acquisition settings and ' +
+        're-enter it with a unit below.',
+    })
+  }
+
+  // Same idea for the spatial unit: a size without a known unit isn't usable either. One shared
+  // PhysicalSizeUnit covers X/Y/Z, so flag whichever axes actually have a value recorded.
+  if (!img.physicalSizeUnit) {
+    if (img.physicalSizeX != null) issues.push({
+      field: 'x',
+      short: 'Pixel size has no unit — click to review',
+      long: 'A pixel size is recorded but its unit is unknown, so the number can\'t be trusted ' +
+        'as-is. Confirm it against your acquisition settings and re-enter it with a unit below.',
+    })
+    if (img.physicalSizeY != null) issues.push({
+      field: 'y',
+      short: 'Pixel size has no unit — click to review',
+      long: 'A pixel size is recorded but its unit is unknown, so the number can\'t be trusted ' +
+        'as-is. Confirm it against your acquisition settings and re-enter it with a unit below.',
+    })
+    if (img.physicalSizeZ != null && !issues.some(i => i.field === 'z')) issues.push({
+      field: 'z',
+      short: 'Voxel depth has no unit — click to review',
+      long: 'A Z step is recorded but its unit is unknown, so the number can\'t be trusted ' +
+        'as-is. Confirm it against your acquisition settings and re-enter it with a unit below.',
+    })
+  }
+
+  return issues
+}
+
+// The single most relevant issue — drives the ImageTable row icon and the dialog's warning line.
+export function metadataWarning(img: CciaImage): MetadataWarning | null {
+  const issues = fieldIssues(img)
+  return issues.length ? { short: issues[0].short, long: issues[0].long } : null
+}
+
+// Which specific fields are implicated — drives per-field highlighting in PhysicalSizeDialog so
+// the user isn't left guessing which of X/Y/Z/Δt the banner text is actually about.
+export function flaggedFields(img: CciaImage): Set<PhysField> {
+  return new Set(fieldIssues(img).map(i => i.field))
+}

--- a/frontend/src/modules/metadata/MetadataPanel.vue
+++ b/frontend/src/modules/metadata/MetadataPanel.vue
@@ -3,6 +3,8 @@ import { ref, computed } from 'vue'
 import { useProjectStore } from '../../stores/project'
 import { useProjectMetaStore } from '../../stores/projectMeta'
 import { useLogStore } from '../../stores/log'
+import { metadataWarning } from '../../lib/imageMetadataWarnings'
+import PhysicalSizeDialog from '../../components/PhysicalSizeDialog.vue'
 
 const props = defineProps<{
   setUid: string | undefined
@@ -252,10 +254,30 @@ async function copyChannelNamesToAll() {
 }
 
 const attrDisabled = computed(() => !selectedAttr.value)
+
+// ── Physical size & timing — opens the shared modal (PhysicalSizeDialog.vue) rather than
+// cramming a full editor into this narrow sidebar; see feedback after the first version shipped.
+
+const showPhysDialog = ref(false)
+const physFocusUid = computed(() => props.selectedUids[0] ?? setImages.value[0]?.uid ?? null)
+const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(i)).length)
 </script>
 
 <template>
   <aside class="metadata-panel">
+
+    <!-- ── Physical size & timing ───────────────────────────────── -->
+    <section class="panel-section">
+      <div class="section-title">Physical size &amp; timing</div>
+      <button class="btn-ghost btn-sm" :disabled="!physFocusUid" @click="showPhysDialog = true"
+        v-tooltip.bottom="'View or fix voxel size and frame interval for the selected image(s).'">
+        <i class="pi pi-ruler" /> Open editor
+        <span v-if="flaggedCount" class="warn-count" v-tooltip.bottom="`${flaggedCount} image(s) in this set are flagged`">{{ flaggedCount }}</span>
+      </button>
+    </section>
+    <PhysicalSizeDialog v-if="showPhysDialog && setUid && physFocusUid"
+      :set-uid="setUid" :focus-uid="physFocusUid" :selected-uids="selectedUids"
+      @close="showPhysDialog = false" />
 
     <!-- ── Attribute management ─────────────────────────────────── -->
     <section class="panel-section">
@@ -487,6 +509,13 @@ const attrDisabled = computed(() => !selectedAttr.value)
 }
 
 .mt-2 { margin-top: 0.5rem; }
+
+.warn-count {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 1.1rem; height: 1.1rem; padding: 0 0.3rem;
+  border-radius: 999px; font-size: 0.65rem; font-weight: 700;
+  background: #7c2d1244; color: #fcd34d;
+}
 
 .btn-sm {
   display: flex; align-items: center; gap: 0.3rem;

--- a/frontend/src/stores/project.ts
+++ b/frontend/src/stores/project.ts
@@ -12,6 +12,13 @@ export interface CciaImage {
   sizeC?: number | null
   sizeT?: number | null
   sizeZ?: number | null
+  physicalSizeX?: number | null
+  physicalSizeY?: number | null
+  physicalSizeZ?: number | null
+  physicalSizeUnit?: string | null
+  physicalSizeZCorrected?: boolean | null
+  timeIncrement?: number | null
+  timeIncrementUnit?: string | null
   channelNames?: string[]
   filepath?: string                       // active version filename (for display)
   activeValueName?: string                // active value name (the _active key from versioned dict)

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -83,17 +83,20 @@ export const useTaskStore = defineStore('tasks', () => {
     if (idx !== -1) tasks.value.splice(idx, 1)
   }
 
-  function clearFinished(module: string) {
+  function clearFinished(module: string, projectUid?: string) {
     const done = new Set<TaskStatus>(['done', 'failed', 'cancelled'])
     for (let i = tasks.value.length - 1; i >= 0; i--) {
       const t = tasks.value[i]
-      if (t.module === module && done.has(t.status))
+      if (t.module === module && done.has(t.status) && (!projectUid || t.projectUid === projectUid))
         tasks.value.splice(i, 1)
     }
   }
 
-  function forModule(module: string) {
-    return tasks.value.filter(t => t.module === module)
+  // projectUid is optional so callers that genuinely want the cross-project view (the /tasks
+  // manager) can still get everything — the per-module sidebar (TaskList/TaskRunner) always
+  // passes the current project so switching projects doesn't leave a stale task list visible.
+  function forModule(module: string, projectUid?: string) {
+    return tasks.value.filter(t => t.module === module && (!projectUid || t.projectUid === projectUid))
   }
 
   const running = () => tasks.value.filter(t => t.status === 'running' || t.status === 'queued')

--- a/frontend/src/stores/ws.ts
+++ b/frontend/src/stores/ws.ts
@@ -229,16 +229,30 @@ export const useWsStore = defineStore('ws', () => {
 
           if (meta.cleared) {
             // primary image removed: wipe dimensions/channels, reset image to pending
-            patch.sizeC        = undefined
-            patch.sizeT        = undefined
-            patch.sizeZ        = undefined
-            patch.channelNames = []
+            patch.sizeC            = undefined
+            patch.sizeT            = undefined
+            patch.sizeZ            = undefined
+            patch.channelNames     = []
+            patch.physicalSizeX    = undefined
+            patch.physicalSizeY    = undefined
+            patch.physicalSizeZ    = undefined
+            patch.physicalSizeUnit = undefined
+            patch.physicalSizeZCorrected = undefined
+            patch.timeIncrement    = undefined
+            patch.timeIncrementUnit = undefined
             useProjectStore().updateImageStatus(imageUid, 'pending')
           } else {
             if (meta.SizeC !== undefined) patch.sizeC = Number(meta.SizeC)
             if (meta.SizeT !== undefined) patch.sizeT = Number(meta.SizeT)
             if (meta.SizeZ !== undefined) patch.sizeZ = Number(meta.SizeZ)
             if (Array.isArray(meta.channel_names)) patch.channelNames = meta.channel_names as string[]
+            if (meta.PhysicalSizeX !== undefined) patch.physicalSizeX = Number(meta.PhysicalSizeX)
+            if (meta.PhysicalSizeY !== undefined) patch.physicalSizeY = Number(meta.PhysicalSizeY)
+            if (meta.PhysicalSizeZ !== undefined) patch.physicalSizeZ = Number(meta.PhysicalSizeZ)
+            if (meta.PhysicalSizeUnit !== undefined) patch.physicalSizeUnit = String(meta.PhysicalSizeUnit)
+            if (meta.PhysicalSizeZ_raw !== undefined) patch.physicalSizeZCorrected = true
+            if (meta.TimeIncrement !== undefined) patch.timeIncrement = Number(meta.TimeIncrement)
+            if (meta.TimeIncrementUnit !== undefined) patch.timeIncrementUnit = String(meta.TimeIncrementUnit)
           }
           useProjectStore().updateImageMeta(imageUid, patch)
         }

--- a/frontend/src/tasks/TaskList.vue
+++ b/frontend/src/tasks/TaskList.vue
@@ -6,16 +6,20 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTaskStore, type TaskEntry, type TaskStatus } from '../stores/tasks'
 import { useWsStore } from '../stores/ws'
+import { useProjectMetaStore } from '../stores/projectMeta'
 
-const props  = defineProps<{ module: string }>()
-const tasks  = useTaskStore()
-const ws     = useWsStore()
-const router = useRouter()
+const props       = defineProps<{ module: string }>()
+const tasks       = useTaskStore()
+const ws          = useWsStore()
+const router      = useRouter()
+const projectMeta = useProjectMetaStore()
 
 const expanded  = ref<Set<string>>(new Set())
 const copied    = ref<Set<string>>(new Set())
 
-const items = computed(() => tasks.forModule(props.module))
+// Scoped to the current project — otherwise switching projects leaves the previous project's
+// (e.g. cancelled) tasks visible in this module's list.
+const items = computed(() => tasks.forModule(props.module, projectMeta.current?.uid))
 
 
 function toggleLog(id: string) {

--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -214,6 +214,27 @@ const runLabel = computed(() => {
   return `Run on ${n} image${n > 1 ? 's' : ''}`
 })
 
+// ── Cancel all running/queued tasks for this module ────────────────────────
+const activeTasks = computed(() =>
+  taskStore.forModule(props.module, projectMeta.current?.uid)
+    .filter(t => t.status === 'running' || t.status === 'queued')
+)
+
+function cancelAll() {
+  const cancelledChainRuns = new Set<string>()
+  for (const t of activeTasks.value) {
+    if (t.chainRunId) {
+      if (cancelledChainRuns.has(t.chainRunId)) continue
+      cancelledChainRuns.add(t.chainRunId)
+      taskStore.cancelChainRun(t.chainRunId)
+      ws.send({ type: 'chain:cancel', runId: t.chainRunId })
+    } else {
+      taskStore.cancel(t.id)
+      ws.send({ type: 'task:cancel', taskId: t.id })
+    }
+  }
+}
+
 // ── Sidebar resize ────────────────────────────────────────────────────────────
 const MIN_W = 200
 const MAX_W = 600
@@ -343,13 +364,23 @@ onUnmounted(() => {
     <section class="runner-section tasks-section">
       <div class="tasks-heading">
         <h3 class="section-heading">Tasks</h3>
-        <button
-          class="clear-btn"
-          @click="taskStore.clearFinished(module)"
-          v-tooltip.left="'Remove all completed and failed tasks from the list.'"
-        >
-          <i class="pi pi-filter-slash" />
-        </button>
+        <div class="tasks-heading-actions">
+          <button
+            v-if="activeTasks.length"
+            class="clear-btn danger"
+            @click="cancelAll"
+            v-tooltip.left="`Cancel all ${activeTasks.length} running/queued task(s) in this module.`"
+          >
+            <i class="pi pi-times-circle" />
+          </button>
+          <button
+            class="clear-btn"
+            @click="taskStore.clearFinished(module, projectMeta.current?.uid)"
+            v-tooltip.left="'Remove all completed and failed tasks from the list.'"
+          >
+            <i class="pi pi-filter-slash" />
+          </button>
+        </div>
       </div>
       <div class="tasks-scroll">
         <TaskList :module="module" />
@@ -399,6 +430,11 @@ onUnmounted(() => {
 }
 .tasks-heading .section-heading { margin-bottom: 0; }
 
+.tasks-heading-actions {
+  display: flex;
+  gap: 0.15rem;
+}
+
 .clear-btn {
   background: none;
   border: none;
@@ -409,6 +445,7 @@ onUnmounted(() => {
   border-radius: 0.2rem;
 }
 .clear-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
+.clear-btn.danger:hover { background: #7f1d1d55; color: #fca5a5; }
 
 .tasks-section {
   flex: 1;


### PR DESCRIPTION
## Summary
- Physical-size/timing metadata review & edit system: ImageJ Z-spacing
  auto-fix at import, OME-XML DeltaT time-interval fallback, warning icons
  + PhysicalSizeDialog.vue (Apply / Copy-to-selected / Fill-flagged, mixed-
  value detection), and `POST /api/images/meta/set` which keeps ccid.json,
  the OME-ZARR's `.zattrs` scale, and `OME/METADATA.ome.xml` in sync so
  napari actually reflects a correction (not just the display copy).
- `resync_ome_meta!` + `POST /api/images/meta/resync` + a table header
  button to backfill physical-size/timing `meta` for images imported
  before this tracking existed — no re-import needed. Always reads the
  `"default"` zarr, never the active one, since processed variants
  (drift/cellpose-correct) carry no OME calibration metadata at all.
- "Cancel all" button in the module Tasks sidebar.
- Per-project task-list scoping — switching projects no longer leaves a
  previous project's tasks visible in the module sidebar.

Docs updated: `docs/OBJECTMODEL.md`, `docs/API.md`, `docs/UI.md`,
`CLAUDE.md` (OME-ZARR dual-format gotcha), `docs/TODO.md` (#00064, #00065).
Vendor-specific OME quirks (Olympus/Imaris/MACSIMA) deferred to #00063.

## Test plan
- [x] Julia package tests: 616/617 pass (1 pre-existing known-broken)
- [x] Frontend typecheck (`vue-tsc --noEmit`) clean
- [x] Verified against real project data (`4kS67f`/`LUkCpP`,
      `NRUBxU`/`CHWgkH`): napari now shows correct Z-spacing and real
      frame times; resync correctly backfills units for pre-rework images
      with a processed (drift-corrected) variant active
- [ ] Manual smoke test in the running app after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)