### PR TITLE
Chain fault isolation: gate on predecessors, not globally (DAG fan-out)

### DIFF
--- a/app/src/tasks/chain.jl
+++ b/app/src/tasks/chain.jl
@@ -410,6 +410,14 @@ function _execute_image_chain!(run::ChainRun, image_uid::String,
     # Exclude them from fault-isolation checks so a failed plot never kills the pipeline.
     incremental_ids = Set(n.id for n in ordered_nodes if n.scope == "incremental")
 
+    # Direct predecessors per node — for predecessor-based fault isolation. In a fan-out
+    # (afDriftCorrect → two independent segmentations) a failed sibling must NOT skip the other
+    # branch, so we gate on a node's OWN predecessors, not on "did any node anywhere fail".
+    preds = Dict{String,Vector{String}}(n.id => String[] for n in ordered_nodes)
+    for e in run.template_snapshot.edges
+        haskey(preds, e.to) && push!(preds[e.to], e.from)
+    end
+
     for node in ordered_nodes
         # Set-scope (picnic) node: always arrive at barrier (avoids deadlock even when
         # cancelled). If cancelled, skip waiting for the set-scope runner to finish.
@@ -430,11 +438,19 @@ function _execute_image_chain!(run::ChainRun, image_uid::String,
             continue
         end
 
-        # Fault isolation: skip downstream nodes if any earlier non-incremental node failed.
-        if any(st.status ∈ (:failed, :cancelled)
-               for (nid, st) in run.image_states[image_uid] if nid ∉ incremental_ids)
-            _update_node_state!(run, image_uid, node.id; status=:skipped, fn=node.fn)
-            continue
+        # Fault isolation: skip this node only if one of ITS OWN predecessors failed/was skipped —
+        # so independent branches in a fan-out stay independent (a failed sibling doesn't skip us).
+        # `:skipped` is in the trigger set so a failure propagates transitively down a branch
+        # (pred failed → this node skipped → its successor sees a skipped pred → also skipped).
+        # Topo order guarantees every predecessor's status is already set when we reach this node.
+        # Incremental (plot) predecessors never gate.
+        let states = run.image_states[image_uid]
+            if any(p -> p ∉ incremental_ids && haskey(states, p) &&
+                        states[p].status ∈ (:failed, :cancelled, :skipped),
+                   preds[node.id])
+                _update_node_state!(run, image_uid, node.id; status=:skipped, fn=node.fn)
+                continue
+            end
         end
 
         effective_params = _apply_overrides(node.params, node.id, overrides)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -485,6 +485,53 @@ end
         rm(proj.root; recursive=true)
     end
 
+    # ── Fault isolation is per-predecessor, not global (DAG fan-out) ─────────────
+    # A failed branch must not skip a SIBLING branch that shares only an upstream ancestor
+    # (e.g. afDriftCorrect → two independent segmentations). Regression guard for the
+    # over-broad "any node failed → skip" check that skipped independent branches.
+    @testset "Chain fault isolation — independent fan-out" begin
+        proj = create_project!(name="chain-fanout-$(rand(1000:9999))", kind="static")
+        s    = add_set!(proj; name="s")
+        img  = add_image!(s; name="img")
+
+        # a → { b (fails), c (ok) } — c is independent of b, must still run
+        save_chain_template!(proj, ChainTemplate("fanout",
+            [ChainNode(id="a", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="b", fn="nonexistent.task",    scope="image", params=Dict{String,Any}()),
+             ChainNode(id="c", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}())],
+            [ChainEdge("a","b"), ChainEdge("a","c")]))
+        st = run_chain(proj, [img.uid]; chain="fanout").image_states[img.uid]
+        @test st["a"].status == :done
+        @test st["b"].status == :failed
+        @test st["c"].status == :done       # independent sibling — NOT skipped by b's failure
+
+        # a (fails) → { b, c } — the shared ancestor failing skips BOTH branches
+        save_chain_template!(proj, ChainTemplate("fanout-root-fail",
+            [ChainNode(id="a", fn="nonexistent.task",    scope="image", params=Dict{String,Any}()),
+             ChainNode(id="b", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="c", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}())],
+            [ChainEdge("a","b"), ChainEdge("a","c")]))
+        st2 = run_chain(proj, [img.uid]; chain="fanout-root-fail").image_states[img.uid]
+        @test st2["a"].status == :failed
+        @test st2["b"].status == :skipped
+        @test st2["c"].status == :skipped
+
+        # transitive: a → b(fail) → c → d — skip propagates down the branch via :skipped
+        save_chain_template!(proj, ChainTemplate("chain-transitive",
+            [ChainNode(id="a", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="b", fn="nonexistent.task",    scope="image", params=Dict{String,Any}()),
+             ChainNode(id="c", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="d", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}())],
+            [ChainEdge("a","b"), ChainEdge("b","c"), ChainEdge("c","d")]))
+        st3 = run_chain(proj, [img.uid]; chain="chain-transitive").image_states[img.uid]
+        @test st3["a"].status == :done
+        @test st3["b"].status == :failed
+        @test st3["c"].status == :skipped   # pred b failed
+        @test st3["d"].status == :skipped   # pred c skipped → propagates
+
+        rm(proj.root; recursive=true)
+    end
+
     # ── Picnic node — require_all aborts if any image failed upstream ────────
     @testset "Picnic node — require_all policy" begin
         proj = create_project!(name="picnic-req-$(rand(1000:9999))", kind="static")

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -400,8 +400,17 @@ run_chain(proj, uids; chain="my-chain")
                               → :failed
                               → :cancelled (cancel_chain_run! killed the subprocess mid-run)
          → :queued → :cancelled (cancel flag seen before the pool worker picked it up)
-         → :skipped  (fault isolation: predecessor :failed/:cancelled)
+         → :skipped  (fault isolation: a DIRECT predecessor is :failed/:cancelled/:skipped)
 ```
+
+**Fault isolation is per-predecessor, not global.** A node is skipped only when one of its *own*
+direct predecessors failed/was cancelled/was skipped — not when *any* node in the chain failed.
+This keeps independent branches of a fan-out independent: with `afDriftCorrect → {segA, segB}`, a
+failure in `segA` does not skip `segB` (they share only the upstream ancestor). `:skipped` is in
+the trigger set so a failure propagates transitively down a branch (pred failed → node skipped →
+its successor sees a skipped pred → also skipped). Topo order guarantees every predecessor's status
+is set before a node is evaluated. Incremental (plot) predecessors never gate. The predecessor map
+is built from `template_snapshot.edges` in `_execute_image_chain!`.
 
 `:queued` is the slot-wait state (job submitted to its pool, no worker free yet); `:running` is
 set when a pool worker actually starts the job — see Queue visibility above.


### PR DESCRIPTION
## Chain fault isolation: gate on predecessors, not globally (DAG fan-out)

The fault-isolation check skipped a node if **any** earlier node for the image failed. Fine
for a linear chain, but in a fan-out (`afDriftCorrect → two independent segmentations`) a
failure in one branch wrongly skipped the sibling that shares only an upstream ancestor.

Now a node is skipped only when one of **its own** direct predecessors is
`:failed`/`:cancelled`/`:skipped` (predecessor map from `template_snapshot.edges`). `:skipped`
is in the trigger set so failure still propagates transitively; topo order guarantees
predecessors are resolved first; incremental (plot) preds never gate.

Tests: new "independent fan-out" testset (sibling still runs; shared-ancestor failure skips
both; transitive propagation). Docs: SCHEDULER.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)