### PR TITLE
fix(qc): time-series chart types (trend/count) when grouping by t

### DIFF
--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -117,6 +117,14 @@ The panel's chart-type dropdown offers **only the charts valid for the selected 
 Backend returns `measureType` so the panel filters; specs keep `chartTypes` as the *allowed* set and
 the panel intersects with what's valid for the measure.
 
+**Time series overrides the set.** When the `groupBy` column is a **temporal** column (`t`), per-frame
+distribution charts make no sense (thousands of boxes), so the dropdown switches to **`trend`**
+(measure mean per frame, geom_smooth/LOESS line) and **`count`** (cells per frame over time, also a
+line), and the selection is moved onto `trend`. Unticking `t` restores the measure-type set. `trend`
+is a real chart type — not a hidden render mode — so the menu label always matches what's drawn (this
+fixed "boxplot secretly renders a smooth line"). The LOESS span (%) and CI-ribbon toggle appear only
+in this mode; render is `buildTrendLine` in `plot.ts`.
+
 ### `count` — objects per series (no measure)
 
 `chart_type = "count"` returns the **row count** per series (`value` = # objects, same series shape

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -204,7 +204,7 @@ function onDocClick(e: MouseEvent) {
 onMounted(() => document.addEventListener('mousedown', onDocClick))
 onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
 // friendly menu labels (the internal ChartType value stays as-is, e.g. 'strip' renders a beeswarm)
-const CHART_LABELS: Partial<Record<ChartType, string>> = { strip: 'beeswarm', stacked100: '100% stacked' }
+const CHART_LABELS: Partial<Record<ChartType, string>> = { strip: 'beeswarm', stacked100: '100% stacked', trend: 'trend (mean/t)', count: 'count' }
 const chartLabel = (c: ChartType) => CHART_LABELS[c] ?? c
 
 const crossImage = computed(() => !!props.setUid)
@@ -223,6 +223,12 @@ function scheduleFetch() { if (fetchTimer) clearTimeout(fetchTimer); fetchTimer 
 // applicable chart types = the spec's allowed set ∩ the charts valid for the detected measure type
 // (docs/PLOTS.md §2). Before the first response (no measureType) just show the spec's set.
 const validCharts = computed<ChartType[]>(() => {
+  // TIME SERIES (grouped by a temporal column, t): the only sensible charts are a trend LINE over
+  // time — measure mean per frame (`trend`, geom_smooth/LOESS) or cell count per frame (`count`).
+  // Distribution charts (boxplot/histogram/violin) would be thousands of per-frame boxes, so they're
+  // dropped — which is why selecting `t` swaps the menu to [trend, count] and the reset watch below
+  // moves the selection onto `trend` (no more "boxplot that secretly renders a smooth line").
+  if (timeSeries.value) return ['trend', 'count']
   const mt = result.value?.measureType
   if (!mt) return props.spec.chartTypes
   const ok = new Set(chartsForMeasure(mt))

--- a/frontend/src/plots/types.ts
+++ b/frontend/src/plots/types.ts
@@ -17,6 +17,7 @@ export type ChartType =
   | 'frequency' | 'stacked' | 'stacked100'                 // categorical
   | 'heatmap'                                              // matrix (profile / crosstab) — measure-type independent
   | 'count'                                                // # objects per series (row count) — measure-independent; the segmentation-integrity headline
+  | 'trend'                                                // time series: measure mean per timepoint, geom_smooth (LOESS) line over t
 
 export interface PlotSpec {
   id: string


### PR DESCRIPTION
Selecting the temporal column `t` in a summary plot's "Split by" put the panel into time-series mode (a geom_smooth/LOESS line), but the chart-type dropdown still offered the distribution charts (boxplot/histogram/violin) — so picking "boxplot" secretly rendered a smooth line. Confusing, and per-frame distributions over thousands of timepoints are meaningless anyway.

Make `trend` a real chart type and switch the menu on temporal grouping:
- validCharts returns [trend, count] when groupBy is a temporal column; the reset watch moves the selection onto `trend`. Unticking t restores the measure-type set.
- `trend` (types.ts) = measure mean per frame, LOESS line; `count` = cells per frame, also a line. Both render via the existing buildTrendLine (buildOpts.trend = timeSeries); the LOESS-span and CI-ribbon controls already show only in this mode.
- Chart labels: trend -> "trend (mean/t)".

Now the menu label always matches what's drawn. Docs: PLOTS.md §2 time-series override.