### PR TITLE
Scope napari viewer preferences per-set (colour-by, 3D, point size, o…

### DIFF
--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -230,10 +230,10 @@ project-wide), which is why they no longer carry per-plot reload buttons. See
 
 ## 3D mode
 
-Setting `viewer.dims.ndisplay = 3` programmatically after `add_image` leaves the camera uninitialized for the 3D extent — the image is invisible until the user manually toggles (which calls `reset_view()` internally). Always follow with `viewer.reset_view()`:
+Setting `viewer.dims.ndisplay = 3` programmatically after `add_image` leaves the camera uninitialized for the 3D extent — the image is invisible until the user manually toggles (which calls `reset_view()` internally). Always follow with `viewer.reset_view()`. The `show_3d` toggle is a per-set preference applied *where possible*, so it only takes effect when the image has a z-axis with depth (a 2D image stays 2D — see *Viewer preference scoping*):
 
 ```python
-if show_3d:
+if show_3d and (self._z_axis_len() or 0) > 1:
     self._viewer.dims.ndisplay = 3
     self._viewer.reset_view()
 ```
@@ -411,9 +411,33 @@ state, a `live.track.*` measure, a cluster id) instead of their defaults. Ports 
 **UI control — "Colour by" dropdown (ViewerPanel).** Next to the Show populations / Show tracks
 toggles, a dropdown lists the open segmentation's obs columns (`/api/gating/channels`). Picking one
 re-pushes the tracks with `colorBy` (if shown) and POSTs `colour-labels`; "colour: default" resets
