### PR TITLE
Fix chain template dir mismatch (settings/chains) — chain runs failed

### DIFF
--- a/app/src/tasks/chain.jl
+++ b/app/src/tasks/chain.jl
@@ -96,7 +96,25 @@ end
 
 # ── Filesystem helpers ────────────────────────────────────────────────────────
 
-_chains_dir(proj::CciaProject)::String         = joinpath(proj.root, "chains")
+# Chains live under `<proj>/settings/chains/` — the same location the API layer reads/writes
+# (`_chains_dir_for_project` in api/src/routes.jl). These MUST agree: the whiteboard saves a
+# template through the API, then `run_chain` loads it through here. They diverged once (API moved
+# chains into settings/, this stayed at `<proj>/chains/`) and every chain run failed with
+# "template not found" — keep them in sync. Mirrors the API's legacy-location migration so a
+# REPL-first project (or one predating settings/) is picked up too.
+function _chains_dir(proj::CciaProject)::String
+    newdir = joinpath(proj.root, "settings", "chains")
+    olddir = joinpath(proj.root, "chains")   # legacy location (pre-settings/)
+    if isdir(olddir) && !isdir(newdir)
+        try
+            mkpath(joinpath(proj.root, "settings"))
+            mv(olddir, newdir)
+        catch e
+            @warn "Could not migrate chains into settings/" project=proj.uid exception=e
+        end
+    end
+    newdir
+end
 _template_path(proj::CciaProject, name::String) = joinpath(_chains_dir(proj), "$name.json")
 _runs_dir(proj::CciaProject)::String           = joinpath(_chains_dir(proj), "runs")
 _cache_dir(proj::CciaProject)::String          = joinpath(_chains_dir(proj), ".cache")

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -363,6 +363,12 @@ end
         )
         save_chain_template!(proj, tpl)
 
+        # Templates must land under settings/chains — the SAME dir the API reads/writes
+        # (api/src/routes.jl _chains_dir_for_project). A divergence here made every whiteboard
+        # chain run fail with "template not found" (saved via API, loaded via package).
+        @test isfile(joinpath(proj.root, "settings", "chains", "test-chain.json"))
+        @test !isfile(joinpath(proj.root, "chains", "test-chain.json"))
+
         loaded = load_chain_template(proj, "test-chain")
         @test loaded.name == "test-chain"
         @test length(loaded.nodes) == 2

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -288,12 +288,20 @@ propagation is an **authoring-time convenience**, not a second execution path.
 
 Two distinct artifacts. This matters for reproducibility.
 
-**Template** (`<project>/chains/<name>.json`) — reusable, no images baked in.
+**Template** (`<project>/settings/chains/<name>.json`) — reusable, no images baked in.
 Editing a template after a run has started does not retroactively change what that run did.
 
-**Run record** (`<project>/chains/runs/<run_id>/run.json`) — created when a template is applied
-to a set of images. Stores a **frozen copy** of the template via a SHA-256 content hash, not a
-pointer to the template file. The template content is cached once under `chains/.cache/<hash>.json`.
+> **Path must match the API.** Chains live under `settings/chains/`, computed identically by the
+> package (`_chains_dir` in `chain.jl`) and the API (`_chains_dir_for_project` in `api/src/routes.jl`).
+> The whiteboard **saves** a template through the API, then `run_chain` **loads** it through the
+> package — if the two dirs disagree, every chain run fails with "template not found". They once
+> diverged (API moved to `settings/chains/`, the package stayed at `<project>/chains/`); both now
+> also migrate a legacy `<project>/chains/` on access. A round-trip test asserts the settings/ path.
+
+**Run record** (`<project>/settings/chains/runs/<run_id>/run.json`) — created when a template is
+applied to a set of images. Stores a **frozen copy** of the template via a SHA-256 content hash, not
+a pointer to the template file. The template content is cached once under
+`settings/chains/.cache/<hash>.json`.
 
 Run records store `template_hash` (not the template inline) to keep `run.json` compact.
 `load_chain_run` resolves the hash to the cached template.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -240,6 +240,18 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00068** — **Every whiteboard chain run failed: "Chain template not found"** (2026-07-03)
+The API layer reads/writes chain templates under `<proj>/settings/chains/` (`_chains_dir_for_project`,
+after chains were consolidated into `settings/`), but the package's `_chains_dir` (`chain.jl`) still
+pointed at the legacy `<proj>/chains/`. So the whiteboard **saved** a template via the API (into
+`settings/chains/`, "Chain X saved" succeeded) and then `run_chain` **loaded** it via the package
+(from `<proj>/chains/`) → `ErrorException("Chain template not found: …/chains/3P.json")` on every
+run. Repointed `_chains_dir` at `settings/chains` to match the API, mirroring its legacy-location
+migration so REPL-first / pre-`settings/` projects are picked up too (templates, runs, and .cache all
+move together). Regression guard: the round-trip test now asserts the template lands under
+`settings/chains/` and not `chains/`. Docs: SCHEDULER.md (*Template vs run record* — added a
+"paths must match the API" note).
+
 **#00067** — **Per-image task-param memory (R moduleFunParams port); replaces cross-project localStorage** (2026-07-03)
 Module-page task params were kept in `localStorage` keyed by `module:task` — not scoped by project,
 so switching projects left the previous project's image/channel/pop selections in the form. The old


### PR DESCRIPTION
## Fix chain template dir mismatch — every chain run failed with "template not found"

The API reads/writes chain templates under `<proj>/settings/chains/`
(`_chains_dir_for_project`, after chains were consolidated into `settings/`), but the
package's `_chains_dir` (`chain.jl`) still pointed at the legacy `<proj>/chains/`. So the
whiteboard **saved** a template via the API (`"Chain X saved"` succeeded) and then
`run_chain` **loaded** it via the package from the wrong dir → every run failed with
`ErrorException("Chain template not found: …/chains/<name>.json")`.

Repointed `_chains_dir` at `settings/chains` to match the API, mirroring its
legacy-location migration so REPL-first / pre-`settings/` projects are picked up too
(templates, runs, `.cache` move together).

- Regression guard: the round-trip test asserts the template lands under `settings/chains/`
  and not `chains/`.
- Docs: SCHEDULER.md (*Template vs run record* — "paths must match the API").

Julia tests pass (642, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)