### PR TITLE
fix(threading): Phase 2 lock audit — guard shared state under -t auto

### DIFF
--- a/api/src/gating_api.jl
+++ b/api/src/gating_api.jl
@@ -194,6 +194,14 @@ function _broadcast_popmap(project_uid, image_uid, vn, pop_type, m::PopulationMa
         "valueName" => vn, "popType" => pop_type, "tree" => to_tree(m)))
 end
 
+# Serialise gating pop CRUD. Each handler does load_pop_map → mutate → save_pop_map!; under
+# `-t auto` two concurrent edits to the same map (rapid clicks / two tabs) would otherwise both
+# load the same tree and the second save would clobber the first (lost update). One process-wide
+# ReentrantLock held across the whole load→save is enough — gating edits are user-paced and cheap,
+# so contention across images/value_names is negligible. (save_pop_map! also writes atomically.)
+const _POPMAP_LOCK = ReentrantLock()
+_with_popmap_lock(f) = lock(f, _POPMAP_LOCK)
+
 # persist a mutated map then broadcast — re-injecting the transient napari pop AFTER save
 # (so it never hits disk) but BEFORE broadcast (so the client keeps showing it). Returns the
 # tree (incl. the transient pop) for the HTTP response.
@@ -489,77 +497,87 @@ end
 function api_gating_pop_add(body_bytes::Vector{UInt8})
     img, vn, pt, body, err = _gating_post(body_bytes); err === nothing || return err
     haskey(body, "name") || return _gerr(400, "name required")
-    m = load_pop_map(img; value_name = vn, pop_type = pt)
-    gate = haskey(body, "gate") && body["gate"] !== nothing ? gate_from_spec(body["gate"]) : nothing
-    flt = get(body, "filter", nothing)
-    try
-        add_pop!(m, String(body["name"]); parent = String(get(body, "parent", ROOT)),
-                 gate = gate, colour = String(get(body, "colour", "#ffffff")),
-                 show = Bool(get(body, "show", true)),
-                 filter_measure = flt === nothing ? nothing : get(flt, "measure", nothing),
-                 filter_fun     = flt === nothing ? nothing : get(flt, "fun", nothing),
-                 filter_values  = flt === nothing ? nothing : get(flt, "values", nothing),
-                 filter_default_all = flt === nothing ? false : Bool(get(flt, "default_all", false)),
-                 is_track = Bool(get(body, "is_track", false)))
-    catch e
-        return _gerr(400, sprint(showerror, e))
+    _with_popmap_lock() do
+        m = load_pop_map(img; value_name = vn, pop_type = pt)
+        gate = haskey(body, "gate") && body["gate"] !== nothing ? gate_from_spec(body["gate"]) : nothing
+        flt = get(body, "filter", nothing)
+        try
+            add_pop!(m, String(body["name"]); parent = String(get(body, "parent", ROOT)),
+                     gate = gate, colour = String(get(body, "colour", "#ffffff")),
+                     show = Bool(get(body, "show", true)),
+                     filter_measure = flt === nothing ? nothing : get(flt, "measure", nothing),
+                     filter_fun     = flt === nothing ? nothing : get(flt, "fun", nothing),
+                     filter_values  = flt === nothing ? nothing : get(flt, "values", nothing),
+                     filter_default_all = flt === nothing ? false : Bool(get(flt, "default_all", false)),
+                     is_track = Bool(get(body, "is_track", false)))
+        catch e
+            return _gerr(400, sprint(showerror, e))
+        end
+        200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
     end
-    200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
 end
 
 function api_gating_pop_set_gate(body_bytes::Vector{UInt8})
     img, vn, pt, body, err = _gating_post(body_bytes); err === nothing || return err
     (haskey(body, "path") && haskey(body, "gate")) || return _gerr(400, "path and gate required")
-    m = load_pop_map(img; value_name = vn, pop_type = pt)
-    has_pop(m, body["path"]) || return _gerr(404, "Population not found: $(body["path"])")
-    try
-        set_gate!(m, String(body["path"]), gate_from_spec(body["gate"]))
-    catch e
-        return _gerr(400, sprint(showerror, e))
+    _with_popmap_lock() do
+        m = load_pop_map(img; value_name = vn, pop_type = pt)
+        has_pop(m, body["path"]) || return _gerr(404, "Population not found: $(body["path"])")
+        try
+            set_gate!(m, String(body["path"]), gate_from_spec(body["gate"]))
+        catch e
+            return _gerr(400, sprint(showerror, e))
+        end
+        200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
     end
