### PR TITLE
Whiteboard: set tasks → picnic nodes, output value_name propagation

### DIFF
--- a/app/src/tasks/chain.jl
+++ b/app/src/tasks/chain.jl
@@ -32,9 +32,25 @@ struct ChainNode
     resource_pool::String
 end
 
-ChainNode(; id, fn, scope="image", params=Dict{String,Any}(),
+# Default scope for a task fun_name, read from its JSON spec's "scope" field. The task JSON is
+# the single source of truth for scope: set-scope (picnic) tasks like behaviour.hmm and
+# clustTracks.cluster declare "scope": "set" there, so a node built from them — in the REPL or
+# dragged onto the whiteboard — becomes a picnic node without the author restating it. Unknown
+# fn or specless task → "image".
+function _task_default_scope(fn::String)::String
+    try
+        task_scope(_task_from_fun_name(fn))   # reads the spec's "scope" field (task.jl)
+    catch
+        "image"
+    end
+end
+
+# An empty scope means "inherit from the task spec" (see _task_default_scope). An explicit
+# non-empty scope always wins, so a caller can still force image-scope on a set task if needed.
+ChainNode(; id, fn, scope="", params=Dict{String,Any}(),
             barrier_policy="all", resource_pool="") =
-    ChainNode(id, fn, scope, params, barrier_policy, resource_pool)
+    ChainNode(id, fn, isempty(scope) ? _task_default_scope(fn) : scope,
+              params, barrier_policy, resource_pool)
 
 struct ChainEdge
     from::String
@@ -91,7 +107,9 @@ function _node_from_dict(d)::ChainNode
     ChainNode(
         string(get(d, "id", get(d, :id, ""))),
         string(get(d, "fn", get(d, :fn, ""))),
-        string(get(d, "scope", get(d, :scope, "image"))),
+        let sc = string(get(d, "scope", get(d, :scope, "")))
+            isempty(sc) ? _task_default_scope(string(get(d, "fn", get(d, :fn, "")))) : sc
+        end,
         Dict{String,Any}(string(k) => v
                          for (k, v) in get(d, "params", get(d, :params, Dict()))),
         string(get(d, "barrier_policy", get(d, :barrier_policy, "all"))),
@@ -945,7 +963,7 @@ Thin constructor for ChainNode with auto-generated id.
 """
 function chain_node(fn::String;
                     id::String             = gen_uid(),
-                    scope::String          = "image",
+                    scope::String          = "",   # "" → inherit from the task spec (see _task_default_scope)
                     params::Dict{String,Any} = Dict{String,Any}(),
                     barrier_policy::String = "all",
                     resource_pool::String  = "")::ChainNode

--- a/app/src/tasks/cleanupImages/af_correct.jl
+++ b/app/src/tasks/cleanupImages/af_correct.jl
@@ -73,7 +73,7 @@ function _run_task(task::AfCorrect, img::CciaImage, params::Dict{String,Any};
 
     on_log("[INFO] AF correction complete.")
 
-    out_value_name = "afCorrected"
+    out_value_name = _spec_output_value_name(task, "afCorrected")
     out_filename   = "ccidAfCorrected.ome.zarr"
 
     raw2 = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(ccid, String)))

--- a/app/src/tasks/cleanupImages/af_correct.json
+++ b/app/src/tasks/cleanupImages/af_correct.json
@@ -5,6 +5,7 @@
   "category": "Cleanup",
   "env": ["local"],
   "resource_pool": "default",
+  "outputValueName": "afCorrected",
   "params": [
     {
       "key": "valueName",

--- a/app/src/tasks/cleanupImages/cellpose_correct.jl
+++ b/app/src/tasks/cleanupImages/cellpose_correct.jl
@@ -60,7 +60,7 @@ function _run_task(task::CellposeCorrect, img::CciaImage, params::Dict{String,An
 
     on_log("[INFO] Cellpose correction complete.")
 
-    out_value_name = "cpCorrected"
+    out_value_name = _spec_output_value_name(task, "cpCorrected")
     out_filename   = "ccidCpCorrected.ome.zarr"
 
     raw2 = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(ccid, String)))

--- a/app/src/tasks/cleanupImages/cellpose_correct.json
+++ b/app/src/tasks/cleanupImages/cellpose_correct.json
@@ -5,6 +5,7 @@
   "category": "Cleanup",
   "env": ["local"],
   "resource_pool": "gpu",
+  "outputValueName": "cpCorrected",
   "params": [
     {
       "key": "valueName",

--- a/app/src/tasks/cleanupImages/drift_correct.jl
+++ b/app/src/tasks/cleanupImages/drift_correct.jl
@@ -56,7 +56,7 @@ function _run_task(task::DriftCorrect, img::CciaImage, params::Dict{String,Any};
 
     on_log("[INFO] Drift correction complete.")
 
-    out_value_name = "driftCorrected"
+    out_value_name = _spec_output_value_name(task, "driftCorrected")
     out_filename   = "ccidDriftCorrected.ome.zarr"
 
     raw2 = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(ccid, String)))

--- a/app/src/tasks/cleanupImages/drift_correct.json
+++ b/app/src/tasks/cleanupImages/drift_correct.json
@@ -5,6 +5,7 @@
   "category": "Cleanup",
   "env": ["local"],
   "resource_pool": "default",
+  "outputValueName": "driftCorrected",
   "params": [
     {
       "key": "valueName",

--- a/app/src/tasks/task.jl
+++ b/app/src/tasks/task.jl
@@ -62,6 +62,18 @@ function _task_spec(task::CciaTask)::Union{Dict{String,Any}, Nothing}
     spec
 end
 
+# Resolve a producer task's output value_name from its JSON spec's top-level "outputValueName".
+# This makes the output handle a single, introspectable source of truth (the JSON) rather than a
+# constant buried in the task's .jl: the whiteboard reads the same field to prefill a downstream
+# node's input `valueName` (see ChainModule value-name propagation). Falls back to `default` when
+# the spec declares no fixed output (e.g. tasks whose output name is a user-set param instead).
+function _spec_output_value_name(task::CciaTask, default::String)::String
+    spec = _task_spec(task)
+    isnothing(spec) && return default
+    v = get(spec, "outputValueName", nothing)
+    isnothing(v) ? default : string(v)
+end
+
 # Subclasses define their spec path by implementing this or we use naming convention.
 # Default: look for <category>/<task>.json next to the .jl file.
 function _spec_path(task::CciaTask)::Union{String, Nothing}

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -277,6 +277,40 @@ end
     end
 
     # ── Chain template round-trip ─────────────────────────────────────────────
+    # ── Chain node scope defaults from the task spec (single source of truth) ────
+    # A node built without an explicit scope inherits the task JSON's "scope": set-scope
+    # tasks (behaviour.hmm, clustTracks.cluster) become picnic nodes automatically, image
+    # tasks stay image-scope. An explicit scope always overrides.
+    @testset "Chain node scope inherits from task spec" begin
+        @test Cecelia._task_default_scope("clustTracks.cluster") == "set"
+        @test Cecelia._task_default_scope("behaviour.hmm")        == "set"
+        @test Cecelia._task_default_scope("importImages.remove")  == "image"
+        @test Cecelia._task_default_scope("nonexistent.task")     == "image"   # unknown fn → image
+
+        # chain_node / ChainNode with no scope kwarg resolve from the spec …
+        @test chain_node("clustTracks.cluster").scope == "set"
+        @test chain_node("importImages.remove").scope == "image"
+        @test ChainNode(id="x", fn="behaviour.hmm").scope == "set"
+        # … and an explicit scope still wins (force a set task to run per-image)
+        @test chain_node("clustTracks.cluster"; scope="image").scope == "image"
+
+        # Deserialisation: a node dict with no "scope" key also inherits from the spec
+        @test Cecelia._node_from_dict(Dict("id"=>"n", "fn"=>"clustTracks.cluster")).scope == "set"
+        # …while a stored scope (frozen template) is honoured verbatim
+        @test Cecelia._node_from_dict(Dict("id"=>"n", "fn"=>"clustTracks.cluster",
+                                           "scope"=>"image")).scope == "image"
+    end
+
+    # ── Producer output value_name is declared in the JSON spec (introspectable) ──
+    # The whiteboard reads this to prefill a downstream node's input `valueName`.
+    @testset "Output value_name from spec" begin
+        @test Cecelia._spec_output_value_name(CellposeCorrect(), "fallback") == "cpCorrected"
+        @test Cecelia._spec_output_value_name(DriftCorrect(),    "fallback") == "driftCorrected"
+        @test Cecelia._spec_output_value_name(AfCorrect(),       "fallback") == "afCorrected"
+        # A task that declares no top-level outputValueName falls back to the caller's default
+        @test Cecelia._spec_output_value_name(RemoveImage(), "fallback") == "fallback"
+    end
+
     @testset "Chain template round-trip" begin
         proj = create_project!(name="chain-tpl-$(rand(1000:9999))", kind="static")
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -77,7 +77,7 @@ im_path  = joinpath(proj_dir, "0", img.uid, string(filename))
 
 ```julia
 out_path       = joinpath(proj_dir, "0", img.uid, "ccidMyResult.zarr")
-out_value_name = "myResult"
+out_value_name = _spec_output_value_name(task, "myResult")   # from the JSON, not hardcoded
 out_filename   = "ccidMyResult.zarr"
 
 # … run the actual work (Python subprocess or pure Julia) …
@@ -90,6 +90,23 @@ return Dict{String,Any}("valueName" => out_value_name, "filename" => out_filenam
 ```
 
 Return `nothing` on failure. The scheduler marks the task failed and the frontend shows it in red.
+
+**Declare a fixed output value_name in the JSON, don't hardcode it in the `.jl`.** A producer's
+output handle is a **single source of truth**: a top-level `"outputValueName"` in the task spec.
+Read it with `_spec_output_value_name(task, "<fallback>")` (`app/src/tasks/task.jl`) rather than
+writing a bare string literal, so the whiteboard can introspect it and prefill a downstream node's
+input `valueName` (see *Value-name propagation* in `docs/SCHEDULER.md`). The fallback keeps a task
+working if the JSON field is ever missing.
+
+```json
+{ "task": "cellposeCorrect", "fun_name": "cleanupImages.cellposeCorrect",
+  "resource_pool": "gpu", "outputValueName": "cpCorrected", "params": [ … ] }
+```
+
+Two other output shapes exist, both already introspectable and not to be re-expressed as a bare
+literal: a task whose output name is **user-chosen** exposes an `outputValueName` **param** (e.g.
+`segment.cellpose`), and a **composite** declares a top-level `outputValueName` that its executor
+collapses `ccid.json` down to (see *`outputValueName` — canonical output registration* below).
 
 ### Running a Python subprocess
 
@@ -430,7 +447,7 @@ Most tasks are **image-scope**: the GUI runs them once per selected image. A **s
 A set-scope task differs from an image-scope task in three places:
 
 1. **`_run_task` dispatches on a vector.** Define `_run_task(::MyTask, imgs::Vector{CciaImage}, params; on_log, on_progress, on_process)` instead of the single-`img` form. Build the pooled cross-image table with `pop_df(imgs, uids, pop_type, pops; …)` (it stacks per-image rows and tags each with a `uID` column). Write results back **per image** (loop `imgs`, write each one's labelProps). See `app/src/tasks/behaviour/hmm_states.jl`.
-2. **The JSON spec declares `"scope": "set"`.** This is what routes the run. `task_scope(task)` reads it (default `"image"`).
+2. **The JSON spec declares `"scope": "set"`.** This is what routes the run. `task_scope(task)` reads it (default `"image"`). It also makes the task a **picnic node** on the whiteboard automatically — a chain node inherits its scope from this field (`_task_default_scope`, see `docs/SCHEDULER.md` → *Node scopes*), so you never restate scope when building a chain.
    ```json
    { "fun_name": "behaviour.hmm_states", "task": "hmmStates", "label": "HMM States", "category": "Behaviour", "scope": "set", "env": ["local"], "resource_pool": "default", "params": [ … ] }
    ```

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -191,6 +191,14 @@ node routes to the correct global pool even when the task spec's default differs
 | `"set"` | Dedicated set-scope thread | Once for the whole set, after ALL images arrive at the barrier |
 | `"incremental"` | Dedicated watcher thread | After each upstream node:done event, debounced |
 
+**Scope is inherited from the task spec, not restated per node.** The task JSON's `"scope"` field
+is the single source of truth (`task_scope`, `task.jl`). A `ChainNode` / `chain_node` built with no
+explicit `scope` resolves it from the spec via `_task_default_scope(fn)` (`chain.jl`) — so
+`chain_node("behaviour.hmm")` and dragging HMM/clustering onto the whiteboard both produce a
+picnic node without the author naming the scope. An explicit non-empty `scope` still overrides
+(force a set task per-image if ever needed); a frozen template's stored scope is honoured verbatim.
+The whiteboard drop handler mirrors this — `def.scope ?? 'image'` picks the node's visual type.
+
 ### Set-scope (picnic) nodes
 
 A picnic node is a synchronisation point: every image must arrive before anything runs.
@@ -247,6 +255,34 @@ thread loop. A failed plot never kills the pipeline. The `incremental_ids` set i
 `_execute_image_chain!` is the mechanism.
 
 ---
+
+## Value-name propagation between linked nodes
+
+A processing task consumes an input image version (a `valueName`) and produces a new one — e.g.
+`cleanupImages.cellposeCorrect` reads `default` and writes `cpCorrected`. Because the output only
+exists on disk **after** the chain runs, a downstream node's `valueNameSelection` widget can't
+offer it from the image (the image still only has `default` at authoring time). Two pieces close
+this gap so a chain like `import → cellposeCorrect → afDriftCorrect` can be wired before any image
+is processed:
+
+1. **Declared output (introspectable).** Every producer declares its output value_name in the JSON
+   spec — a top-level `"outputValueName"` for a fixed output (`cpCorrected`, `driftCorrected`,
+   `afCorrected`), or an `outputValueName` **param** when the user names it (`segment.cellpose`).
+   The task's `_run_task` reads the fixed form via `_spec_output_value_name(task, default)` instead
+   of hardcoding the string, so exactly one place states it. `GET /api/tasks/definitions` serves
+   the field to the whiteboard.
+
+2. **Edge-driven prefill (whiteboard).** On connecting A→B, `ChainModule.vue` reads A's declared
+   output (`nodeOutputValueName`) and prefills every field-compatible `valueNameSelection` param on
+   B with it (`propagateValueName`) — matched by field (`filepath` vs `labels`). The value is
+   **auto-populated but editable**: it's offered through `paramContext.extraValueNames` (upstream
+   outputs merged into the dropdown even though they don't exist on the image yet), and
+   `ParamRenderer`'s auto-select watch keeps an already-valid edge value instead of resetting it to
+   the image's active version.
+
+The chain executor already threads real outputs at run time — the composite step-wiring
+(`params["valueName"] = result["valueName"]`, `task.jl`) and each node re-reading `ccid.json` — so
+propagation is an **authoring-time convenience**, not a second execution path.
 
 ## Template vs run record
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -240,6 +240,25 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00066** — **Whiteboard: set tasks weren't picnic nodes; downstream input value_name couldn't be pre-wired** (2026-07-03)
+Two chain-authoring gaps surfaced while building real pipelines. (1) **Scope wasn't inherited from
+the task spec.** HMM/clustering tasks declare `"scope": "set"` in their JSON, but the whiteboard
+drop handler hardcoded `scope='image'` (and `chain_node`/`ChainNode` defaulted to `"image"`), so
+they dropped in as ordinary per-image nodes instead of picnic nodes. The task JSON is now the single
+source of truth: `_task_default_scope(fn)` (`chain.jl`, delegating to `task_scope`) resolves an
+empty scope from the spec in `ChainNode`/`chain_node`/`_node_from_dict`; the frontend uses
+`def.scope ?? 'image'`. An explicit scope and a frozen template's stored scope still win. (2)
+**Downstream nodes couldn't select an upstream node's output value_name** (`import → cellposeCorrect
+→ afDriftCorrect` — `cpCorrected` doesn't exist on the image until the chain runs). Unified the
+producer output contract as a top-level `"outputValueName"` in the JSON (added to
+`cellpose_correct`/`drift_correct`/`af_correct`; read via `_spec_output_value_name(task, default)`
+instead of a hardcoded literal). On drawing an edge, `ChainModule.propagateValueName` prefills the
+downstream node's field-compatible `valueNameSelection` params with the upstream output
+(auto-populated, editable); `paramContext.extraValueNames` + `ParamRenderer` (union into the option
+list, keep an already-valid edge value) make the not-yet-on-disk name selectable. Docs:
+SCHEDULER.md (*Node scopes*, *Value-name propagation*), MODULES.md. Tests: scope-from-spec +
+output-value-name-from-spec in `runtests.jl`.
+
 **#00065** — **Task-manager "cancel all" + per-project task-list scoping; resync silently no-op'd against processed variants** (2026-07-03)
 Three related fixes to today's real-data testing round. (1) Added a "cancel all" button next to
 "clear finished" in the module Tasks sidebar — cancels every running/queued task for that

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -346,14 +346,16 @@ function onCanvasDrop(event: DragEvent) {
   const def = dragDef
   dragDef = null
   const id = `${def.fun_name}.${Date.now()}`
-  const scope = 'image'  // default; user can change in config panel
+  // Scope defaults from the task spec: a set-scope task (behaviour.hmm, clustTracks.cluster)
+  // drops in as a picnic node. The user can still change it in the config panel.
+  const scope = def.scope ?? 'image'
   const initialParams: Record<string, unknown> = {}
   for (const p of def.params) {
     if (p.default !== undefined) initialParams[p.key] = p.default
   }
   addNodes([{
     id,
-    type: 'task',
+    type: scope === 'set' ? 'picnic' : 'task',
     position: pos,
     data: {
       fn:             def.fun_name,
@@ -366,6 +368,59 @@ function onCanvasDrop(event: DragEvent) {
   }])
 }
 
+// ── Value-name propagation ────────────────────────────────────────────────────
+// A processing task's output value_name (e.g. cellposeCorrect → "cpCorrected") only exists on
+// disk after the chain runs, so a downstream node's `valueNameSelection` can't offer it from the
+// image. Instead we read the producer's declared output (TaskDef.outputValueName, or an
+// `outputValueName` param for tasks whose output name is user-set) and, when an edge is drawn,
+// prefill the downstream node's input valueName with it — auto-populated but still editable.
+
+function taskDefFor(fn: string): TaskDef | undefined {
+  return allTaskDefs.value.find(d => d.fun_name === fn)
+}
+
+// filepath vs labels — the two image fields a value_name can live under. Consumer params tag this
+// via `field` ('labels' | 'filepath' | 'imFilepath'); anything not 'labels' is a filepath.
+function normField(f: string | undefined): 'filepath' | 'labels' {
+  return f === 'labels' ? 'labels' : 'filepath'
+}
+
+// The value_name a node produces, or null if it declares none (import, plots, …).
+function nodeOutputValueName(node: Node): { name: string; field: 'filepath' | 'labels' } | null {
+  const def = taskDefFor(node.data.fn)
+  if (!def) return null
+  if (def.outputValueName)
+    return { name: def.outputValueName, field: normField(def.outputField) }
+  // Output name is a user-set param (e.g. segment.cellpose "outputValueName") → labels output.
+  const outParam = def.params?.find(p => p.key === 'outputValueName')
+  if (outParam) {
+    const v = (node.data.params?.outputValueName ?? outParam.default) as unknown
+    if (v) return { name: String(v), field: normField(outParam.field) || 'labels' }
+  }
+  return null
+}
+
+// Prefill every field-compatible valueNameSelection param on `target` with `source`'s output.
+function propagateValueName(sourceId: string, targetId: string) {
+  const source = findNode(sourceId)
+  const target = findNode(targetId)
+  if (!source || !target) return
+  const out = nodeOutputValueName(source)
+  if (!out) return
+  const def = taskDefFor(target.data.fn)
+  if (!def) return
+  const patch: Record<string, unknown> = {}
+  for (const p of def.params ?? []) {
+    if (p.type === 'valueNameSelection' && normField(p.field) === out.field)
+      patch[p.key] = out.name
+  }
+  if (Object.keys(patch).length) {
+    updateNode(targetId, {
+      data: { ...target.data, params: { ...target.data.params, ...patch } },
+    })
+  }
+}
+
 // ── Edge connections ─────────────────────────────────────────────────────────
 
 onConnect((params) => {
@@ -374,6 +429,7 @@ onConnect((params) => {
     id: `${params.source}->${params.target}`,
     style: { stroke: 'var(--cc-accent, #a78bfa)' },
   }])
+  if (params.source && params.target) propagateValueName(params.source, params.target)
 })
 
 // Double-click an edge to remove it.
@@ -447,7 +503,15 @@ const paramContext = computed(() => {
   const imgs = runSelectedUids.value.length
     ? runImages.value.filter(i => runSelectedUids.value.includes(i.uid))
     : runImages.value
-  return { images: imgs }
+  // Value_names produced by nodes feeding the selected node — offered in its valueNameSelection
+  // dropdowns even though they don't exist on the image until the chain runs.
+  const extraValueNames = selectedNodeId.value
+    ? edges.value
+        .filter(e => e.target === selectedNodeId.value)
+        .map(e => { const s = findNode(e.source); return s ? nodeOutputValueName(s)?.name : null })
+        .filter((n): n is string => !!n)
+    : []
+  return { images: imgs, extraValueNames }
 })
 
 const runAllSelected = computed(() =>

--- a/frontend/src/tasks/ParamRenderer.vue
+++ b/frontend/src/tasks/ParamRenderer.vue
@@ -14,6 +14,9 @@ export interface ParamContext {
   images: CciaImage[]
   projectUid?: string        // popSelection: needed to query the gating popmap
   values?: ParamValues       // sibling param values (popSelection reads valueName)
+  extraValueNames?: string[] // valueNameSelection: value_names not (yet) on disk — e.g. the output
+                             // of an upstream whiteboard node ("cpCorrected") that only exists once
+                             // the chain runs. Merged into the option list so it can be selected.
 }
 
 const props = defineProps<{
@@ -44,12 +47,18 @@ function imageFieldKeys(img: CciaImage, field: string | undefined): string[] {
 }
 
 const availableValueNames = computed(() => {
+  const extra = props.context?.extraValueNames ?? []
   const images = props.context?.images ?? []
-  if (images.length === 0) return ['default']
-  const field = props.param.field
-  const sets = images.map(img => new Set(imageFieldKeys(img, field)))
-  const first = sets[0]
-  return [...first].filter(k => sets.every(s => s.has(k)))
+  // Base names: intersection of what exists on the selected images (or just "default" if none).
+  const base = images.length === 0
+    ? ['default']
+    : (() => {
+        const field = props.param.field
+        const sets = images.map(img => new Set(imageFieldKeys(img, field)))
+        return [...sets[0]].filter(k => sets.every(s => s.has(k)))
+      })()
+  // Union in chain-propagated names (upstream node outputs), de-duplicated, preserving order.
+  return [...new Set([...base, ...extra])]
 })
 
 // When images change, auto-select an appropriate value name.
@@ -58,6 +67,9 @@ const availableValueNames = computed(() => {
 watch(() => props.context?.images, (images) => {
   if (props.param.type !== 'valueNameSelection') return
   if (!images || images.length === 0) return
+  // Keep an already-valid selection — notably an edge-propagated chain value like
+  // "cpCorrected" — rather than resetting it to the active/first name on every image change.
+  if (props.modelValue && availableValueNames.value.includes(props.modelValue as string)) return
   const field = props.param.field
   const first = availableValueNames.value[0] ?? 'default'
   const preferred = (field === undefined || field === 'filepath')

--- a/frontend/src/tasks/types.ts
+++ b/frontend/src/tasks/types.ts
@@ -37,6 +37,10 @@ export interface TaskDef {
   params: ParamDef[]
   resource_pool?: string  // default resource profile for this task
   scope?: string          // "image" (default) | "set" — set-scope runs once over all selected images
+  outputValueName?: string // the value_name this task produces (e.g. "cpCorrected"); read by the
+                           // whiteboard to prefill a downstream node's input valueName. Absent when
+                           // the output name is a user-set param instead (segment.cellpose).
+  outputField?: string    // which image field the output lands in ('filepath' | 'labels'); default 'filepath'
 }
 
 export type ParamValues = Record<string, unknown>


### PR DESCRIPTION
## Whiteboard: set tasks → picnic nodes, and output value_name propagation

### Set tasks weren't picnic nodes
HMM/clustering tasks declare `"scope": "set"` in their JSON, but the whiteboard drop
handler hardcoded `scope='image'` and `chain_node`/`ChainNode` defaulted to `"image"`,
so they dropped in as ordinary per-image nodes. The task JSON is now the single source
of truth: `_task_default_scope(fn)` (delegates to `task_scope`) resolves an empty scope
from the spec in `ChainNode`/`chain_node`/`_node_from_dict`; the frontend uses
`def.scope ?? 'image'`. Explicit scope and a frozen template's stored scope still win.

### Can't select an upstream node's output value_name
`import → cellposeCorrect → afDriftCorrect`: `cpCorrected` doesn't exist on the image
until the chain runs, so the downstream `valueNameSelection` couldn't offer it.
- Unified the producer output contract as a top-level `"outputValueName"` in the JSON
  (added to cellpose_correct / drift_correct / af_correct; read via
  `_spec_output_value_name(task, default)` instead of a hardcoded literal).
- On drawing an edge, `ChainModule.propagateValueName` prefills the downstream node's
  field-compatible `valueNameSelection` params with the upstream output — auto-populated,
  editable. `paramContext.extraValueNames` + `ParamRenderer` (union into the option list,
  keep an already-valid edge value) make the not-yet-on-disk name selectable.

### Verification
- Julia tests pass (added scope-from-spec + output-value-name-from-spec testsets).
- Frontend typechecks (`vue-tsc -b`).
- Docs: SCHEDULER.md (Node scopes, Value-name propagation), MODULES.md, TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)