### PR TITLE
fix(scheduler): decouple WS broadcast, harden cancel, add chain start…

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -141,6 +141,7 @@ function api_task_definitions(req::HTTP.Request)
     for entry in readdir(_TASK_SPECS_ROOT; join=true)
         isdir(entry) || continue
         entry == frag_dir && continue          # skip shared fragments
+        basename(entry) == "testTasks" && continue   # dev-only stubs for the test suite — never user-facing
         category = basename(entry)
         (!isempty(cat) && category != cat) && continue
         specs = Any[]

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -22,13 +22,45 @@ include("repl_api.jl")
 const _ws_clients      = Set{Any}()
 const _ws_clients_lock = ReentrantLock()
 
-function broadcast_ws(msg::Dict)
-    clients = lock(_ws_clients_lock) do; copy(_ws_clients); end
-    for ws in clients
-        try
-            HTTP.WebSockets.send(ws, JSON3.write(msg))
-        catch; end
+# Outbound broadcast is DECOUPLED from the caller. Task events now fan out on every log/progress/status
+# line from many worker threads; writing sockets inline would (a) let concurrent worker threads write
+# the SAME socket at once (frame corruption) and (b) let one slow/half-open client BLOCK a worker —
+# which stalls a pool slot and, cascaded, leaves every task stuck at :queued. Instead callers enqueue a
+# pre-serialised frame and a single background task drains the queue, writes to each client, and prunes
+# any that error. The queue is bounded and DROPS on overflow — WS telemetry is lossy-safe, and a worker
+# thread must never block on WS I/O.
+const _WS_OUT_CAP        = 4096
+const _WS_OUT            = Channel{String}(_WS_OUT_CAP)
+const _ws_sender_started = Ref(false)
+
+function _ws_sender_loop()
+    for json in _WS_OUT
+        clients = lock(_ws_clients_lock) do; copy(_ws_clients); end
+        dead = Any[]
+        for ws in clients
+            try; HTTP.WebSockets.send(ws, json); catch; push!(dead, ws); end
+        end
+        isempty(dead) || lock(_ws_clients_lock) do
+            for ws in dead; delete!(_ws_clients, ws); end
+        end
     end
+end
+
+function _ws_ensure_sender!()
+    _ws_sender_started[] && return
+    lock(_ws_clients_lock) do
+        _ws_sender_started[] && return
+        _ws_sender_started[] = true
+        Threads.@spawn _ws_sender_loop()
+    end
+end
+
+function broadcast_ws(msg::Dict)
+    _ws_ensure_sender!()
+    json = JSON3.write(msg)
+    # non-blocking enqueue: drop when the buffer is full (a stuck client backing up) rather than block
+    Base.n_avail(_WS_OUT) < _WS_OUT_CAP && put!(_WS_OUT, json)
+    nothing
 end
 
 # ── Chain event → WS bridge ───────────────────────────────────────────────────
@@ -386,6 +418,7 @@ const _BOUND_HOST = Ref{String}("")
 
 function start(; host=HOST, port=PORT)
     _BOUND_HOST[] = string(host)
+    _ws_ensure_sender!()   # start the single WS broadcast drainer before we accept connections
     @info "CeceliaAPI starting" host port threads=Threads.nthreads() projects_dir=projects_dir()
     HTTP.listen(handle_stream, host, port)
 end

--- a/api/src/sockets.jl
+++ b/api/src/sockets.jl
@@ -1,24 +1,22 @@
 # ── WebSocket helpers ─────────────────────────────────────────────────────────
 
-function ws_send(ws, msg)
-    try
-        HTTP.WebSockets.send(ws, JSON3.write(msg))
-    catch e
-        @warn "WS send failed" exception = e
-    end
-end
+# Task events (log / status / progress / result) are keyed by taskId and BROADCAST to every connected
+# client — not just the socket that launched the task. So a second GUI tab AND the read-only task
+# console (api/task_console.jl) both get live progress; previously these went point-to-point to the
+# launching socket, which is why the console (a separate client) showed chain runs — those already
+# broadcast — but never a module task's progress. The `ws` arg is kept for call-site compatibility.
+_broadcast_task(msg::NamedTuple) = broadcast_ws(Dict{String,Any}(String(k) => v for (k, v) in pairs(msg)))
 
-ws_log(ws, task_id, line)              = ws_send(ws, (; type="task:log",      taskId=task_id, line=line))
+ws_log(_ws, task_id, line)             = _broadcast_task((; type="task:log",      taskId=task_id, line=line))
 # `image_uids` carries ALL images a task touched — for a set/combined task, `uid` is just the
 # representative (first) member, so the frontend needs the full list to invalidate every member's plots
 # (task-refresh; see docs/todo/TASK_DATA_REFRESH_PLAN.md). Defaults empty → single-image tasks fall back
 # to `imageUid` on the frontend.
-ws_status(ws, task_id, status, uid=""; image_uids=String[]) = ws_send(ws, (; type="task:status", taskId=task_id, status=status, imageUid=uid, imageUids=image_uids))
-ws_result(ws, task_id, uid, meta)      = ws_send(ws, (; type="task:result",    taskId=task_id, imageUid=uid, meta=meta))
+ws_status(_ws, task_id, status, uid=""; image_uids=String[]) = _broadcast_task((; type="task:status", taskId=task_id, status=status, imageUid=uid, imageUids=image_uids))
+ws_result(_ws, task_id, uid, meta)     = _broadcast_task((; type="task:result",    taskId=task_id, imageUid=uid, meta=meta))
 
-function ws_progress(ws, task_id, fraction::Float64)
-    ws_send(ws, (; type="task:progress", taskId=task_id, progress=clamp(fraction, 0.0, 1.0)))
-end
+ws_progress(_ws, task_id, fraction::Float64) =
+    _broadcast_task((; type="task:progress", taskId=task_id, progress=clamp(fraction, 0.0, 1.0)))
 ws_progress(ws, task_id, n::Int, total::Int) =
     ws_progress(ws, task_id, total > 0 ? n / total : 0.0)
 
@@ -186,7 +184,11 @@ function handle_task_run(ws, data)
                               on_log           = line -> ws_log(ws, task_id, line),
                               on_progress      = (n, t) -> ws_progress(ws, task_id, n, t),
                               on_status_change = rec -> begin
-                                  if rec.status in (:queued, :running)
+                                  # queued/running forwarded live; also forward :cancelled at once (it
+                                  # has no result to order before it) so a cancelled task — especially a
+                                  # still-QUEUED one — reflects immediately, not only when a worker later
+                                  # dequeues and skips it. :done/:failed still wait for the final send.
+                                  if rec.status in (:queued, :running, :cancelled)
                                       ws_status(ws, task_id, string(rec.status), rep)
                                   end
                                   final_status[] = rec.status
@@ -218,8 +220,10 @@ function handle_task_run(ws, data)
                           on_log           = line -> ws_log(ws, task_id, line),
                           on_progress      = (n, t) -> ws_progress(ws, task_id, n, t),
                           on_status_change = rec -> begin