-    200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
 end
 
 function api_gating_pop_delete(body_bytes::Vector{UInt8})
     img, vn, pt, body, err = _gating_post(body_bytes); err === nothing || return err
     haskey(body, "path") || return _gerr(400, "path required")
-    m = load_pop_map(img; value_name = vn, pop_type = pt)
-    has_pop(m, body["path"]) || return _gerr(404, "Population not found: $(body["path"])")
-    del_pop!(m, String(body["path"]))
-    200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
+    _with_popmap_lock() do
+        m = load_pop_map(img; value_name = vn, pop_type = pt)
+        has_pop(m, body["path"]) || return _gerr(404, "Population not found: $(body["path"])")
+        del_pop!(m, String(body["path"]))
+        200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
+    end
 end
 
 function api_gating_pop_update(body_bytes::Vector{UInt8})
     img, vn, pt, body, err = _gating_post(body_bytes); err === nothing || return err
     haskey(body, "path") || return _gerr(400, "path required")
-    m = load_pop_map(img; value_name = vn, pop_type = pt)
-    has_pop(m, body["path"]) || return _gerr(404, "Population not found: $(body["path"])")
-    p = pop_at(m, String(body["path"]))
-    haskey(body, "colour") && (p.colour = String(body["colour"]))
-    haskey(body, "show")   && (p.show = Bool(body["show"]))
-    # filter update — the tick-cluster-into-population UX toggles which cluster IDs belong to a
-    # `clust`/`trackclust` pop by rewriting its filter (typically filter_values). Mutates only the
-    # keys present in the `filter` dict, so a `{values:[…]}` tick leaves measure/fun untouched.
-    flt = get(body, "filter", nothing)
-    if flt !== nothing
-        haskey(flt, "measure")     && (p.filter_measure = get(flt, "measure", nothing))
-        haskey(flt, "fun")         && (p.filter_fun = get(flt, "fun", nothing))
-        haskey(flt, "values")      && (p.filter_values = get(flt, "values", nothing))
-        haskey(flt, "default_all") && (p.filter_default_all = Bool(get(flt, "default_all", false)))
+    _with_popmap_lock() do
+        m = load_pop_map(img; value_name = vn, pop_type = pt)
+        has_pop(m, body["path"]) || return _gerr(404, "Population not found: $(body["path"])")
+        p = pop_at(m, String(body["path"]))
+        haskey(body, "colour") && (p.colour = String(body["colour"]))
+        haskey(body, "show")   && (p.show = Bool(body["show"]))
+        # filter update — the tick-cluster-into-population UX toggles which cluster IDs belong to a
+        # `clust`/`trackclust` pop by rewriting its filter (typically filter_values). Mutates only the
+        # keys present in the `filter` dict, so a `{values:[…]}` tick leaves measure/fun untouched.
+        flt = get(body, "filter", nothing)
+        if flt !== nothing
+            haskey(flt, "measure")     && (p.filter_measure = get(flt, "measure", nothing))
+            haskey(flt, "fun")         && (p.filter_fun = get(flt, "fun", nothing))
+            haskey(flt, "values")      && (p.filter_values = get(flt, "values", nothing))
+            haskey(flt, "default_all") && (p.filter_default_all = Bool(get(flt, "default_all", false)))
+        end
+        200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
     end
-    200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
 end
 
 function api_gating_pop_rename(body_bytes::Vector{UInt8})
     img, vn, pt, body, err = _gating_post(body_bytes); err === nothing || return err
     (haskey(body, "path") && haskey(body, "newName")) || return _gerr(400, "path and newName required")