-both. The choice is **remembered** (`settings.napariColourBy`) and re-applied on image open (labels
-recoloured after they're shown; tracks carry `colorBy` via `pushTracks`). A remembered column not
-present in the newly-opened segmentation is dropped.
+both. The choice is remembered **per set** (see *Viewer preference scoping* below) and re-applied on
+open — labels recoloured after they're shown, tracks via `pushTracks`. It is **NOT global**: a
+colour-by chosen in one experiment must never bleed onto another set's images (that silently
+recoloured plain labels — and for a segmentation with no obs columns there's no dropdown to reset it,
+so napari's distinct default colouring just vanished). On-open the labels are recoloured **only if the
+opened segmentation actually has that column** (`obsCols.includes`); if the current image's
+segmentation lacks the set's column the local selection is blanked for display **but the persisted
+per-set value is kept** (another image in the set may have it — it's restored per image on open).
+
+### Viewer preference scoping — global / per-set / per-image
+
+napari viewer preferences persist at **three** scopes; the rule is: **per-image** when applying it to
+the wrong image is destructive or can't be undone from the UI; **per-set** when it's an experiment-level
+viewing choice you set once and hold across a set's images; **global** when it's a workflow/UI
+preference that either no-ops or shows something obvious-and-toggleable everywhere.
+
+| Scope | Settings (store keys) | Why |
+|---|---|---|
+| **Per-image** (`getLabelVisibility`/`getTrackVisibility`, keyed by image uid) | which of *this image's* segmentations show labels / tracks (the per-segmentation rows) | segmentations differ image to image; row state is inherently image-specific |
+| **Per-set** (`get/set{ColourBy,Show3D,ShowGatedTracks,PointSize,PopVisible}`, one `cc.napariSetPrefs` map keyed by **set uid**) | colour-by · show-3D · gated-tracks toggle · point size · per-popType overlay visibility | one experiment = consistent viewing; set once, holds as you click through the set. Bleed to *another* set is prevented, but re-picking per image is avoided |
+| **Global** (plain `localStorage`) | update-on-task · reset-on-reload · auto-save-props · as-dask · task-follow · auto-refresh · sidebar/right collapse | workflow/UI prefs, not viewing state |
+
+The set uid for the open/gated image comes from `projectStore.setUidOfImage(imageUid)`. Historical note:
+the old R app made these **global** (Shiny bookmarks made that easy), but per-set was always the intent —
+global colour-by is exactly what silently broke plain-label colouring across images. **show-3D** is
+applied "where possible": the bridge only switches to `ndisplay = 3` when the image has a z-axis with
+depth (`_z_axis_len() > 1`), so a 2D image opened with the set's 3D toggle on stays flat.
 
 ### Producer direction — cell selection (napari → flow plots)
 

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -1103,7 +1103,7 @@ These are deliberate shortcuts; know them before changing the plot components.
   selection reverts from the dimmed backdrop to normal pseudocolour/contour). It's never persisted,
   so there's no pop to delete. The manager's per-pop `pi-images` column toggles a pop's napari visibility
   (its `show` flag) and re-pushes via `store.refreshNapariPops` (silent); the Options box has a
-  **Napari dots** size slider (`settings.napariPointSize`, re-pushes on release). The ViewerPanel
+  **Napari dots** size slider (per-set `settings.get/setPointSize(setUid)`, re-pushes on release). The ViewerPanel
   *Show populations* toggle re-pushes live on every `gating:popmap` while shown, so the napari
   overlay tracks gate edits / pop add-remove as you gate. The transient selection pop is **not**
   pushed back into napari (it would steal the active layer mid-draw). See `docs/NAPARI.md` and

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -264,7 +264,7 @@ async function openInNapari(imageUid: string) {
         imageUid,
         autoSaveProps: autoProps,
         autoLoadProps: autoProps,
-        show3D:        settings.napariShow3D,
+        show3D:        settings.getShow3D(props.setUid),   // per-set (only applied where a z-axis exists)
         asDask:        settings.napariAsDask,
       }),
     })

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -51,12 +51,28 @@ const valueNames = computed(() => Object.keys(napariImage.value?.filepaths ?? {}
 const labelNames  = computed(() => Object.keys(napariImage.value?.labels ?? {}))
 const hasLabels   = computed(() => labelNames.value.length > 0)
 
+// the set the open image belongs to — the key for per-set napari viewer prefs (colour-by, show-3D,
+// point size, overlay toggles). These are experiment-level: set once, hold across the set's images.
+const currentSetUid = computed(() =>
+  projectStore.napariImageUid ? projectStore.setUidOfImage(projectStore.napariImageUid) : null)
+// per-set option accessors bound to the open image's set (write-throughs persist to the settings store)
+const show3D = computed<boolean>({
+  get: () => currentSetUid.value ? settings.getShow3D(currentSetUid.value) : false,
+  set: v => { if (currentSetUid.value) settings.setShow3D(currentSetUid.value, v) } })
+const pointSize = computed<number>({
+  get: () => currentSetUid.value ? settings.getPointSize(currentSetUid.value) : 6,
+  set: v => { if (currentSetUid.value) settings.setPointSize(currentSetUid.value, v) } })
+const popVisible = (popType: string): boolean =>
+  currentSetUid.value ? settings.getPopVisible(currentSetUid.value, popType) : false
+const setPopVisible = (popType: string, v: boolean) => {
+  if (currentSetUid.value) settings.setPopVisible(currentSetUid.value, popType, v) }
+
 
 watch(napariImage, (img) => {
   // restore the remembered preference rather than always starting hidden — the actual layers
   // are (re)pushed by onNapariOpened / onGatingChange once the image + centroids are ready.
-  gatedTracksShown.value = settings.napariShowGatedTracks
-  colourByCol.value = settings.napariColourBy
+  gatedTracksShown.value = currentSetUid.value ? settings.getShowGatedTracks(currentSetUid.value) : false
+  colourByCol.value = currentSetUid.value ? settings.getColourBy(currentSetUid.value) : ''   // per-set
   if (!img) { selectedValueName.value = ''; visibleLabels.value = {}; trackVns.value = {}; obsCols.value = []; return }
   trackVns.value = settings.getTrackVisibility(img.uid, Object.keys(img.labels ?? {}))
   const names = Object.keys(img.filepaths ?? {})
@@ -84,7 +100,7 @@ async function openInNapari(valueName: string) {
     valueName:     valueName || undefined,
     autoSaveProps: autoProps,
     autoLoadProps: autoProps,
-    show3D:        settings.napariShow3D,
+    show3D:        show3D.value,
     asDask:        settings.napariAsDask,
   }
   if (hasLabels.value) {
@@ -125,7 +141,7 @@ async function pushPopulations(popType: string, show: boolean, valueName?: strin
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ projectUid, imageUid: uid,
                              valueName: valueName || undefined,   // blank → server uses active segmentation
-                             popType, show, pointsSize: settings.napariPointSize }),
+                             popType, show, pointsSize: pointSize.value }),
     })
     return res.ok
   } catch { return false }   // napari not running, etc.
