### PR TITLE
test(api): add API-layer test harness + CI + pixi tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Instantiate Julia (server env)
         run: julia --project=api -e 'using Pkg; Pkg.instantiate()'
 
+      # API-layer unit tests: load the handlers with CECELIA_NO_SERVE (no socket) and exercise them
+      # directly. Fixture-free, so it runs on every OS in the matrix.
+      - name: API tests
+        run: pixi run test-api
+
       - name: Build frontend
         working-directory: frontend
         run: |

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -388,4 +388,6 @@ function start(; host=HOST, port=PORT)
     HTTP.listen(handle_stream, host, port)
 end
 
-start()
+# Auto-start on load — EXCEPT when `CECELIA_NO_SERVE` is set, so `api/test/runtests.jl` can `include`
+# this file to get the handlers (and shared state like `_BOUND_HOST`) without binding a socket.
+haskey(ENV, "CECELIA_NO_SERVE") || start()

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -1,0 +1,72 @@
+# API-layer tests. The package (`app/test/runtests.jl`) covers Cecelia headless; this covers the thin
+# HTTP adapters in `api/src`. We load the server module WITHOUT binding a socket (`CECELIA_NO_SERVE`)
+# and call the handler functions directly — no live server, no ports, so it runs in CI headless.
+#
+# Run: `julia --project=api api/test/runtests.jl`  (or `pixi run test-api`).
+ENV["CECELIA_NO_SERVE"] = "1"
+
+using Test
+include(joinpath(@__DIR__, "..", "src", "server.jl"))   # defines handlers + shared state; does not start
+using JSON3
+
+# call a POST handler the way the router does: JSON body → Vector{UInt8}
+_post(f, obj) = f(Vector{UInt8}(JSON3.write(obj)))
+_repl(code) = _post(api_repl, Dict("code" => code))
+
+@testset "API: diagnostics" begin
+    st, body = api_diagnostics(HTTP.Request("GET", "/api/diagnostics"))
+    @test st == 200
+    d = JSON3.read(body)
+    @test d.threads >= 1
+    @test !isempty(String(d.julia))
+    @test haskey(d, :replAvailable) && haskey(d, :loopback) && haskey(d, :replEnabled)
+end
+
+@testset "API: debug console gating" begin
+    # disabled (default) → refused
+    _repl_on[] = false; _BOUND_HOST[] = "127.0.0.1"
+    st, _ = _repl("1 + 1"); @test st == 403
+    @test !_repl_available()
+
+    # enabled but the server is network-bound → refused (loopback is the hard gate)
+    _repl_on[] = true; _BOUND_HOST[] = "0.0.0.0"
+    st, body = _repl("1 + 1")
+    @test st == 403
+    @test occursin("loopback", JSON3.read(body).error)
+    @test !_repl_available()
+
+    # enabled AND loopback-bound → available
+    _BOUND_HOST[] = "127.0.0.1"
+    @test _repl_available()
+end
+
+@testset "API: debug console eval" begin
+    _repl_on[] = true; _BOUND_HOST[] = "127.0.0.1"
+
+    # value
+    st, body = _repl("1 + 1")
+    r = JSON3.read(body)
+    @test st == 200 && r.ok == true && r.value == "2"
+
+    # captured stdout + last value from a multi-statement block
+    r = JSON3.read(_repl("println(\"hi\"); 3 + 4")[2])
+    @test r.value == "7" && occursin("hi", r.output)
+
+    # error path: ok=false + message, still HTTP 200
+    r = JSON3.read(_repl("sqrt(-1)")[2])
+    @test r.ok == false && occursin("DomainError", r.error)
+
+    # empty code → 400
+    @test _repl("   ")[1] == 400
+end
+
+@testset "API: repl config toggle" begin
+    _BOUND_HOST[] = "127.0.0.1"
+    st, body = _post(api_repl_config, Dict("enabled" => false))
+    @test st == 200 && JSON3.read(body).replEnabled == false
+    @test _repl("1+1")[1] == 403                      # now disabled
+
+    st, body = _post(api_repl_config, Dict("enabled" => true))
+    @test st == 200 && JSON3.read(body).replEnabled == true
+    @test _repl("1+1")[1] == 200                      # enabled again
+end

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -105,6 +105,16 @@ Cut **off `main`** after the relevant PRs have merged, by pushing a tag:
 
 Rationale and the full packaging/update model live in [`docs/SHIPPING.md`](SHIPPING.md).
 
