### PR TITLE
feat(shipping): add dev install channel + document task console

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,51 @@ in-app **Update** button when a new release is available.
 
 ---
 
+## Monitoring tasks (terminal console)
+
+Long jobs — segmentation, tracking, and whole **chain runs** — are handled by a background scheduler.
+Alongside the in-app view, you can watch them from a terminal with a live, **read-only** dashboard:
+which tasks are running, their progress, how many are queued, and how many have finished. It only
+*reads* the running Cecelia (it never starts or cancels anything), so it's safe to leave open next to
+the app.
+
+With Cecelia running, from the install directory:
+
+```sh
+# Linux / macOS
+cd ~/.local/share/cecelia && pixi run console
+```
+```powershell
+# Windows
+cd $env:LOCALAPPDATA\cecelia ; pixi run console
+```
+
+Add `-- --stream` for an append-only log you can pipe to a file (`pixi run console -- --stream | tee run.log`).
+Press `Ctrl-C` to close it — your tasks keep running.
+
+---
+
+## Bleeding-edge builds (dev channel)
+
+To run the **current GitHub state** without waiting for a tagged release, set `CECELIA_CHANNEL=dev`.
+The installer then downloads the latest `main` instead of a release and builds the frontend locally,
+so **[Node.js](https://nodejs.org) (npm) ≥ 20 must be installed**. Re-run the same command to update
+to the newest `main`. The installed commit is recorded in `.cecelia-version` for bug reports.
+
+```sh
+# Linux / macOS
+curl -LsSf https://raw.githubusercontent.com/schienstockd/cecelia/main/install.sh | CECELIA_CHANNEL=dev sh
+```
+```powershell
+# Windows
+$env:CECELIA_CHANNEL='dev'; irm https://raw.githubusercontent.com/schienstockd/cecelia/main/install.ps1 | iex
+```
+
+Everything else (projects folder, running) is identical to a stable install. Dev builds track HEAD,
+so expect the occasional rough edge — for routine use, prefer the default stable channel above.
+
+---
+
 ## Developing
 
 Running from source with hot-reload (`pixi run dev` + `pixi run frontend`) is covered in

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -125,6 +125,34 @@ launcher.
 **First-run size:** the env is multi-GB and downloads at install time. `install.ps1` is authored but
 **not yet verified on Windows hardware** — the first real test is a Windows machine / runner.
 
+### Install channels (stable vs dev)
+
+`CECELIA_CHANNEL` selects *what* the installer fetches; the provisioning (Pixi + Juliaup +
+`julia instantiate`) is identical either way.
+
+| `CECELIA_CHANNEL` | Source | Frontend | To update |
+|---|---|---|---|
+| `stable` (default) | newest tagged Release's `cecelia.tar.gz` | prebuilt (shipped in the bundle) | re-run installer / `pixi run update` / in-app Update |
+| `dev` | `main` branch tarball (`archive/refs/heads/<branch>.tar.gz`) | **built locally** (`npm ci && npm run build`) | re-run installer (re-downloads current `main`) |
+
+**Why a dev channel.** So testers can track HEAD without a tag being cut every couple of days. GitHub
+serves any branch as a tarball at `archive/refs/heads/<branch>.tar.gz` — no release, no asset upload —
+so the dev path just points the *same* installer at that URL. `CECELIA_BRANCH` overrides the branch.
+
+**The one extra requirement: Node.** A release bundle ships a prebuilt `frontend/dist`; a branch
+archive is source only, so the dev channel builds the frontend on the machine and therefore needs
+Node.js (npm) on PATH — the installer errors clearly if it's absent. (Node stays on fnm in dev and is
+baked into the release bundle for stable, so this is the one case an end user needs it — see *Julia and
+Node are not in Pixi*.) The multi-GB Pixi env is cached across re-runs, so a dev "update" only
+re-downloads the few-MB source and rebuilds the frontend (seconds), not the environment.
+
+**Provenance.** Both channels write `<install>/.cecelia-version` — the tag for stable, `dev @ <branch>
+<sha>` for dev (the SHA resolved via the commits API) — so a bug report can name the exact state.
+
+The branch archive wraps everything in one `<repo>-<branch>/` dir, so the dev extraction uses
+`tar --strip-components=1`; the flat release bundle must not (it would hoist `api/`'s contents to the
+root). This is the only structural difference between the two paths.
+
 ---
 
 ## Updates

