### PR TITLE
fix(rechunk): don't re-rechunk backups when scanning a directory

### DIFF
--- a/app/py/utils/rechunk_zarr.py
+++ b/app/py/utils/rechunk_zarr.py
@@ -93,16 +93,22 @@ def rechunk_store(path, xy_tile=512, replace=False, force=False):
 
 
 def _find_stores(root):
-    """Yield every ``*.ome.zarr`` dir under `root` without descending into one."""
-    if root.endswith(".ome.zarr"):
-        yield root
+    """Yield every ``*.ome.zarr`` dir under `root` without descending into one. Backups
+    (``*.bak.ome.zarr``) and temps (``*.rechunk_tmp``) are skipped — `--replace` leaves a backup
+    behind, and a rescan must NOT then re-rechunk that backup (its own name also ends in .ome.zarr)."""
+    root_norm = root.rstrip("/")
+    if root_norm.endswith(".ome.zarr"):
+        if not root_norm.endswith(".bak.ome.zarr"):           # explicit backup target → skip
+            yield root
         return
     for dirpath, dirnames, _ in os.walk(root):
         keep = []
         for d in dirnames:
+            if d.endswith((".bak.ome.zarr", ".rechunk_tmp")):
+                continue                              # never yield OR descend into backups/temps
             if d.endswith(".ome.zarr"):
                 yield os.path.join(dirpath, d)
-            elif not d.endswith((".bak.ome.zarr", ".rechunk_tmp")):
+            else:
                 keep.append(d)
         dirnames[:] = keep
 


### PR DESCRIPTION
_find_stores matched d.endswith(".ome.zarr"), which ALSO matches *.bak.ome.zarr — so running `rechunk_zarr.py <dir> --replace` a second time (after a first --replace left backups) would pick up and re-rechunk each backup, producing backup-of-backup churn and wasting time on data that is already safe.

Fix: _find_stores skips *.bak.ome.zarr and *.rechunk_tmp entirely (neither yielded nor descended into); an explicitly-passed .bak path is skipped too.

Surfaced while resuming an interrupted in-place rechunk: the re-run started re-chunking a completed image's backup instead of moving on to the pending images. Verified against a real dir containing a .bak — only the real stores are yielded.