-                              # Forward queued/running immediately; hold terminal until after result.
-                              if rec.status in (:queued, :running)
+                              # Forward queued/running immediately, and :cancelled too (no result to
+                              # order before it) so a cancelled — especially still-QUEUED — task
+                              # reflects at once. Hold :done/:failed until after the result is sent.
+                              if rec.status in (:queued, :running, :cancelled)
                                   ws_status(ws, task_id, string(rec.status), image_uid)
                               end
                               final_status[] = rec.status

--- a/api/task_console.jl
+++ b/api/task_console.jl
@@ -55,14 +55,22 @@ mutable struct TaskView
     updated::DateTime
 end
 
-const TASKS      = Dict{String,TaskView}()   # taskId => view
-const EVENTS     = String[]                   # ring buffer of rendered event lines
+const TASKS      = Dict{String,TaskView}()   # taskId => view — ACTIVE tasks only (finished ones drop out)
+const EVENTS     = String[]                   # ring buffer of rendered ACTIVITY lines (status/chain/result)
+const LOGS       = String[]                   # ring buffer of task LOG lines — shown in their own pane
 const LOCK       = ReentrantLock()
 const MAX_EVENTS = 500
-const KEEP_DONE  = 12                         # cap on lingering finished rows
+const MAX_LOGS   = 500
+# Finished tasks are collapsed to a COUNT, not kept as rows — the console answers "what's running now
+# and how many are done", not "show all 50". TALLY holds cumulative terminal outcomes; SEEN_TERM stops
+# a task being re-counted / re-added (by a late WS event or the snapshot poll) once it has finished.
+const TALLY      = Dict{String,Int}("done" => 0, "failed" => 0, "cancelled" => 0)
+const SEEN_TERM  = Set{String}()
 
 now_hms() = Dates.format(Dates.now(), "HH:MM:SS")
-short(id::AbstractString, n::Int=8) = length(id) <= n ? String(id) : String(last(id, n))
+# Display only the id TAIL — task ids are full UUIDs; 6 chars is plenty to eyeball-correlate a handful
+# of concurrent tasks (and matches the backend's 6-char gen_uid object ids). The real id is untouched.
+short(id::AbstractString, n::Int=6) = length(id) <= n ? String(id) : String(last(id, n))
 trunc_s(s::AbstractString, n::Int) = length(s) <= n ? String(s) : String(first(s, max(0, n - 1))) * "…"
 
 # Get-or-create a task view, so a WS event for a not-yet-snapshotted task still shows up.
@@ -80,15 +88,21 @@ function push_event!(kind::AbstractString, detail::AbstractString; colour=nothin
     STREAM_MODE && println(line)
 end
 
-# Drop the oldest finished rows so the table can't grow without bound.
-function _prune_done!()
-    done_ids = [t.id for t in values(TASKS) if t.status in TERMINAL]
-    if length(done_ids) > KEEP_DONE
-        sort!(done_ids, by = id -> TASKS[id].updated)
-        for id in done_ids[1:(length(done_ids) - KEEP_DONE)]
-            delete!(TASKS, id)
-        end
-    end
+# Task log lines go in their OWN buffer, rendered in a separate confined pane (they're high-volume and
+# would otherwise drown the activity stream). Prefixed with the short task id for context.
+function push_log!(id::AbstractString, line::AbstractString)
+    entry = string(col(GREY, now_hms()), "  ", col(DIM, short(id)), "  ", line)
+    push!(LOGS, entry)
+    length(LOGS) > MAX_LOGS && deleteat!(LOGS, 1:(length(LOGS) - MAX_LOGS))
+    STREAM_MODE && println(entry)
+end
+
+# A task's first terminal sighting: bump its outcome tally and drop the row (kept only as a count).
+function _note_terminal!(id::AbstractString, status::AbstractString)
+    id in SEEN_TERM && return
+    push!(SEEN_TERM, id)
+    haskey(TALLY, status) && (TALLY[status] += 1)
+    delete!(TASKS, id)
 end
 
 # ── HTTP snapshot (fills in fun_name / image / pool for in-flight tasks) ─────────
@@ -98,14 +112,19 @@ function refresh_snapshot!()
         rows = JSON3.read(String(r.body))
         lock(LOCK) do
             for row in rows
-                t = _task!(String(row.id))
+                id = String(row.id)
+                id in SEEN_TERM && continue                 # already finished + counted — don't resurrect
+                status = String(get(row, :status, ""))
+                if status in TERMINAL                       # finished before we saw it live → just count it
+                    _note_terminal!(id, status)
+                    continue
+                end
+                t = _task!(id)
                 t.fun_name     = String(get(row, :fun_name, t.fun_name))
                 t.image_uid    = String(get(row, :image_uid, t.image_uid))
                 t.pool_name    = String(get(row, :pool_name, t.pool_name))
                 t.chain_run_id = String(get(row, :chain_run_id, t.chain_run_id))
-                # Only trust the snapshot's status for tasks it still knows about; the WS
-                # stream owns terminal transitions (finished tasks deregister server-side).
-                t.status in TERMINAL || (t.status = String(get(row, :status, t.status)))
+                isempty(status) || (t.status = status)
             end
         end
         return true
@@ -120,19 +139,24 @@ function handle_ws(raw::AbstractString)
     type = String(get(msg, :type, ""))
     lock(LOCK) do
         if type == "task:status"
-            id = String(get(msg, :taskId, "")); isempty(id) && return
-            t = _task!(id)
-            t.status  = String(get(msg, :status, t.status))
-            uid = String(get(msg, :imageUid, "")); isempty(uid) || (t.image_uid = uid)
-            t.updated = Dates.now()
+            id = String(get(msg, :taskId, "")); (isempty(id) || id in SEEN_TERM) && return
+            status = String(get(msg, :status, ""))
+            fn = haskey(TASKS, id) ? TASKS[id].fun_name : ""
             push_event!("status", string(col(BOLD, short(id)), " ",
-                        col(status_colour(t.status), t.status),
-                        isempty(t.fun_name) ? "" : col(DIM, " ($(t.fun_name))"));
-                        colour = status_colour(t.status))
-            t.status in TERMINAL && _prune_done!()
+                        col(status_colour(status), status),
+                        isempty(fn) ? "" : col(DIM, " ($fn)"));
+                        colour = status_colour(status))
+            if status in TERMINAL
+                _note_terminal!(id, status)            # collapse to a count, drop the row
+            else
+                t = _task!(id)
+                isempty(status) || (t.status = status)
+                uid = String(get(msg, :imageUid, "")); isempty(uid) || (t.image_uid = uid)
+                t.updated = Dates.now()
+            end
 
         elseif type == "task:progress"
-            id = String(get(msg, :taskId, "")); isempty(id) && return
+            id = String(get(msg, :taskId, "")); (isempty(id) || id in SEEN_TERM) && return
             t = _task!(id)
             t.progress = clamp(Float64(get(msg, :progress, 0.0)), 0.0, 1.0)
             t.updated  = Dates.now()
@@ -141,7 +165,7 @@ function handle_ws(raw::AbstractString)
             id = String(get(msg, :taskId, "")); isempty(id) && return
             line = String(get(msg, :line, ""))
             t = _task!(id); t.last_log = line; t.updated = Dates.now()