--- a/install.ps1
+++ b/install.ps1
@@ -1,19 +1,27 @@
 # Cecelia installer — Windows (PowerShell 5+).
 #
-# Installs Pixi and Julia (juliaup) if missing, downloads the latest Cecelia release (ships a
-# prebuilt frontend, so no Node needed), provisions the environment, and adds a Start Menu
-# shortcut. Re-runnable.
+# Installs Pixi and Julia (juliaup) if missing, downloads Cecelia, provisions the environment, and
+# adds a Start Menu shortcut. Re-runnable.
+#
+# Two channels ($env:CECELIA_CHANNEL):
+#   stable (default) — the latest tagged GitHub Release; ships a prebuilt frontend (no Node needed).
+#   dev              — the current GitHub state (the `main` branch tarball); the frontend is built
+#                      locally, so Node.js (npm) must be on PATH. Tracks HEAD without waiting for a
+#                      tagged release — just re-run to update. See docs/SHIPPING.md.
 #
 #   powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/schienstockd/cecelia/main/install.ps1 | iex"
+#   powershell -ExecutionPolicy Bypass -c "$env:CECELIA_CHANNEL='dev'; irm https://raw.githubusercontent.com/schienstockd/cecelia/main/install.ps1 | iex"
 #
 # NOTE: authored on Linux and not yet verified on Windows hardware — first real test is a
 # Windows CI runner. See docs/SHIPPING.md.
 #
-# Env overrides:  $env:CECELIA_VERSION = 'v0.1.0' ;  $env:CECELIA_HOME = 'C:\path'
+# Env overrides:  $env:CECELIA_CHANNEL = 'stable'|'dev' ;  $env:CECELIA_VERSION = 'v0.1.0' ;
+#                 $env:CECELIA_BRANCH = 'main' ;  $env:CECELIA_HOME = 'C:\path'
 $ErrorActionPreference = 'Stop'
 
 $Repo       = 'schienstockd/cecelia'
 $InstallDir = if ($env:CECELIA_HOME) { $env:CECELIA_HOME } else { Join-Path $env:LOCALAPPDATA 'cecelia' }
+$Channel    = if ($env:CECELIA_CHANNEL) { $env:CECELIA_CHANNEL } else { 'stable' }
 $Version    = if ($env:CECELIA_VERSION) { $env:CECELIA_VERSION } else { 'latest' }
 
 function Say($m) { Write-Host "[cecelia] $m" -ForegroundColor Cyan }