@@ -133,8 +149,8 @@ async function pushPopulations(popType: string, show: boolean, valueName?: strin
 
 // Per-pop-type visibility toggle; the choice is remembered (persisted) so it carries across opens.
 async function togglePopType(popType: string) {
-  const next = !settings.popVisible(popType)
-  if (await pushPopulations(popType, next)) settings.setPopVisible(popType, next)
+  const next = !popVisible(popType)
+  if (await pushPopulations(popType, next)) setPopVisible(popType, next)
 }
 
 // Push the tracks for the currently-toggled-on segmentations (one Tracks layer per segmentation,
@@ -150,7 +166,7 @@ async function pushTracks(): Promise<boolean> {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ projectUid, imageUid: uid, valueNames: onTrackVns.value,
                              showGatedTracks: gatedTracksShown.value,
-                             showTrackclust: settings.popVisible('trackclust'),
+                             showTrackclust: popVisible('trackclust'),
                              colorBy: colourByCol.value }),
     })
     return res.ok
@@ -169,14 +185,14 @@ async function toggleTrack(vn: string) {
 async function toggleGatedTracks() {
   const next = !gatedTracksShown.value
   gatedTracksShown.value = next
-  settings.napariShowGatedTracks = next
+  if (currentSetUid.value) settings.setShowGatedTracks(currentSetUid.value, next)
   await pushTracks()
 }
 
 // Master toggle for the trackclust (track-cluster) populations as ribbons. Persisted per pop type
-// (settings.popVisible('trackclust')); re-pushes the track overlays (one call covers all ribbons).
+// (per-set popVis['trackclust']); re-pushes the track overlays (one call covers all ribbons).
 async function toggleTrackclust() {
-  settings.setPopVisible('trackclust', !settings.popVisible('trackclust'))
+  setPopVisible('trackclust', !popVisible('trackclust'))
   await pushTracks()
 }
 
@@ -193,7 +209,9 @@ async function loadObsCols() {
     const res = await fetch(`/api/gating/channels?${q}`)
     obsCols.value = res.ok ? ((await res.json() as { obsColumns?: string[] }).obsColumns ?? []) : []
   } catch { obsCols.value = [] }
-  // drop a remembered colour-by column that isn't available for this segmentation
+  // this image's segmentation may not have the SET's colour-by column (segmentations differ across a
+  // set) — don't select/apply it here, but do NOT clear the persisted per-set value: another image in
+  // the set may have it, and it's restored per image from the set on open.
   if (colourByCol.value && !obsCols.value.includes(colourByCol.value)) colourByCol.value = ''
 }
 
@@ -214,7 +232,7 @@ async function pushColourLabels(column: string): Promise<boolean> {
 function onColourBy(e: Event) {
   const col = (e.target as HTMLSelectElement).value
   colourByCol.value = col
-  settings.napariColourBy = col
+  if (currentSetUid.value) settings.setColourBy(currentSetUid.value, col)   // per-set
   if (onTrackVns.value.length || gatedTracksShown.value) pushTracks()   // re-push tracks w/ new color_by
   pushColourLabels(col)                       // recolour labels (or reset when col === '')
 }
@@ -230,8 +248,8 @@ function onGatingChange(data: Record<string, unknown>) {
   // re-push that pop type's POINT overlay if it's visible.
   const pt = String(data.popType ?? 'flow')
   if (pt === 'track' || pt === 'trackclust') {
-    if (gatedTracksShown.value || settings.popVisible('trackclust')) pushTracks()
-  } else if (settings.popVisible(pt)) {
+    if (gatedTracksShown.value || popVisible('trackclust')) pushTracks()
+  } else if (popVisible(pt)) {
     pushPopulations(pt, true, vn)
   }
 }
@@ -343,21 +361,23 @@ function pushAllOverlays() {
           body:    JSON.stringify({ allLabels: toShow, showLabels: true }),
         }).then(async res => {
           if (!res.ok) { log.error(`Show labels on open failed: ${await _resError(res)}`, { source: 'napari' }); return }
-          if (colourByCol.value) pushColourLabels(colourByCol.value)   // apply remembered colour-by
+          // apply the remembered colour-by ONLY if this segmentation actually has that column —
+          // otherwise a stale/absent column would recolour (and hide) napari's distinct default labels
+          if (colourByCol.value && obsCols.value.includes(colourByCol.value)) pushColourLabels(colourByCol.value)
         }).catch(e =>
           log.error(`Show labels on open failed: ${e instanceof Error ? e.message : String(e)}`,
                     { source: 'napari' }))
       }
     }
     // auto-show each pop type's point overlay that the user last had on (remembered preference)