-            push_event!("log", string(col(DIM, short(id)), " ", line))
+            push_log!(id, line)
 
         elseif type == "task:result"
             id = String(get(msg, :taskId, ""))
@@ -183,27 +207,43 @@ function render()
     io = IOBuffer()
     rows, cols = try displaysize(stdout) catch; (40, 120) end
 
-    tasks = collect(values(TASKS))
-    order = Dict("running" => 0, "queued" => 1, "done" => 2, "failed" => 3, "cancelled" => 4)
-    sort!(tasks, by = t -> (get(order, t.status, 9), t.fun_name, t.id))
+    w = min(cols, 100)
+
+    # Only ACTIVE tasks are rows — running first, then queued. Finished ones live in TALLY as counts.
+    tasks = sort(collect(values(TASKS)), by = t -> (t.status == "running" ? 0 : 1, t.fun_name, t.id))
     n_run = count(t -> t.status == "running", tasks)
     n_q   = count(t -> t.status == "queued", tasks)
 
-    # header
+    # ── ONE height budget so nothing ever clips: fixed chrome (title/counts/blank, table header,
+    # dividers, footer) ≈ 6 lines (+1 with a logs pane), reserved generously; the rest splits between
+    # the task table (priority), a small activity peek and the logs pane. EVERY section obeys this — no
+    # per-pane minimum can push content past the window (the earlier bug: min-6 logs + min-3 activity
+    # overran a short terminal and shoved the header off the top).
+    haveLogs  = !isempty(LOGS)
+    content   = max(4, rows - 9 - (haveLogs ? 1 : 0))
+    logCap    = haveLogs ? clamp(content ÷ 3, 1, 6) : 0
+    evtCap    = clamp(content ÷ 4, 1, 4)
+    tableRoom = max(2, content - logCap - evtCap)
+    truncated = length(tasks) > tableRoom
+    nShown    = truncated ? max(1, tableRoom - 1) : length(tasks)   # reserve a line for "…and N more"
+
+    # header — live counts + cumulative finished tallies (so you see "how many done" without 50 rows)
     print(io, "\e[H\e[2J")
     print(io, col(BOLD, "Cecelia task console"), col(DIM, "  $HTTP_BASE"),
           "   ", col(GREY, Dates.format(Dates.now(), "yyyy-mm-dd HH:MM:SS")), "\n")
     print(io, col(CYAN, "$n_run running"), col(DIM, " · "), col(YELLOW, "$n_q queued"),
-          col(DIM, " · $(length(tasks)) shown"), "\n\n")
+          col(DIM, " · "), col(GREEN, "$(TALLY["done"]) done"),
+          col(DIM, " · "), col(RED, "$(TALLY["failed"]) failed"),
+          TALLY["cancelled"] > 0 ? string(col(DIM, " · "), col(MAGENTA, "$(TALLY["cancelled"]) cancelled")) : "",
+          "\n\n")
 
-    # task table
+    # active task table
     if isempty(tasks)
-        print(io, col(DIM, "  no tasks in flight\n"))
+        print(io, col(DIM, "  no active tasks — waiting for work\n"))
     else
-        hdr = string(rpad("TASK", 9), rpad("FUNCTION", 26), rpad("IMAGE", 10),
-                     rpad("POOL", 10), rpad("STATUS", 11), "PROGRESS")
-        print(io, col(DIM, hdr), "\n")
-        for t in tasks
+        print(io, col(DIM, string(rpad("TASK", 9), rpad("FUNCTION", 26), rpad("IMAGE", 10),
+                                   rpad("POOL", 10), rpad("STATUS", 11), "PROGRESS")), "\n")
+        for t in tasks[1:nShown]
             chain = isempty(t.chain_run_id) ? "" : " ⛓"
             print(io,
                 rpad(short(t.id), 9),
@@ -211,21 +251,24 @@ function render()
                 rpad(short(t.image_uid), 10),
                 rpad(trunc_s(t.pool_name, 9), 10),
                 col(status_colour(t.status), rpad(t.status, 11)),
-                t.status == "running" ? progress_bar(t.progress) :
-                    col(DIM, t.status in TERMINAL ? "done" : ""),
+                t.status == "running" ? progress_bar(t.progress) : col(DIM, "waiting"),
                 "\n")
         end
+        truncated && print(io, col(DIM, "  …and $(length(tasks) - nShown) more active\n"))
     end
 
-    # event log — fill the remaining terminal height
-    print(io, "\n", col(DIM, "─"^min(cols, 100)), "\n")
-    used  = length(tasks) + 8
-    avail = max(4, rows - used - 1)
-    tail  = length(EVENTS) > avail ? EVENTS[(end - avail + 1):end] : EVENTS
-    for line in tail
+    # activity peek, then the confined logs pane — both bounded by the budget above
+    print(io, col(DIM, "── activity " * "─"^max(0, w - 12)), "\n")
+    for line in (length(EVENTS) > evtCap ? EVENTS[(end - evtCap + 1):end] : EVENTS)
         print(io, trunc_s(line, cols + 40), "\n")   # +40 slack for ANSI escape bytes
     end
-    print(io, col(DIM, "\n(reporting only — Ctrl-C to quit)"))
+    if logCap > 0
+        print(io, col(DIM, "── logs " * "─"^max(0, w - 8)), "\n")
+        for line in (length(LOGS) > logCap ? LOGS[(end - logCap + 1):end] : LOGS)
+            print(io, trunc_s(line, cols + 40), "\n")
+        end
+    end
+    print(io, col(DIM, "(reporting only — Ctrl-C to quit)"))
 
     print(String(take!(io)))
     flush(stdout)
@@ -251,6 +294,13 @@ function run_console()
         connected = Ref(true)
         try
             HTTP.WebSockets.open(WS_URL; connect_timeout=3) do ws
+                # A (re)connect on localhost means the server (re)started — its task ids and in-flight
+                # set are gone, so drop our stale view and re-seed from the fresh snapshot. Otherwise
+                # tasks from the previous server session would linger forever (we only ever add rows).
+                lock(LOCK) do
+                    empty!(TASKS); empty!(EVENTS); empty!(LOGS); empty!(SEEN_TERM)
+                    for k in keys(TALLY); TALLY[k] = 0; end
+                end
                 # seed the snapshot, then keep it fresh + keep the socket alive
                 refresh_snapshot!()
                 STREAM_MODE || render()

--- a/app/src/tasks/chain.jl
+++ b/app/src/tasks/chain.jl
@@ -61,7 +61,12 @@ struct ChainTemplate
     name::String
     nodes::Vector{ChainNode}
     edges::Vector{ChainEdge}
+    # UML "start" dot targets: node ids the start dot links to. When non-empty, a run executes ONLY the
+    # nodes reachable from these (their inclusive descendants) — everything else is a draft, left in the
+    # editor but skipped. Empty ⇒ run the whole chain from its natural roots (backward-compatible).
+    start_targets::Vector{String}
 end
+ChainTemplate(name, nodes, edges) = ChainTemplate(name, nodes, edges, String[])
 
 # ── Run record ────────────────────────────────────────────────────────────────
 