@@ -36,18 +44,34 @@ if (-not $Julia -and -not (Test-Path (Join-Path $env:USERPROFILE '.juliaup\bin\j
 }
 if (-not $Julia) { $Julia = Join-Path $env:USERPROFILE '.juliaup\bin\julia.exe' }
 
-# ── Download the release bundle ────────────────────────────────────────────────
-# GitHub's `releases/latest` endpoint only ever resolves to a NON-prerelease release, so while the
-# project is still on release candidates (v*-rcN, all marked prerelease) it 404s. Resolve the newest
-# published release ourselves via the API — it lists prereleases too, newest first.
-if ($Version -eq 'latest') {
-  Say 'Resolving the latest release...'
-  $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases" -Headers @{ 'User-Agent' = 'cecelia-installer' }
-  $Version = $rel[0].tag_name
-  if (-not $Version) { throw 'Could not resolve the latest release from the GitHub API.' }
-  Say "Latest release is $Version"
+# ── Fetch Cecelia (release bundle, or branch source for the dev channel) ───────
+if ($Channel -eq 'dev') {
+  # Current GitHub state: a branch archive (source only — the frontend is built below). GitHub serves
+  # any branch as a tarball at archive/refs/heads/<branch>.tar.gz, so no tag/release is needed.
+  if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    throw "The dev channel builds the frontend from source and needs Node.js (npm) on PATH. Install Node >= 20 and re-run, or use the default stable channel."
+  }
+  $Branch = if ($env:CECELIA_BRANCH) { $env:CECELIA_BRANCH } else { 'main' }
+  $Url = "https://github.com/$Repo/archive/refs/heads/$Branch.tar.gz"
+  Say "Resolving current $Branch commit..."
+  $commit = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/commits/$Branch" -Headers @{ 'User-Agent' = 'cecelia-installer' }
+  $Sha = $commit.sha
+  $Provenance = "dev @ $Branch $Sha"
+} else {
+  # GitHub's `releases/latest` endpoint only ever resolves to a NON-prerelease release, so while the
+  # project is still on release candidates (v*-rcN, all marked prerelease) it 404s. Resolve the newest
+  # published release ourselves via the API — it lists prereleases too, newest first.
+  if ($Version -eq 'latest') {
+    Say 'Resolving the latest release...'
+    $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases" -Headers @{ 'User-Agent' = 'cecelia-installer' }
+    $Version = $rel[0].tag_name
+    if (-not $Version) { throw 'Could not resolve the latest release from the GitHub API.' }
+    Say "Latest release is $Version"
+  }
+  $Url = "https://github.com/$Repo/releases/download/$Version/cecelia.tar.gz"
+  $Provenance = $Version
 }
-$Url = "https://github.com/$Repo/releases/download/$Version/cecelia.tar.gz"
+
 $Tmp = New-TemporaryFile
 Say "Downloading $Url"
 Invoke-WebRequest -Uri $Url -OutFile $Tmp
@@ -55,7 +79,14 @@ Invoke-WebRequest -Uri $Url -OutFile $Tmp
 Say "Installing to $InstallDir"
 if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir }
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-tar -xzf $Tmp -C $InstallDir    # bsdtar ships with Windows 10+
+# A release bundle extracts flat (api\, app\, …); a branch archive wraps everything in one
+# `<repo>-<branch>\` dir, so strip that leading component for the dev channel only. bsdtar ships
+# with Windows 10+.
+if ($Channel -eq 'dev') {
+  tar -xzf $Tmp -C $InstallDir --strip-components=1
+} else {
+  tar -xzf $Tmp -C $InstallDir
+}
 Remove-Item $Tmp
 
 # ── Provision ───────────────────────────────────────────────────────────────────
@@ -64,7 +95,19 @@ Say 'Installing the Python environment (downloads a few GB on first run)...'
 & $Pixi install
 Say 'Precompiling Julia (a few minutes on first run)...'
 & $Julia --project=api -e 'using Pkg; Pkg.instantiate()'
+# The dev channel ships source only — build the frontend the server serves (stable already has it).
+if ($Channel -eq 'dev') {
+  Say 'Building the frontend (dev channel)...'
+  Push-Location (Join-Path $InstallDir 'frontend')
+  npm ci
+  npm run build
+  Pop-Location
+}
 Pop-Location
+
+# Record what was installed (channel + tag/commit) for provenance and bug reports.
+Set-Content -Path (Join-Path $InstallDir '.cecelia-version') -Value $Provenance
+Say "Installed: $Provenance"
 
 # ── Start Menu shortcut ───────────────────────────────────────────────────────
 $Lnk = Join-Path ([Environment]::GetFolderPath('Programs')) 'Cecelia.lnk'

--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,25 @@
 #!/usr/bin/env sh
 # Cecelia installer — Linux & macOS.
 #
-# Installs Pixi and Juliaup if missing, downloads the latest Cecelia release (which ships a
-# prebuilt frontend, so no Node is needed), provisions the environment, and adds a desktop
-# launcher. Re-runnable — it replaces the install in place.
+# Installs Pixi and Juliaup if missing, downloads Cecelia, provisions the environment, and adds a
+# desktop launcher. Re-runnable — it replaces the install in place.
+#
+# Two channels (CECELIA_CHANNEL):
+#   stable (default) — the latest tagged GitHub Release; ships a prebuilt frontend (no Node needed).
+#   dev              — the current GitHub state (the `main` branch tarball); the frontend is built
+#                      locally, so Node.js (npm) must be on PATH. Tracks HEAD without waiting for a
+#                      tagged release — just re-run to update. See docs/SHIPPING.md.
 #
 #   curl -LsSf https://raw.githubusercontent.com/schienstockd/cecelia/main/install.sh | sh
+#   curl -LsSf https://raw.githubusercontent.com/schienstockd/cecelia/main/install.sh | CECELIA_CHANNEL=dev sh
 #
-# Env overrides:  CECELIA_VERSION=v0.1.0  CECELIA_HOME=~/.local/share/cecelia
+# Env overrides:  CECELIA_CHANNEL=stable|dev  CECELIA_VERSION=v0.1.0  CECELIA_BRANCH=main
+#                 CECELIA_HOME=~/.local/share/cecelia
 set -eu
 
 REPO="schienstockd/cecelia"
 INSTALL_DIR="${CECELIA_HOME:-$HOME/.local/share/cecelia}"
+CHANNEL="${CECELIA_CHANNEL:-stable}"
 VERSION="${CECELIA_VERSION:-latest}"
 
 say() { printf '\033[1;36m[cecelia]\033[0m %s\n' "$1"; }
@@ -42,27 +50,50 @@ fi
 JULIA="$(command -v julia 2>/dev/null || echo "$HOME/.juliaup/bin/julia")"
 [ -x "$JULIA" ] || err "Julia not found after install — open a new terminal and re-run."
 
-# ── Download the release bundle ──────────────────────────────────────────────
-# GitHub's `releases/latest` endpoint only ever resolves to a NON-prerelease release, so while the
-# project is still on release candidates (v*-rcN, all marked prerelease) it 404s. Resolve the newest
-# published release ourselves via the API — it lists prereleases too, newest first.
-if [ "$VERSION" = "latest" ]; then
-  say "Resolving the latest release…"
-  VERSION="$(curl -fsSL "https://api.github.com/repos/$REPO/releases" \
-             | grep -m1 '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
-  [ -n "$VERSION" ] || err "Could not resolve the latest release from the GitHub API."
-  say "Latest release is $VERSION"
-fi
-URL="https://github.com/$REPO/releases/download/$VERSION/cecelia.tar.gz"
+# ── Fetch Cecelia (release bundle, or branch source for the dev channel) ─────
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+
+if [ "$CHANNEL" = "dev" ]; then
+  # Current GitHub state: a branch archive (source only — the frontend is built below). GitHub serves
+  # any branch as a tarball at archive/refs/heads/<branch>.tar.gz, so no tag/release is needed.
+  have npm || err "The dev channel builds the frontend from source and needs Node.js (npm) on PATH.
+       Install Node >= 20 (e.g. via fnm or nvm), then re-run — or use the default stable channel."
+  BRANCH="${CECELIA_BRANCH:-main}"
+  URL="https://github.com/$REPO/archive/refs/heads/$BRANCH.tar.gz"
+  say "Resolving current $BRANCH commit…"
+  SHA="$(curl -fsSL "https://api.github.com/repos/$REPO/commits/$BRANCH" \
+         | grep -m1 '"sha":' | sed -E 's/.*"sha": *"([^"]+)".*/\1/')"
+  PROVENANCE="dev @ $BRANCH ${SHA:-unknown}"
+else
+  # GitHub's `releases/latest` endpoint only ever resolves to a NON-prerelease release, so while the
+  # project is still on release candidates (v*-rcN, all marked prerelease) it 404s. Resolve the newest
+  # published release ourselves via the API — it lists prereleases too, newest first.
+  if [ "$VERSION" = "latest" ]; then
+    say "Resolving the latest release…"
+    VERSION="$(curl -fsSL "https://api.github.com/repos/$REPO/releases" \
+               | grep -m1 '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+    [ -n "$VERSION" ] || err "Could not resolve the latest release from the GitHub API."
+    say "Latest release is $VERSION"
+  fi
+  URL="https://github.com/$REPO/releases/download/$VERSION/cecelia.tar.gz"
+  PROVENANCE="$VERSION"
+fi
+
 say "Downloading $URL"
