### PR TITLE
feat(settings): diagnostics panel + gated localhost-only debug console

### DIFF
--- a/api/src/repl_api.jl
+++ b/api/src/repl_api.jl
@@ -1,0 +1,102 @@
+# ── Diagnostics + (opt-in) debug console ─────────────────────────────────────────
+#
+# `GET /api/diagnostics` — read-only server health (threads, versions, memory, paths). Always on;
+# powers the Settings-page Diagnostics panel (and answers "is the multithreaded server actually on?").
+#
+# `POST /api/repl` — evaluate Julia in the SERVER process. This is arbitrary code execution, so it is
+# gated by TWO independent conditions, BOTH required:
+#   1. `CECELIA_REPL=1` — the operator explicitly opts in at launch (default off).
+#   2. the server is bound to LOOPBACK (`_BOUND_HOST` is 127.0.0.1/::1) — so the OS itself refuses
+#      non-local connections. This is the network control: unlike a Host header it can't be spoofed,
+#      because a network client cannot even open a socket to a loopback-bound server.
+# So a `0.0.0.0`-bound (network-reachable) server NEVER serves the REPL, even with the flag on — the
+# operator must relaunch with `CECELIA_HOST=127.0.0.1`. Server code is `include`d into `Main`, so eval
+# runs with `Cecelia`, `projects_dir`, etc. in scope — the point of a debug console.
+
+const _REPL_LOCK = ReentrantLock()   # serialise evals (redirect_stdout is process-global)
+# `_repl_on` is a RUNTIME toggle (the Settings switch flips it via POST /api/repl/config); it seeds from
+# CECELIA_REPL at startup so the env var still auto-enables. It is NOT a security boundary — eval is
+# hard-gated by the loopback bind below regardless — it just controls whether the console is offered.
+_repl_env_default() = lowercase(strip(get(ENV, "CECELIA_REPL", ""))) in ("1", "true", "yes", "on")
+const _repl_on = Ref{Bool}(_repl_env_default())
+_host_is_loopback() = _BOUND_HOST[] in ("127.0.0.1", "::1", "localhost", "[::1]")
+# Usable only when the toggle is on AND the server is loopback-bound. The loopback bind is the hard
+# network control (a 0.0.0.0 server never serves the REPL, toggle or not); the UI reads `replAvailable`.
+_repl_available() = _repl_on[] && _host_is_loopback()
+
+# POST /api/repl/config {enabled} — flip the runtime toggle. Not a security boundary (eval still needs a
+# loopback bind), so it's safe to accept from the UI; returns the resulting state.
+function api_repl_config(body_bytes::Vector{UInt8})
+    body = try; JSON3.read(String(body_bytes), Dict{String,Any}); catch; return 400, JSON3.write((; error="invalid JSON body")); end
+    _repl_on[] = Bool(get(body, "enabled", false))
+    200, JSON3.write((; replEnabled = _repl_on[], loopback = _host_is_loopback(), replAvailable = _repl_available()))
+end
+
+function api_diagnostics(::HTTP.Request)
+    gb(x) = round(x / 2^30; digits = 2)
+    200, JSON3.write((;
+        threads     = Threads.nthreads(),
+        julia       = string(VERSION),
+        projectsDir = projects_dir(),
+        memFreeGB   = gb(Sys.free_memory()),
+        memTotalGB  = gb(Sys.total_memory()),
+        gcLiveMB    = round(Base.gc_live_bytes() / 2^20; digits = 1),
+        host        = HOST,
+        port        = PORT,
+        loopback    = _host_is_loopback(),
+        replEnabled = _repl_on[],           # runtime toggle state
+        replAvailable = _repl_available(),  # toggle on AND loopback-bound → console usable
+    ))
+end
+
+# Render a value the way the REPL would (text/plain), length-capped so a huge object can't flood the UI.
+function _repl_show(x)::String
+    io = IOBuffer()
+    try
+        show(IOContext(io, :limit => true, :displaysize => (60, 120)), MIME"text/plain"(), x)
+    catch e
+        print(io, "<unshowable: ", sprint(showerror, e), ">")
+    end
+    s = String(take!(io))
+    length(s) > 20_000 ? s[1:20_000] * "\n… [truncated]" : s
+end
+
+function api_repl(body_bytes::Vector{UInt8})
+    _repl_on[] || return 403, JSON3.write((;
+        error = "Debug console is disabled. Turn it on in Settings."))
+    _host_is_loopback() || return 403, JSON3.write((;
+        error = "Debug console requires a loopback bind (the server is on $(_BOUND_HOST[])). " *
+                "Relaunch with CECELIA_HOST=127.0.0.1 to use it."))
+    body = try
+        JSON3.read(String(body_bytes), Dict{String,Any})
+    catch
+        return 400, JSON3.write((; error = "invalid JSON body"))
+    end
+    code = strip(string(get(body, "code", "")))
+    isempty(code) && return 400, JSON3.write((; error = "empty code"))
+    value = nothing; errmsg = nothing; output = ""
+    # capture stdout+stderr so `println`/`@info` show in the console. `redirect_stdout` swaps the
+    # PROCESS-global stream, so evals are serialised under a lock (one at a time) to avoid two evals —
+    # or another thread's output — clobbering each other; an async reader drains the pipe so large
+    # output can't deadlock on a full pipe buffer.
+    lock(_REPL_LOCK) do
+        old_o, old_e = stdout, stderr
+        rd, wr = redirect_stdout()
+        redirect_stderr(wr)
+        reader = @async read(rd, String)
+        try
+            value = Core.eval(Main, Meta.parseall(String(code)))
+        catch e
+            errmsg = sprint(showerror, e, catch_backtrace())
+        finally
+            redirect_stdout(old_o); redirect_stderr(old_e); close(wr)
+        end
+        output = fetch(reader)
+    end
+    200, JSON3.write((;
+        ok     = errmsg === nothing,
+        value  = value === nothing ? "" : _repl_show(value),
+        output = output,
+        error  = errmsg,
+    ))
+end

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -15,6 +15,7 @@ include("gating_api.jl")
 include("plotting_api.jl")
 include("tracking_api.jl")
 include("update_api.jl")
