### PR TITLE
feat(plots): delayed loading spinner for heavy plots

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -333,6 +333,26 @@ graphics lib gives the cleaner publication look for pre-aggregated summaries. Ne
 job well, so we keep both. Never add or swap a charting library without updating this doc, `docs/PLOTS.md`,
 and the `cecelia-charting-decision` rationale.
 
+### Plot loading state — delayed spinner
+
+Heavy plots (a slow `/api/plot_data`, a big WebGL point fetch) must show they're working — a blank
+panel reads as "frozen". But a spinner that flashes on every quick plot is worse noise. So the rule:
+**a delayed spinner, never an immediate one.**
+
+- `composables/useDelayedLoading.ts` — `useDelayedLoading(loadingRef, delayMs = 350)` → a `show` ref
+  that flips true ONLY if loading stays true past the threshold, and clears instantly when it ends.
+  Fast/cheap plots finish before 350 ms, so they never flash it; only genuinely heavy loads reveal it.
+  Use `toRef(props, 'loading')` when the loading state is a prop.
+- `components/plots/PlotSpinner.vue` — the shared wheel overlay. Put it inside a `position: relative`
+  container: `<PlotSpinner v-if="showSpinner" label="Loading…" />`. It's `pointer-events: none`, so it
+  never blocks the plot underneath, and honours `prefers-reduced-motion`.
+
+Do **not** hand-roll per-plot "…" text or an immediate spinner. **Small/embedded plots stay out**: the
+gating-strategy montage tiles (compact `GateScatterCell`) keep an unobtrusive dot, not a wheel per tile
+— gate the overlay on `!compact` (or equivalent). Wired today in `SummaryPanel` and the full-size
+`GateScatterCell` (Gate page); `UmapView` has its own empty-state wheel. New heavy plots: reuse these
+two primitives.
+
 ### Generic plot-integration interface (reuse across surfaces)
 
 A plot is defined **once** and appears on any surface — module page, **Analysis board**, and (future)

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -13,6 +13,8 @@
 import { ref, computed, watch, nextTick, onMounted, onUnmounted, useTemplateRef } from 'vue'
 import CanvasPanel from './CanvasPanel.vue'
 import PlotChart from '../plots/PlotChart.vue'
+import PlotSpinner from '../plots/PlotSpinner.vue'
+import { useDelayedLoading } from '../../composables/useDelayedLoading'
 import { backendChart, chartsForMeasure, plotDataToCsv, defaultVis, type VisProps, type BuildOpts } from '../../plots/plot'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import type { PlotSpec, PlotDataResponse, PlotSeries, ChartType, SeriesTarget } from '../../plots/types'
@@ -210,6 +212,8 @@ const chartLabel = (c: ChartType) => CHART_LABELS[c] ?? c
 const crossImage = computed(() => !!props.setUid)
 const result = ref<PlotDataResponse | null>(null)
 const loading = ref(false)
+// delayed spinner — only shows if a fetch runs past the threshold, so quick plots never flash it
+const showSpinner = useDelayedLoading(loading)
 const error = ref('')
 // Fetch coordination. Rapid setting changes cascade through several watchers (measure → validCharts →
 // chartType, groupBy → timeSeries, …); without this those fired overlapping requests whose responses
@@ -502,10 +506,9 @@ defineExpose({ getCsv, exportImage })
     <div class="sp-body">
       <div v-if="!series.length" class="sp-msg">Select one or more populations (eye icon) to plot.</div>
       <div v-else-if="error" class="sp-msg sp-err">{{ error }}</div>
-      <div v-else-if="!hasData && loading" class="sp-msg">…</div>
-      <div v-else-if="!hasData" class="sp-msg">No data for the selected populations.</div>
-      <PlotChart v-else ref="plotRef" :data="result" :opts="buildOpts" />
-      <div v-if="loading && hasData" class="sp-loading">…</div>
+      <div v-else-if="!hasData && !loading" class="sp-msg">No data for the selected populations.</div>
+      <PlotChart v-else-if="hasData" ref="plotRef" :data="result" :opts="buildOpts" />
+      <PlotSpinner v-if="showSpinner" label="Loading…" />
     </div>
   </CanvasPanel>
 </template>
