### PR TITLE
Defer QC plot fetch until the current image's columns load

### DIFF
--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -252,6 +252,20 @@ docs/TODO.md.)
    + derived `/_tracked`) and `track` gates (per-track-measure gates from `{vn}__tracks.json`), each
    tagged with its `popType`; the panel groups series by popType and fetches one `/api/plot_data` per
    group, merging the results. So `/_tracked` and a track gate can sit on one plot.
+9. **Column-load coordination (fetch defers until cols are current).** `SummaryPanel` discovers each
+   image's columns async (`/api/gating/channels` → `varCols`/`obsCols`/…). On an image/segmentation
+   switch those refs are **not** cleared mid-load — clearing them would reset the user's measure pick
+   and make the selects "cycle" — so for the async window they still describe the *previous* image.
+   For `measuresFromData` plots (the QC morphology list is built from the image's own columns) a fetch
+   fired in that window would request the previous image's measure — e.g. 3D-only `euler_number`
+   against a 2D image → a `label_props.jl` **"ignoring unknown columns"** warning + a transient empty
+   plot. Guard: `loadObsCols` stamps `colsFor = (imageUid, valueName)` (and discards a stale in-flight
+   response if the image switched mid-load); `fetchData` **defers** while `!colsReady`
+   (`colsFor ≠ current key`); `colsReady` is a fetch-watch source, so the deferred fetch re-fires the
+   instant the columns land — by which point the measure-reset watch (declared earlier, so it flushes
+   first) has already moved `measure` onto a valid option. Static-measure specs and cross-image mode
+   are unaffected (the guard is `measuresFromData`-only; the no-image path still stamps `colsFor`, so
+   it never deadlocks).
 
 ## 9. Heatmaps (matrix) — DONE; tiled maps — roadmap
 

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -57,6 +57,13 @@ const varCols = ref<string[]>([])        // var columns (morphology + intensity)
 const channelCols = ref<string[]>([])    // intensity var columns specifically (mean_intensity_* / renamed)
 const obsCols = ref<string[]>([])        // obs columns (live.cell.*, hmm.state, cluster ids, …)
 const temporalCols = ref<string[]>([])   // obsm temporal col(s) (e.g. "t") — groupable but not in obs
+// which (imageUid, valueName) the loaded columns belong to. On an image/segmentation switch the col
+// refs are NOT cleared mid-load (that would reset the user's measure pick and "cycle") — so they still
+// describe the PREVIOUS image until loadObsCols resolves. `colsReady` tells the fetch to wait for the
+// current image's columns, so it never requests the previous image's measure (see fetchData guard).
+const colsKey = () => `${props.imageUid ?? ''}|${props.series[0]?.valueName ?? ''}`
+const colsFor = ref('')
+const colsReady = computed(() => colsFor.value === colsKey())
 const measureOpts = computed(() => {
   const ds = props.spec.dataSource
   // measuresFromData: offer every MORPHOLOGY measurement present — all var columns EXCEPT the
@@ -99,17 +106,24 @@ const errorMetric = computed<'sd' | 'sem' | 'ci95'>({ get: () => props.ui.errorM
 // empty split), filtered to categorical-looking names; a spec may add explicit hints that exist.
 const CATEGORICAL_OBS = /(\.hmm\.state\.|\.hmm\.transitions\.|\.clusters?\.|track_generation|track_state)/
 async function loadObsCols() {
+  const key = colsKey()
   const vn = props.series[0]?.valueName
-  if (!props.imageUid || !vn) { obsCols.value = []; temporalCols.value = []; return }
+  if (!props.imageUid || !vn) { obsCols.value = []; temporalCols.value = []; colsFor.value = key; return }
   try {
     const q = `projectUid=${props.projectUid}&imageUid=${props.imageUid}&valueName=${encodeURIComponent(vn)}`
     const res = await fetch(`/api/gating/channels?${q}`)
     const j = res.ok ? (await res.json() as { columns?: string[]; channels?: string[]; obsColumns?: string[]; temporalColumns?: string[] }) : {}
+    if (colsKey() !== key) return          // image/segmentation switched mid-load — discard the stale response
     varCols.value = j.columns ?? []
     channelCols.value = j.channels ?? []
     obsCols.value = j.obsColumns ?? []
     temporalCols.value = j.temporalColumns ?? []
-  } catch { varCols.value = []; channelCols.value = []; obsCols.value = []; temporalCols.value = [] }
+    colsFor.value = key
+  } catch {
+    if (colsKey() !== key) return
+    varCols.value = []; channelCols.value = []; obsCols.value = []; temporalCols.value = []
+    colsFor.value = key
+  }
 }
 watch([() => props.imageUid, () => props.series.map(t => t.valueName).join(',')], loadObsCols, { immediate: true })
 const groupByOpts = computed<string[]>(() => {
@@ -258,6 +272,12 @@ async function fetchData() {
   const seq = ++fetchSeq                                   // only this call may write `result` (see below)
   if (!props.series.length) { result.value = null; return }
   if (!crossImage.value && !props.imageUid) { result.value = null; return }
+  // measuresFromData offers measures built from THIS image's columns, so a fetch fired before the new
+  // image's columns have loaded would request the previous image's measure (e.g. 3D-only `euler_number`
+  // against a 2D image) → a backend "ignoring unknown columns" warning + a transient empty plot. Defer
+  // until loadObsCols reports the current (imageUid, valueName)'s columns; the `colsReady` fetch-watch
+  // re-fires this, by which point the measure-reset watch has moved `measure` onto a valid option.
+  if (props.spec.dataSource.measuresFromData && !colsReady.value) return
   loading.value = true; error.value = ''
 
   // matrix/heatmap pools the whole frame into ONE grid, so it's a single request (not the per-popType
@@ -348,7 +368,7 @@ async function fetchData() {
 // (count/bar) but isn't otherwise a fetch input; matrixCategory drives the heatmap category.
 watch([() => props.series.map(t => `${t.popType}:${t.valueName}${t.pop}`).join('|'),
        measure, chartType, bins, normalize, groupBy, timeSeries, () => props.collapseSeries,
-       matrixMode, zscore, matrixNormalize, matrixCategory,
+       matrixMode, zscore, matrixNormalize, matrixCategory, colsReady,
        () => props.imageUid, () => props.setUid, () => (props.groupAttr ?? []).join(','),
        () => (props.imageUids ?? []).join(','), () => props.scope, () => props.reloadToken],
       scheduleFetch)


### PR DESCRIPTION
## Defer QC plot fetch until the current image's columns load

### Problem
Switching image/segmentation in a segmentation-QC (or any `measuresFromData`)
plot logged `LabelProps: ignoring unknown columns ["euler_number"]`
(`label_props.jl:285`) and briefly showed an empty plot.

**Root cause:** `SummaryPanel` discovers each image's columns async
(`/api/gating/channels`). On a switch the column refs (`varCols`/`obsCols`/…)
are *deliberately* not cleared mid-load — clearing them would reset the user's
measure pick and make the selects "cycle". So for the async window they still
describe the **previous** image, and the plot fetch could fire with the previous
image's measure (e.g. 3D-only `euler_number` against a 2D image). The backend
gracefully drops the unknown column (hence the warning, not an error), but the
plot flashes empty until the reset watch corrects the measure and refetches.

### Fix
- Track which `(imageUid, valueName)` the loaded columns belong to (`colsFor`),
  exposed as `colsReady`. `loadObsCols` stamps it and **discards a stale
  in-flight response** if the image switched mid-load.
- `fetchData` **defers** for `measuresFromData` specs while `!colsReady`;
  `colsReady` is a fetch-watch source, so the deferred fetch re-fires the moment
  columns arrive — by which point the measure-reset watch (declared earlier, so
  it flushes first) has moved `measure` onto a valid option.
- Scoped to `measuresFromData` only; static-measure specs and cross-image mode
  are untouched (the no-image path still stamps `colsFor`, so the fetch never
  deadlocks).

Net: no stale request, no warning, no empty-plot flash.

### Docs
`docs/PLOTS.md` §8.9 records the fetch-coordination invariant.

### Testing
`vue-tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)