@@ -153,6 +158,7 @@ function load_chain_template(proj::CciaProject, name::String)::ChainTemplate
         string(get(raw, :name, name)),
         [_node_from_dict(n) for n in get(raw, :nodes, [])],
         [_edge_from_dict(e) for e in get(raw, :edges, [])],
+        String[string(s) for s in get(raw, :startTargets, get(raw, :start_targets, []))],
     )
 end
 
@@ -169,6 +175,7 @@ function save_chain_template!(proj::CciaProject, t::ChainTemplate)::ChainTemplat
                        barrier_policy=n.barrier_policy, resource_pool=n.resource_pool)
                      for n in t.nodes],
             edges = [(; from=e.from, to=e.to) for e in t.edges],
+            startTargets = t.start_targets,
         ))
     end
     t
@@ -186,6 +193,7 @@ function _template_json(t::ChainTemplate)::String
                    barrier_policy=n.barrier_policy, resource_pool=n.resource_pool)
                  for n in t.nodes],
         edges = [(; from=e.from, to=e.to) for e in t.edges],
+        startTargets = t.start_targets,
     ))
 end
 
@@ -224,6 +232,7 @@ function load_template_from_cache(proj::CciaProject, hash::String)::ChainTemplat
         string(get(raw, :name, "")),
         [_node_from_dict(n) for n in get(raw, :nodes, [])],
         [_edge_from_dict(e) for e in get(raw, :edges, [])],
+        String[string(s) for s in get(raw, :startTargets, get(raw, :start_targets, []))],
     )
 end
 
@@ -783,6 +792,30 @@ function _descendants(template::ChainTemplate, node_id::String)::Set{String}
     out
 end
 
+# UML start-dot pruning: restrict a template to the nodes reachable from its `start_targets` (their
+# inclusive descendants). Targets become effective roots — edges into them from now-excluded nodes are
+# dropped, so a mid-chain start runs from there on, and disconnected branches (unreachable from the
+# start dot) drop out as drafts. No start targets ⇒ the template is returned unchanged (run all).
+function _prune_to_start(template::ChainTemplate)::ChainTemplate
+    isempty(template.start_targets) && return template
+    ids  = Set(n.id for n in template.nodes)
+    exec = Set{String}()
+    for t in template.start_targets
+        t in ids || continue                       # stale target (node since deleted) — ignore
+        push!(exec, t)
+        union!(exec, _descendants(template, t))
+    end
+    # All targets stale ⇒ fall back to running the whole chain rather than erroring on an empty run
+    # (a dangling start dot shouldn't brick the run — better to run everything and let the user notice).
+    if isempty(exec)
+        @warn "Chain start dot targets no existing nodes — running the whole chain" targets=template.start_targets
+        return ChainTemplate(template.name, template.nodes, template.edges, String[])
+    end
+    nodes = [n for n in template.nodes if n.id in exec]
+    edges = [e for e in template.edges if e.from in exec && e.to in exec]
+    ChainTemplate(template.name, nodes, edges, String[])   # start consumed into the node set
+end
+
 # Explicit "start node" for resume: force `start_node` and everything downstream back to :pending
 # across ALL images, even nodes that are :done with matching params (which `_reset_stale_nodes!`
 # would otherwise keep and skip). This is the whiteboard "resume from here" — re-run a completed
@@ -951,7 +984,11 @@ function run_chain(proj::CciaProject, image_uids::Vector{String};
         isempty(chain) && error("run_chain requires `chain` name when `run_id` is not given")
         isempty(image_uids) && error("run_chain requires at least one image UID")
 
-        template      = load_chain_template(proj, chain)
+        # UML start dot: if the template has start targets, run ONLY the reachable subgraph (the rest
+        # are drafts). Pruning here means every downstream stage (topo, states, resume) sees one clean
+        # effective template — targets are roots, unreachable branches simply don't exist for this run.
+        template      = _prune_to_start(load_chain_template(proj, chain))
+        isempty(template.nodes) && error("run_chain: start dot reaches no nodes (nothing to run)")
         ordered_nodes = _topo_sort(template)
 
         image_states  = Dict{String,Dict{String,ImageNodeState}}(

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -512,6 +512,33 @@ end
         rm(proj.root; recursive=true)
     end
 
+    # ── Chain start dot — prune to the reachable subgraph ─────────────────────
+    @testset "Chain start dot — prune to reachable subgraph" begin
+        tpl = ChainTemplate(
+            "start-chain",
+            [ChainNode(id="a", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="b", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="c", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="d", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="x", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="y", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}())],
+            [ChainEdge("a","b"), ChainEdge("b","c"), ChainEdge("c","d"), ChainEdge("x","y")],
+            ["c"],                                          # start dot → c (mid-chain)
+        )
+        pruned = Cecelia._prune_to_start(tpl)
+        @test Set(n.id for n in pruned.nodes) == Set(["c","d"])        # c + downstream only
+        @test Set((e.from, e.to) for e in pruned.edges) == Set([("c","d")])
+        @test isempty(pruned.start_targets)                            # consumed into the node set
+        # disconnected draft branch (x→y) dropped; a→b upstream of the start dot dropped too
+        @test !any(n.id in ("a","b","x","y") for n in pruned.nodes)
+        # no start targets ⇒ unchanged (run the whole chain)
+        @test length(Cecelia._prune_to_start(ChainTemplate("t", tpl.nodes, tpl.edges)).nodes) == 6
+        # start dot pointing ONLY at since-deleted nodes ⇒ fall back to run-all, not an empty run
+        stale = Cecelia._prune_to_start(ChainTemplate("t", tpl.nodes, tpl.edges, ["ghost"]))
+        @test length(stale.nodes) == 6
+        @test isempty(stale.start_targets)
+    end
+
     # ── Chain run — set-scope (picnic) node ──────────────────────────────────
     @testset "Chain run — picnic node" begin
         proj = create_project!(name="chain-picnic-$(rand(1000:9999))", kind="static")
@@ -550,6 +577,43 @@ end
         # Set-scope task log appeared exactly once (ran once, not once per image)
         set_logs = filter(l -> contains(l, "setTask ran"), logs)
         @test length(set_logs) == 1
+
+        rm(proj.root; recursive=true)
+    end
+
+    # ── Chain start dot — end-to-end run prunes to the reachable subgraph ─────
+    # Reservation guard: pruning to a start dot must still work when the reachable subgraph contains a
+    # picnic (set-scope barrier) node. The target becomes a root — its dropped upstream doesn't block
+    # it — and the barrier still fires once across all images. Also covers the save/load round-trip of
+    # `startTargets` and that pruned-out nodes never enter the run.
+    @testset "Chain start dot — run prunes to subgraph (set-scope)" begin
+        proj = create_project!(name="chain-startrun-$(rand(1000:9999))", kind="static")
+        s    = add_set!(proj; name="s")
+        imgs = map(("img-a", "img-b")) do nm; add_image!(s; name=nm); end
+
+        # n1(image) → n2(set) → n3(image); start dot → n2, so n1 is an upstream draft (excluded)
+        tpl = ChainTemplate(
+            "startrun-chain",
+            [ChainNode(id="n1", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}()),
+             ChainNode(id="n2", fn="testTasks.setTask",   scope="set",   params=Dict{String,Any}()),
+             ChainNode(id="n3", fn="testTasks.imageTask", scope="image", params=Dict{String,Any}())],
+            [ChainEdge("n1","n2"), ChainEdge("n2","n3")],
+            ["n2"],                                        # start dot → n2 (a set-scope node)
+        )
+        save_chain_template!(proj, tpl)
+
+        logs = String[]
+        run = run_chain(proj, [i.uid for i in imgs]; chain="startrun-chain",
+                        on_log = line -> push!(logs, line))
+
+        # only the reachable subgraph exists in the run — n1 pruned out entirely
+        @test Set(keys(run.image_states[imgs[1].uid])) == Set(["n2", "n3"])
+        for img in imgs
+            @test run.image_states[img.uid]["n2"].status == :done   # set-scope barrier fired as root
+            @test run.image_states[img.uid]["n3"].status == :done
+        end
+        @test run.image_states[imgs[1].uid]["n2"].result["image_count"] == 2
+        @test length(filter(l -> contains(l, "setTask ran"), logs)) == 1   # ran once, not per image
 
         rm(proj.root; recursive=true)
     end