-    m = load_pop_map(img; value_name = vn, pop_type = pt)
-    has_pop(m, body["path"]) || return _gerr(404, "Population not found: $(body["path"])")
-    newpath = try
-        rename_pop!(m, String(body["path"]), String(body["newName"]))
-    catch e
-        return _gerr(400, sprint(showerror, e))
+    _with_popmap_lock() do
+        m = load_pop_map(img; value_name = vn, pop_type = pt)
+        has_pop(m, body["path"]) || return _gerr(404, "Population not found: $(body["path"])")
+        newpath = try
+            rename_pop!(m, String(body["path"]), String(body["newName"]))
+        catch e
+            return _gerr(400, sprint(showerror, e))
+        end
+        tree = _persist_and_broadcast!(m, img, body, vn, pt)
+        200, JSON3.write((; tree = tree, path = newpath))
     end
-    tree = _persist_and_broadcast!(m, img, body, vn, pt)
-    200, JSON3.write((; tree = tree, path = newpath))
 end

--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -11,6 +11,13 @@ const _viewer_starting = Ref(false)
 const _current_zarr_path = Ref{Union{String,Nothing}}(nothing)
 const _current_task_dir  = Ref{Union{String,Nothing}}(nothing)
 
+# Serialise all interaction with the single bridge process. Under `-t auto` two concurrent napari
+# requests would otherwise interleave command sequences on the one bridge (e.g. a screenshot mid-open,
+# or two opens racing the `_current_*` refs → a stale auto-save target). Hold this around each
+# handler's full send-sequence so bridge interaction is single-flighted. `_viewer_lock` is reentrant,
+# so `_ensure_viewer!`'s own locking nests fine.
+_with_viewer(f) = lock(f, _viewer_lock)
+
 # coerce a JSON value (Int/Float/String/null) to a non-negative Int; blank/garbage → 0.
 # Used for the z-window dial, which can arrive as null (empty input) or a float.
 function _to_int(x)::Int
@@ -102,6 +109,7 @@ function _execute_pending_open()
     isnothing(pending) && return
     v = _viewer()
     isnothing(v) && return
+    _with_viewer() do
     try
         # Re-resolve _active at fire time — a task may have completed between the
         # eye-button click and Napari becoming ready.
@@ -134,6 +142,7 @@ function _execute_pending_open()
     catch e
         @warn "Failed to open pending image in Napari" exception = e
     end
+    end  # _with_viewer
 end
 
 function _do_open!(v::NapariViewer, zarr_path::String, task_dir::String,
@@ -233,6 +242,7 @@ function api_napari_open(body_bytes::Vector{UInt8})
 
     v = _viewer()
     isnothing(v) && return 500, JSON3.write((; error = "Viewer not initialised"))
+    _with_viewer() do
     try
         # Auto-save layer props for the currently open image before switching
         if auto_save && !isnothing(_current_zarr_path[]) && !isnothing(_current_task_dir[])
@@ -259,6 +269,7 @@ function api_napari_open(body_bytes::Vector{UInt8})
         @warn "Failed to open image in Napari" image_uid exception = e
         500, JSON3.write((; error = sprint(showerror, e)))
     end
+    end  # _with_viewer
 end
 
 # ── REST: POST /api/napari/close ──────────────────────────────────────────────
@@ -266,11 +277,13 @@ end
 function api_napari_close(body_bytes::Vector{UInt8})
     v = _viewer()
     isnothing(v) && return 200, JSON3.write((; ok = true, message = "Napari was not running"))
-    try
-        close!(v)
-        200, JSON3.write((; ok = true))
-    catch e
-        500, JSON3.write((; error = sprint(showerror, e)))
+    _with_viewer() do
+        try
+            close!(v)
+            200, JSON3.write((; ok = true))
+        catch e
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
     end
 end
 
@@ -282,6 +295,7 @@ function api_napari_screenshot(body_bytes::Vector{UInt8})
     v = _viewer()
     (isnothing(v) || !_viewer_alive()) && return 400, JSON3.write((; error = "Napari not running"))
     path = tempname() * ".png"
+    _with_viewer() do
     try
         save_screenshot!(v, path; canvas_only = true)
         return 200, read(path)   # Vector{UInt8} → octet-stream (server.jl)
@@ -290,6 +304,7 @@ function api_napari_screenshot(body_bytes::Vector{UInt8})
     finally
         isfile(path) && rm(path; force = true)
     end
+    end  # _with_viewer
 end
 
 # ── REST: POST /api/napari/restart ────────────────────────────────────────────
@@ -297,11 +312,13 @@ end
 function api_napari_restart(body_bytes::Vector{UInt8})
     v = _viewer()
     isnothing(v) && return api_napari_open(body_bytes)
-    try
-        restart!(v)
-        200, JSON3.write((; ok = true))
-    catch e
-        500, JSON3.write((; error = sprint(showerror, e)))
+    _with_viewer() do
+        try
+            restart!(v)
+            200, JSON3.write((; ok = true))
+        catch e
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
     end
 end
 
@@ -315,11 +332,13 @@ function api_napari_show_labels(body_bytes::Vector{UInt8})
     v = _viewer()
     isnothing(v) && return 400, JSON3.write((; error = "Napari not running"))
 
-    try
-        _show_all_labels!(v, all_labels, show)
-        200, JSON3.write((; ok = true))
-    catch e
-        500, JSON3.write((; error = sprint(showerror, e)))
+    _with_viewer() do
+        try
+            _show_all_labels!(v, all_labels, show)
+            200, JSON3.write((; ok = true))
+        catch e
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
     end
 end
 
@@ -364,13 +383,15 @@ function api_napari_show_populations(body_bytes::Vector{UInt8})
                 "show" => p.show, "is_track" => p.is_track, "label_ids" => labs))
         end
     end   # show=false → empty pops → bridge removes the existing pop layers
