### PR TITLE
fix(chain): flatten nested `section` params before running a task

### DIFF
--- a/app/src/tasks/chain.jl
+++ b/app/src/tasks/chain.jl
@@ -613,8 +613,10 @@ function _run_set_scope_node!(run::ChainRun, node::ChainNode,
     end
 
     result = try
+        # set-scope nodes call _run_task directly (not via run_task), so flatten nested `section`
+        # params here too — else a chain-saved section param (e.g. clustering options) is dropped.
         _run_task(task_struct, imgs,
-                  merge(effective_params, Dict("_task_id" => tid));
+                  _flatten_sections(task_struct, merge(effective_params, Dict("_task_id" => tid)));
                   on_log      = line -> Base.invokelatest(on_log, "[set/$(node.id)] $line"),
                   on_process  = _ -> nothing)
     catch e
@@ -675,7 +677,7 @@ function _run_incremental_node!(run::ChainRun, node::ChainNode,
 
     function run_plot!(imgs_snap::Vector{CciaImage})
         result = try
-            _run_task(task_struct, imgs_snap, effective_params;
+            _run_task(task_struct, imgs_snap, _flatten_sections(task_struct, effective_params);
                       on_log     = line -> Base.invokelatest(on_log, "[incr/$(node.id)] $line"),
                       on_process = _ -> nothing)
         catch e

--- a/app/src/tasks/scheduler.jl
+++ b/app/src/tasks/scheduler.jl
@@ -303,6 +303,7 @@ function run_task(task::CciaTask, img::CciaImage, params::Dict{String,Any};
                   on_progress::Function      = (n, t) -> nothing,
                   on_process::Function       = _ -> nothing,
                   on_status_change::Function = _ -> nothing)
+    params = _flatten_sections(task, params)   # lift nested `section` params (chain-saved) to top level
     validate_params(task, params)
     fun_name  = _fun_name_from_task(task)
     pool_name = isempty(pool_name) ? _task_pool_name(task) : pool_name
@@ -337,6 +338,7 @@ function run_task(task::CciaTask, imgs::Vector{CciaImage}, params::Dict{String,A
                   on_process::Function       = _ -> nothing,
                   on_status_change::Function = _ -> nothing)
     isempty(imgs) && error("run_task (set-scope): no images")
+    params = _flatten_sections(task, params)   # lift nested `section` params (chain-saved) to top level
     validate_params(task, params)
     fun_name  = _fun_name_from_task(task)
     pool_name = isempty(pool_name) ? _task_pool_name(task) : pool_name

--- a/app/src/tasks/task.jl
+++ b/app/src/tasks/task.jl
@@ -238,6 +238,46 @@ function _task_spec(task::CompositeTask)::Union{Dict{String,Any}, Nothing}
     end
 end
 
+# `section` params are a UI grouping only — their sub-params belong at the TOP LEVEL of the params
+# dict, which is where validate_params and every task's `_run_task` read them. The module-page runner
+# flattens before sending (frontend `TaskRunner.flattenParams`), but the whiteboard/chain persists them
+# NESTED under the section key (e.g. `measureOptions => {extendedMeasures: true}`), so a chain run would
+# otherwise drop every section param (extendedMeasures, the imageTiling block, …) to its default.
+# `run_task` normalises here so both paths — and already-saved chains — behave identically. Composites
+# carry no params of their own, so their section keys come from the sub-task specs.
+function _section_keys(task::CciaTask)::Set{String}
+    spec = _task_spec(task)
+    ks = Set{String}()
+    isnothing(spec) && return ks
+    for step in get(spec, "composite", String[])
+        sub = try _task_from_fun_name(string(step)) catch; nothing end
+        isnothing(sub) || union!(ks, _section_keys(sub))
+    end
+    for p in get(spec, "params", [])
+        (p isa AbstractDict && string(get(p, "type", "")) == "section") && push!(ks, string(get(p, "key", "")))
+    end
+    ks
+end
+
+# Lift nested `section` sub-params to the top level. Idempotent: already-flat params have no section
+# key to lift; an explicit top-level value is never clobbered by a section entry of the same name.
+function _flatten_sections(task::CciaTask, params::Dict{String,Any})::Dict{String,Any}
+    section_keys = _section_keys(task)
+    isempty(section_keys) && return params
+    out = params; copied = false
+    for k in section_keys
+        v = get(out, k, nothing)
+        v isa AbstractDict || continue
+        copied || (out = copy(out); copied = true)
+        for (sk, sv) in v
+            skk = string(sk)
+            haskey(out, skk) || (out[skk] = sv)
+        end
+        delete!(out, k)
+    end
+    out
+end
+
 """
     task_scope(task) -> "image" | "set"
 

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -148,6 +148,32 @@ end
             ClustPops(), Dict{String,Any}("resolution" => "not-a-number"))
     end
 
+    # ── Section-param flattening (whiteboard/chain stores section params NESTED) ───
+    # Regression: a chain node saves `section` params under the section key (e.g.
+    # measureOptions => {extendedMeasures: true}), but tasks read them flat. run_task must lift them.
+    @testset "Section params flatten (chain nesting)" begin
+        ml = _task_from_fun_name("segment.measureLabels")
+        # measureLabels declares `measureOptions` + `imageTiling` sections
+        @test "measureOptions" in Cecelia._section_keys(ml)
+        @test "imageTiling"    in Cecelia._section_keys(ml)
+        nested = Dict{String,Any}(
+            "outputValueName" => "T",
+            "measureOptions"  => Dict{String,Any}("extendedMeasures" => true, "saveMeshes" => false),
+            "imageTiling"     => Dict{String,Any}("blockSize" => 4096, "overlap" => 0))
+        flat = Cecelia._flatten_sections(ml, nested)
+        @test flat["extendedMeasures"] == true          # was buried under measureOptions
+        @test flat["blockSize"] == 4096                  # was buried under imageTiling
+        @test !haskey(flat, "measureOptions")            # section container dropped
+        @test flat["outputValueName"] == "T"             # top-level survives
+        # composite pulls section keys from its sub-tasks (cellpose + measureLabels)
+        comp = _task_from_fun_name("segment.cellposeMeasure")
+        @test "measureOptions" in Cecelia._section_keys(comp)
+        @test Cecelia._flatten_sections(comp,
+            Dict{String,Any}("measureOptions" => Dict{String,Any}("extendedMeasures" => true)))["extendedMeasures"] == true
+        # already-flat params are unchanged (idempotent)
+        @test Cecelia._flatten_sections(ml, Dict{String,Any}("extendedMeasures" => true))["extendedMeasures"] == true
+    end
+
     # ── Dispatch + param validation — ClustTracks (clustTracks.cluster, set-scope) ───
     @testset "Param validation — ClustTracks" begin
         @test _task_from_fun_name("clustTracks.cluster") isa ClustTracks


### PR DESCRIPTION
## fix(chain): flatten nested `section` params before running a task

`section` params are a **UI grouping only** — their sub-params belong at the top level of the params dict, where `validate_params` and every task's `_run_task` read them. The module-page runner flattens before sending (frontend `TaskRunner.flattenParams`), but the **whiteboard/chain persists them nested** under the section key (e.g. `measureOptions => {extendedMeasures: true}`, `imageTiling => {blockSize, overlap}`). So a chain run silently dropped every section param to its default — **which is why a ticked "Extended 3D measures" on a whiteboard node never reached the measurement.**

### Fix — normalize at the backend run chokepoints
So both paths **and already-saved chains** behave identically (no re-saving needed):
- `_section_keys` / `_flatten_sections` (`task.jl`) — spec-aware; recurses into composites so a composite's section keys come from its sub-task specs.
- `run_task` (`scheduler.jl`) — flatten before validate (image-scope + direct API/module runs).
- `chain.jl` — set-scope and incremental nodes call `_run_task` directly, so flatten there too.

Idempotent: already-flat params have no section key to lift; `group` (index-keyed) params are untouched.

### Impact
Affects **every `section` param in every chain-run task** — `extendedMeasures`, `saveMeshes`, the whole `imageTiling` block (`blockSize`/`overlap`/`blockSizeZ`/`overlapZ`), and clustering options on set-scope nodes.

Tests: new testset asserts nested `measureOptions`/`imageTiling` lift to top level, composites pull section keys from sub-tasks, flat params unchanged. Julia 722 pass.