-curl -fSL "$URL" -o "$TMP/cecelia.tar.gz" || err "Download failed — does the release exist yet?"
+curl -fSL "$URL" -o "$TMP/cecelia.tar.gz" \
+  || err "Download failed — $([ "$CHANNEL" = dev ] && echo "is branch '$BRANCH' correct?" || echo "does the release exist yet?")"
 
 say "Installing to $INSTALL_DIR"
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
-tar -xzf "$TMP/cecelia.tar.gz" -C "$INSTALL_DIR"
+# A release bundle extracts flat (api/, app/, …); a branch archive wraps everything in one
+# `<repo>-<branch>/` dir, so strip that leading component for the dev channel only.
+if [ "$CHANNEL" = "dev" ]; then
+  tar -xzf "$TMP/cecelia.tar.gz" -C "$INSTALL_DIR" --strip-components=1
+else
+  tar -xzf "$TMP/cecelia.tar.gz" -C "$INSTALL_DIR"
+fi
 
 # ── Provision ────────────────────────────────────────────────────────────────
 cd "$INSTALL_DIR"
@@ -70,6 +101,16 @@ say "Installing the Python environment (downloads a few GB on first run)…"
 "$PIXI" install
 say "Precompiling Julia (a few minutes on first run)…"
 "$JULIA" --project=api -e 'using Pkg; Pkg.instantiate()'