-    try
-        send(v, Dict{String,Any}("type" => "show_populations", "pop_type" => pop_type,
-            "value_name" => vn, "points_size" => points_size, "pops" => pops))
-        200, JSON3.write((; ok = true, n = length(pops)))
-    catch e
-        @warn "show_populations failed" exception = e
-        500, JSON3.write((; error = sprint(showerror, e)))
+    _with_viewer() do
+        try
+            send(v, Dict{String,Any}("type" => "show_populations", "pop_type" => pop_type,
+                "value_name" => vn, "points_size" => points_size, "pops" => pops))
+            200, JSON3.write((; ok = true, n = length(pops)))
+        catch e
+            @warn "show_populations failed" exception = e
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
     end
 end
 
@@ -468,13 +489,15 @@ function api_napari_show_tracks(body_bytes::Vector{UInt8})
             end
         end
     end   # empty want + no gated + no trackclust → empty pops → bridge removes existing track layers
-    try
-        send(v, Dict{String,Any}("type" => "show_tracks",
-            "tail_width" => tail_width, "color_by" => color_by, "pops" => pops))
-        200, JSON3.write((; ok = true, n = length(pops)))
-    catch e
-        @warn "show_tracks failed" exception = e
-        500, JSON3.write((; error = sprint(showerror, e)))
+    _with_viewer() do
+        try
+            send(v, Dict{String,Any}("type" => "show_tracks",
+                "tail_width" => tail_width, "color_by" => color_by, "pops" => pops))
+            200, JSON3.write((; ok = true, n = length(pops)))
+        catch e
+            @warn "show_tracks failed" exception = e
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
     end
 end
 
@@ -494,12 +517,14 @@ function api_napari_colour_labels(body_bytes::Vector{UInt8})
 
     v = _viewer()
     isnothing(v) && return 400, JSON3.write((; error = "Napari not running"))
-    try
-        send(v, Dict{String,Any}("type" => "colour_labels", "value_name" => vn, "column" => column))
-        200, JSON3.write((; ok = true))
-    catch e
-        @warn "colour_labels failed" exception = e
-        500, JSON3.write((; error = sprint(showerror, e)))
+    _with_viewer() do
+        try
+            send(v, Dict{String,Any}("type" => "colour_labels", "value_name" => vn, "column" => column))
+            200, JSON3.write((; ok = true))
+        catch e
+            @warn "colour_labels failed" exception = e
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
     end
 end
 
@@ -521,14 +546,16 @@ function api_napari_start_selection(body_bytes::Vector{UInt8})
     # (default) ignores z and selects across the whole stack (docs/NAPARI.md).
     z_mode   = String(get(data, :zMode, "stack"))
     z_window = _to_int(get(data, :zWindow, 0))