+include("repl_api.jl")
 
 # ── WS broadcast ──────────────────────────────────────────────────────────────
 
@@ -96,6 +97,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
     if method == "GET"
         status, body = if path == "/api/health"
             200, JSON3.write((; ok=true, version="CeceliaAPI"))
+        elseif path == "/api/diagnostics"
+            api_diagnostics(req)
         elseif path == "/api/version"
             api_version(req)
         elseif path == "/api/update/check"
@@ -226,6 +229,10 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_gating_pop_rename(body_bytes)
         elseif path == "/api/plot_data"
             api_plot_data(body_bytes)
+        elseif path == "/api/repl"
+            api_repl(body_bytes)
+        elseif path == "/api/repl/config"
+            api_repl_config(body_bytes)
         elseif path == "/api/update/apply"
             api_update_apply(body_bytes)
         else
@@ -366,11 +373,18 @@ end
 
 # ── Entry point ───────────────────────────────────────────────────────────────
 
-const HOST = get(ENV, "CECELIA_HOST", "0.0.0.0")
+# Cecelia is a LOCAL app, so bind loopback by default — not reachable from the network, which is both
+# the safer default and what lets the debug console run (its hard gate is a loopback bind). Set
+# CECELIA_HOST=0.0.0.0 to deliberately expose it (the console then refuses to run).
+const HOST = get(ENV, "CECELIA_HOST", "127.0.0.1")
 const PORT = parse(Int, get(ENV, "CECELIA_PORT", "8080"))
+# The address the server is ACTUALLY bound to (set in `start`). The debug REPL keys off this: it only
+# runs when the bind is loopback, so a loopback bind — not a spoofable header — is the network control.
+const _BOUND_HOST = Ref{String}("")
 
 function start(; host=HOST, port=PORT)
-    @info "CeceliaAPI starting" host port projects_dir=projects_dir()
+    _BOUND_HOST[] = string(host)
+    @info "CeceliaAPI starting" host port threads=Threads.nthreads() projects_dir=projects_dir()
     HTTP.listen(handle_stream, host, port)
 end
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,9 +1,11 @@
 # HTTP / WebSocket API
 
 The Julia API server (`api/src/server.jl`) exposes the package over HTTP + WS on port
-**8080** (Vite dev proxies `/api` and `/ws` → 8080). The package itself
-(`Cecelia.jl`) is headless and HTTP-agnostic (`ARCHITECTURE.md`); routes are thin adapters
-that resolve objects and call package functions.
+**8080** (Vite dev proxies `/api` and `/ws` → 8080). It binds **`127.0.0.1`** by default
+(Cecelia is a local app); set `CECELIA_HOST=0.0.0.0` to expose it on the network. Handlers run on
+the thread pool (`-t auto`), so a blocking read doesn't stall the accept loop; Julia HDF5 access is
+serialised (`_with_h5`). The package itself (`Cecelia.jl`) is headless and HTTP-agnostic
+(`ARCHITECTURE.md`); routes are thin adapters that resolve objects and call package functions.
 
 ## Conventions
 
