### PR TITLE
Chain resume + "resume from here" start node (Live tab)

### DIFF
--- a/api/src/sockets.jl
+++ b/api/src/sockets.jl
@@ -55,13 +55,19 @@ function handle_chain_run(ws, data)
     project_uid = String(get(data, :projectUid, ""))
     chain_name  = String(get(data, :chain, ""))
     image_uids  = String[String(u) for u in get(data, :imageUids, [])]
+    # Resume: a `runId` re-runs a persisted run (restore from disk, re-do failed/incomplete/changed
+    # nodes). An optional `startNode` force-restarts that node + everything downstream ("resume from
+    # here"). When resuming, `chain`/`imageUids` are read from the run, so they're not required.
+    run_id      = String(get(data, :runId, ""))
+    start_node  = String(get(data, :startNode, ""))
+    resuming    = !isempty(run_id)
 
-    if isempty(project_uid) || isempty(chain_name)
+    if isempty(project_uid) || (!resuming && isempty(chain_name))
         HTTP.WebSockets.send(ws, JSON3.write((; type="chain:run:failed",
                                                error="projectUid and chain are required")))
         return
     end
-    if isempty(image_uids)
+    if !resuming && isempty(image_uids)
         HTTP.WebSockets.send(ws, JSON3.write((; type="chain:run:failed",
                                                error="No images selected")))
         return
@@ -77,18 +83,29 @@ function handle_chain_run(ws, data)
 
     HTTP.WebSockets.send(ws, JSON3.write((; type="chain:run:started",
                                            chain=chain_name,
+                                           runId=(resuming ? run_id : nothing),
                                            imageCount=length(image_uids))))
 
     Threads.@spawn try
-        run_chain(proj, image_uids; chain=chain_name,
-                  on_cancel_check = is_chain_cancelled,
-                  on_log = line -> begin
-                      println(line)
-                      broadcast_ws(Dict{String,Any}("type" => "chain:log", "line" => line))
-                  end)
+        if resuming
+            run_chain(proj, String[]; run_id=run_id,
+                      start_node = isempty(start_node) ? nothing : start_node,
+                      on_cancel_check = is_chain_cancelled,
+                      on_log = line -> begin
+                          println(line)
+                          broadcast_ws(Dict{String,Any}("type" => "chain:log", "line" => line))
+                      end)
+        else
+            run_chain(proj, image_uids; chain=chain_name,
+                      on_cancel_check = is_chain_cancelled,
+                      on_log = line -> begin
+                          println(line)
+                          broadcast_ws(Dict{String,Any}("type" => "chain:log", "line" => line))
+                      end)
+        end
         broadcast_ws(Dict{String,Any}("type" => "chain:run:done", "chain" => chain_name))
     catch e
-        @warn "chain:run error" chain=chain_name exception=e
+        @warn "chain:run error" chain=chain_name run_id=run_id exception=e
         broadcast_ws(Dict{String,Any}("type"  => "chain:run:failed",
                                       "chain" => chain_name,
                                       "error" => string(e)))

--- a/app/src/tasks/chain.jl
+++ b/app/src/tasks/chain.jl
@@ -763,6 +763,46 @@ end
 
 # ── Resume helpers ────────────────────────────────────────────────────────────
 