-    for (const { key } of POP_TYPES) if (settings.popVisible(key)) pushPopulations(key, true)
+    for (const { key } of POP_TYPES) if (popVisible(key)) pushPopulations(key, true)
     // re-show the track overlays from the REMEMBERED state, read straight from settings (the trackVns
     // ref is restored by the napariImage watch, which may not have run yet when this open event fires).
     const uid = projectStore.napariImageUid
     if (uid) {
-      trackVns.value = settings.getTrackVisibility(uid, labelNames.value)   // keep the ref in sync
-      gatedTracksShown.value = settings.napariShowGatedTracks
-      if (onTrackVns.value.length || gatedTracksShown.value || settings.popVisible('trackclust')) pushTracks()
+      trackVns.value = settings.getTrackVisibility(uid, labelNames.value)   // keep the ref in sync (per-image)
+      gatedTracksShown.value = currentSetUid.value ? settings.getShowGatedTracks(currentSetUid.value) : false
+      if (onTrackVns.value.length || gatedTracksShown.value || popVisible('trackclust')) pushTracks()
     }
   })
 }
@@ -485,9 +505,9 @@ onUnmounted(() => {
       ><i class="pi pi-bookmark" /></button>
 
       <button
-        class="opt-btn" :class="{ active: settings.napariShow3D }"
-        @click="settings.napariShow3D = !settings.napariShow3D"
-        v-tooltip.bottom="'3D view: open image in 3D viewer instead of 2D'"
+        class="opt-btn" :class="{ active: show3D }" :disabled="!currentSetUid"
+        @click="show3D = !show3D"
+        v-tooltip.bottom="'3D view: open images in 3D where they have a z-axis (per experiment/set)'"
       ><span class="opt-text">3D</span></button>
 
       <button
@@ -506,9 +526,9 @@ onUnmounted(() => {
            v-tooltip.bottom="'Toggles for the population types to show'" />
         <button
           v-for="pt in POP_TYPES" :key="pt.key"
-          class="opt-btn" :class="{ active: settings.popVisible(pt.key) }"
+          class="opt-btn" :class="{ active: popVisible(pt.key) }"
           @click="togglePopType(pt.key)"
-          v-tooltip.bottom="`${settings.popVisible(pt.key) ? 'Hide' : 'Show'} ${pt.label} (points)`"
+          v-tooltip.bottom="`${popVisible(pt.key) ? 'Hide' : 'Show'} ${pt.label} (points)`"
         ><i :class="['pi', pt.icon]" /></button>
         <!-- Tracks as ribbons (TEST/SDGF gated track pops); per-segmentation _tracked toggles live
              in the labels list above (directions icon per row) -->
@@ -518,9 +538,9 @@ onUnmounted(() => {
           v-tooltip.bottom="gatedTracksShown ? 'Hide track-pop ribbons' : 'Show track populations as ribbons (track-measure gates)'"
         ><i class="pi pi-share-alt" /></button>
         <button
-          class="opt-btn" :class="{ active: settings.popVisible('trackclust') }"
+          class="opt-btn" :class="{ active: popVisible('trackclust') }"
           @click="toggleTrackclust"
-          v-tooltip.bottom="settings.popVisible('trackclust') ? 'Hide track-cluster ribbons' : 'Show track-cluster populations as ribbons'"
+          v-tooltip.bottom="popVisible('trackclust') ? 'Hide track-cluster ribbons' : 'Show track-cluster populations as ribbons'"
         ><i class="pi pi-sitemap" /></button>
       </div>
       <!-- colour tracks + labels by an obs column (e.g. HMM state); '' = default colouring -->

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -17,6 +17,7 @@
 import { ref, computed } from 'vue'
 import { useGatingStore, isReservedPopName, type FlatPop } from '../../stores/gating'
 import { useLogStore } from '../../stores/log'
+import { useProjectStore } from '../../stores/project'
 import { useSettingsStore } from '../../stores/settings'
 import PopulationPanelShell from './PopulationPanelShell.vue'
 import type { VisProps } from '../../plots/plot'
@@ -49,7 +50,16 @@ const emit = defineEmits<{
 }>()
 const g = useGatingStore()
 const log = useLogStore()
+const projectStore = useProjectStore()
 const settings = useSettingsStore()
+
+// napari point size is a PER-SET viewer preference (keyed by the gated image's set), set once and
+// held across the set's images. Guard the setter so we never write under an empty set key.
+const napariSetUid = computed(() => (g.imageUid ? projectStore.setUidOfImage(g.imageUid) : null) ?? '')
+const napariPointSize = computed<number>({
+  get: () => settings.getPointSize(napariSetUid.value),
+  set: v => { if (napariSetUid.value) settings.setPointSize(napariSetUid.value, v) },
+})
 
 const optionsOpen = ref(false)     // gate / viewer options box (host-specific, in the shell #options slot)
 const editing = ref<string | null>(null)
@@ -226,11 +236,11 @@ async function addClusterPopulation() {
             <!-- napari point size (re-renders the napari overlay on release) -->
             <div class="pm-opt-row">
               <span class="pm-opt-label">Napari dots</span>
-              <input type="range" min="1" max="20" step="1" :value="settings.napariPointSize"
-                     v-tooltip.top="'Population point size in napari'"
-                     @input="settings.napariPointSize = parseInt(($event.target as HTMLInputElement).value)"
+              <input type="range" min="1" max="20" step="1" :value="napariPointSize"
+                     v-tooltip.top="'Population point size in napari (per experiment/set)'"
+                     @input="napariPointSize = parseInt(($event.target as HTMLInputElement).value)"
                      @change="g.refreshNapariPops()" />
-              <span class="pm-opt-val">{{ settings.napariPointSize }}</span>
+              <span class="pm-opt-val">{{ napariPointSize }}</span>
             </div>
           </template>
         </div>

--- a/frontend/src/stores/gating.ts
+++ b/frontend/src/stores/gating.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { useLogStore } from './log'
 import { useProjectMetaStore } from './projectMeta'
+import { useProjectStore } from './project'
 import { useSettingsStore } from './settings'
 
 // Derived populations (e.g. `_tracked`, future clustering pops) own a reserved namespace:
@@ -75,6 +76,7 @@ function gateSignatures(tree: PopTree): Map<string, string> {
 export const useGatingStore = defineStore('gating', () => {
   const log = useLogStore()
   const meta = useProjectMetaStore()
+  const projStore = useProjectStore()
   const settings = useSettingsStore()
 
   const imageUid  = ref<string | null>(null)
@@ -110,6 +112,8 @@ export const useGatingStore = defineStore('gating', () => {
   // transient pops (e.g. the napari cell selection) — auto-highlighted on the plots
   const transientPaths = computed(() => flat.value.filter(p => p.transient).map(p => p.path))
   const projectUid = () => meta.current?.uid ?? ''
+  // the set the gated image belongs to — keys the per-set napari point size (see settings store)
+  const napariSetUid = () => (imageUid.value ? projStore.setUidOfImage(imageUid.value) : null) ?? ''
 
   // resolve a raw column to its display label: intensity columns → channel name (R
   // change_channel_names), everything else (morphology, etc.) stays as-is.
@@ -263,7 +267,7 @@ export const useGatingStore = defineStore('gating', () => {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ projectUid: projectUid(), imageUid: imageUid.value,
                                valueName: valueName.value, popType: popType.value,
-                               pointsSize: settings.napariPointSize, ...extra }),
+                               pointsSize: settings.getPointSize(napariSetUid()), ...extra }),
       })
       const d = await res.json().catch(() => ({})) as { error?: string }
       if (!res.ok) throw new Error(d.error ?? `HTTP ${res.status}`)

--- a/frontend/src/stores/project.ts
+++ b/frontend/src/stores/project.ts
@@ -72,6 +72,11 @@ export const useProjectStore = defineStore('project', () => {
 
   const activeSet = () => sets.value.find(s => s.uid === activeSetUid.value) ?? null
 
+  // Which set an image belongs to (an image lives in exactly one set). Used to key per-set napari
+  // viewer preferences (colour-by / show-3D / point size / overlay toggles) — see settings store.
+  const setUidOfImage = (imageUid: string): string | null =>
+    sets.value.find(s => s.images.some(i => i.uid === imageUid))?.uid ?? null
+
   // Called when a project is opened — replaces the in-memory set/image list.
   function loadFromApi(apiSets: CciaSet[]) {
     sets.value = apiSets
@@ -187,5 +192,5 @@ export const useProjectStore = defineStore('project', () => {
     }
   }
 
-  return { sets, activeSetUid, napariImageUid, napariReloadTick, requestNapariReload, dataVersion, bumpDataVersion, dataVersionFor, activeSet, getImageSelection, setImageSelection, loadFromApi, clear, addSetFromApi, deleteSet, addImages, addImagesFromApi, deleteImage, updateImageStatus, updateImageMeta, addAttrKey, removeAttrKey, setAttrValues, removeLabelSet }
+  return { sets, activeSetUid, napariImageUid, napariReloadTick, requestNapariReload, dataVersion, bumpDataVersion, dataVersionFor, activeSet, setUidOfImage, getImageSelection, setImageSelection, loadFromApi, clear, addSetFromApi, deleteSet, addImages, addImagesFromApi, deleteImage, updateImageStatus, updateImageMeta, addAttrKey, removeAttrKey, setAttrValues, removeLabelSet }
 })

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -28,48 +28,9 @@ export const useSettingsStore = defineStore('settings', () => {
     localStorage.getItem('cc.napariAutoSaveLayerProps') === 'true'  // default false
   )
 
-  const napariShow3D = ref(
-    localStorage.getItem('cc.napariShow3D') === 'true'   // default false
-  )
-
   const napariAsDask = ref(
     localStorage.getItem('cc.napariAsDask') !== 'false'  // default true
   )
-
-  // size of population centroid points drawn in napari (old GUI default: 6)
-  const napariPointSize = ref(
-    Number(localStorage.getItem('cc.napariPointSize') ?? 6)
-  )
-
-  // remember whether gating populations are shown as points in napari, so opening an image
-  // restores the user's last choice instead of always starting hidden (default true)
-  const napariShowPopulations = ref(
-    localStorage.getItem('cc.napariShowPopulations') !== 'false'
-  )
-
-  // remember whether track populations are shown as napari Tracks layers (default false — tracks
-  // are a heavier, more specialised overlay than population points). Mirrors napariShowPopulations.
-  const napariShowTracks = ref(
-    localStorage.getItem('cc.napariShowTracks') === 'true'
-  )
-
-  // remember the obs column the napari tracks/labels are coloured by ('' = default colouring)
-  const napariColourBy = ref(localStorage.getItem('cc.napariColourBy') ?? '')
-
-  // master "show gated track populations" toggle (TEST/SDGF track-measure gates), like Show
-  // populations but for the Tracks overlay. Default off (heavier). Mirrors napariShowPopulations.
-  const napariShowGatedTracks = ref(localStorage.getItem('cc.napariShowGatedTracks') === 'true')
-
-  // per-pop-type napari overlay visibility: { [popType]: boolean } (flow / clust / track /
-  // trackclust). Each toggles that pop type's populations as coloured centroid points in napari
-  // (bridge namespaces layers by `(popType)`, so they coexist). Default hidden; persisted.
-  const _popVis = ref<Record<string, boolean>>(
-    JSON.parse(localStorage.getItem('cc.napariPopVisibility') ?? '{}'))
-  const popVisible = (popType: string): boolean => _popVis.value[popType] ?? false
-  function setPopVisible(popType: string, v: boolean) {
-    _popVis.value = { ..._popVis.value, [popType]: v }
-    localStorage.setItem('cc.napariPopVisibility', JSON.stringify(_popVis.value))
-  }
 
   // ── Layout: collapse the main nav sidebar (left) and the module function/tasks panel (right)
   // to free up working space. Both default expanded, both persist across sessions.
@@ -108,20 +69,50 @@ export const useSettingsStore = defineStore('settings', () => {
     localStorage.setItem('cc.napariTrackVisibility', JSON.stringify(_trackVisStore.value))
   }
 
+  // ── Per-SET napari viewer preferences, keyed by set uid: { [setUid]: {...} } ──────────────────
+  // These are the viewer-level DISPLAY toggles (colour-by, show-3D, point size, per-popType overlay
+  // visibility, show-gated-tracks). They were always MEANT to be per-set (one experiment = consistent
+  // viewing); the old R app made them global only because Shiny bookmarks made that easy. Per-set (not
+  // global) so a choice made in one experiment never bleeds onto another's images (e.g. a colour-by
+  // column that a different set's segmentation doesn't have), and not per-image so you set it ONCE and
+  // it holds as you click through the set's images. Per-image state (which segmentations/tracks are
+  // shown — the per-segmentation rows) stays keyed by image uid above.
+  interface NapariSetPrefs {
+    colourBy?: string                       // obs column to colour labels/tracks by ('' = default)
+    show3D?: boolean                        // open images volumetric (only applied where a z-axis exists)
+    showGatedTracks?: boolean               // overlay gated track populations
+    pointSize?: number                      // population centroid point size in napari
+    popVis?: Record<string, boolean>        // per-popType point-overlay visibility (flow/clust/track/trackclust)
+  }
+  const _setPrefs = ref<Record<string, NapariSetPrefs>>(
+    JSON.parse(localStorage.getItem('cc.napariSetPrefs') ?? '{}')
+  )
+  function _patchSet(setUid: string, patch: Partial<NapariSetPrefs>) {
+    _setPrefs.value = { ..._setPrefs.value, [setUid]: { ...(_setPrefs.value[setUid] ?? {}), ...patch } }
+    localStorage.setItem('cc.napariSetPrefs', JSON.stringify(_setPrefs.value))
+  }
+  const getColourBy = (setUid: string): string => _setPrefs.value[setUid]?.colourBy ?? ''
+  const setColourBy = (setUid: string, column: string) => _patchSet(setUid, { colourBy: column })
+  const getShow3D = (setUid: string): boolean => _setPrefs.value[setUid]?.show3D ?? false
+  const setShow3D = (setUid: string, v: boolean) => _patchSet(setUid, { show3D: v })
+  const getShowGatedTracks = (setUid: string): boolean => _setPrefs.value[setUid]?.showGatedTracks ?? false
+  const setShowGatedTracks = (setUid: string, v: boolean) => _patchSet(setUid, { showGatedTracks: v })
+  const getPointSize = (setUid: string): number => _setPrefs.value[setUid]?.pointSize ?? 6   // old GUI default 6
+  const setPointSize = (setUid: string, v: number) => _patchSet(setUid, { pointSize: v })
+  const getPopVisible = (setUid: string, popType: string): boolean =>
+    _setPrefs.value[setUid]?.popVis?.[popType] ?? false                                       // default hidden
+  function setPopVisible(setUid: string, popType: string, v: boolean) {
+    _patchSet(setUid, { popVis: { ...(_setPrefs.value[setUid]?.popVis ?? {}), [popType]: v } })
+  }
+
   watch(taskListAutoFollow,       v => localStorage.setItem('cc.taskListAutoFollow',       String(v)))
   watch(autoRefreshOnTask,        v => localStorage.setItem('cc.autoRefreshOnTask',        String(v)))
   watch(napariUpdateImage,        v => localStorage.setItem('cc.napariUpdateImage',        String(v)))
   watch(napariResetOnReload,      v => localStorage.setItem('cc.napariResetOnReload',      String(v)))
   watch(napariAutoSaveLayerProps, v => localStorage.setItem('cc.napariAutoSaveLayerProps', String(v)))
-  watch(napariShow3D,             v => localStorage.setItem('cc.napariShow3D',             String(v)))
   watch(napariAsDask,             v => localStorage.setItem('cc.napariAsDask',             String(v)))
-  watch(napariPointSize,          v => localStorage.setItem('cc.napariPointSize',          String(v)))
-  watch(napariShowPopulations,    v => localStorage.setItem('cc.napariShowPopulations',    String(v)))
-  watch(napariShowTracks,         v => localStorage.setItem('cc.napariShowTracks',         String(v)))
-  watch(napariColourBy,           v => localStorage.setItem('cc.napariColourBy',           String(v)))
-  watch(napariShowGatedTracks,    v => localStorage.setItem('cc.napariShowGatedTracks',    String(v)))
   watch(sidebarCollapsed,         v => localStorage.setItem('cc.sidebarCollapsed',         String(v)))
   watch(rightPanelCollapsed,      v => localStorage.setItem('cc.rightPanelCollapsed',      String(v)))
 
-  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, napariResetOnReload, napariAutoSaveLayerProps, napariShow3D, napariAsDask, napariPointSize, napariShowPopulations, napariShowTracks, napariShowGatedTracks, napariColourBy, sidebarCollapsed, rightPanelCollapsed, popVisible, setPopVisible, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility }
+  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, sidebarCollapsed, rightPanelCollapsed, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible }
 })

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -143,9 +143,26 @@ class NapariState:
         # timecourse: show an elapsed-time stamp that follows the t slider (ports old `add_timestamp`)
         self._setup_timestamp(path)
 
-        if show_3d:
+        # 3D view is a per-set preference applied "where possible": only switch to volumetric display
+        # when the image actually has a z-axis with depth. A 2D image (no z, or z==1) stays 2D, so
+        # clicking through a mixed 2D/3D set with the toggle on shows each image correctly rather than
+        # forcing a flat plane into a rotatable 3D view.
+        if show_3d and (self._z_axis_len() or 0) > 1:
             self._viewer.dims.ndisplay = 3
             self._viewer.reset_view()
+
+    def _z_axis_len(self):
+        """Length of the image's `z` axis, or None if there is no `z` axis / no data loaded.
+        Reads from the full (channel-inclusive) data shape, since `self._axes` includes `c`."""
+        if not self._axes or not self._im_data:
+            return None
+        low = [a.lower() for a in self._axes]
+        if "z" not in low:
+            return None
+        try:
+            return int(self._im_data[0].shape[low.index("z")])
+        except Exception:
+            return None
 
     def _time_axis_len(self):
         """Length of the image's `t` axis, or None if there is no `t` axis / no data loaded.


### PR DESCRIPTION
## Scope napari viewer preferences per-set

### Problem
The napari viewer **display toggles were stored as a single global value**, so a choice made on one image silently applied to *every* image opened afterwards. For **colour-by** this actively broke rendering: a column chosen on a tracked image recoloured plain labels on an unrelated image — and on a segmentation with **no obs columns there's no dropdown to reset it**, so napari's distinct default label colouring just vanished (the reported symptom on `LUkCpP`).

These toggles were always *meant* to be per-set (one experiment = consistent viewing); the old R app only made them global because Shiny bookmarks made that easy.

### Scope model
| Scope | Settings | |
|---|---|---|
| **Per-image** (unchanged) | label / track visibility — the per-segmentation rows | segmentations differ image to image |
| **Per-set** (new `cc.napariSetPrefs`, keyed by set uid) | colour-by, show-3D, gated-tracks toggle, point size, per-popType overlay visibility | set once, holds across the set's images; never bleeds to another set |
| **Global** (unchanged) | update-on-task, reset-on-reload, auto-save-props, as-dask, layout, task-follow, auto-refresh | workflow/UI prefs, not viewing state |

### Changes
- **project store** — `setUidOfImage(uid)` resolves an image's set.
- **settings store** — one per-set prefs map with `get/set` for each pref; removed the old globals and the **dead** `napariShowPopulations` / `napariShowTracks` refs.
- **ViewerPanel / ImageTable / PopulationManager / gating store** — read + write through the per-set accessors, keyed by the open (or gated) image's set.
- **colour-by clear** no longer wipes the set value when the current image's segmentation lacks the column (another image in the set may have it); it only *applies* where `obsCols.includes(column)`.
- **napari bridge** — show-3D applies "where possible": only switch to `ndisplay = 3` when the image has a z-axis with depth (`_z_axis_len() > 1`), so a 2D image in a mixed set stays flat.

### Notes
- **Clean slate:** old global pref keys are orphaned — overlays/3D/point-size/colour-by reset once per set (by design; fixes the stuck global colour-by).
- **Bridge restart** needed to exercise the 3D behaviour (`napari_bridge.py` is a separate process).

### Docs
`NAPARI.md` (colour-by rewritten to per-set, new *Viewer preference scoping* table, 3D snippet), `UI.md` (point-size note).

### Testing
`vue-tsc --noEmit` + `vite build` pass; swept for stale references to removed settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)