-    try
-        send(v, Dict{String,Any}("type" => "start_cell_selection",
-            "project_uid" => project_uid, "image_uid" => image_uid,
-            "value_name" => vn, "api_url" => api_url,
-            "z_mode" => z_mode, "z_window" => z_window))
-        200, JSON3.write((; ok = true))
-    catch e
-        500, JSON3.write((; error = sprint(showerror, e)))
+    _with_viewer() do
+        try
+            send(v, Dict{String,Any}("type" => "start_cell_selection",
+                "project_uid" => project_uid, "image_uid" => image_uid,
+                "value_name" => vn, "api_url" => api_url,
+                "z_mode" => z_mode, "z_window" => z_window))
+            200, JSON3.write((; ok = true))
+        catch e
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
     end
 end
 
@@ -543,12 +570,14 @@ function api_napari_selection_scope(body_bytes::Vector{UInt8})
     isnothing(v) && return 400, JSON3.write((; error = "Napari not running"))
     z_mode   = String(get(data, :zMode, "stack"))
     z_window = _to_int(get(data, :zWindow, 0))
-    try
-        send(v, Dict{String,Any}("type" => "update_selection_scope",
-            "z_mode" => z_mode, "z_window" => z_window))
-        200, JSON3.write((; ok = true))
-    catch e
-        500, JSON3.write((; error = sprint(showerror, e)))
+    _with_viewer() do
+        try
+            send(v, Dict{String,Any}("type" => "update_selection_scope",
+                "z_mode" => z_mode, "z_window" => z_window))
+            200, JSON3.write((; ok = true))
+        catch e
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
     end
 end
 
@@ -574,7 +603,9 @@ function api_napari_stop_selection(body_bytes::Vector{UInt8})
     v = _viewer()
     if v !== nothing
         # "Cell selection" mirrors SELECTION_LAYER in napari_bridge.py
-        try; send(v, Dict{String,Any}("type" => "remove_layer", "name" => "Cell selection")); catch; end
+        _with_viewer() do
+            try; send(v, Dict{String,Any}("type" => "remove_layer", "name" => "Cell selection")); catch; end
+        end
     end
     200, JSON3.write((; ok = true))
 end

--- a/api/src/repl_api.jl
+++ b/api/src/repl_api.jl
@@ -76,9 +76,16 @@ function api_repl(body_bytes::Vector{UInt8})
     isempty(code) && return 400, JSON3.write((; error = "empty code"))
     value = nothing; errmsg = nothing; output = ""
     # capture stdout+stderr so `println`/`@info` show in the console. `redirect_stdout` swaps the
-    # PROCESS-global stream, so evals are serialised under a lock (one at a time) to avoid two evals —
-    # or another thread's output — clobbering each other; an async reader drains the pipe so large
-    # output can't deadlock on a full pipe buffer.
+    # PROCESS-global stream, so evals are serialised under a lock (one at a time) to avoid two evals
+    # clobbering each other; an async reader drains the pipe so large output can't deadlock on a full
+    # pipe buffer.
+    #
+    # KNOWN LIMITATION (accepted, not fixed — see docs/API.md): the lock only serialises evals against
+    # each other. Under `-t auto`, any OTHER handler / pool task running concurrently with an eval has
+    # its stdout/stderr (`println`/`@info`/`@warn`) captured into this pipe too — so during an eval,
+    # unrelated server-log lines may appear in the console output or go missing from the server log. A
+    # real fix needs per-task output capture rather than a process-global redirect, which isn't worth
+    # the machinery for a loopback-only, opt-in debug console. The UI shows a note to this effect.
     lock(_REPL_LOCK) do
         old_o, old_e = stdout, stderr
         rd, wr = redirect_stdout()