--- a/docs/API.md
+++ b/docs/API.md
@@ -86,7 +86,21 @@ Settings → Debug console UI shows a note to this effect.
 | — | **Gating** (below) | population manager + gating |
 
 Task execution + status flow over **WS** (`task:run`/`task:status`/…), not HTTP — see
-`ARCHITECTURE.md` and `SCHEDULER.md`.
+`ARCHITECTURE.md` and `SCHEDULER.md`. Task events (`task:log`/`task:status`/`task:progress`/`task:result`)
+are **broadcast to every connected client** (`_broadcast_task` → `broadcast_ws`), not sent point-to-point
+to the launching socket — so a second GUI tab and the read-only **task console** (`api/task_console.jl`,
+`pixi run console`) both see live progress. (They're keyed by `taskId`, so clients filter to what they
+care about. Chain events already broadcast.) Broadcast is **decoupled from the caller**: `broadcast_ws`
+enqueues a pre-serialised frame onto a bounded, drop-on-full channel that a single background task
+drains and writes to each client (pruning any that error). This is deliberate — task events fan out on
+every log/progress line from many worker threads, so writing sockets inline would let concurrent
+threads corrupt a shared socket and let one slow/half-open client block a worker (which strands a pool
+slot → tasks stuck at `queued`). Workers must never block on WS I/O. `handle_task_run` forwards
+`queued`/`running` **and
+`cancelled`** from `on_status_change` immediately (cancel has no result to order before it), so
+cancelling a task — especially a still-**queued** one — reflects at once instead of only when a worker
+later dequeues and skips it; `done`/`failed` are held until the result is sent. The console drops its
+whole view on reconnect (a localhost drop = server restart), so stale tasks don't linger.
 
 ---
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -114,6 +114,9 @@ Rationale and the full packaging/update model live in [`docs/SHIPPING.md`](SHIPP
   without binding a socket, then calls handlers directly (no live server, no ports). Fixture-free, so
   it runs in CI (`.github/workflows/ci.yml`) on every OS. Covers diagnostics + the debug-console
   gating/eval; extend it as more adapters gain logic worth pinning.
+- **Frontend:** `npm test` (Vitest, `frontend/`) for pure logic extracted out of `.vue` SFCs into
+  `src/utils/*` (e.g. `startDot.ts` — the chain start-dot save/reload round-trip). Keep testable logic
+  in plain `.ts` modules rather than the component so it can be unit-tested without mounting Vue.
 
 ## Diagnostics & debug console
 

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -390,6 +390,24 @@ The WS `chain:run` message carries `runId` (→ resume) and optional `startNode`
 tab sends them when you hit **Resume** (with or without a picked node). See `docs/UI.md` → Chain
 whiteboard.
 
+### Fresh-run start dot (`start_targets` — UML initial node)
+
+For a *fresh* run there's an authored entry point: a **UML start dot** on the edit whiteboard, linked
+to the task(s) a run begins from. It's persisted as `ChainTemplate.start_targets` (the node ids the
+dot links to; the dot isn't a task). At run start, `run_chain` calls `_prune_to_start`:
+
+- `start_targets` empty ⇒ template unchanged — run the whole chain from its natural roots (backward-
+  compatible; existing chains are untouched).
+- non-empty ⇒ execute **only the reachable subgraph** — the inclusive descendants of the targets.
+  Edges into a target from now-excluded nodes are dropped, so a target becomes an effective root.
+
+So dropping the dot mid-chain runs from there onward (upstream tasks kept in the editor as drafts,
+skipped for the run), and linking it to one branch runs that branch while a disconnected branch stays
+a draft. Pruning happens once, up front, so every downstream stage (topo sort, per-image state,
+resume, the frozen `template_snapshot`) sees one clean effective template — no node knows it was
+pruned. Distinct from `start_node` above: `start_targets` is a persisted *authoring* choice for fresh
+runs; `start_node` is a transient *resume* choice made on the Live tab.
+
 ### In-place restart (no new task record)
 
 Resume re-uses the existing `run.id`. There is no "new task created" on resume — the run record

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -617,13 +617,26 @@ The tab badge shows the count of currently-running nodes.
 |---|---|---|
 | `"task"` | `"image"` or `"incremental"` | Purple accent border, solid (image) or dashed (incremental) |
 | `"picnic"` | `"set"` | Amber/orange border, ◆ badge, barrier policy shown |
+| `"start"` | (not a task) | UML initial node — a filled dot; drag + link to the first task(s). Moveable, source-only |
 | `"live"` | (live view only) | Status-colored header bar; grey=queued, blue=running, green=done, red=failed, grey=cancelled |
 
-Custom node components: `ChainTaskNode.vue`, `ChainPicnicNode.vue`, `ChainLiveNode.vue`.
+Custom node components: `ChainTaskNode.vue`, `ChainStartNode.vue`, `ChainPicnicNode.vue`, `ChainLiveNode.vue`.
+
+**Start dot (UML initial node).** A moveable dot (reserved id `__start__`, one per chain) marking where a
+run begins — added by the toolbar button and **by default on a new chain** (which then centers/zooms on
+it so it's obviously visible). You link it to the task(s) a run should start from; **only tasks reachable
+from it run**, the rest stay in the editor as drafts (backend `_prune_to_start`, `docs/SCHEDULER.md`). So
+drop it mid-chain to run just the later tasks, or link it to one branch and leave another as a draft. It's
+not a task: excluded from `nodes` on save and recorded as `startTargets` (the linked node ids); its
+position persists under `positions['__start__']`. No start dot / unlinked ⇒ `startTargets` empty ⇒ run the
+whole chain (backward-compatible). The config panel shows only a hint for it (no scope/params).
 
 ### Chain JSON format
 
-The whiteboard sends the standard `{name, nodes[], edges[]}` template format plus an optional `positions: {nodeId: {x, y}}` field. The backend preserves all fields verbatim (the scheduler ignores unknown fields when loading). Positions are purely a whiteboard concern — they survive save/load cycles but don't affect chain execution.
+The whiteboard sends the standard `{name, nodes[], edges[]}` template format plus optional `positions:
+{nodeId: {x, y}}` and `startTargets: string[]` (the UML start-dot links) fields. The backend preserves all
+fields verbatim (the scheduler ignores unknown fields when loading). Positions are purely a whiteboard
+concern; `startTargets` drives which subgraph a run executes (`_prune_to_start`).
 
 ### Per-node param form
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@vue/tsconfig": "^0.9.1",
         "typescript": "~6.0.2",
         "vite": "^8.0.12",
+        "vitest": "^4.1.9",
         "vue-tsc": "^3.2.8"
       }
     },
