### PR TITLE
fix(zarr): per-plane chunking for corrections (was chunked across who…

### DIFF
--- a/app/py/utils/rechunk_zarr.py
+++ b/app/py/utils/rechunk_zarr.py
@@ -1,0 +1,128 @@
+"""Rechunk existing OME-ZARR corrections to per-plane chunks (one-off maintenance).
+
+Corrections written before the plane-chunk fix (``zarr_utils.plane_chunks``) can be chunked across the
+whole T/C axes (dask ``chunks='auto'`` → ~128 MB chunks). napari slices per (t,c,z), so a single plane
+access then costs a full-timecourse read — slow on first open, fast once OS-cached. This rewrites each
+multiscale level with per-plane chunks (1 along T/C/Z, ``xy_tile``-capped along Y/X). **Pixel data is
+unchanged** — only the on-disk chunk layout differs.
+
+Usage (run in the analysis env, e.g. ``pixi run python``):
+    python app/py/utils/rechunk_zarr.py PATH [--replace] [--force] [--xy-tile 512]
+
+    PATH       a single ``*.ome.zarr`` store, or a directory scanned recursively for corrected stores.
+    --replace  swap the rechunked copy in place; the original is backed up to ``<name>.bak.ome.zarr``.
+               Without it, a ``<name>.rechunked.ome.zarr`` is written and the original left untouched.
+    --force    rechunk even if the store already looks per-plane-chunked.
+
+Only FLAT corrected stores (numeric level arrays at the group root, i.e. our correction output) are
+touched; bioformats2raw originals (a nested series group) are skipped — they're already pyramided.
+"""
+import argparse
+import os
+import shutil
+import sys
+
+import dask.array as da
+import zarr
+
+# app/ on the path so `py.utils.zarr_utils` imports whether run as a script or a module.
+_APP_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+if _APP_DIR not in sys.path:
+    sys.path.insert(0, _APP_DIR)
+from py.utils.zarr_utils import plane_chunks   # noqa: E402
+
+
+def _levels(group):
+    """Numeric level arrays at the group root (our flat correction layout), sorted 0,1,2,…"""
+    return sorted((k for k in group.array_keys() if str(k).isdigit()), key=int)
+
+
+def needs_rechunk(arr, xy_tile=512):
+    """True if any non-spatial (all but the last two) axis has a chunk > 1 — i.e. the chunk spans
+    time/channel/z, the pattern that makes napari plane access read far more than one plane."""
+    n = len(arr.shape)
+    return any(c > 1 for i, c in enumerate(arr.chunks) if i < n - 2)
+
+
+def rechunk_store(path, xy_tile=512, replace=False, force=False):
+    """Rechunk one ``*.ome.zarr``. Returns (status, detail)."""
+    try:
+        src = zarr.open_group(path, mode="r")
+    except Exception as e:
+        return ("skip", f"not a zarr group ({e})")
+    levels = _levels(src)
+    if not levels:
+        return ("skip", "no root-level arrays (bioformats2raw original or unknown layout)")
+    if not force and not needs_rechunk(src[levels[0]], xy_tile):
+        return ("ok", "already per-plane chunked")
+
+    tmp = path.rstrip("/") + ".rechunk_tmp"
+    if os.path.exists(tmp):
+        shutil.rmtree(tmp)
+    dst = zarr.open_group(tmp, mode="w", zarr_format=2)
+    dst.attrs.update(dict(src.attrs))                         # multiscales metadata, verbatim
+    for k in levels:
+        s = src[k]
+        ch = plane_chunks(s.shape, xy_tile=xy_tile)
+        d = dst.create_array(k, shape=s.shape, chunks=ch, dtype=s.dtype)
+        da.store(da.from_array(s, chunks=ch), d, lock=False)  # streams level→level, plane-chunked
+    # copy any non-array members verbatim (e.g. an `OME/` metadata subgroup); levels + dotfiles handled
+    for entry in os.listdir(path):
+        if entry in levels or entry.startswith("."):
+            continue
+        dstp = os.path.join(tmp, entry)
+        if os.path.exists(dstp):
+            continue
+        srcp = os.path.join(path, entry)
+        (shutil.copytree if os.path.isdir(srcp) else shutil.copy2)(srcp, dstp)
+
+    base = path.rstrip("/")
+    base = base[: -len(".ome.zarr")] if base.endswith(".ome.zarr") else base
+    if replace:
+        bak = base + ".bak.ome.zarr"
+        if os.path.exists(bak):
+            shutil.rmtree(bak)
+        os.rename(path, bak)          # keep the original as a backup
+        os.rename(tmp, path)
+        return ("rechunked", f"replaced in place (backup: {os.path.basename(bak)})")
+    out = base + ".rechunked.ome.zarr"
+    if os.path.exists(out):
+        shutil.rmtree(out)
+    os.rename(tmp, out)
+    return ("rechunked", f"wrote {os.path.basename(out)} (original untouched)")
+
+
+def _find_stores(root):
+    """Yield every ``*.ome.zarr`` dir under `root` without descending into one."""
+    if root.endswith(".ome.zarr"):
+        yield root
+        return
+    for dirpath, dirnames, _ in os.walk(root):
+        keep = []
+        for d in dirnames:
+            if d.endswith(".ome.zarr"):
+                yield os.path.join(dirpath, d)
+            elif not d.endswith((".bak.ome.zarr", ".rechunk_tmp")):
+                keep.append(d)
+        dirnames[:] = keep
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Rechunk OME-ZARR corrections to per-plane chunks.")
+    ap.add_argument("path", help="a .ome.zarr store or a directory to scan")
+    ap.add_argument("--replace", action="store_true", help="swap in place (backs up to *.bak.ome.zarr)")
+    ap.add_argument("--force", action="store_true", help="rechunk even if already per-plane")
+    ap.add_argument("--xy-tile", type=int, default=512, help="max chunk size along Y/X (default 512)")
+    a = ap.parse_args(argv)
+
+    stores = list(_find_stores(os.path.abspath(a.path)))
+    if not stores:
+        print(f"no .ome.zarr stores under {a.path}")
+        return
+    for s in stores:
+        status, detail = rechunk_store(s, xy_tile=a.xy_tile, replace=a.replace, force=a.force)
+        print(f"[{status:>9}] {s} — {detail}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/py/utils/zarr_utils.py
+++ b/app/py/utils/zarr_utils.py
@@ -71,6 +71,23 @@ def chunks(im_array):
     return [x if isinstance(x, int) else x[0] for x in im_chunks]
 
 
+def plane_chunks(shape, dim_utils=None, xy_tile=512):
+    """Per-plane chunking for an OME-ZARR consumed by napari: 1 along the non-spatial axes
+    (T/C/Z) and `xy_tile`-capped along the two spatial axes (Y/X). napari slices per (t,c,z),
+    so a chunk must NOT span the time/channel axes — `dask`'s `chunks='auto'` packs the whole
+    time series into one ~128 MB chunk, which makes a single plane cost a full-timecourse read
+    (slow first open, fast once OS-cached). Spatial axes come from `dim_utils` when available,
+    else assumed to be the last two (bioformats2raw TCZYX order)."""
+    n = len(shape)
+    spatial = set()
+    order = getattr(dim_utils, "im_dim_order", None) if dim_utils is not None else None
+    if order and len(order) == n:
+        spatial = {i for i, ax in enumerate(order) if str(ax).upper() in ("X", "Y")}
+    if not spatial:
+        spatial = {n - 2, n - 1}
+    return tuple(min(int(s), xy_tile) if i in spatial else 1 for i, s in enumerate(shape))
+
+
 def open_labels_as_dask(filepath, multiscales=None):
     zarr_data, zarr_group_info = open_labels_as_zarr(filepath, multiscales=multiscales)
     return zarr_data_to_dask(zarr_data), zarr_group_info
@@ -198,12 +215,16 @@ def create_multiscales(im_array, filepath, dim_utils=None, im_chunks=None,
     multiscales_zarr.attrs['multiscales'] = [ms_entry]
 
     if isinstance(im_array, dask.array.core.Array):
-        # Write into the group so the sub-array inherits zarr v2 format.
+        # Write into the group so the sub-array inherits zarr v2 format. Chunk PER PLANE — NOT with the
+        # dask array's own chunksize, which for a correction built via `chunks='auto'` spans the whole
+        # T/C axes (~128 MB chunks) and makes every napari plane access a full-timecourse read. `da.store`
+        # writes across the differing source chunking fine.
+        pchunks = plane_chunks(im_array.shape, dim_utils)
         dest = multiscales_zarr.create_array(
-            "0", shape=im_array.shape, chunks=im_array.chunksize, dtype=im_array.dtype
+            "0", shape=im_array.shape, chunks=pchunks, dtype=im_array.dtype
         )
         da.store(im_array, dest, lock=False)
-        im_chunks = chunks(im_array)
+        im_chunks = list(pchunks)
     elif isinstance(im_array, zarr.Array):
         dest = multiscales_zarr.create_array("0", shape=im_array.shape, chunks=im_array.chunks, dtype=im_array.dtype)
         dest[:] = im_array[:]


### PR DESCRIPTION
## Fix per-plane chunking for corrections (was chunked across the whole T/C axes)

### The bug
Napari's **first open** of a drift-corrected image was very slow (a spinner that wasn't there
before); re-opening the same image was fast. Root cause: `create_multiscales`' dask-array path
persisted the dask array's `chunks='auto'` sizing. For a correction that path packs the **entire
timecourse and all channels** into ~128 MB chunks (e.g. `[94, 4, 13, 117, 117]` for a 94×4×13×728×618
`u2` image). napari slices per (t, c, z), so displaying a single plane forced dask to read every
xy-tile chunk covering it — and each chunk contains the whole time series + all channels → hundreds of
MB→GB read per plane, per channel. Slow cold; fast once the OS page-cached it. `cpCorrected` was fine
because it takes the ndarray path and inherits the reference's `[1,1,1,512,512]` chunks.

### The fix
- **`zarr_utils.plane_chunks()`** + `create_multiscales` now writes the dask path **per-plane**:
  `1` along T/C/Z, 512-tiled along Y/X (spatial axes from `dim_utils`, else the last two). Fixes drift
  and AF corrections going forward. `da.store` writes across the differing source chunking fine.
- **`app/py/utils/rechunk_zarr.py`** — one-off utility to rewrite *already-written* stores to per-plane
  chunks (the writer fix only affects future corrections). Skips bioformats2raw originals and
  already-good stores; `--replace` swaps in place with a `*.bak.ome.zarr` backup. Pixel data and
  `.zattrs` are preserved.

### Verification
Synthetic store (chunks + pixel data + `.zattrs` preserved; idempotent) and the real "B and T" set
(`4kS67f`): every `ccidDriftCorrected` was `[T, 4, 13, …]`-chunked; rechunked to per-plane in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)