@@ -43,6 +45,9 @@ that resolve objects and call package functions.
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/api/health` | liveness |
+| GET | `/api/diagnostics` | server health: threads, Julia version, memory, bound host/port, projects dir, debug-console state — powers Settings → Diagnostics |
+| POST | `/api/repl` | `{code}` — evaluate Julia in the server's `Main` (value + captured stdout/stderr + error). **Gated**: only when the debug console is toggled on AND the server is loopback-bound; a `0.0.0.0` bind always refuses it. Localhost-only dev tool (`repl_api.jl`) |
+| POST | `/api/repl/config` | `{enabled}` — flip the runtime debug-console toggle (Settings → Developer). Not a security boundary; eval is still loopback-gated |
 | GET | `/api/projects`, POST `/api/projects/{list,create,load,save,rename}` | project CRUD |
 | POST | `/api/sets/{create,delete}` | set CRUD |
 | GET | `/api/images/meta`, POST `/api/images/{register,delete,channelnames,labels/delete}`, `/api/images/attr/{create,delete,set}` | image CRUD/metadata |

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -104,3 +104,28 @@ Cut **off `main`** after the relevant PRs have merged, by pushing a tag:
   makes the `releases/latest` install one-liner resolve.
 
 Rationale and the full packaging/update model live in [`docs/SHIPPING.md`](SHIPPING.md).
+
+## Diagnostics & debug console
+
+**Settings → Diagnostics** (always on) shows server threads, Julia version, memory, the bound
+host/port, and the projects dir — read from `GET /api/diagnostics`. Use it to confirm the API is
+multithreaded (`threads` > 1; the server also logs `threads=N` at startup) and to see the bind.
+
+**Settings → Developer → "Enable debug console"** exposes a Julia REPL that evaluates in the running
+server's `Main` (so `Cecelia`, `projects_dir`, scheduler/napari state are all in scope) — e.g.
+`Threads.nthreads()`, inspecting a `label_props`, poking a `CciaImage`. It returns the value plus
+captured `stdout`/`stderr`.
+
+Because that is arbitrary code execution, it is gated:
+
+- **Hard gate — a loopback bind.** Eval runs only when the server is bound to `127.0.0.1`/`::1`. A
+  `0.0.0.0` (network-reachable) server refuses it regardless of the toggle — the OS won't accept a
+  remote connection to a loopback socket, so there's no header to spoof. The default bind is loopback
+  (`CECELIA_HOST`), so it works out of the box locally; deliberately exposing the server with
+  `CECELIA_HOST=0.0.0.0` disables the console.
+- **Runtime toggle.** The Settings switch flips a server flag via `POST /api/repl/config` (no
+  restart); it seeds from `CECELIA_REPL=1`. Off by default. It is *not* a security boundary — the
+  loopback gate is.
+
+Implementation: `api/src/repl_api.jl`. `redirect_stdout` is process-global, so evals are serialised
+under a lock and drained by an async pipe reader.

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -76,11 +76,69 @@ async function applyUpdate() {
 }
 
 onMounted(checkUpdates)
+
+// ── Diagnostics + debug console ──────────────────────────────────────────────
+interface Diag {
+  threads: number; julia: string; projectsDir: string
+  memFreeGB: number; memTotalGB: number; gcLiveMB: number
+  host: string; port: number; loopback: boolean
+  replEnabled: boolean; replAvailable: boolean
+}
+const diag = ref<Diag | null>(null)
+const diagBusy = ref(false)
+const replToggle = ref(false)   // mirrors the server's runtime enable flag (diag.replEnabled)
+async function loadDiag() {
+  diagBusy.value = true
+  try {
+    diag.value = await (await fetch('/api/diagnostics')).json() as Diag
+    replToggle.value = !!diag.value?.replEnabled
+  } catch { diag.value = null }
+  finally { diagBusy.value = false }
+}
+// flip the server-side runtime flag; loopback bind is still required for the console to work (server-side)
+async function toggleRepl() {
+  const enabled = replToggle.value
+  try {
+    await fetch('/api/repl/config', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ enabled }),
+    })
+  } catch { /* ignore — loadDiag re-syncs the true state */ }
+  await loadDiag()
+}
+
+// gated debug REPL (only rendered when the server reports replEnabled)
+interface ReplEntry { code: string; ok: boolean; value?: string; output?: string; error?: string }
+const replCode = ref('')
+const replBusy = ref(false)
+const replLog = ref<ReplEntry[]>([])
+async function runRepl() {
+  const code = replCode.value.trim()
+  if (!code || replBusy.value) return
+  replBusy.value = true
+  try {
+    const res = await fetch('/api/repl', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ code }),
+    })
+    const d = await res.json() as { ok?: boolean; value?: string; output?: string; error?: string }
+    replLog.value.push({ code, ok: res.ok && !!d.ok, value: d.value, output: d.output, error: d.error })
+    if (res.ok) replCode.value = ''
+  } catch (e) {
+    replLog.value.push({ code, ok: false, error: String(e) })
+  } finally { replBusy.value = false }
+}
+// ⌘/Ctrl+Enter runs (plain Enter stays a newline — it's a multi-line editor)
+function replKeydown(e: KeyboardEvent) {
+  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); runRepl() }
+}
+onMounted(loadDiag)
 </script>
 
 <template>
   <div class="settings-page">
     <h1 class="page-title">Settings</h1>
+
+    <div class="settings-cols">
+    <div class="settings-col">
 
     <!-- ── Project ─────────────────────────────────────────────────────── -->
     <section class="settings-section">
@@ -179,13 +237,103 @@ onMounted(checkUpdates)
 
       <span v-if="updateMsg" class="field-hint">{{ updateMsg }}</span>
     </section>
+
+    </div>
+    <div class="settings-col">
+
+    <!-- ── Diagnostics ─────────────────────────────────────────────────── -->
+    <section class="settings-section">
+      <h2 class="section-title">Diagnostics</h2>
+
+      <div v-if="diag" class="diag-grid">
+        <span>Server threads</span><span class="mono">{{ diag.threads }}</span>
+        <span>Julia</span><span class="mono">{{ diag.julia }}</span>
+        <span>Memory</span><span class="mono">{{ diag.memFreeGB }} / {{ diag.memTotalGB }} GB free · GC live {{ diag.gcLiveMB }} MB</span>
+        <span>Host</span><span class="mono">{{ diag.host }}:{{ diag.port }}</span>
+        <span>Projects dir</span><span class="mono">{{ diag.projectsDir }}</span>
+      </div>
+
+      <div class="field-row" style="margin-top:0.6rem">
+        <button class="save-btn" :disabled="diagBusy" @click="loadDiag" v-tooltip.right="'Re-read server diagnostics'">
+          <i :class="['pi', diagBusy ? 'pi-spin pi-cog' : 'pi-refresh']" /> Refresh
+        </button>
+      </div>
+      <span v-if="diag && diag.threads > 1" class="field-hint">Multithreaded API active ({{ diag.threads }} threads).</span>
+      <span v-else-if="diag" class="field-hint">Single-threaded — relaunch the API with <code>-t auto</code> for parallelism.</span>
+    </section>
+
+    <!-- ── Developer ───────────────────────────────────────────────────── -->
+    <section v-if="diag" class="settings-section">
+      <h2 class="section-title">Developer</h2>
+
+      <div class="field">
+        <label class="toggle-row" v-tooltip.right="'Show a Julia console that evaluates code in the running server. Only works when the server is loopback-bound (127.0.0.1); a network-bound server refuses it regardless.'">
+          <input type="checkbox" v-model="replToggle" @change="toggleRepl" />
+          <span class="toggle-label">Enable debug console</span>
+        </label>
+      </div>
+
+      <!-- toggle is on but the server is network-bound → eval is refused server-side (loopback required) -->
+      <span v-if="replToggle && !diag.loopback" class="field-hint">
+        The server is bound to <code>{{ diag.host }}</code>, so the console is disabled for safety.
+        Relaunch loopback-only to use it: <code>CECELIA_HOST=127.0.0.1 CECELIA_REPL=1 pixi run dev</code>.
+      </span>
+    </section>
+
+    <!-- ── Debug console — only when BOTH gates pass: flag on AND loopback bind ─── -->
+    <section v-if="diag?.replAvailable" class="settings-section">
+      <h2 class="section-title">Debug console</h2>
+      <span class="field-hint">
+        Evaluates Julia in the running server process (<code>CECELIA_REPL</code> on, loopback-bound).
+        Full access to the server — use with care.
+      </span>
+
+      <div v-if="replLog.length" class="repl-log">
+        <div v-for="(e, i) in replLog" :key="i" class="repl-entry">
+          <div class="repl-code">» {{ e.code }}</div>
+          <pre v-if="e.output" class="repl-out">{{ e.output }}</pre>
+          <pre v-if="e.value" class="repl-val">{{ e.value }}</pre>
+          <pre v-if="e.error" class="repl-err">{{ e.error }}</pre>
+        </div>
+      </div>
+
+      <textarea
+        class="repl-input mono"
+        v-model="replCode"
+        rows="3"
+        spellcheck="false"
+        placeholder="Threads.nthreads()"
+        @keydown="replKeydown"
+      />
+      <div class="field-row" style="margin-top:0.5rem">
+        <button class="save-btn" :disabled="replBusy || !replCode.trim()" @click="runRepl">
+          <i :class="['pi', replBusy ? 'pi-spin pi-cog' : 'pi-play']" /> Run (⌘/Ctrl+Enter)
+        </button>
+      </div>
+    </section>
+
+    </div>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .settings-page {
-  max-width: 560px;
+  max-width: 1180px;
   padding: 2rem 2.5rem;
+}
+
+/* two columns: existing settings left, diagnostics/developer right. Collapses to one on narrow
+   viewports. `align-items: start` so the columns don't stretch to equal height. */
+.settings-cols {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 3rem;
+  align-items: start;
+}
+.settings-col { min-width: 0; }
+@media (max-width: 860px) {
+  .settings-cols { grid-template-columns: 1fr; gap: 0; }
 }
 
 .page-title {
@@ -283,5 +431,42 @@ onMounted(checkUpdates)
 .no-project {
   font-size: 0.8rem;
   color: var(--cc-text-dim);
+}
+
+/* diagnostics key/value grid */
+.diag-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.3rem 0.9rem;
+  font-size: 0.78rem;
+  color: var(--cc-text);
+}
+.diag-grid > span:nth-child(odd) { color: var(--cc-text-dim); }
+.mono { font-family: var(--cc-mono); font-size: 0.74rem; word-break: break-all; }
+.field-hint code, .diag-grid code { font-family: var(--cc-mono); font-size: 0.72rem; }
+
+/* debug console */
+.repl-log {
+  max-height: 320px;
+  overflow: auto;
+  margin: 0.6rem 0;
+  border: 1px solid var(--cc-border);
+  border-radius: 0.35rem;
+  background: var(--cc-surface-1);
+  padding: 0.4rem 0.6rem;
+}
+.repl-entry { padding: 0.35rem 0; border-bottom: 1px solid var(--cc-border); }
+.repl-entry:last-child { border-bottom: none; }
+.repl-code { font-family: var(--cc-mono); font-size: 0.74rem; color: var(--cc-accent); white-space: pre-wrap; }
+.repl-out, .repl-val, .repl-err {
+  margin: 0.2rem 0 0; font-family: var(--cc-mono); font-size: 0.72rem;
+  white-space: pre-wrap; word-break: break-word;
+}
+.repl-out { color: var(--cc-text-dim); }
+.repl-val { color: var(--cc-text); }
+.repl-err { color: var(--cc-danger, #f87171); }
+.repl-input {
+  width: 100%; resize: vertical; font-family: var(--cc-mono); font-size: 0.76rem;
+  padding: 0.5rem; border-radius: 0.35rem;
 }
 </style>


### PR DESCRIPTION
## Settings: diagnostics panel + gated localhost-only debug console

Adds a **Diagnostics** panel and a gated **debug console** to the Settings page (two-column
layout so it doesn't become one long scroll).

### Diagnostics (always on)
`GET /api/diagnostics` → server threads, Julia version, memory, bound host/port, projects dir.
Confirms the multithreaded server at a glance (and logs `threads=N` at startup).

### Debug console (Settings → Developer, off by default)
A Julia REPL that evaluates in the running server's `Main` — `Cecelia`, `projects_dir`, scheduler
and napari state all in scope — returning the value plus captured `stdout`/`stderr` and errors.

Because it's arbitrary code execution it's gated:
- **Hard gate — loopback bind.** Eval runs only when the server is bound to `127.0.0.1`/`::1`. A
  `0.0.0.0` (network) bind refuses it regardless of the toggle — the OS won't accept a remote
  connection to a loopback socket, so there's no header to spoof. **Default bind changed to
  `127.0.0.1`** (Cecelia is a local app); `CECELIA_HOST=0.0.0.0` deliberately exposes it and disables
  the console.
- **Runtime toggle** (`POST /api/repl/config`) — the Settings switch, no restart; seeds from
  `CECELIA_REPL`. Not a security boundary (the loopback gate is).

Output is captured via a pipe + async reader, serialised by a lock (`redirect_stdout` is
process-global — safe under the multithreaded server).

### Docs
`docs/API.md` route index + loopback/threading notes; `docs/DEV.md` new *Diagnostics & debug console*
section. No tests (no API test harness exists yet — see follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)