### PR TITLE
fix(tasks): persist section-nested params instead of reverting to def…

### DIFF
--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -95,10 +95,12 @@ function buildParamValues(def: TaskDef, saved: ParamValues): ParamValues {
   const vals: ParamValues = {}
   for (const p of def.params) {
     if (p.type === 'section') {
+      // Sections are stored flat (flattenParams hoists children to the top level on run), so read
+      // the child from the flat key. savedSection is kept first for any legacy nested records.
       const savedSection = ((saved[p.key] ?? {}) as ParamValues)
       const sectionVals: ParamValues = {}
       for (const sp of p.params ?? []) {
-        sectionVals[sp.key] = savedSection[sp.key] ?? sp.default ?? null
+        sectionVals[sp.key] = savedSection[sp.key] ?? saved[sp.key] ?? sp.default ?? null
       }
       vals[p.key] = sectionVals
     } else {


### PR DESCRIPTION
## Fix nested/section task params reverting to default

### Problem
Ticking a param that lives inside a `section` group — e.g. **extended measurements** (`extendedMeasures`) in the *measure* task — and then running the task, the checkbox reverts to its default. The choice isn't remembered.

### Cause
The save and load paths in `frontend/src/tasks/TaskRunner.vue` are asymmetric:
- **Save/run** — `flattenParams` *hoists* section children to the top level (`extendedMeasures` is stored flat).
- **Load** — `buildParamValues` reads section children from a *nested* key (`saved["measureOptions"]["extendedMeasures"]`), which never exists, so it falls back to `sp.default`.

Top-level params round-trip fine; only `section`-nested ones were affected. Note the *running* task always received the correct value (it reads live form state on click) — only the persisted memory of the choice was lost.

### Fix
One line in `buildParamValues`: read the flat key on load too, keeping the nested read first for any legacy records:
```ts
sectionVals[sp.key] = savedSection[sp.key] ?? saved[sp.key] ?? sp.default ?? null
No backend change — the Julia (measure_labels.jl) and Python (measure_utils.py) task code already reads the flat extendedMeasures key.

🤖 Generated with Claude Code