@@ -616,6 +617,13 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -626,12 +634,29 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -677,6 +702,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -1062,6 +1210,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -1128,6 +1286,16 @@
       "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==",
       "license": "MIT"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -1171,6 +1339,13 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-anything": {
@@ -1674,6 +1849,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1689,6 +1871,16 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -2208,6 +2400,20 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -2504,6 +2710,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2521,6 +2734,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -2568,6 +2795,23 @@
         "node": ">=16"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2582,6 +2826,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/topojson-client": {
@@ -3245,6 +3499,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -3377,6 +3721,23 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@observablehq/plot": "^0.6.17",
@@ -28,6 +29,7 @@
     "@vue/tsconfig": "^0.9.1",
     "typescript": "~6.0.2",
     "vite": "^8.0.12",
+    "vitest": "^4.1.9",
     "vue-tsc": "^3.2.8"
   }
 }

--- a/frontend/src/components/ChainStartNode.vue
+++ b/frontend/src/components/ChainStartNode.vue
@@ -1,0 +1,55 @@
+<!--
+  UML "start" (initial) node for the chain whiteboard: a filled dot you link to the task(s) where a
+  run should BEGIN. A run executes only the nodes reachable from here (backend `_prune_to_start`) —
+  so you can drop it mid-chain to run just the later tasks (earlier ones kept as drafts), or link it
+  to one branch and leave another disconnected as a draft. Source-only (an initial node has no input);
+  draggable like any node. There is at most one per chain (id `__start__`).
+-->
+<script setup lang="ts">
+import { Handle, Position } from '@vue-flow/core'
+
+defineProps<{ id: string; selected: boolean }>()
+</script>
+
+<template>
+  <div class="chain-start-node" :class="{ selected }" title="Start — link to the task(s) a run begins from">
+    <span class="start-dot" />
+    <span class="start-label">start</span>
+    <!-- initial node: source only (no target handle) -->
+    <Handle type="source" :position="Position.Right" class="node-handle" />
+  </div>
+</template>
+
+<style scoped>
+.chain-start-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  cursor: pointer;
+  position: relative;
+}
+.start-dot {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--cc-text, #e2e2f0);
+  border: 3px solid var(--cc-accent, #a78bfa);
+  box-shadow: 0 0 0 2px transparent;
+  transition: box-shadow 0.12s;
+}
+.chain-start-node.selected .start-dot {
+  box-shadow: 0 0 0 3px var(--cc-accent, #a78bfa);
+}
+.start-label {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--cc-text-dim, #8b8ca7);
+}
+.node-handle {
+  width: 10px;
+  height: 10px;
+}
+</style>

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onActivated, markRaw } from 'vue'
+import { ref, computed, watch, onMounted, onActivated, markRaw, nextTick } from 'vue'
 defineOptions({ name: 'ChainModule' })
 import {
   VueFlow, useVueFlow,
@@ -11,6 +11,7 @@ import { Background } from '@vue-flow/background'
 import '@vue-flow/core/dist/style.css'
 import '@vue-flow/core/dist/theme-default.css'
 import ChainTaskNode from '../components/ChainTaskNode.vue'
+import ChainStartNode from '../components/ChainStartNode.vue'
 import ChainPicnicNode from '../components/ChainPicnicNode.vue'
 import ChainLiveNode from '../components/ChainLiveNode.vue'
 import ChainLiveLabel from '../components/ChainLiveLabel.vue'
@@ -24,6 +25,7 @@ import { useTaskStore, type TaskStatus } from '../stores/tasks'
 import { useWsStore } from '../stores/ws'
 import { useLogStore } from '../stores/log'
 import type { TaskDef, ChainTemplate } from '../tasks/types'
+import { START_ID, startTargetsOf, touchesStart, buildStartGraph } from '../utils/startDot'
 
 // ── Stores & composables ─────────────────────────────────────────────────────
 
@@ -41,12 +43,13 @@ const {
   addNodes, addEdges, removeNodes, removeEdges,
   findNode, updateNode, toObject,
   onConnect, onNodeClick, onEdgeDoubleClick,
-  screenToFlowCoordinate,
+  screenToFlowCoordinate, setCenter,
 } = useVueFlow({ id: 'chain-whiteboard' })
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const nodeTypes: NodeTypesObject = {
   task:      markRaw(ChainTaskNode)   as any,
+  start:     markRaw(ChainStartNode)  as any,
   picnic:    markRaw(ChainPicnicNode) as any,
   live:      markRaw(ChainLiveNode)   as any,
   liveLabel: markRaw(ChainLiveLabel)  as any,
@@ -557,6 +560,15 @@ async function loadChain(name: string) {
   }
 }
 
+// the single UML start dot (an initial node, not a task) — START_ID + pure round-trip in utils/startDot
+const hasStartNode = computed(() => nodes.value.some(n => n.id === START_ID))
+
+// Add the start dot once, near the top-left; the user drags it and links it to the first task(s).
+function addStartNode() {
+  if (hasStartNode.value) return
+  addNodes([{ id: START_ID, type: 'start', position: { x: 20, y: 40 }, data: {} }])
+}
+
 function applyTemplate(
   tmpl: ChainTemplate,
   positions: Record<string, { x: number; y: number }>,
@@ -596,15 +608,29 @@ function applyTemplate(
     style:  { stroke: 'var(--cc-accent, #a78bfa)' },
   }))
 
+  // Reconstruct the UML start dot + its edges (pure logic in utils/startDot): links restored from the
+  // persisted startTargets (dropping any since-deleted), position from the reserved '__start__' key —
+  // and the dot is kept even when unlinked if a position was saved (so the default dot survives reload).
+  const start = buildStartGraph(
+    tmpl.startTargets,
+    new Set(tmpl.nodes.map(n => n.id)),
+    positions[START_ID] ?? { x: 20, y: 40 },
+    START_ID in positions,
+  )
+  if (start) { newNodes.push(start.node); newEdges.push(...start.edges) }
+
   addNodes(newNodes)
   addEdges(newEdges)
 }
 
 function currentTemplate(): ChainTemplate & { positions: Record<string, {x:number; y:number}> } {
   const obj = toObject()
+  // The UML start dot is not a task: exclude it from nodes/edges and instead record the tasks it
+  // links to as `startTargets` (pure logic in utils/startDot). Its position is still persisted
+  // (positions['__start__']) so it reappears where the user left it — even when unlinked.
   return {
     name:  activeChain.value,
-    nodes: obj.nodes.map(n => ({
+    nodes: obj.nodes.filter(n => n.id !== START_ID).map(n => ({
       id:             n.id,
       fn:             n.data.fn,
       scope:          n.data.scope,
@@ -612,7 +638,10 @@ function currentTemplate(): ChainTemplate & { positions: Record<string, {x:numbe
       barrier_policy: n.data.barrier_policy,
       resource_pool:  n.data.resource_pool,
     })),
-    edges: obj.edges.map(e => ({ from: e.source, to: e.target })),
+    edges: obj.edges
+      .filter(e => !touchesStart(e))
+      .map(e => ({ from: e.source, to: e.target })),
+    startTargets: startTargetsOf(obj.edges),
     positions: Object.fromEntries(obj.nodes.map(n => [n.id, n.position])),
   }
 }
@@ -685,8 +714,14 @@ async function createChain() {
     removeNodes(nodes.value.map(n => n.id))
     removeEdges(edges.value.map(e => e.id))
     selectedNodeId.value = null
+    addStartNode()                       // new chains get a UML start dot by default — link it to the first task
     newChainName.value = ''
     showNewInput.value = false
+    // Center + zoom on the start dot (which sits at ~20,40) so it's obviously visible on an otherwise
+    // empty canvas — "here's the start, drop your first task to the right" — instead of parked
+    // off-screen at the origin. Offset right so there's room for tasks.
+    await nextTick()
+    setCenter(230, 60, { zoom: 1, duration: 350 })
     log.info(`Chain "${name}" created.`, { source: 'whiteboard' })
   } catch (e) {
     log.error(`Create failed: ${e}`, { source: 'whiteboard' })
@@ -834,12 +869,15 @@ function propagateValueName(sourceId: string, targetId: string) {
 // ── Edge connections ─────────────────────────────────────────────────────────
 
 onConnect((params) => {
+  const fromStart = params.source === START_ID
   addEdges([{
     ...params,
     id: `${params.source}->${params.target}`,
-    style: { stroke: 'var(--cc-accent, #a78bfa)' },
+    // start-dot edges are dashed (they mark the entry, not a data dependency)
+    style: { stroke: 'var(--cc-accent, #a78bfa)', ...(fromStart ? { strokeDasharray: '4 3' } : {}) },
   }])
-  if (params.source && params.target) propagateValueName(params.source, params.target)
+  // value-name propagation is a task→task concern; the start dot has no output, so skip it there
+  if (params.source && params.target && !fromStart) propagateValueName(params.source, params.target)
 })
 
 // Double-click an edge to remove it.
@@ -1157,6 +1195,14 @@ onActivated(async () => {
           </button>
           <button
             class="wb-btn"
+            :disabled="!activeChain || hasStartNode"
+            @click="addStartNode"
+            v-tooltip.right="'Add a start node — link it to the task(s) a run begins from. Only tasks reachable from it run; the rest stay as drafts.'"
+          >
+            <i class="pi pi-circle-fill" />
+          </button>
+          <button
+            class="wb-btn"
             :disabled="!activeChain"
             @click="loadChain(activeChain)"
             v-tooltip.right="'Reload chain from disk — discards unsaved edits.'"
@@ -1336,7 +1382,7 @@ onActivated(async () => {
       <template v-if="selectedNode">
 
         <div class="config-header">
-          <div class="config-title">Node</div>
+          <div class="config-title">{{ selectedNode.type === 'start' ? 'Start node' : 'Node' }}</div>
           <button
             class="wb-btn wb-btn-danger"
             @click="deleteSelectedNode"
@@ -1346,6 +1392,12 @@ onActivated(async () => {
           </button>
         </div>
 
+        <div v-if="selectedNode.type === 'start'" class="config-section">
+          <p class="no-params-hint">Link this to the task(s) a run should begin from. Only tasks
+          reachable from it will run — the rest stay in the editor as drafts.</p>
+        </div>
+
+        <template v-else>
         <!-- Identity -->
         <div class="config-section">
           <label class="config-label">ID</label>
@@ -1418,6 +1470,7 @@ onActivated(async () => {
         <div class="config-section" v-else>
           <span class="no-params-hint">Function not found in task definitions.</span>
         </div>
+        </template>
 
       </template>
 
@@ -1518,6 +1571,18 @@ onActivated(async () => {
 .qc-toggle { color: var(--cc-text-dim); }
 .qc-toggle:hover:not(:disabled) { color: var(--cc-text); }
 .qc-toggle.qc-on { color: var(--cc-accent); border-color: var(--cc-accent); }
+
+/* Resume is a LABELLED action, not a 26px icon square (.wb-btn) — auto-width + padding + gap so the
+   play icon and text both show, accent-styled as the Live tab's primary action. */
+.live-resume-btn {
+  width: auto;
+  padding: 0 0.55rem;
+  gap: 0.35rem;
+  color: var(--cc-accent);
+  border-color: var(--cc-accent);
+}
+.live-resume-btn:hover:not(:disabled) { background: var(--cc-accent); color: #fff; }
+.live-resume-lbl { font-size: 0.72rem; font-weight: 600; white-space: nowrap; }
 
 .qc-expand-overlay {
   position: absolute; inset: 0; z-index: 20;

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { shortId } from '../utils/id'
 
 export type TaskStatus = 'queued' | 'running' | 'done' | 'failed' | 'cancelled'
 
@@ -30,7 +31,7 @@ export const useTaskStore = defineStore('tasks', () => {
   const _seqRef = ref(0)
 
   function add(t: Omit<TaskEntry, 'id' | 'log' | 'seq'>): TaskEntry {
-    const entry: TaskEntry = { ...t, id: crypto.randomUUID(), log: [], seq: ++_seqRef.value }
+    const entry: TaskEntry = { ...t, id: shortId(), log: [], seq: ++_seqRef.value }
     tasks.value.unshift(entry)
     return entry
   }

--- a/frontend/src/tasks/types.ts
+++ b/frontend/src/tasks/types.ts
@@ -67,4 +67,9 @@ export interface ChainTemplate {
   name: string
   nodes: ChainNodeSpec[]
   edges: ChainEdgeSpec[]
+  // UML start-dot targets: node ids the start dot links to. When set, a run executes only the nodes
+  // reachable from these (rest are drafts). Persisted verbatim; the whiteboard also stores the dot's
+  // position under positions['__start__'].
+  startTargets?: string[]
+  positions?: Record<string, { x: number; y: number }>
 }

--- a/frontend/src/utils/id.ts
+++ b/frontend/src/utils/id.ts
@@ -1,0 +1,14 @@
+// Short client-side ids — a per-session correlation handle (module task runs, and any future
+// client-minted id). Mirrors the backend's `gen_uid` shape (app/src/utils.jl: 6 base62 chars) so an
+// id reads the same everywhere — frontend task list, WS messages, backend logs, the task console —
+// instead of a 36-char UUID that only ever showed truncated. ~57 billion values (62^6); collision-free
+// within a session. NOT security-sensitive — purely a display/correlation handle.
+export const ID_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+export const ID_LENGTH = 6
+
+export function shortId(n: number = ID_LENGTH): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(n))
+  let s = ''
+  for (let i = 0; i < n; i++) s += ID_CHARS[bytes[i] % ID_CHARS.length]
+  return s
+}

--- a/frontend/src/utils/startDot.test.ts
+++ b/frontend/src/utils/startDot.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { START_ID, startTargetsOf, touchesStart, buildStartGraph } from './startDot'
+
+// Round-trip the whiteboard's UML start dot through save (currentTemplate) → load (applyTemplate),
+// the reservation that was previously only static-verified. Exercises the exact pure helpers both
+// sides of ChainModule use.
+describe('start dot round-trip', () => {
+  it('extracts startTargets from the start-dot edges only', () => {
+    const edges = [{ source: START_ID, target: 'seg' }, { source: 'seg', target: 'meas' }]
+    expect(startTargetsOf(edges)).toEqual(['seg'])
+  })
+
+  it('save → load preserves the linked target (and excludes the start dot from task edges)', () => {
+    const edges = [{ source: START_ID, target: 'seg' }, { source: 'seg', target: 'meas' }]
+    // save side
+    const startTargets = startTargetsOf(edges)
+    const taskEdges = edges.filter(e => !touchesStart(e))
+    expect(taskEdges).toEqual([{ source: 'seg', target: 'meas' }])
+    // load side
+    const start = buildStartGraph(startTargets, new Set(['seg', 'meas']), { x: 20, y: 40 }, true)
+    expect(start).not.toBeNull()
+    expect(start!.node.id).toBe(START_ID)
+    expect(start!.node.position).toEqual({ x: 20, y: 40 })
+    expect(start!.edges.map(e => e.target)).toEqual(['seg'])
+    expect(start!.edges[0].source).toBe(START_ID)
+  })
+
+  it('keeps an unlinked dot when a position was persisted (default on a new chain)', () => {
+    const start = buildStartGraph([], new Set(['seg']), { x: 20, y: 40 }, true)
+    expect(start).not.toBeNull()
+    expect(start!.edges).toHaveLength(0)
+  })
+
+  it('drops the dot entirely when there are no targets and no persisted position', () => {
+    expect(buildStartGraph([], new Set(['seg']), { x: 0, y: 0 }, false)).toBeNull()
+    expect(buildStartGraph(undefined, new Set(['seg']), { x: 0, y: 0 }, false)).toBeNull()
+  })
+
+  it('drops links to since-deleted nodes but keeps the valid ones', () => {
+    const start = buildStartGraph(['seg', 'ghost'], new Set(['seg']), { x: 0, y: 0 }, false)
+    expect(start!.edges.map(e => e.target)).toEqual(['seg'])
+  })
+})

--- a/frontend/src/utils/startDot.ts
+++ b/frontend/src/utils/startDot.ts
@@ -1,0 +1,43 @@
+// Pure round-trip logic for the chain whiteboard's UML start dot (see ChainModule / docs/UI.md).
+// Kept out of the .vue SFC so it's unit-testable (utils/startDot.test.ts) — the save side extracts
+// the dot's links as `startTargets`; the load side rebuilds the dot node + edges from them. The dot
+// itself is never a template task node; only its position persists (under the reserved id below).
+
+export const START_ID = '__start__'
+
+export interface EdgeLite { source: string; target: string }
+
+/** SAVE: the task ids the start dot links to = the targets of edges out of the start node. */
+export function startTargetsOf(edges: EdgeLite[]): string[] {
+  return edges.filter(e => e.source === START_ID).map(e => e.target)
+}
+
+/** True for the start node / any edge touching it — used to exclude it from the saved template. */
+export const isStartId = (id: string): boolean => id === START_ID
+export const touchesStart = (e: EdgeLite): boolean => e.source === START_ID || e.target === START_ID
+
+export interface StartNodeSpec { id: string; type: 'start'; position: { x: number; y: number }; data: Record<string, never> }
+export interface StartEdgeSpec { id: string; source: string; target: string; style: Record<string, string> }
+
+/**
+ * LOAD: rebuild the start dot + its (dashed) edges to add to the canvas.
+ * Reconstructs when the dot links to at least one still-existing target OR a position was persisted
+ * for it (so an unlinked-but-placed dot — e.g. the default on a new chain — survives save/reload).
+ * Returns null when there's nothing to add. Targets not in `existingIds` (deleted nodes) are dropped.
+ */
+export function buildStartGraph(
+  targets: string[] | undefined,
+  existingIds: Set<string>,
+  pos: { x: number; y: number },
+  hasPersistedPos: boolean,
+): { node: StartNodeSpec; edges: StartEdgeSpec[] } | null {
+  const valid = (targets ?? []).filter(t => existingIds.has(t))
+  if (!valid.length && !hasPersistedPos) return null
+  return {
+    node: { id: START_ID, type: 'start', position: pos, data: {} },
+    edges: valid.map(t => ({
+      id: `${START_ID}->${t}`, source: START_ID, target: t,
+      style: { stroke: 'var(--cc-accent, #a78bfa)', strokeDasharray: '4 3' },
+    })),
+  }
+}


### PR DESCRIPTION
## fix(scheduler): sort out scheduler & chain runs

A grouped set of scheduler + chain-run fixes.

### Scheduler / cancellation
- **Decoupled task-event broadcast.** Task `log`/`progress`/`status` events now enqueue onto a
  bounded, drop-on-full queue drained by a single background sender, instead of fanning out
  synchronously from worker threads. A blocking send to a half-open client no longer stalls a
  pool worker → fixes the "no tasks running, everything stuck at queued" regression. Dead clients
  are pruned.
- **Cancel-all now actually cancels.** `:cancelled` is broadcast immediately (was only reflected
  after the worker unwound), so **queued** tasks are killed too, not just running ones.
- **Console no longer shows stale tasks after a server restart** — it resets its state on reconnect.

### Chain runs
- **"Resume from here" start node** on the Live tab — force-restarts a node and its descendants
  via `run_id` + `params_hash` (with an icon on the button).
- **UML start dot on the edit whiteboard** — a moveable filled dot you link to tasks. Only nodes
  reachable from it run; unreached tasks/branches stay as drafts (mid-chain start &
  disconnected-branch drafts supported). Falls back to running the whole chain (with a warning)
  when the dot links only to since-deleted nodes. Added by default on new chains; the canvas
  centers/zooms on it.

### Task console
- Live progress updates; logs moved to a **separate confined pane** (no more scroll-through).
- **Active-only table** with done/failed/cancelled counts and "…and N more active"; **unified
  height budget** so nothing clips.

### Housekeeping
- **6-char base62 task-run ids** (shared constant, matching backend `gen_uid`) instead of 36-char UUIDs.
- **`testTasks` hidden** from the served whiteboard palette (kept on disk as the test-suite backbone).

### Tests / verification
- Julia **743 pass**; Vitest **5 pass** (new `startDot.ts` save/reload round-trip — Vitest added as
  the frontend test runner, `npm test`).
- `vue-tsc --noEmit` + `vite build` clean.

> ⚠️ `api/src/*.jl` and `api/task_console.jl` are not Revise-tracked — **restart the server and the
> console** to pick these up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)