+## Tests
+
+- **Package (headless Cecelia):** `pixi run test-pkg` (`app/test/runtests.jl`). Some testsets
+  `@test_skip` when their `test-data/` fixtures are absent.
+- **API adapters:** `pixi run test-api` (`api/test/runtests.jl`). Loads `server.jl` with
+  `CECELIA_NO_SERVE=1` so the handlers + shared state (`_BOUND_HOST`, `_repl_on`, …) are defined
+  without binding a socket, then calls handlers directly (no live server, no ports). Fixture-free, so
+  it runs in CI (`.github/workflows/ci.yml`) on every OS. Covers diagnostics + the debug-console
+  gating/eval; extend it as more adapters gain logic worth pinning.
+
 ## Diagnostics & debug console
 
 **Settings → Diagnostics** (always on) shows server threads, Julia version, memory, the bound

--- a/pixi.toml
+++ b/pixi.toml
@@ -84,6 +84,10 @@ torchvision = ">=0.21"
 dev  = { cmd = "julia --project -t auto -e 'using Revise; includet(\"src/server.jl\")'", cwd = "api" }  # hot-reload (development)
 prod = { cmd = "julia --project -t auto src/server.jl", cwd = "api" }                                    # plain include (production)
 
+# Tests. Package (headless Cecelia) + API adapters (loaded with CECELIA_NO_SERVE — no socket bound).
+test-pkg = { cmd = "julia --project test/runtests.jl", cwd = "app" }
+test-api = { cmd = "julia --project test/runtests.jl", cwd = "api" }
+
 # Frontend — Vite (port 5173).
 frontend = { cmd = "npm run dev", cwd = "frontend" }    # dev server, hot reload
 build    = { cmd = "npm run build", cwd = "frontend" }  # static production build


### PR DESCRIPTION
## Add an API-layer test harness (+ CI + pixi tasks)

First automated tests for the `api/` HTTP adapters. The package suite (`app/test`) covers headless
Cecelia; nothing exercised the HTTP layer until now.

### How it works
`api/test/runtests.jl` loads `server.jl` with **`CECELIA_NO_SERVE=1`** — a new guard so the file
defines all handlers and shared state (`_BOUND_HOST`, `_repl_on`, …) **without binding a socket** —
then calls the handler functions directly. No live server, no ports → runs headless in CI on every OS.

### Coverage (18 tests)
- `api_diagnostics` — shape + keys (threads, julia, replAvailable/loopback/replEnabled).
- Debug-console **gating** — disabled → 403; enabled but `0.0.0.0`-bound → 403 (loopback is the hard
  gate); enabled + loopback → available.
- Debug-console **eval** — value display, captured `stdout`, multi-statement last value, the
  `sqrt(-1)` error path (ok=false + message, still HTTP 200), empty code → 400.
- `api_repl_config` — toggling the runtime flag enables/disables eval.

### Wiring
- `pixi run test-api` and `pixi run test-pkg` tasks.
- CI (`.github/workflows/ci.yml`) runs `pixi run test-api` after instantiating the server env —
  fixture-free, so it's safe on the full OS matrix. (Package tests stay out of CI; they need
  `test-data/`.)
- `docs/DEV.md`: new *Tests* section.

Stacked on `feat/settings-repl-console` (needs `repl_api.jl` to test) — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)