@@ -538,5 +541,4 @@ defineExpose({ getCsv, exportImage })
 .sp-body { position: relative; flex: 1; min-height: 200px; padding: 8px; overflow: hidden; }
 .sp-msg { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--cc-text-dim); font-size: 12px; text-align: center; padding: 12px; }
 .sp-err { color: var(--cc-danger, #f87171); }
-.sp-loading { position: absolute; top: 6px; right: 8px; font-size: 11px; color: var(--cc-text-dim); }
 </style>

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -13,16 +13,18 @@
   (each layer re-renders hi-res), so both hosts export identically.
 -->
 <script setup lang="ts">
-import { useTemplateRef } from 'vue'
+import { useTemplateRef, toRef } from 'vue'
 import type { GateSpec } from '../../stores/gating'
 import ScatterGL from './ScatterGL.vue'
+import PlotSpinner from './PlotSpinner.vue'
+import { useDelayedLoading } from '../../composables/useDelayedLoading'
 import PlotLayers, { type PopLayer } from './PlotLayers.vue'
 import GateOverlay from './GateOverlay.vue'
 import { rasterPlotToImageURL } from '../../plots/export'
 
 type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   points: Float32Array | null
   extents: Ext                                   // fixed full-data range (ScatterGL)
   viewExtents: Ext                               // live (zoom-synced) extents (PlotLayers/GateOverlay/ticks)
@@ -46,6 +48,10 @@ withDefaults(defineProps<{
   mode: 'off', gateLineWidth: 1.5, gateLabels: false, viewTick: 0, loading: false, compact: false, readonly: false,
 })
 const emit = defineEmits<{ draw: [Partial<GateSpec>]; edit: [{ path: string; gate: GateSpec }]; cancel: [] }>()
+
+// delayed spinner for the full-size scatter only; compact montage cells (gating strategy) are small
+// plots — they keep the unobtrusive dot rather than a wheel over every tile.
+const showSpinner = useDelayedLoading(toRef(props, 'loading'))
 
 // ticks positioned against the LIVE view extents so labels track pan/zoom
 const tickX = (pos: number, e: Ext) => `${((pos - e.xMin) / Math.max(1e-9, e.xMax - e.xMin)) * 100}%`
@@ -117,7 +123,8 @@ function baseColorMode(renderMode: string, showPops: boolean): 'density' | 'flat
       </span>
       <span class="axis-x">{{ xLabel }}</span>
       <span class="axis-y">{{ yLabel }}</span>
-      <div v-if="loading" class="panel-loading">…</div>
+      <PlotSpinner v-if="showSpinner && !compact" label="Loading…" />
+      <div v-else-if="loading && compact" class="panel-loading">…</div>
       <slot />
     </div>
   </div>

--- a/frontend/src/components/plots/PlotSpinner.vue
+++ b/frontend/src/components/plots/PlotSpinner.vue
@@ -1,0 +1,52 @@
+<!--
+  Shared loading-spinner overlay for heavy plots. Drive it with `useDelayedLoading` (composables/) so
+  it only appears once a load runs past the threshold — never on small/fast plots (docs/UI.md →
+  "Plot loading state"). Place inside a `position: relative` container; it fills and centres.
+
+    <div class="plot-host" style="position: relative">
+      <PlotChart :data="..." :opts="..." />
+      <PlotSpinner v-if="showSpinner" label="Loading…" />
+    </div>
+-->
+<script setup lang="ts">
+defineProps<{ label?: string }>()
+</script>
+
+<template>
+  <div class="plot-spinner" role="status" aria-live="polite">
+    <div class="plot-spinner__wheel" aria-hidden="true" />
+    <span v-if="label" class="plot-spinner__label">{{ label }}</span>
+  </div>
+</template>
+
+<style scoped>
+.plot-spinner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  /* translucent scrim so it reads as "working" over whatever is (or isn't) already drawn */
+  background: color-mix(in srgb, var(--cc-surface-1) 45%, transparent);
+  pointer-events: none;   /* never block interaction with the plot underneath */
+  z-index: 5;
+}
+.plot-spinner__wheel {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2.5px solid var(--cc-border);
+  border-top-color: var(--cc-accent);
+  animation: plot-spinner-rot 0.7s linear infinite;
+}
+.plot-spinner__label {
+  font-size: 11px;
+  color: var(--cc-text-dim);
+}
+@keyframes plot-spinner-rot { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .plot-spinner__wheel { animation-duration: 2.4s; }
+}
+</style>

--- a/frontend/src/composables/useDelayedLoading.ts
+++ b/frontend/src/composables/useDelayedLoading.ts
@@ -1,0 +1,25 @@
+import { ref, watch, onUnmounted, type Ref } from 'vue'
+
+/**
+ * Delayed loading flag for plot spinners (docs/UI.md → "Plot loading state").
+ *
+ * Returns a `show` ref that becomes true ONLY if `loading` stays true for `delayMs` (default 350 ms),
+ * and resets to false the instant loading ends. This is the "don't flash a spinner on small plots"
+ * rule: a fast/cheap plot finishes before the threshold, so `show` never flips — only a genuinely
+ * heavy load reveals the wheel. Use it in every plot host instead of hand-rolled "…" loading text.
+ *
+ *   const showSpinner = useDelayedLoading(loading)         // loading: Ref<boolean>
+ *   const showSpinner = useDelayedLoading(toRef(props, 'loading'))   // when loading is a prop
+ */
+export function useDelayedLoading(loading: Ref<boolean>, delayMs = 350): Ref<boolean> {
+  const show = ref(false)
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const clear = () => { if (timer !== null) { clearTimeout(timer); timer = null } }
+  watch(loading, (v) => {
+    clear()
+    if (v) timer = setTimeout(() => { show.value = true; timer = null }, delayMs)
+    else show.value = false
+  }, { immediate: true })
+  onUnmounted(clear)
+  return show
+}


### PR DESCRIPTION
## feat(plots): delayed loading spinner for heavy plots

A blank panel during a slow plot load reads as "frozen" — but an immediate spinner on every quick plot is noise. So this adds a **delayed** spinner.

- **`composables/useDelayedLoading.ts`** — `useDelayedLoading(loadingRef, delayMs = 350)` → a `show` ref that flips true only if loading stays true past the threshold, and clears instantly when it ends. Fast/small plots finish first and never flash it; only genuinely heavy loads reveal the wheel. (`toRef(props, 'loading')` when loading is a prop.)
- **`components/plots/PlotSpinner.vue`** — shared wheel overlay; `pointer-events: none` (never blocks the plot), honours `prefers-reduced-motion`.
- **Wired into** `SummaryPanel` (all summary/QC plots) and the full-size gating scatter (`GateScatterCell` via `GatePlotPanel`). Gated on `!compact`, so the gating-strategy **montage tiles keep their unobtrusive dot** rather than a wheel per tile. `UmapView` already has its own empty-state wheel.

Convention documented in `docs/UI.md` ("Plot loading state — delayed spinner") so future heavy plots reuse these two primitives instead of hand-rolling loading text.