### PR TITLE
Phase 1: multithreaded API (threads + handler offload + HDF5 lock)

### DIFF
--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -335,14 +335,21 @@ function handle_stream(stream::HTTP.Stream)
     end
 
     body_bytes = read(stream)
-    # A handler exception would otherwise surface as an opaque 500 with no body — catch it,
-    # log it, and return the message as JSON so the client (and logs) show the real cause.
-    status, body = try
-        handle_http(req, body_bytes)
-    catch e
-        @error "Unhandled error in $(req.method) $(req.target)" exception = (e, catch_backtrace())
-        500, JSON3.write((; error = sprint(showerror, e)))
-    end
+    # Run the handler on the thread POOL (not this connection's task), so a CPU/IO-bound handler — e.g.
+    # a big HDF5 label-table read, a blocking C call that never yields — doesn't stall the accept loop
+    # or other in-flight requests (a napari open would otherwise queue behind it). Under `-t 1` this is
+    # just a cooperative task (no behaviour change); under `-t auto` it's real parallelism. Shared state
+    # is already lock-guarded (WS clients, napari, chain runs) and Julia HDF5 is serialised via
+    # `_with_h5`. Error handling lives INSIDE the spawned task, so `fetch` always yields a (status, body)
+    # tuple and never rethrows a TaskFailedException.
+    status, body = fetch(Threads.@spawn begin
+        try
+            handle_http(req, body_bytes)
+        catch e
+            @error "Unhandled error in $(req.method) $(req.target)" exception = (e, catch_backtrace())
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
+    end)
 
     # Binary handlers (gating plotdata/density/membership) return a byte vector → octet-stream;
     # everything else returns a JSON string.

--- a/app/src/label_props.jl
+++ b/app/src/label_props.jl
@@ -2,6 +2,16 @@ using HDF5
 using DataFrames
 using JSON3
 
+# HDF5.jl / the underlying libhdf5 we link is NOT thread-safe: concurrent `h5open` (even on different
+# files) from parallel tasks can crash or corrupt. This is the single Julia HDF5 chokepoint — every
+# read/write here goes through `_with_h5`, which serialises access under one process-wide lock. It's a
+# no-op under `-t 1`, and the safety net once the server runs multithreaded (parallel API handlers AND
+# the scheduler's per-image task functions, both of which land here). ReentrantLock so a task that
+# nests HDF5 calls doesn't self-deadlock.
+const _HDF5_LOCK = ReentrantLock()
+_with_h5(f::Function, path::AbstractString, mode::AbstractString="r") =
+    lock(() -> h5open(f, path, mode), _HDF5_LOCK)
+
 # ── LabelProps — Julia-native lazy reader for AnnData .h5ad ──────────────────────
 #
 # Mirrors the old Python `LabelPropsView` (inst/py/label_props_view.py) but reads
@@ -168,7 +178,7 @@ end
 
 """Feature names (var_names) or obs column names."""
 function col_names(lp::LabelProps; data_type::Symbol=:vars)::Vector{String}
-    h5open(lp.path, "r") do fid
+    _with_h5(lp.path, "r") do fid
         if data_type === :vars
             return _as_strings(read(fid["var/_index"]))
         elseif data_type === :obs
@@ -186,7 +196,7 @@ _intensity_measure(fid) = haskey(fid, "uns/intensity_measure") ?
 
 """Per-channel intensity var names (e.g. `mean_intensity_0`). Renamed to channel names if requested."""
 function channel_columns(lp::LabelProps; as_channel_names::Bool=false)::Vector{String}
-    h5open(lp.path, "r") do fid
+    _with_h5(lp.path, "r") do fid
         vars = _as_strings(read(fid["var/_index"]))
         measure = _intensity_measure(fid)
         pat = Regex("(^|_)$(measure)_intensity_\\d+\$")
@@ -210,7 +220,7 @@ end
 """Spatial centroid column names from `uns/spatial_cols` (skimage order: z?, y, x),
 optionally restricted to `order` length. Mirrors the Python `LabelPropsView.centroid_columns`."""
 function centroid_columns(lp::LabelProps; order=nothing)::Vector{String}
-    h5open(lp.path, "r") do fid
+    _with_h5(lp.path, "r") do fid
         cols = haskey(fid, "uns/spatial_cols") ? _as_strings(read(fid["uns/spatial_cols"])) : String[]
         if !isnothing(order)
             want = ["centroid-$(i)" for i in 0:(length(order)-1)]   # array-order names
@@ -223,7 +233,7 @@ end
 """Temporal column names from `uns/temporal_cols` (e.g. `["t"]`; empty for non-timecourse).
 Mirrors the Python `LabelPropsView.temporal_columns`."""
 function temporal_columns(lp::LabelProps)::Vector{String}
-    h5open(lp.path, "r") do fid
+    _with_h5(lp.path, "r") do fid
         haskey(fid, "uns/temporal_cols") ? _as_strings(read(fid["uns/temporal_cols"])) : String[]
     end
 end