--- a/app/src/gating/population_manager.jl
+++ b/app/src/gating/population_manager.jl
@@ -254,9 +254,15 @@ gating_path(task_dir::AbstractString, value_name::AbstractString; pop_type::Abst
 function save_pop_map!(m::PopulationMap, task_dir::AbstractString)
     dir = gating_dir(task_dir)
     isdir(dir) || mkpath(dir)
-    open(gating_path(task_dir, m.value_name; pop_type=m.pop_type), "w") do f
+    path = gating_path(task_dir, m.value_name; pop_type=m.pop_type)
+    # Write to a temp file then atomically rename, so a concurrent reader never observes a
+    # half-written (truncated) JSON. The load→mutate→save critical section is itself serialised
+    # by `_POPMAP_LOCK` in the gating API handlers (against lost updates); this guards the file.
+    tmp = path * ".tmp"
+    open(tmp, "w") do f
         JSON3.pretty(f, to_tree(m; include_transient = false))
     end
+    mv(tmp, path; force = true)
     m
 end
 

--- a/app/src/tasks/scheduler.jl
+++ b/app/src/tasks/scheduler.jl
@@ -127,7 +127,10 @@ mutable struct TaskRecord
     image_uid::String
     chain_run_id::String                    # "" for standalone tasks; run.id for chain nodes
     status::Symbol                          # :queued | :running | :done | :failed | :cancelled
-    proc::Union{Base.Process, Nothing}
+    # Written by a worker thread (on_process), read by cancel_task! on another — `@atomic` gives
+    # guaranteed cross-thread visibility of the assignment (the cancel-before-set logical race is
+    # already handled by the on_process race guard below).
+    @atomic proc::Union{Base.Process, Nothing}
     on_status_change::Function
 end
 
@@ -181,7 +184,7 @@ function cancel_task!(task_id::String)
     rec = lock(_TASKS_LOCK) do; get(_TASKS, task_id, nothing); end
     isnothing(rec) && return
     _set_status!(rec, :cancelled)
-    proc = rec.proc
+    proc = @atomic rec.proc
     isnothing(proc) && return
     try
         pid = Int(ccall(:uv_process_get_pid, Cint, (Ptr{Cvoid},), proc.handle))
@@ -225,7 +228,7 @@ function _execute_job!(job::TaskJob)
                   on_log      = line -> Base.invokelatest(job.on_log, line),
                   on_progress = (n, t) -> Base.invokelatest(job.on_progress, n, t),
                   on_process  = proc -> begin
-                      rec.proc = proc
+                      @atomic rec.proc = proc
                       # Race guard: if cancel arrived between :running and now, rec.proc
                       # was nothing when cancel_task! ran, so the kill was skipped. Kill
                       # here now that we hold the process handle.

--- a/app/src/tasks/task.jl
+++ b/app/src/tasks/task.jl
@@ -2,8 +2,12 @@ abstract type CciaTask end
 
 # ── Spec loading ──────────────────────────────────────────────────────────────
 
-const _SPEC_CACHE    = Dict{String, Any}()
-const _FRAGMENTS_DIR = joinpath(@__DIR__, "fragments")
+const _SPEC_CACHE      = Dict{String, Any}()
+# _task_spec is called on every run_task (validate_params/task_scope/pool lookup) and from
+# handle_task_run — concurrent under `-t auto`. An unlocked lazy Dict write can rehash mid-read
+# on another thread → corruption/crash. Serialise the check-and-fill (specs are tiny; contention nil).
+const _SPEC_CACHE_LOCK = ReentrantLock()
+const _FRAGMENTS_DIR   = joinpath(@__DIR__, "fragments")
 
 # Expand a params array: items with {"$include": "name"} are replaced in-place
 # by all items from fragments/name.json. Recurses into nested dicts.
@@ -49,17 +53,19 @@ end
 
 function _task_spec(task::CciaTask)::Union{Dict{String,Any}, Nothing}
     key = string(typeof(task))
-    haskey(_SPEC_CACHE, key) && return _SPEC_CACHE[key]
+    lock(_SPEC_CACHE_LOCK) do
+        haskey(_SPEC_CACHE, key) && return _SPEC_CACHE[key]
 
-    # Map type name → relative spec path inside app/src/tasks/
-    spec_file = _spec_path(task)
-    isnothing(spec_file) && return nothing
-    isfile(spec_file) || return nothing
+        # Map type name → relative spec path inside app/src/tasks/
+        spec_file = _spec_path(task)
+        isnothing(spec_file) && return nothing
+        isfile(spec_file) || return nothing
 
-    spec = JSON3.read(read(spec_file, String), Dict{String,Any})
-    spec = _resolve_spec_includes(spec, _FRAGMENTS_DIR)
-    _SPEC_CACHE[key] = spec
-    spec
+        spec = JSON3.read(read(spec_file, String), Dict{String,Any})
+        spec = _resolve_spec_includes(spec, _FRAGMENTS_DIR)
+        _SPEC_CACHE[key] = spec
+        spec
+    end
 end
 
 # Resolve a producer task's output value_name from its JSON spec's top-level "outputValueName".
@@ -220,14 +226,16 @@ end
 # Override spec caching: CompositeTask type alone is not unique — include fun_name.
 function _task_spec(task::CompositeTask)::Union{Dict{String,Any}, Nothing}
     key = "CompositeTask:$(task.fun_name)"
-    haskey(_SPEC_CACHE, key) && return _SPEC_CACHE[key]
-    spec_file = _spec_path(task)
-    isnothing(spec_file) && return nothing
-    isfile(spec_file)    || return nothing
-    spec = JSON3.read(read(spec_file, String), Dict{String,Any})
-    spec = _resolve_spec_includes(spec, _FRAGMENTS_DIR)
-    _SPEC_CACHE[key] = spec
-    spec
+    lock(_SPEC_CACHE_LOCK) do
+        haskey(_SPEC_CACHE, key) && return _SPEC_CACHE[key]
+        spec_file = _spec_path(task)
+        isnothing(spec_file) && return nothing
+        isfile(spec_file)    || return nothing
+        spec = JSON3.read(read(spec_file, String), Dict{String,Any})
+        spec = _resolve_spec_includes(spec, _FRAGMENTS_DIR)
+        _SPEC_CACHE[key] = spec
+        spec
+    end
 end
 
 """

--- a/app/src/tasks/tracking/track_measures.jl
+++ b/app/src/tasks/tracking/track_measures.jl
@@ -371,11 +371,16 @@ end
 # Cached by the h5ad's mtime (re-tracking auto-invalidates) — so the run-form preflight and the task
 # share one cheap computation per file version. Reads only centroid + track_id (one pass).
 const _MOTION_DIMS_CACHE = Dict{String, MotionDims}()
+# Written from both the GET /api/tracking/motion-dims preflight AND the track_measures task, so
+# concurrent under `-t auto`. Serialise the check-and-fill to avoid an unlocked-Dict rehash race.
+const _MOTION_DIMS_CACHE_LOCK = ReentrantLock()
 function detect_motion_dims(props_path::AbstractString, pixel_res, time_step; flush::Bool=false)::MotionDims
     key = "$(props_path)|$(isfile(props_path) ? mtime(props_path) : 0.0)"
-    (!flush && haskey(_MOTION_DIMS_CACHE, key)) && return _MOTION_DIMS_CACHE[key]
-    tracks = [tr for (tr, _) in _load_tracks_with_labels(props_path, pixel_res, time_step)]
-    _MOTION_DIMS_CACHE[key] = _detect_motion_dims(tracks)
+    lock(_MOTION_DIMS_CACHE_LOCK) do
+        (!flush && haskey(_MOTION_DIMS_CACHE, key)) && return _MOTION_DIMS_CACHE[key]
+        tracks = [tr for (tr, _) in _load_tracks_with_labels(props_path, pixel_res, time_step)]
+        _MOTION_DIMS_CACHE[key] = _detect_motion_dims(tracks)
+    end
 end
 
 # ── Main task entry point ──────────────────────────────────────────────────────

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -1726,6 +1726,8 @@ end
         td = mktempdir()
         save_pop_map!(m, td)
         @test isfile(gating_path(td, "B"))
+        # atomic write: the temp file is renamed into place, never left behind
+        @test !isfile(gating_path(td, "B") * ".tmp")
         m2 = load_pop_map(td, "B")
         @test pop_paths(m2) == pop_paths(m)
         @test pop_at(m2, "/cd4").colour == "#f00"

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,6 +7,30 @@ the thread pool (`-t auto`), so a blocking read doesn't stall the accept loop; J
 serialised (`_with_h5`). The package itself (`Cecelia.jl`) is headless and HTTP-agnostic
 (`ARCHITECTURE.md`); routes are thin adapters that resolve objects and call package functions.
 
+## Thread safety (`-t auto`)
+
+Every handler runs on the thread pool, so two requests can execute concurrently. Anything they
+share must be guarded. All Python runs as a **subprocess** (`run_py`) — there is no in-process
+CPython/PyCall, so the GIL is a non-issue. The locks that exist:
+
+| Shared state | Lock | Where |
+|---|---|---|
+| HDF5 / `.h5ad` access | `_HDF5_LOCK` (`_with_h5`) | `app/src/label_props.jl` |
+| Task-spec cache (`_SPEC_CACHE`) | `_SPEC_CACHE_LOCK` | `app/src/tasks/task.jl` |
+| Motion-dims cache (`_MOTION_DIMS_CACHE`) | `_MOTION_DIMS_CACHE_LOCK` | `app/src/tasks/tracking/track_measures.jl` |
+| Gating pop CRUD (load→mutate→save) | `_POPMAP_LOCK` + atomic temp-file write | `api/src/gating_api.jl`, `app/src/gating/population_manager.jl` |
+| Scheduler task registry / pools / cancels | `_TASKS_LOCK` / `_POOLS_LOCK` / `_CANCELLED_CHAINS_LOCK` | `app/src/tasks/scheduler.jl` |
+| The single napari bridge process | `_viewer_lock` (`_with_viewer`) — every handler holds it across its send-sequence | `api/src/napari_api.jl` |
+
+`TaskRecord.proc` is `@atomic` (written by a worker, read by `cancel_task!`).
+
+**Known limitation — debug console output capture.** `/api/repl` uses `redirect_stdout`, which
+swaps the **process-global** stream. `_REPL_LOCK` serialises evals against each other, but any
+*other* handler/task running concurrently with an eval has its `println`/`@info` captured into the
+eval's pipe (or missing from the server log) for the eval's duration. Accepted, not fixed: a real
+fix needs per-task output capture, disproportionate for a loopback-only, opt-in dev console. The
+Settings → Debug console UI shows a note to this effect.
+
 ## Conventions
 
 - **Routing**: a flat dispatch in `server.jl` `handle_http(req, body_bytes)` — GET reads

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -284,8 +284,8 @@ onMounted(loadDiag)
     <section v-if="diag?.replAvailable" class="settings-section">
       <h2 class="section-title">Debug console</h2>
       <span class="field-hint">
-        Evaluates Julia in the running server process (<code>CECELIA_REPL</code> on, loopback-bound).
-        Full access to the server — use with care.
+        Evaluates Julia in the running server — full access, use with care.
+        Concurrent task logs may briefly appear here during a run.
       </span>
 
       <div v-if="replLog.length" class="repl-log">


### PR DESCRIPTION
## fix(threading): Phase 2 lock audit

Handlers run concurrently on the thread pool (`-t auto`). Phase 1 covered HDF5 (`_with_h5`);
this closes the remaining shared-state gaps from a full `api/src` + `app/src` audit.

**Reassuring finding:** there is **no in-process Python** — all Python runs as a `run_py`
subprocess — so the GIL/PyCall risk doesn't exist. The real surface was caches, gating
files, and the single napari bridge.

### Fixes
| # | Severity | Fix |
|---|---|---|
| 1 | HIGH | `_SPEC_CACHE_LOCK` around `_task_spec` (`task.jl`) — lazy Dict written on every `run_task`; concurrent cold-cache fills could rehash-corrupt/crash |
| 2 | HIGH | `_MOTION_DIMS_CACHE_LOCK` (`track_measures.jl`) — written from both the motion-dims GET preflight and the task |
| 3 | MED | `_POPMAP_LOCK` across load→mutate→save in all 5 gating CRUD handlers + atomic temp-file write in `save_pop_map!` — no lost updates / torn JSON from two tabs or rapid clicks |
| 5 | LOW | `_with_viewer` (`_viewer_lock`) around every napari handler's send-sequence + the `_current_*` refs — single-flights the one bridge process |
| 6 | LOW | `@atomic proc` on `TaskRecord` (`scheduler.jl`) — written by a worker, read by `cancel_task!` |

### Documented, not fixed (#4)
`/api/repl` uses process-global `redirect_stdout`, so during an eval, concurrent task logs
can land in the console output (and briefly miss the server log). Accepted for a loopback-only,
opt-in dev console — a real fix needs per-task capture. Noted in `docs/API.md` (new **Thread
safety** section) and the console UI.

### Notes
- `api/src` isn't Revise-tracked and `@atomic` is a struct change → **restart the server**.
- Tests: package suite **713 pass** (+ atomic-write no-leftover-`.tmp` assertion), api harness **18 pass**.