+# All nodes reachable downstream of `node_id` (successors, transitively) — NOT including itself.
+function _descendants(template::ChainTemplate, node_id::String)::Set{String}
+    succ = Dict{String,Vector{String}}()
+    for e in template.edges
+        push!(get!(succ, e.from, String[]), e.to)
+    end
+    out   = Set{String}()
+    queue = String[node_id]
+    while !isempty(queue)
+        n = popfirst!(queue)
+        for c in get(succ, n, String[])
+            if c ∉ out
+                push!(out, c)
+                push!(queue, c)
+            end
+        end
+    end
+    out
+end
+
+# Explicit "start node" for resume: force `start_node` and everything downstream back to :pending
+# across ALL images, even nodes that are :done with matching params (which `_reset_stale_nodes!`
+# would otherwise keep and skip). This is the whiteboard "resume from here" — re-run a completed
+# section (e.g. measurements) without touching upstream nodes, which stay :done and are skipped.
+function _force_restart_from!(run::ChainRun, start_node::String)
+    targets = _descendants(run.template_snapshot, start_node)
+    push!(targets, start_node)
+    changed = false
+    for uid in run.image_uids, nid in targets
+        haskey(run.image_states[uid], nid) || continue
+        st = run.image_states[uid][nid]
+        if st.status != :pending
+            st.status = :pending; st.params_hash = nothing
+            st.result = nothing;  st.task_id     = nothing
+            changed   = true
+        end
+    end
+    changed && _save_run!(run)
+end
+
 # Pre-pass before re-running a chain: resets nodes that need re-execution.
 # Handles crash recovery (:running → :failed), retries (:failed/:skipped/:cancelled → :pending),
 # params staleness (:done with changed params → :pending), and propagates dirtiness downstream.
@@ -894,16 +934,19 @@ overrides: node_id => param overrides merged on top of template params.
 function run_chain(proj::CciaProject, image_uids::Vector{String};
                    chain::String                  = "",
                    run_id::Union{String,Nothing}  = nothing,
+                   start_node::Union{String,Nothing} = nothing,
                    overrides::Dict{String,Any}    = Dict{String,Any}(),
                    on_log::Function               = line -> println(line),
                    on_status_change::Function     = _ -> nothing,
                    on_cancel_check::Function      = _ -> false)::ChainRun
 
     if !isnothing(run_id)
-        # Resume: restore run from disk, reset stale/failed nodes, keep :done ones
+        # Resume: restore run from disk, reset stale/failed nodes, keep :done ones. An explicit
+        # `start_node` additionally force-restarts that node + everything downstream (re-run from here).
         run           = load_chain_run(proj, run_id)
         ordered_nodes = _topo_sort(run.template_snapshot)
         _reset_stale_nodes!(run, overrides, ordered_nodes)
+        isnothing(start_node) || _force_restart_from!(run, start_node)
     else
         isempty(chain) && error("run_chain requires `chain` name when `run_id` is not given")
         isempty(image_uids) && error("run_chain requires at least one image UID")

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -469,6 +469,49 @@ end
         rm(proj.root; recursive=true)
     end
 
+    # ── Chain resume — explicit start node (re-run from here) ─────────────────
+    @testset "Chain resume — start node force-restart" begin
+        # descendants: pure graph reachability over n1→n2→n3
+        tpl = ChainTemplate(
+            "restart-chain",
+            [ChainNode(id="n1", fn="importImages.remove",
+                       params=Dict{String,Any}("valueName"=>"default","newDefault"=>"default")),
+             ChainNode(id="n2", fn="importImages.remove",
+                       params=Dict{String,Any}("valueName"=>"default","newDefault"=>"default")),
+             ChainNode(id="n3", fn="importImages.remove",
+                       params=Dict{String,Any}("valueName"=>"default","newDefault"=>"default"))],
+            [ChainEdge("n1","n2"), ChainEdge("n2","n3")],
+        )
+        @test Cecelia._descendants(tpl, "n1") == Set(["n2","n3"])
+        @test Cecelia._descendants(tpl, "n2") == Set(["n3"])
+        @test isempty(Cecelia._descendants(tpl, "n3"))
+
+        # force-restart from n2 on a run whose nodes are all :done → n2,n3 reset to :pending; n1 kept
+        proj = create_project!(name="chain-restart-$(rand(1000:9999))", kind="static")
+        s    = add_set!(proj; name="s")
+        img  = add_image!(s; name="img")
+        img.status = "done"; save!(img)
+        states = Dict(img.uid => Dict(
+            "n1" => Cecelia.ImageNodeState(), "n2" => Cecelia.ImageNodeState(),
+            "n3" => Cecelia.ImageNodeState()))
+        for nid in ("n1","n2","n3")
+            states[img.uid][nid].status      = :done
+            states[img.uid][nid].params_hash = "h"
+        end
+        run = Cecelia.ChainRun("rid", "restart-chain", proj.uid, [img.uid], tpl,
+                               "hash", states, time(), joinpath(Cecelia._runs_dir(proj), "rid"),
+                               ReentrantLock(), Dict{String,Channel{Nothing}}(),
+                               Dict{String,Channel{Nothing}}())
+        mkpath(run._dir)
+        Cecelia._force_restart_from!(run, "n2")
+        @test run.image_states[img.uid]["n1"].status == :done       # upstream untouched
+        @test run.image_states[img.uid]["n2"].status == :pending    # start node reset
+        @test run.image_states[img.uid]["n3"].status == :pending    # downstream reset
+        @test run.image_states[img.uid]["n2"].params_hash === nothing
+
+        rm(proj.root; recursive=true)
+    end
+
     # ── Chain run — set-scope (picnic) node ──────────────────────────────────
     @testset "Chain run — picnic node" begin
         proj = create_project!(name="chain-picnic-$(rand(1000:9999))", kind="static")

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -369,6 +369,27 @@ Iterates nodes in topological order. For each node and each image:
 Staleness propagates downstream via a topo-ordered predecessor map — if n3 re-runs because its
 params changed, n4 and n5 are also reset even if their own params are unchanged.
 
