### PR TITLE
perf(napari): cut per-open I/O — coarsest-level contrast sample + cac…

### DIFF
--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -104,11 +104,20 @@ If a raw (uncorrected) image appears empty, check `zarr_array.dtype` — `>u2` o
 `layer.reset_contrast_limits()` silently sets `[0, 65535]` for dask/zarr arrays that haven't been computed yet (napari 0.7.1 behaviour — it can't scan an uncomputed array).
 
 Instead we use `_set_contrast_from_sample(layer)`:
+- Samples the **coarsest** pyramid level (`raw[-1]`), not the full-res level — this is a contrast
+  *estimate*, so reading the smallest level is orders of magnitude less I/O. It matters because this
+  runs once **per visible layer**, and with `channel_axis` set each channel is its own layer, so a
+  full-res sample would read one full-res plane per channel on every open.
 - Indexes the middle position along every axis except Y and X (so for CZYX: middle C, middle Z, all Y, all X)
 - Computes 1st–99.9th percentile of non-zero pixels
 - Falls back to `reset_contrast_limits()` only if the sample is too sparse or computation fails
 
 This runs on every visible layer after `add_image`.
+
+**OME-XML metadata is parsed once per store.** `_read_unit_from_ome_xml` / `_read_scale_from_ome_xml`
+/ `_read_time_increment` all go through `_load_ome_xml`, which is `lru_cache`d on `(path, mtime)` — a
+long-lived bridge parses each store's `METADATA.ome.xml` at most once instead of 2–3× per open, and
+the lazy `ome_types` import (pydantic model build) is paid only on the first parse.
 
 ---
 

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -14,6 +14,7 @@ import queue
 import sys
 import threading
 import urllib.request
+from functools import lru_cache
 
 import dask.array as da
 import napari
@@ -812,7 +813,9 @@ def _set_contrast_from_sample(layer) -> None:
     try:
         raw = layer.data
         if isinstance(raw, list):
-            raw = raw[0]   # first scale level for multiscale
+            raw = raw[-1]  # coarsest scale level — a contrast SAMPLE only, so read the
+                           # smallest pyramid level (orders of magnitude less I/O than the
+                           # full-res level, and per-channel this runs once per visible layer)
         ndim = raw.ndim
         # Build index that selects middle position along all axes except the last two (y, x)
         idx = tuple(
@@ -883,19 +886,37 @@ def _read_axes(path: str):
     return [ax["name"] for ax in axes] if axes else None
 
 
-def _read_unit_from_ome_xml(path: str) -> str:
-    """Read physical pixel unit from OME-XML metadata. Returns 'µm' as default."""
+@lru_cache(maxsize=64)
+def _parse_ome_xml(xml_path: str, _mtime: float):
+    """Parse one OME-XML file. Cached on (path, mtime) — a long-lived bridge parses each store's
+    metadata at most once (mtime in the key invalidates it if the file is rewritten). `ome_types`
+    is imported lazily here so its pydantic model-build cost is paid on first use, not at import."""
+    from ome_types import from_xml
+    with open(xml_path) as f:
+        return from_xml(f.read())
+
+
+def _load_ome_xml(path: str):
+    """Locate and parse a store's OME-XML (OME/METADATA.ome.xml or METADATA.ome.xml), or None.
+    Shared by the readers below so a single open parses the file once instead of two or three times."""
     import os
-    for candidate in [
+    for candidate in (
         os.path.join(path, "OME", "METADATA.ome.xml"),
         os.path.join(path, "METADATA.ome.xml"),
-    ]:
-        if not os.path.isfile(candidate):
-            continue
+    ):
+        if os.path.isfile(candidate):
+            try:
+                return _parse_ome_xml(candidate, os.path.getmtime(candidate))
+            except Exception:
+                return None
+    return None
+
+
+def _read_unit_from_ome_xml(path: str) -> str:
+    """Read physical pixel unit from OME-XML metadata. Returns 'µm' as default."""
+    omexml = _load_ome_xml(path)
+    if omexml is not None:
         try:
-            from ome_types import from_xml
-            with open(candidate) as f:
-                omexml = from_xml(f.read())
             unit = omexml.images[0].pixels.physical_size_x_unit
             if unit is not None:
                 return unit.value  # e.g. 'µm', 'nm', 'mm'
@@ -906,16 +927,10 @@ def _read_unit_from_ome_xml(path: str) -> str:
 
 def _read_scale_from_ome_xml(path: str, axes):
     """Read physical pixel scale from OME-XML metadata, returning values in axis order."""
-    import os
-    ome_xml_path = os.path.join(path, "OME", "METADATA.ome.xml")
-    if not os.path.isfile(ome_xml_path):
-        ome_xml_path = os.path.join(path, "METADATA.ome.xml")
-        if not os.path.isfile(ome_xml_path):
-            return None
+    omexml = _load_ome_xml(path)
+    if omexml is None:
+        return None
     try:
-        from ome_types import from_xml
-        with open(ome_xml_path) as f:
-            omexml = from_xml(f.read())
         pixels = omexml.images[0].pixels
         sizes = {
             'x': pixels.physical_size_x,
@@ -944,16 +959,11 @@ def _read_scale(path: str):
 def _read_time_increment(path: str):
     """Seconds between timepoints from OME-XML `pixels.time_increment` (with its unit), or None.
     Used for the timecourse timestamp overlay. Converts ms/min/h to seconds where the unit says so."""
-    import os
-    ome_xml_path = os.path.join(path, "OME", "METADATA.ome.xml")
-    if not os.path.isfile(ome_xml_path):
-        ome_xml_path = os.path.join(path, "METADATA.ome.xml")
-        if not os.path.isfile(ome_xml_path):
-            return None
+    omexml = _load_ome_xml(path)
+    if omexml is None:
+        return None
     try:
-        from ome_types import from_xml
-        with open(ome_xml_path) as f:
-            pixels = from_xml(f.read()).images[0].pixels
+        pixels = omexml.images[0].pixels
         inc = pixels.time_increment
         if inc is None:
             return None


### PR DESCRIPTION
## perf(napari): cut per-open I/O in the bridge

Follow-up to the zarr chunking fix (#42). That fix removed the full-timecourse
per-plane reads; this removes two remaining open-path costs the investigation
surfaced — both live in the napari bridge process.

### Changes
- **Contrast sample reads the coarsest pyramid level.** `_set_contrast_from_sample`
  now samples `raw[-1]` (smallest level) instead of `raw[0]` (full-res). It's only a
  contrast *estimate*, and it runs **once per visible layer** — so with `channel_axis`
  set it was reading one full-res plane **per channel** on every open. Coarsest-level
  sampling is orders of magnitude less I/O.
- **OME-XML parsed once per store.** `_read_unit_from_ome_xml`, `_read_scale_from_ome_xml`
  and `_read_time_increment` now share `_load_ome_xml`, `lru_cache`d on `(path, mtime)`.
  Each store's `METADATA.ome.xml` is parsed once instead of 2–3× per open, and the lazy
  `ome_types` (pydantic model-build) import is paid only on the first parse. `mtime` in
  the key invalidates the cache if a store's metadata is rewritten.

### Notes
- Bridge-only change → **restart the napari bridge** to pick it up (backend adopts a
  fresh one on next open).
- The remaining first-open cost is the one-time bridge cold-start (napari import + Qt
  viewer construction), folded into the first open via lazy `_ensure_viewer!`. That's
  one-time-per-process and left as-is (pre-warming is a Tauri/packaging-era change).
- `docs/NAPARI.md` updated (Contrast limits section).