+
+# The dev channel ships source only — build the frontend the server serves (stable already has it).
+if [ "$CHANNEL" = "dev" ]; then
+  say "Building the frontend (dev channel)…"
+  ( cd "$INSTALL_DIR/frontend" && npm ci && npm run build )
+fi
+
+# Record what was installed (channel + tag/commit) for provenance and bug reports.
+printf '%s\n' "$PROVENANCE" > "$INSTALL_DIR/.cecelia-version"
+say "Installed: $PROVENANCE"
 
 # ── Desktop launcher ─────────────────────────────────────────────────────────
 ICON="$INSTALL_DIR/frontend/dist/favicon.svg"


### PR DESCRIPTION
## feat(shipping): dev install channel + task-console docs

Let users run the **current GitHub state** without waiting for a tagged release, and document the
terminal task console as a user-facing feature.

### Dev install channel
- `CECELIA_CHANNEL=dev` makes `install.sh` / `install.ps1` download the **`main` branch tarball**
  (`archive/refs/heads/<branch>.tar.gz`) instead of a release, and **build the frontend locally**
  (release bundles ship a prebuilt `dist`; a branch archive is source only). `CECELIA_BRANCH`
  overrides the branch.
- Needs **Node.js (npm) ≥ 20** on PATH for the local frontend build — the installer errors clearly
  if it's absent. The multi-GB Pixi env is cached, so a dev "update" only re-downloads the few-MB
  source + rebuilds the frontend.
- Both channels write **`<install>/.cecelia-version`** — the tag for stable, `dev @ <branch> <sha>`
  for dev (SHA via the commits API) — for provenance in bug reports.
- The branch archive wraps everything in a `<repo>-<branch>/` dir, so the dev extraction uses
  `tar --strip-components=1`; the flat release bundle must not (it would hoist `api/` to the root).

### Docs
- **README:** new "Bleeding-edge builds (dev channel)" and "Monitoring tasks (terminal console)"
  sections (`pixi run console`, read-only, `--stream`, Ctrl-C to close).
- **SHIPPING.md:** install-channels table (stable vs dev) + rationale — why a dev channel, the Node
  requirement, provenance, and the strip-components difference.

### Verification
- `install.sh` passes `sh -n`; `pixi.toml` (unchanged here) + `ci.yml` valid. `install.ps1` isn't
  parse-checkable in the agent env (no `pwsh`) — first real test is the Windows CI runner, same as
  its existing status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)