+### Explicit start node (`start_node` — "resume from here")
+
+`_reset_stale_nodes!` only re-runs nodes that are *stale* (failed / crashed / params-changed) and
+their descendants — a node that is `:done` with unchanged params is always kept and skipped. To
+**force** a re-run of a completed section (e.g. re-do measurements with the same params), `run_chain`
+takes an optional `start_node`:
+
+```julia
+run_chain(proj, String[]; run_id, start_node = "n3")   # re-run n3 + everything downstream
+```
+
+`_force_restart_from!` resets `start_node` **and all its descendants** (`_descendants`, transitive
+successors over the edge set) back to `:pending` across every image — regardless of status or
+`params_hash`. It runs *after* `_reset_stale_nodes!`, so it only ever adds to the reset set. Upstream
+(ancestor) nodes are untouched: they stay `:done` and are skipped. This is the whiteboard Live-tab
+"resume from here" — pick a node, everything from it down re-runs, everything above it is reused.
+
+The WS `chain:run` message carries `runId` (→ resume) and optional `startNode`; the frontend Live
+tab sends them when you hit **Resume** (with or without a picked node). See `docs/UI.md` → Chain
+whiteboard.
+
 ### In-place restart (no new task record)
 
 Resume re-uses the existing `run.id`. There is no "new task created" on resume — the run record

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -597,6 +597,18 @@ falling back to `fn.split('.').pop()` only if defs haven't loaded yet.
 (not `failed`). `setStatus` makes user-initiated `cancelled` sticky, so a late backend event can't
 flip a cancelled task back to running/done/green.
 
+**Resume / resume-from-here**: the Live toolbar has a **Resume** button (`resumeRun`) that re-runs
+the selected run — WS `chain:run` with `runId` (no `chain`/`imageUids` needed; the backend restores
+them from the run). By default it re-runs only failed / unfinished / params-changed nodes (see
+`docs/SCHEDULER.md` → *Resume*). Clicking a **task node** picks it as the **start node**
+(`restartNodeId`, a chain-template node id); the button then sends `startNode` too, force-re-running
+that node **and everything downstream** even if `:done` — so it's obvious *where* a resume begins.
+The picked node (solid accent + "resume from" badge) and its descendants (`rerunNodeIds`, dashed
+accent) are highlighted; a ✕ clears the pick. Resume is disabled while the run is busy (`resumeBusy`
+— any node running/queued). A resumed run **merges** live status over the persisted snapshot
+(`selectedRunTasks`), so skipped `:done` nodes stay on the graph while the re-run section updates
+live, rather than the graph collapsing to only the re-run nodes.
+
 The tab badge shows the count of currently-running nodes.
 
 ### Node types

