### PR TITLE
fix(segment/qc): morphology-measure parity + var-measures-are-numeric

### DIFF
--- a/app/py/utils/measure_utils.py
+++ b/app/py/utils/measure_utils.py
@@ -30,9 +30,10 @@ try:
 except ImportError:
     _HAS_TRIMESH = False
 
-# 2D regionprops (standard set)
+# 2D regionprops (standard set). `bbox` is intentionally NOT measured — it's a structural extent,
+# not a QC morphology measure, and nothing downstream reads it (it only cluttered the h5ad var).
 _PROPS_2D = [
-    'label', 'centroid', 'bbox', 'area',
+    'label', 'centroid', 'area',
     'eccentricity', 'orientation', 'perimeter',
     'convex_area', 'equivalent_diameter', 'extent',
     'feret_diameter_max', 'major_axis_length', 'minor_axis_length', 'solidity',
@@ -40,15 +41,15 @@ _PROPS_2D = [
 
 # 3D regionprops — used when extendedMeasures is False or trimesh is unavailable.
 # solidity excluded: qhull convex hull fails for cells spanning only one Z-slice,
-# flooding stderr. feret_diameter_max excluded: O(n²) voxel distance matrix.
+# flooding stderr. feret_diameter_max excluded: O(n²) voxel distance matrix. bbox excluded (see 2D).
 _PROPS_3D = [
-    'label', 'centroid', 'bbox', 'area', 'extent',
+    'label', 'centroid', 'area', 'extent',
     'equivalent_diameter_area', 'euler_number', 'inertia_tensor_eigvals',
 ]
 
 # Minimal 3D props used when trimesh handles shape descriptors.
 _PROPS_3D_BASE = [
-    'label', 'centroid', 'bbox', 'area', 'extent',
+    'label', 'centroid', 'area', 'extent',
 ]
 
 
@@ -175,17 +176,21 @@ class MeasureUtils:
         return df
 
     def _add_2d_derived(self, df: pd.DataFrame) -> pd.DataFrame:
+        # 2D shape descriptors — ported verbatim from the old R measure_utils.py so the two versions
+        # agree (2D block, lines ~570-596). Axis-length ratios (NOT the circularity proxy the interim
+        # port used): oblate/prolate are minor↔major axis ratios, matching the 3D ellipticity set.
         if 'major_axis_length' in df and 'minor_axis_length' in df:
-            maj = df['major_axis_length'].replace(0, np.nan)
-            df['aspect_ratio']      = df['minor_axis_length'] / maj
+            maj  = df['major_axis_length'].replace(0, np.nan)
+            minr = df['minor_axis_length'].replace(0, np.nan)
+            df['oblate']  = df['minor_axis_length'] / maj      # ∈ (0,1], 1 = round
+            df['prolate'] = df['major_axis_length'] / minr     # ≥ 1
+        if 'major_axis_length' in df and 'equivalent_diameter' in df:      # Mesmer-style aspect ratio
+            df['aspect_ratio'] = df['major_axis_length'] / df['equivalent_diameter'].replace(0, np.nan)
         if 'perimeter' in df and 'area' in df:
-            area = df['area'].replace(0, np.nan)
-            df['perimeter_to_area'] = df['perimeter'] / area
-            # circularity / oblate proxy
-            df['oblate']  = (4 * np.pi * area) / (df['perimeter'] ** 2).replace(0, np.nan)
-        if 'minor_axis_length' in df and 'major_axis_length' in df:
-            maj = df['major_axis_length'].replace(0, np.nan)
-            df['prolate'] = df['minor_axis_length'] ** 2 / (maj * df.get('interm_axis_length', maj)).replace(0, np.nan)
+            df['perimeter_to_area'] = (df['perimeter'] ** 2) / df['area'].replace(0, np.nan)
+        if 'convex_area' in df and 'area' in df:                          # fraction of hull NOT filled
+            ca = df['convex_area'].replace(0, np.nan)
+            df['fill'] = (df['convex_area'] - df['area']) / ca
         return df
 
     def _add_3d_derived(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -205,6 +210,25 @@ class MeasureUtils:
             df['interm_axis_length'] = axes[np.arange(len(axes)), idx[:, 1]]
             df['minor_axis_length']  = axes[np.arange(len(axes)), idx[:, 2]]
             df.drop(columns=ev_cols, inplace=True)
+            # ellipticity ratios from the ellipsoid axis lengths — cheap (no mesh, no extendedMeasures),
+            # so a plain 3D segmentation gets oblate/prolate too. Ports the old R 3D ellipticity set
+            # (measure_utils.py lines ~557-560): minor↔major and the intermediate-axis variants.
+            df = self._add_ellipticity(df)
+        return df
+
+    @staticmethod
+    def _add_ellipticity(df: pd.DataFrame) -> pd.DataFrame:
+        """3D ellipticity ratios from major ≥ interm ≥ minor axis lengths (old R `ellipticity_*`)."""
+        need = ('major_axis_length', 'interm_axis_length', 'minor_axis_length')
+        if not all(c in df for c in need):
+            return df
+        maj    = df['major_axis_length'].replace(0, np.nan)
+        interm = df['interm_axis_length'].replace(0, np.nan)
+        minr   = df['minor_axis_length'].replace(0, np.nan)
+        df['ellipticity_oblate']         = df['minor_axis_length']  / maj      # ∈ (0,1], 1 = spherical
+        df['ellipticity_prolate']        = df['major_axis_length']  / minr     # ≥ 1
+        df['ellipticity_interm_oblate']  = df['minor_axis_length']  / interm
+        df['ellipticity_interm_prolate'] = df['interm_axis_length'] / minr
         return df
 
     # ── extended 3D via trimesh ───────────────────────────────────────────────
@@ -243,9 +267,10 @@ class MeasureUtils:
                 'euler_number_mesh':  float(mesh.euler_number),
             }
 
-            # solidity from mesh volumes
+            # solidity from mesh volumes (only meaningful measure of solidity in 3D → keep the plain
+            # name, matching old R; the 2D regionprops `solidity` never coexists with the mesh path)
             if ch.volume > 0:
-                row['solidity_mesh'] = float(mesh.volume) / float(ch.volume)
+                row['solidity'] = float(mesh.volume) / float(ch.volume)
 
             # surface-to-volume
             if mesh.volume > 0:
@@ -266,9 +291,8 @@ class MeasureUtils:
                 row['major_axis_length']  = float(radii[0])
                 row['interm_axis_length'] = float(radii[1])
                 row['minor_axis_length']  = float(radii[2])
-                if radii[0] > 0:
-                    row['ellipticity_oblate']  = radii[2] / radii[0]
-                    row['ellipticity_prolate'] = radii[1] / radii[0]
+                # ellipticity ratios are derived from these axis lengths below (via _add_ellipticity),
+                # so both the mesh and moments paths use the SAME formula (was inconsistent here).
             except Exception:
                 pass
 
@@ -289,6 +313,8 @@ class MeasureUtils:
             for col in ext_df.columns:
                 if col not in ('major_axis_length', 'interm_axis_length', 'minor_axis_length'):
                     df[col] = ext_df[col]
+            # ellipticity ratios from the mesh-derived axis lengths — same formula as the moments path
+            df = self._add_ellipticity(df)
 
         return df
 

--- a/app/src/plotting/plot_data.jl
+++ b/app/src/plotting/plot_data.jl
@@ -128,12 +128,29 @@ function _downsample(vals::Vector{Float64}, cap::Int)::Vector{Float64}
     vals[round.(Int, range(1, n; length = cap))]
 end
 
+# Morphology/intensity `var` columns are quantitative by construction — an integer-valued one
+# (`euler_number`, voxel-count `area`) is STILL numeric. The categorical heuristic (`_is_categorical_col`)
+# is only for `obs` columns (hmm.state, clusters, generation — written as anndata categoricals). So the
+# measure type of a var column is always numeric; only an obs measure defers to detection. This is the
+# structural rule that replaces the old R `config.yml parameters.labelStats` per-column map.
+function _var_measure_set(img::CciaImage, value_name)::Set{String}
+    vn = something(value_name, get(img.label_props, "_active", "default"))
+    try
+        Set(String.(col_names(label_props(img; value_name=vn); data_type=:vars)))
+    catch
+        Set{String}()
+    end
+end
+_var_measure_set(imgs::AbstractVector{<:CciaImage}, value_name)::Set{String} =
+    isempty(imgs) ? Set{String}() : _var_measure_set(first(imgs), value_name)
+
 # Shared aggregation core over an already-built pop_df frame. `by_image` → one series per source
 # image (cross-image comparison); else images (if any) are pooled. Used by both the single-image
 # and the multi-image `plot_summary_data` methods so the chart logic lives in one place.
 function _summary_agg(df::DataFrame, chart_type::AbstractString;
                       measure::Union{AbstractString,Nothing}, granularity::Symbol,
                       nbins::Int, normalize::Symbol, by_image::Bool,
+                      var_cols::Set{String}=Set{String}(),
                       group_by::Union{AbstractString,Nothing}=nothing, collapse_series::Bool=false,
                       raw_points::Bool=false, max_points::Int=1500,
                       matrix_mode::Union{AbstractString,Nothing}=nothing,
@@ -159,7 +176,8 @@ function _summary_agg(df::DataFrame, chart_type::AbstractString;
     # detected measure type (numeric vs categorical) so the panel can offer only the applicable
     # chart types (docs/PLOTS.md §2). Auto-detection is shared with track_props (`_is_categorical_col`).
     mtype = (measure !== nothing && String(measure) in names(df)) ?
-            (_is_categorical_col(df[!, String(measure)], String(measure)) ? "categorical" : "numeric") : "numeric"
+            (String(measure) in var_cols ? "numeric" :                        # var = quantitative, always
+             _is_categorical_col(df[!, String(measure)], String(measure)) ? "categorical" : "numeric") : "numeric"
     if chart_type == "points"
         # raw (downsampled) values per series — the data source for strip/jitter and (client-side
         # density) violin charts. No server aggregation beyond the per-group downsample.
@@ -444,6 +462,7 @@ function plot_summary_data(img::CciaImage, pop_type::AbstractString, pops, chart
                 raw_channel_names=(chart_type == "matrix"))
     _summary_agg(df, chart_type; measure=measure, granularity=granularity,
                  nbins=nbins, normalize=normalize, by_image=false, group_by=group_by,
+                 var_cols=_var_measure_set(img, value_name),
                  collapse_series=collapse_series, raw_points=raw_points, max_points=max_points,
                  matrix_mode=matrix_mode, measures=measures, category=category,
                  separator=separator, zscore=zscore, matrix_normalize=matrix_normalize)
@@ -469,7 +488,8 @@ function plot_summary_data(imgs::AbstractVector{<:CciaImage}, uids::AbstractVect
                 raw_channel_names=(chart_type == "matrix"))
     result = _summary_agg(df, chart_type; measure=measure, granularity=granularity,
                           nbins=nbins, normalize=normalize, by_image=(scope == :per_image),
-                          group_by=group_by, collapse_series=collapse_series,
+                          group_by=group_by, var_cols=_var_measure_set(imgs, value_name),
+                          collapse_series=collapse_series,
                           raw_points=raw_points, max_points=max_points,
                           matrix_mode=matrix_mode, measures=measures, category=category,
                           separator=separator, zscore=zscore, matrix_normalize=matrix_normalize,
@@ -520,6 +540,7 @@ function plot_summary_data(img::CciaImage, pop_type::AbstractString,
                raw_channel_names=(chart_type == "matrix")))
     _summary_agg(df, chart_type; measure=measure, granularity=granularity,
                  nbins=nbins, normalize=normalize, by_image=false, group_by=group_by,
+                 var_cols=_var_measure_set(img, isempty(targets) ? nothing : first(targets)[1]),
                  collapse_series=collapse_series, raw_points=raw_points, max_points=max_points,
                  matrix_mode=matrix_mode, measures=measures, category=category,
                  separator=separator, zscore=zscore, matrix_normalize=matrix_normalize)
@@ -546,7 +567,9 @@ function plot_summary_data(imgs::AbstractVector{<:CciaImage}, uids::AbstractVect
                raw_channel_names=(chart_type == "matrix")))
     result = _summary_agg(df, chart_type; measure=measure, granularity=granularity,
                           nbins=nbins, normalize=normalize, by_image=(scope == :per_image),
-                          group_by=group_by, collapse_series=collapse_series,
+                          group_by=group_by,
+                          var_cols=_var_measure_set(imgs, isempty(targets) ? nothing : first(targets)[1]),
+                          collapse_series=collapse_series,
                           raw_points=raw_points, max_points=max_points,
                           matrix_mode=matrix_mode, measures=measures, category=category,
                           separator=separator, zscore=zscore, matrix_normalize=matrix_normalize,

--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -64,7 +64,13 @@ add a new plot with its own popover/menu, follow this pattern — a plain absolu
 
 1. **Measure type** — auto-detected (`project_measure_type_detection`): **numeric** (continuous, e.g.
    `live.track.speed`) vs **categorical** (string / integer-coded, e.g. `live.cell.hmm.state.*`,
-   `track_generation`). Decides which chart types are *applicable*.
+   `track_generation`). Decides which chart types are *applicable*. **Structural rule:** a **`var`
+   column (morphology/intensity) is always numeric** — even integer-valued ones (`euler_number`,
+   voxel-count `area`) — so the integer-code heuristic never mislabels a shape measure as categorical
+   (which would drop the numeric charts and reset the panel to `count`). The heuristic runs only for
+   `obs` measures, where genuine categoricals are anyway written as anndata `categorical`. This
+   replaces the old R `config.yml parameters.labelStats` per-column map (`_var_measure_set` in
+   `plot_data.jl`).
 2. **Data source** — **one image** / **multiple images (`per_image`)** / **pooled** (images merged) /
    **by attribute** (images grouped by one or more shared image attributes, e.g. `Treatment`, or
    `Treatment` × `Mouse`). Set by the canvas "compare" control; orthogonal to chart type. *By attribute*

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -245,11 +245,15 @@ Flat `Dict{String,String}` — value_name → h5ad filename. Written by `measure
 
 ### Morphology properties
 
-**2D**: area, perimeter, eccentricity, orientation, major/minor axis, solidity, feret diameter, convex area, equivalent diameter, extent → derived: aspect ratio, perimeter-to-area, oblate index.
+The derived shape descriptors are ported from the old R `measure_utils.py` so the two versions agree
+(`oblate`/`prolate` are **axis-length ratios**, not a circularity proxy). `bbox` is **not** saved — it's a
+structural extent, not a QC measure, and nothing reads it.
 
-**3D basic** (skimage): area (voxel count = volume), extent, solidity, equivalent diameter, euler number, feret diameter max, inertia tensor eigenvalues → derived: major/minor/intermediate axis lengths.
+**2D**: area, perimeter, eccentricity, orientation, major/minor axis, solidity, feret diameter, convex area, equivalent diameter, extent → derived: `oblate` (minor/major), `prolate` (major/minor), `aspect_ratio` (major/equivalent_diameter), `perimeter_to_area` (perimeter²/area), `fill` ((convex−area)/convex).
 
-**3D extended** (`extendedMeasures=true`, requires trimesh): surface area, mesh volume, convex hull area/volume, sphericity, compactness, surface-to-volume, ellipsoid axis lengths from convex hull vertex PCA, ellipticity oblate/prolate. Overrides skimage axis lengths with ellipsoid-fit values.
+**3D basic** (skimage, no mesh): area (voxel count = volume), extent, `equivalent_diameter_area`, `euler_number`, inertia tensor eigenvalues → derived: major/interm/minor axis lengths **and** the ellipticity ratios `ellipticity_oblate` (minor/major), `ellipticity_prolate` (major/minor), `ellipticity_interm_oblate` (minor/interm), `ellipticity_interm_prolate` (interm/minor). Axis ratios come from the moments — no mesh — so a plain 3D segmentation gets oblate/prolate too. `solidity` is **not** available here (needs a convex hull → extended).
+
+**3D extended** (`extendedMeasures=true`, requires trimesh): `surface_area`, `volume_mesh`, convex hull area/volume, `solidity` (mesh/hull volume), `sphericity`, `compactness`, `surface_to_volume`, `feret_diameter_max_mesh`, ellipsoid axis lengths from convex-hull vertex PCA, and the same `ellipticity_*` ratios (computed from those axis lengths — one formula for both paths). Overrides skimage axis lengths with ellipsoid-fit values.
 
 ### $include template system
 

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -48,6 +48,9 @@ const param = (k: string, d: unknown) => props.spec.params?.find(p => p.key === 
 // discovered columns of the selected image+segmentation (loaded in loadObsCols below). Declared up
 // here — BEFORE measureOpts/its watch — because `watch(measureOpts)` evaluates its getter at setup,
 // which reads these refs; declaring them later would be a temporal-dead-zone crash.
+// structural regionprops that are not QC morphology measures (bounding box, centroid, raw inertia
+// eigvals, the label index). New measurements no longer save bbox; this also hides it in existing data.
+const STRUCTURAL_COL = /^(label$|bbox[-_]|centroid[-_]|inertia_tensor)/
 const varCols = ref<string[]>([])        // var columns (morphology + intensity)
 const channelCols = ref<string[]>([])    // intensity var columns specifically (mean_intensity_* / renamed)
 const obsCols = ref<string[]>([])        // obs columns (live.cell.*, hmm.state, cluster ids, …)
@@ -60,7 +63,10 @@ const measureOpts = computed(() => {
   // curated subset and not the intensity channels. Default measure first.
   if (ds.measuresFromData && varCols.value.length) {
     const intensity = new Set(channelCols.value)
-    const morph = varCols.value.filter(c => !intensity.has(c))
+    // structural regionprops (bounding box, centroid, raw inertia eigvals, the label index) are not
+    // QC morphology measures. New measurements no longer save bbox at all (measure_utils), but existing
+    // h5ads still carry `bbox-*` — filter them here so the list stays to actual shape descriptors.
+    const morph = varCols.value.filter(c => !intensity.has(c) && !STRUCTURAL_COL.test(c))
     const rest = morph.filter(c => c !== ds.measure).sort((a, b) => a.localeCompare(b))
     return morph.includes(ds.measure) ? [ds.measure, ...rest] : rest
   }


### PR DESCRIPTION
## fix(segment/qc): morphology-measure parity + var-measures-are-numeric

Restores the old-R shape-descriptor set for segmentation QC and fixes two QC-plot bugs.

### `measure_utils.py` — derived measures to old-R parity
`oblate`/`prolate` are now **axis-length ratios** (matching old R), not the interim circularity proxy.
- **2D**: `oblate`=minor/major, `prolate`=major/minor, `aspect_ratio`=major/equiv_diameter, `perimeter_to_area`=perimeter²/area, `fill`=(convex−area)/convex.
- **3D (no mesh)**: `ellipticity_oblate/prolate` + `ellipticity_interm_oblate/prolate` derived from the inertia-tensor axis lengths — so a plain 3D segmentation gets oblate/prolate too (previously only via the extended mesh path).
- **3D extended**: same ellipticity formula as the moments path (fixes the wrong `ellipticity_prolate`); `solidity_mesh` → `solidity`.
- **`bbox` is no longer measured/saved** — structural extent, not a QC measure, and unread downstream.

### `plot_data.jl` — measure-type rule
A `var` (morphology/intensity) column is **always numeric**, even integer-valued (`euler_number`, voxel-count `area`). The integer-code categorical heuristic now runs only for `obs` measures. Fixes the QC panel resetting the chart type to `count` when an integer morphology measure was selected. Replaces the old R `config.yml parameters.labelStats` map (`_var_measure_set`).

### `SummaryPanel.vue`
Hides structural columns (`bbox-*`/`centroid-*`/`inertia`/`label`) from the QC measure list — covers existing h5ads that still carry `bbox-*`.

### Notes
- Docs: `SEGMENTATION.md` morphology table, `PLOTS.md` measure-type rule.
- **Existing h5ads need re-measuring** to gain the new/renamed columns.
- Tests: Julia 722 pass; frontend typecheck clean; derived-measure golden values verified.