### PR TITLE
feat(metadata): flag that calibration edits don't reach existing vari…

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -247,7 +247,10 @@ with, or just the focused image if none), **Copy to selected** (the other select
 **Fill flagged** (only the *other* selected images that currently show a warning — the
 batch-fix-from-a-known-good-reference workflow). Also reachable via an "Open editor" button in
 `MetadataPanel`'s sidebar (no specific image clicked — focuses the first selected/set image)
-alongside a flagged-count badge for the set.
+alongside a flagged-count badge for the set. When a target already has processed versions or
+segmentations, a second (informational) line via `downstreamArtifactsNote` reminds that those were
+built with the current calibration and must be re-run — corrections/measurements read pixel size
+from the zarr, not this dialog, so an edit doesn't reach them retroactively.
 
 **Name-column header buttons** (`ImageTable.vue`, next to "Name"): a `pi-exclamation-triangle`
 toggle to select/deselect every currently-flagged image in one click (`selectFlagged`, amber when

--- a/frontend/src/components/PhysicalSizeDialog.vue
+++ b/frontend/src/components/PhysicalSizeDialog.vue
@@ -10,7 +10,7 @@ import { ref, computed, watch } from 'vue'
 import { useProjectStore, type CciaImage } from '../stores/project'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useLogStore } from '../stores/log'
-import { metadataWarning, flaggedFields, type PhysField as WarnField } from '../lib/imageMetadataWarnings'
+import { metadataWarning, flaggedFields, downstreamArtifactsNote, type PhysField as WarnField } from '../lib/imageMetadataWarnings'
 
 const props = defineProps<{
   setUid: string
@@ -26,6 +26,14 @@ const log         = useLogStore()
 const setImages = computed(() => project.sets.find(s => s.uid === props.setUid)?.images ?? [])
 const focusedImg = computed(() => setImages.value.find(i => i.uid === props.focusUid) ?? null)
 const focusedWarning = computed(() => focusedImg.value ? metadataWarning(focusedImg.value) : null)
+// Any target that already has processed versions/segmentations built from its current calibration.
+const downstreamNote = computed(() => {
+  for (const uid of targetUids.value) {
+    const note = downstreamArtifactsNote(setImages.value.find(i => i.uid === uid) ?? ({} as CciaImage))
+    if (note) return note
+  }
+  return null
+})
 
 // Always includes — and leads with — the focused image (the one whose icon was actually
 // clicked), regardless of whether it happens to be checked: opening an image's own editor must
@@ -250,6 +258,10 @@ async function fillFlagged() {
           <i class="pi pi-exclamation-triangle" /> {{ focusedWarning.short }}
         </p>
 
+        <p v-if="downstreamNote" class="rerun-line" v-tooltip.bottom="downstreamNote.long">
+          <i class="pi pi-history" /> {{ downstreamNote.short }}
+        </p>
+
         <div class="toggle-row" v-tooltip.bottom="'Which fields Apply / Copy / Fill flagged write — untick what\'s already correct.'">
           <label class="toggle-chip" :class="{ on: includeX, warn: targetFlags.has('x') }"><input type="checkbox" v-model="includeX" />X</label>
           <label class="toggle-chip" :class="{ on: includeY, warn: targetFlags.has('y') }"><input type="checkbox" v-model="includeY" />Y</label>
@@ -357,6 +369,14 @@ async function fillFlagged() {
   display: flex; align-items: center; gap: 0.4rem; margin: 0;
   font-size: 0.78rem; color: #fcd34d;
   background: #7c2d1244; border: 1px solid #92400e55;
+  border-radius: 0.3rem; padding: 0.35rem 0.55rem; cursor: help;
+}
+
+/* Informational (not an error): downstream artifacts need a re-run after a calibration change. */
+.rerun-line {
+  display: flex; align-items: center; gap: 0.4rem; margin: 0;
+  font-size: 0.78rem; color: var(--cc-text-dim);
+  background: var(--cc-surface-2); border: 1px solid var(--cc-border);
   border-radius: 0.3rem; padding: 0.35rem 0.55rem; cursor: help;
 }
 

--- a/frontend/src/lib/imageMetadataWarnings.ts
+++ b/frontend/src/lib/imageMetadataWarnings.ts
@@ -118,3 +118,17 @@ export function metadataWarning(img: CciaImage): MetadataWarning | null {
 export function flaggedFields(img: CciaImage): Set<PhysField> {
   return new Set(fieldIssues(img).map(i => i.field))
 }
+
+// Processed versions (drift/AF/cellpose) and segmentations bake in the calibration they were built
+// with — corrections and measurements read pixel size from the image zarr, not this dialog — so a
+// calibration change (or one that was wrong from the start) doesn't reach them until they're re-run.
+export function downstreamArtifactsNote(img: CciaImage): MetadataWarning | null {
+  const hasVariants = Object.keys(img.filepaths ?? {}).some(k => k !== 'default')
+  const hasSegs = Object.keys(img.labels ?? {}).length > 0
+  if (!hasVariants && !hasSegs) return null
+  return {
+    short: 'Has processed versions/segmentations — re-run them after correcting',
+    long: 'Existing corrections, segmentations and measurements were built with the current ' +
+      'calibration and won’t update on their own. Re-run them so analysis uses the new values.',
+  }
+}


### PR DESCRIPTION
## feat(metadata): flag that calibration edits don't reach existing variants/segmentations

Follow-up to #34 (physical-size/timing calibration cleanup). A calibration correction is written to
the `"default"` zarr, but the correction tasks bake calibration into each processed variant and the
measurement tasks read pixel size from the image zarr (not ccid.json). So editing calibration after
processed versions or segmentations exist — or importing with wrong calibration and only fixing it
later — leaves those downstream results on the old values until they're re-run.

`PhysicalSizeDialog` now shows a concise informational line (`downstreamArtifactsNote`) whenever a
target image already has processed versions or segmentations, reminding the user to re-run them.
Detected client-side from the image payload's `filepaths` (versions) and `labels`.

Styled as a muted info line (not the amber error style); one short line + tooltip detail.

Docs: `UI.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)