--- a/frontend/src/components/ChainLiveNode.vue
+++ b/frontend/src/components/ChainLiveNode.vue
@@ -13,6 +13,8 @@ const props = defineProps<{
     status: TaskStatus
     startedAt?: number    // epoch ms
     finishedAt?: number   // epoch ms
+    nodeId?: string       // chain template node id (for "resume from here")
+    restart?: 'start' | 'rerun'   // 'start' = chosen resume node; 'rerun' = downstream (will re-run)
   }
 }>()
 
@@ -59,10 +61,12 @@ const STATUS_ICONS: Record<TaskStatus, string> = {
 </script>
 
 <template>
-  <div class="live-node" :style="{ borderColor: STATUS_COLORS[data.status] }">
+  <div class="live-node" :class="{ 'restart-start': data.restart === 'start', 'restart-rerun': data.restart === 'rerun' }"
+       :style="{ borderColor: data.restart ? undefined : STATUS_COLORS[data.status] }">
     <!-- anchor points for the execution-order edges (not user-connectable) -->
     <Handle type="target" :position="Position.Left" class="live-handle" :connectable="false" />
     <Handle type="source" :position="Position.Right" class="live-handle" :connectable="false" />
+    <span v-if="data.restart === 'start'" class="restart-badge">resume from</span>
     <div class="live-status-bar" :style="{ background: STATUS_COLORS[data.status] }">
       <i :class="['pi', STATUS_ICONS[data.status]]"
          :style="{ color: STATUS_TEXT[data.status] }" />
@@ -87,8 +91,32 @@ const STATUS_ICONS: Record<TaskStatus, string> = {
   padding: 5px 9px;
   font-size: 11px;
   min-width: 110px;
-  cursor: default;
+  cursor: pointer;              /* clickable: pick as the resume-from node */
   position: relative;
+}
+
+/* resume-from highlight: the chosen start node (solid accent) + everything downstream that will
+   re-run (dashed accent). Overrides the status border while a start node is picked. */
+.live-node.restart-start {
+  border-color: var(--cc-accent, #a78bfa) !important;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--cc-accent, #a78bfa) 40%, transparent);
+}
+.live-node.restart-rerun {
+  border-style: dashed;
+  border-color: var(--cc-accent, #a78bfa) !important;
+}
+.restart-badge {
+  position: absolute;
+  top: -8px; left: 6px;
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--cc-surface-1, #1e1b2e);
+  background: var(--cc-accent, #a78bfa);
+  border-radius: 3px;
+  padding: 1px 4px;
+  z-index: 1;
 }
 
 /* handles are pure edge anchors here — keep them subtle and non-interactive */

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -139,7 +139,10 @@ function runLabel(o: RunOption): string {
   return `${base}${ts ? ` · ${ts}` : ''}${o.live ? ' · live' : ''}`
 }
 
-// Tasks for the selected run — live (task store) if present, else the loaded persisted run.
+// Tasks for the selected run. Persisted (run.json) is the full frozen graph; live (task store) is
+// this session's in-flight nodes. On a RESUME both exist: only the re-run nodes emit live events, so
+// we OVERLAY live status onto the persisted snapshot (by node+image) rather than replacing it — else
+// the skipped :done nodes would vanish from the graph while the resumed section runs.
 const selectedRunTasks = computed<LiveTaskLike[]>(() => {
   const rid = selectedRunId.value
   if (!rid) return []
@@ -148,7 +151,15 @@ const selectedRunTasks = computed<LiveTaskLike[]>(() => {
     funName: t.funName, label: t.label, status: t.status,
     startedAt: t.startedAt?.getTime(), finishedAt: t.finishedAt?.getTime(), chainName: t.chainName,
   } as LiveTaskLike))
-  return live.length ? live : (loadedRuns.value.get(rid)?.tasks ?? [])
+  const persisted = loadedRuns.value.get(rid)?.tasks ?? []
+  if (!live.length) return persisted
+  if (!persisted.length) return live
+  const key = (t: LiveTaskLike) => `${t.chainNodeId}::${t.imageUid}`
+  const liveByKey = new Map(live.map(t => [key(t), t]))
+  const persistedKeys = new Set(persisted.map(key))
+  const merged = persisted.map(t => liveByKey.get(key(t)) ?? t)     // live wins where present
+  for (const t of live) if (!persistedKeys.has(key(t))) merged.push(t)   // + any brand-new node
+  return merged
 })
 
 // Auto-select: focus a newly-appeared live run; else keep a valid selection, else newest.
@@ -314,6 +325,9 @@ const liveNodes = computed<Node[]>(() => {
         fn: t.funName, label: t.label, variant: nodeVariant(t.chainNodeId),
         imageUid: t.imageUid, status: t.status,
         startedAt: t.startedAt, finishedAt: t.finishedAt,
+        nodeId: t.chainNodeId,                       // template node id — for "resume from here"
+        restart: t.chainNodeId === restartNodeId.value ? 'start'
+               : rerunNodeIds.value.has(t.chainNodeId) ? 'rerun' : undefined,
       },
       draggable: false, selectable: false, connectable: false,
     })
@@ -446,12 +460,58 @@ watch([selectedRunId, () => liveLayout.value.imageIds.join(',')], loadQcValueNam
 watch([selectedRunId, showQc, doneCount, qcColumns, qcValueNames],
       () => { qcData.value = new Map(); scheduleQcFetch() })
 
-// A QC thumbnail id is `qc:${nodeId}::${valueName}` — expand it to the full segmentation QC canvas.
-function onLiveNodeClick(nodeId: string) {
-  if (!nodeId.startsWith('qc:')) return
-  const [, vn] = nodeId.slice(3).split('::')
-  if (!vn) return
-  qcExpand.value = { label: 'Segmentation QC', valueName: vn, imageUids: liveLayout.value.imageIds }
+// A live-graph node click does one of two things by node type:
+//  • a QC thumbnail (`qc:${nodeId}::${valueName}`) → expand the full segmentation QC canvas;
+//  • a task node → pick/unpick it as the RESUME START NODE (re-run from here). The picked node and
+//    everything downstream are then highlighted so it's obvious what a Resume will re-run.
+function onLiveNodeClick(node: { id: string; data?: Record<string, unknown> }) {
+  if (node.id.startsWith('qc:')) {
+    const [, vn] = node.id.slice(3).split('::')
+    if (!vn) return
+    qcExpand.value = { label: 'Segmentation QC', valueName: vn, imageUids: liveLayout.value.imageIds }
+    return
+  }
+  const nid = node.data?.nodeId as string | undefined
+  if (!nid || resumeBusy.value) return                          // no picking a start node mid-run
+  restartNodeId.value = restartNodeId.value === nid ? null : nid
+}
+
+// ── Resume ───────────────────────────────────────────────────────────────────
+// The chosen "resume from here" node (a chain template node id), and everything downstream of it —
+// what a Resume with a start node will re-run. Used to highlight the graph and label the button.
+const restartNodeId = ref<string | null>(null)
+const rerunNodeIds = computed<Set<string>>(() => {
+  const start = restartNodeId.value
+  const edges = liveTemplate.value?.edges
+  if (!start || !edges) return new Set()
+  const succ = new Map<string, string[]>()
+  for (const e of edges) (succ.get(e.from) ?? succ.set(e.from, []).get(e.from)!).push(e.to)
+  const out = new Set<string>([start]); const q = [start]
+  while (q.length) { for (const c of succ.get(q.shift()!) ?? []) if (!out.has(c)) { out.add(c); q.push(c) } }
+  return out
+})
+const restartLabel = computed(() => {
+  if (!restartNodeId.value) return ''
+  const n = liveTemplate.value?.nodes.find(nn => nn.id === restartNodeId.value)
+  return n ? (allTaskDefs.value.find(d => d.fun_name === n.fn)?.label ?? n.fn.split('.').pop() ?? n.fn) : ''
+})
+// A run is busy (can't resume) while any of its nodes are running/queued.
+const resumeBusy = computed(() =>
+  selectedRunTasks.value.some(t => t.status === 'running' || t.status === 'queued'))
+// clear the start-node pick when switching runs (it refers to the selected run's template)
+watch(selectedRunId, () => { restartNodeId.value = null })
+
+function resumeRun() {
+  const uid = projectMeta.current?.uid
+  const rid = selectedRunId.value
+  if (!uid || !rid || resumeBusy.value) return
+  ws.send({
+    type:       'chain:run',
+    projectUid: uid,
+    runId:      rid,
+    ...(restartNodeId.value ? { startNode: restartNodeId.value } : {}),
+  })
+  restartNodeId.value = null
 }
 
 // ── Chain list & selection ───────────────────────────────────────────────────
@@ -977,6 +1037,28 @@ onActivated(async () => {
         </select>
         <button
           v-if="selectedRunId"
+          class="wb-btn live-resume-btn"
+          :disabled="resumeBusy"
+          @click="resumeRun"
+          v-tooltip.bottom="resumeBusy
+            ? 'Run is still in progress'
+            : restartLabel
+              ? `Re-run from “${restartLabel}” and everything downstream (upstream stays done)`
+              : 'Resume: re-run failed / unfinished / changed nodes. Click a node to re-run from there instead.'"
+        >
+          <i class="pi pi-play" />
+          <span class="live-resume-lbl">{{ restartLabel ? `Resume from ${restartLabel}` : 'Resume' }}</span>
+        </button>
+        <button
+          v-if="restartNodeId"
+          class="wb-btn live-copy-btn"
+          @click="restartNodeId = null"
+          v-tooltip.bottom="'Clear the resume-from node'"
+        >
+          <i class="pi pi-times" />
+        </button>
+        <button
+          v-if="selectedRunId"
           class="wb-btn live-copy-btn"
           @click="copyRunId"
           v-tooltip.bottom="`Copy run ID (${selectedRunId}) — e.g. for load_chain_run in the REPL`"
@@ -1015,7 +1097,7 @@ onActivated(async () => {
           :max-zoom="2"
           fit-view-on-init
           class="vue-flow-canvas"
-          @node-click="onLiveNodeClick(($event as NodeMouseEvent).node.id)"
+          @node-click="onLiveNodeClick(($event as NodeMouseEvent).node)"
         >
           <Background pattern-color="#2a2742" :gap="20" />
         </VueFlow>


### PR DESCRIPTION
## Chain resume + "resume from here" start node (Live tab)

The chain already had resume machinery — `run_chain(...; run_id)` restores a run and re-runs failed / unfinished / params-changed nodes and their descendants — but it was **unreachable from the UI**, and there was no way to force a re-run of a section that completed with unchanged params.

### Backend (`chain.jl`)
- `run_chain` gains `start_node`. `_descendants` (transitive successors over the edge set) + `_force_restart_from!` reset the start node **and everything downstream** to `:pending` across all images — regardless of status / `params_hash` — *after* `_reset_stale_nodes!`. Ancestors stay `:done` and are skipped. This is the "resume from here": re-run a completed section (e.g. measurements) without touching upstream.

### WS (`sockets.jl`)
- `handle_chain_run` branches on `runId` → resume (chain/imageUids read from the run), with optional `startNode`.

### Frontend (`ChainModule.vue`, `ChainLiveNode.vue`)
- Live toolbar **Resume** button (`resumeRun`): re-runs failed / unfinished / changed nodes. Clicking a task node picks it as the **start node** — the node (solid accent + "resume from" badge) and its descendants (dashed accent) highlight, so it's clear *where* a resume begins. Disabled while the run is busy.
- `selectedRunTasks` **merges** live status over the persisted snapshot, so a resumed run keeps the whole graph visible (done nodes stay while the re-run section updates live) rather than collapsing to only the re-run nodes.

### Tests
`_descendants` + `_force_restart_from!` (n1→n2→n3: resume from n2 keeps n1 `:done`, resets n2/n3). Suite:
729 pass.

### Docs
`SCHEDULER.md` (start_node semantics), `UI.md` (Live-tab Resume).

### ⚠️ Note
`sockets.jl` lives in `api/` (not Revierver** to pick up the resume WS pathbefore testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code) 