### PR TITLE
test(ci): run frontend Vitest in CI + add test-frontend pixi task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,13 @@ jobs:
           npm ci
           npm run build
 
+      # Frontend unit tests (Vitest): pure logic extracted from .vue SFCs into src/utils/*
+      # (e.g. the chain start-dot save/reload round-trip). node_modules is already installed by the
+      # build step's `npm ci`. Fast + fixture-free, so it runs on every OS in the matrix.
+      - name: Frontend tests
+        working-directory: frontend
+        run: npm test
+
       - name: Start server and verify health + frontend serving
         run: |
           set -uo pipefail

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -86,7 +86,8 @@ git push -u origin feat/<short-slug>
 ## CI
 
 Every push/PR runs `.github/workflows/ci.yml` (smoke: fresh checkout → `pixi install` →
-`julia … instantiate` → frontend build → server serves `/api/health` + the frontend). It runs the
+`julia … instantiate` → API tests → frontend build → **frontend tests (Vitest)** → server serves
+`/api/health` + the frontend). It runs the
 **full chain as a matrix on Linux, Windows and macOS-arm64** (`fail-fast: false`), so a
 platform-specific install/build/boot failure is caught in CI rather than by a tester — e.g. a PyPI
 dep with no macOS wheel falling back to a source build (TODO #00062). The repo is public, so
@@ -107,16 +108,24 @@ Rationale and the full packaging/update model live in [`docs/SHIPPING.md`](SHIPP
 
 ## Tests
 
-- **Package (headless Cecelia):** `pixi run test-pkg` (`app/test/runtests.jl`). Some testsets
-  `@test_skip` when their `test-data/` fixtures are absent.
+Three categories, one per language layer. **All three run in CI** (`.github/workflows/ci.yml`) on every
+OS in the matrix, and each has a `pixi run` task:
+
+- **Package (headless Cecelia):** `pixi run test-pkg` (`app/test/runtests.jl`). The data model,
+  persistence, task dispatch, scheduler + chain logic. Some testsets `@test_skip` when their
+  `test-data/` fixtures are absent.
 - **API adapters:** `pixi run test-api` (`api/test/runtests.jl`). Loads `server.jl` with
   `CECELIA_NO_SERVE=1` so the handlers + shared state (`_BOUND_HOST`, `_repl_on`, …) are defined
-  without binding a socket, then calls handlers directly (no live server, no ports). Fixture-free, so
-  it runs in CI (`.github/workflows/ci.yml`) on every OS. Covers diagnostics + the debug-console
-  gating/eval; extend it as more adapters gain logic worth pinning.
-- **Frontend:** `npm test` (Vitest, `frontend/`) for pure logic extracted out of `.vue` SFCs into
-  `src/utils/*` (e.g. `startDot.ts` — the chain start-dot save/reload round-trip). Keep testable logic
-  in plain `.ts` modules rather than the component so it can be unit-tested without mounting Vue.
+  without binding a socket, then calls handlers directly (no live server, no ports). Fixture-free.
+  Covers diagnostics + the debug-console gating/eval; extend it as more adapters gain logic worth pinning.
+- **Frontend:** `pixi run test-frontend` (Vitest, `frontend/` — or `npm test` there directly).
+  **Scope is deliberately narrow: pure logic extracted out of `.vue` SFCs into `src/utils/*`**
+  (e.g. `startDot.ts` — the chain start-dot save/reload round-trip, which mirrors the Julia
+  `_prune_to_start` pruning; a two-sided contract that can silently drift). **No component mounting,
+  no jsdom, no DOM/E2E** — those are a separate, heavier decision (`@vue/test-utils`, a DOM shim) not
+  taken here. Vitest is zero-config on top of the existing Vite toolchain, so the category stays cheap.
+  The convention this enforces: **keep testable logic in plain `.ts` modules, not the component**, so it
+  can be unit-tested without mounting Vue.
 
 ## Diagnostics & debug console
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -84,9 +84,11 @@ torchvision = ">=0.21"
 dev  = { cmd = "julia --project -t auto -e 'using Revise; includet(\"src/server.jl\")'", cwd = "api" }  # hot-reload (development)
 prod = { cmd = "julia --project -t auto src/server.jl", cwd = "api" }                                    # plain include (production)
 
-# Tests. Package (headless Cecelia) + API adapters (loaded with CECELIA_NO_SERVE — no socket bound).
-test-pkg = { cmd = "julia --project test/runtests.jl", cwd = "app" }
-test-api = { cmd = "julia --project test/runtests.jl", cwd = "api" }
+# Tests. Package (headless Cecelia) + API adapters (loaded with CECELIA_NO_SERVE — no socket bound)
+# + frontend (Vitest — pure logic extracted from .vue into src/utils/*; no component/DOM/E2E).
+test-pkg      = { cmd = "julia --project test/runtests.jl", cwd = "app" }
+test-api      = { cmd = "julia --project test/runtests.jl", cwd = "api" }
+test-frontend = { cmd = "npm test", cwd = "frontend" }
 
 # Frontend — Vite (port 5173).
 frontend = { cmd = "npm run dev", cwd = "frontend" }    # dev server, hot reload


### PR DESCRIPTION
## fix(scheduler): sort out scheduler & chain runs

  A grouped set of scheduler + chain-run fixes, plus wiring the new frontend tests into CI.

  ### Scheduler / cancellation
  - **Decoupled task-event broadcast.** Task `log`/`progress`/`status` events now enqueue onto a
    bounded, drop-on-full queue drained by a single background sender, instead of fanning out
    synchronously from worker threads. A blocking send to a half-open client no longer stalls a
    pool worker → fixes the "no tasks running, everything stuck at queued" regression. Dead clients
    are pruned.
  - **Cancel-all now actually cancels.** `:cancelled` is broadcast immediately (was only reflected
    after the worker unwound), so **queued** tasks are killed too, not just running ones.
  - **Console no longer shows stale tasks after a server restart** — it resets its state on reconnect.

  ### Chain runs
  - **"Resume from here" start node** on the Live tab — force-restarts a node and its descendants
    via `run_id` + `params_hash` (with an icon on the button).
  - **UML start dot on the edit whiteboard** — a moveable filled dot you link to tasks. Only nodes
    reachable from it run; unreached tasks/branches stay as drafts (mid-chain start &
    disconnected-branch drafts supported). Falls back to running the whole chain (with a warning)
    when the dot links only to since-deleted nodes. Added by default on new chains; the canvas
    centers/zooms on it.

  ### Task console
  - Live progress updates; logs moved to a **separate confined pane** (no more scroll-through).
  - **Active-only table** with done/failed/cancelled counts and "…and N more active"; **unified
    height budget** so nothing clips.

  ### Housekeeping
  - **6-char base62 task-run ids** (shared constant, matching backend `gen_uid`) instead of 36-char UUIDs.
  - **`testTasks` hidden** from the served whiteboard palette (kept on disk as the test-suite backbone).

  ### Tests / CI
  - Added **Vitest** as the frontend test runner for pure logic extracted out of `.vue` SFCs into
    `src/utils/*` (`startDot.ts` — the chain start-dot save/reload round-trip, mirroring the Julia
    `_prune_to_start` pruning).
  - Wired it in as a first-class category: **`pixi run test-frontend`** + a **Vitest step in CI**
    (runs on every OS in the matrix; scope pinned to pure logic — no component/DOM/E2E). Documented
    the three test categories in `DEV.md`.
  - Julia **743 pass**; Vitest **5 pass**; `vue-tsc --noEmit` + `vite build` clean.

  > ⚠️ `api/src/*.jl` and `api/task_console.jl` are not Revise-tracked — **restart the server and the
  > console** to pick these up.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)