@@ -236,7 +246,7 @@ end
 Reads only the requested columns from disk. Always includes a `label` column.
 """
 function as_df(lp::LabelProps; include_x::Bool=lp.include_x, include_obs::Bool=lp.include_obs)::DataFrame
-    h5open(lp.path, "r") do fid
+    _with_h5(lp.path, "r") do fid
         # ── index + sizes ──
         labels_raw = _as_strings(read(fid["obs/_index"]))
         n_obs = length(labels_raw)
@@ -330,7 +340,7 @@ as_matrix(lp::LabelProps) = as_df(lp; include_x=true, include_obs=false)
 Names of the `obsm` matrices present in the file (e.g. `["spatial", "temporal", "X_umap"]`).
 """
 function obsm_keys(lp::LabelProps)::Vector{String}
-    h5open(lp.path, "r") do fid
+    _with_h5(lp.path, "r") do fid
         haskey(fid, "obsm") ? collect(String, keys(fid["obsm"])) : String[]
     end
 end
@@ -344,7 +354,7 @@ column from `as_df` for alignment. Returns a `0×0` matrix if the key is absent.
 (AnnData writes `(n_obs, k)` C-order; HDF5.jl may report it transposed).
 """
 function obsm(lp::LabelProps, key::AbstractString)::Matrix{Float64}
-    h5open(lp.path, "r") do fid
+    _with_h5(lp.path, "r") do fid
         haskey(fid, "obsm/$key") || return Matrix{Float64}(undef, 0, 0)
         n_obs = length(_as_strings(read(fid["obs/_index"])))
         dset  = fid["obsm/$key"]
@@ -442,7 +452,7 @@ function save!(lp::LabelProps)
     # dataset (e.g. overwriting a categorical hmm.state with a numeric one in one chain).
     drops = filter(c -> c ∉ valcols, drops)
 
-    h5open(lp.path, "r+") do fid
+    _with_h5(lp.path, "r+") do fid
         obs        = fid["obs"]
         idx_labels = _maybe_int.(_as_strings(read(obs["_index"])))
         rowof      = Dict(l => i for (i, l) in enumerate(idx_labels))

--- a/pixi.toml
+++ b/pixi.toml
@@ -77,8 +77,12 @@ torchvision = ">=0.21"
 # [target.win-64.tasks] block below).
 [tasks]
 # Backend — Julia API server (port 8080). NB: api/src/*.jl are NOT Revise-tracked → restart for api edits.
-dev  = { cmd = "julia --project -e 'using Revise; includet(\"src/server.jl\")'", cwd = "api" }  # hot-reload (development)
-prod = { cmd = "julia --project src/server.jl", cwd = "api" }                                    # plain include (production)
+# `-t auto` runs the API multithreaded: handlers run on the thread pool so a blocking HDF5 read no
+# longer stalls the accept loop / a napari open, and the scheduler's per-image task functions
+# (Threads.@spawn) actually parallelise. Julia HDF5 is serialised via `_with_h5`; shared API state is
+# lock-guarded. Override with JULIA_NUM_THREADS if you want a fixed count.
+dev  = { cmd = "julia --project -t auto -e 'using Revise; includet(\"src/server.jl\")'", cwd = "api" }  # hot-reload (development)
+prod = { cmd = "julia --project -t auto src/server.jl", cwd = "api" }                                    # plain include (production)
 
 # Frontend — Vite (port 5173).
 frontend = { cmd = "npm run dev", cwd = "frontend" }    # dev server, hot reload


### PR DESCRIPTION
## Phase 1: multithreaded API (threads + handler offload + HDF5 lock)

Runs the API multithreaded so a blocking handler no longer stalls everything else. A big
HDF5 label-table read is a C call that never yields, so on a single thread it froze the
accept loop — a napari open (or any request) queued behind it.

### Changes
- **`pixi.toml`** — launch Julia with `-t auto` (dev + prod); override via `JULIA_NUM_THREADS`.
- **`api/src/server.jl`** — each handler runs on the thread pool (`Threads.@spawn` + `fetch`),
  with error handling inside the spawned task so `fetch` always yields `(status, body)`.
  No-op under `-t 1`; real parallelism under `-t auto`.
- **`app/src/label_props.jl`** — `_with_h5` wraps every `h5open` (8 sites) in one process-wide
  `ReentrantLock`. HDF5.jl/libhdf5 is not thread-safe — concurrent opens can crash/corrupt;
  this is the single Julia HDF5 chokepoint for both API handlers and the scheduler's
  now-parallel per-image task functions.

### Safety
Shared API state was already lock-guarded (WS clients, napari viewer + selection, chain runs).
`init_object` is fresh per request; no in-process PyCall.

### Verification
- Package tests pass (712 / 1 broken, unchanged).
- Concurrency smoke: 4 threads × 64 concurrent `.h5ad` reads return identical row counts.
- On-server check pending: heavy plot + simultaneous napari open should stay responsive.

### Follow-up (Phase 2, separate PR)
Audit + lock any remaining shared mutable state once mutation-heavy handlers (chain-start,
gate-save) run truly in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)