### PR TITLE
Chore/post session polish

### DIFF
--- a/api/src/repl_api.jl
+++ b/api/src/repl_api.jl
@@ -13,6 +13,8 @@
 # operator must relaunch with `CECELIA_HOST=127.0.0.1`. Server code is `include`d into `Main`, so eval
 # runs with `Cecelia`, `projects_dir`, etc. in scope — the point of a debug console.
 
+import Pkg   # for the in-process Julia package inventory (api_packages)
+
 const _REPL_LOCK = ReentrantLock()   # serialise evals (redirect_stdout is process-global)
 # `_repl_on` is a RUNTIME toggle (the Settings switch flips it via POST /api/repl/config); it seeds from
 # CECELIA_REPL at startup so the env var still auto-enables. It is NOT a security boundary — eval is
@@ -32,11 +34,62 @@ function api_repl_config(body_bytes::Vector{UInt8})
     200, JSON3.write((; replEnabled = _repl_on[], loopback = _host_is_loopback(), replAvailable = _repl_available()))
 end
 
+# Installed-build provenance: the installer writes `.cecelia-version` at the install root (the repo
+# root, two levels up from api/src) — a tag for stable, "dev @ <branch> <sha>" for the dev channel.
+# Absent in a plain source/dev checkout → report that instead. See docs/SHIPPING.md → install channels.
+function _installed_version()
+    f = joinpath(dirname(dirname(@__DIR__)), ".cecelia-version")
+    isfile(f) || return "dev (source checkout)"
+    v = strip(read(f, String))
+    isempty(v) ? "unknown" : v
+end
+
+# GET /api/diagnostics/packages — the installed-package inventory, split by ecosystem because the two
+# stacks are provisioned SEPARATELY and neither tool sees the other: the Python analysis env (conda +
+# pypi) lives in Pixi, while Julia is on juliaup + Manifest (docs/SHIPPING.md → "Julia and Node are not
+# in Pixi"). So `pixi list` alone misses every Julia package. We query both:
+#   • Julia  — in-process via Pkg.dependencies() (the server IS Julia; free, no subprocess)
+#   • Python — `pixi list --json` at the install root (conda + pypi = the complete engine env)
+# Lazy — its own endpoint, not part of /api/diagnostics — because the pixi subprocess is slowish and
+# shouldn't run on every Settings load.
+function _julia_packages()
+    pkgs = [(; name = i.name, version = i.version === nothing ? "" : string(i.version))
+            for (_, i) in Pkg.dependencies() if i.name !== nothing]
+    sort(pkgs; by = p -> lowercase(p.name))
+end
+
+function _pixi_packages()
+    root = dirname(dirname(@__DIR__))   # install/repo root — where pixi.toml lives (server cwd is api/)
+    out  = read(Cmd(`pixi list --json`; dir = root), String)
+    arr  = JSON3.read(out)
+    pkgs = [(; name     = string(p.name),
+               version  = string(p.version),
+               kind     = haskey(p, :kind) ? string(p.kind) : "",
+               explicit = haskey(p, :is_explicit) && p.is_explicit === true) for p in arr]
+    sort(pkgs; by = p -> lowercase(p.name))
+end
+
+function api_packages(::HTTP.Request)
+    jl = try
+        _julia_packages()
+    catch e
+        @warn "Julia package list failed" exception = e
+        NamedTuple[]
+    end
+    py, pyerr = try
+        _pixi_packages(), nothing
+    catch e
+        NamedTuple[], "Could not run `pixi list` (is pixi on PATH?): " * sprint(showerror, e)
+    end
+    200, JSON3.write((; julia = jl, python = py, pythonError = pyerr))
+end
+
 function api_diagnostics(::HTTP.Request)
     gb(x) = round(x / 2^30; digits = 2)
     200, JSON3.write((;
         threads     = Threads.nthreads(),
         julia       = string(VERSION),
+        version     = _installed_version(),
         projectsDir = projects_dir(),
         memFreeGB   = gb(Sys.free_memory()),
         memTotalGB  = gb(Sys.total_memory()),

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -19,47 +19,42 @@ include("repl_api.jl")
 
 # ── WS broadcast ──────────────────────────────────────────────────────────────
 
-const _ws_clients      = Set{Any}()
+# Outbound broadcast is DECOUPLED from the caller, with a PER-CLIENT queue. Task events fan out on
+# every log/progress/status line from many worker threads; writing sockets inline would (a) let
+# concurrent worker threads write the SAME socket at once (frame corruption) and (b) let one
+# slow/half-open client BLOCK a worker — which stalls a pool slot and, cascaded, leaves every task
+# stuck at :queued. Instead each client gets its own bounded queue drained by its own background
+# task: callers enqueue a pre-serialised frame per client (non-blocking, DROP on overflow), so a
+# stuck client backs up ONLY its own queue and is dropped alone — it can neither block a worker nor,
+# via head-of-line blocking on a shared sender, freeze telemetry for the other clients. WS telemetry
+# is lossy-safe (the console reconciles from GET /api/tasks); a worker thread must never block on WS I/O.
+const _WS_OUT_CAP      = 4096
+const _ws_clients      = Dict{Any,Channel{String}}()   # ws => its private outbound queue
 const _ws_clients_lock = ReentrantLock()
 
-# Outbound broadcast is DECOUPLED from the caller. Task events now fan out on every log/progress/status
-# line from many worker threads; writing sockets inline would (a) let concurrent worker threads write
-# the SAME socket at once (frame corruption) and (b) let one slow/half-open client BLOCK a worker —
-# which stalls a pool slot and, cascaded, leaves every task stuck at :queued. Instead callers enqueue a
-# pre-serialised frame and a single background task drains the queue, writes to each client, and prunes
-# any that error. The queue is bounded and DROPS on overflow — WS telemetry is lossy-safe, and a worker
-# thread must never block on WS I/O.
-const _WS_OUT_CAP        = 4096
-const _WS_OUT            = Channel{String}(_WS_OUT_CAP)
-const _ws_sender_started = Ref(false)
-
-function _ws_sender_loop()
-    for json in _WS_OUT
-        clients = lock(_ws_clients_lock) do; copy(_ws_clients); end
-        dead = Any[]
-        for ws in clients
-            try; HTTP.WebSockets.send(ws, json); catch; push!(dead, ws); end
+# One sender per client: drains that client's queue in order and writes frames. Exits when the queue
+# is closed (on disconnect) or a send fails; either way the client is removed.
+function _ws_client_sender(ws, q::Channel{String})
+    try
+        for json in q
+            HTTP.WebSockets.send(ws, json)
         end
-        isempty(dead) || lock(_ws_clients_lock) do
-            for ws in dead; delete!(_ws_clients, ws); end
-        end
-    end
-end
-
-function _ws_ensure_sender!()
-    _ws_sender_started[] && return
-    lock(_ws_clients_lock) do
-        _ws_sender_started[] && return
-        _ws_sender_started[] = true
-        Threads.@spawn _ws_sender_loop()
+    catch
+        # send failed / client gone — drop it (handle_ws's finally also cleans up on the receive side)
+        lock(_ws_clients_lock) do; delete!(_ws_clients, ws); end
+        try; close(ws); catch; end
     end
 end
 
 function broadcast_ws(msg::Dict)
-    _ws_ensure_sender!()
-    json = JSON3.write(msg)
-    # non-blocking enqueue: drop when the buffer is full (a stuck client backing up) rather than block
-    Base.n_avail(_WS_OUT) < _WS_OUT_CAP && put!(_WS_OUT, json)
+    json   = JSON3.write(msg)
+    queues = lock(_ws_clients_lock) do; collect(values(_ws_clients)); end
+    for q in queues
+        # non-blocking, per-client: skip this frame for a client whose queue is full (it's stuck),
+        # never block the caller (a worker thread). The check-then-put race can only ever cost a
+        # microsecond wait behind a HEALTHY client's drain, never a block behind a stuck one.
+        isopen(q) && Base.n_avail(q) < _WS_OUT_CAP && try; put!(q, json); catch; end
+    end
     nothing
 end
 
@@ -131,6 +126,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             200, JSON3.write((; ok=true, version="CeceliaAPI"))
         elseif path == "/api/diagnostics"
             api_diagnostics(req)
+        elseif path == "/api/diagnostics/packages"
+            api_packages(req)
         elseif path == "/api/version"
             api_version(req)
         elseif path == "/api/update/check"
@@ -280,7 +277,9 @@ end
 # ── WebSocket handler ─────────────────────────────────────────────────────────
 
 function handle_ws(ws)
-    lock(_ws_clients_lock) do; push!(_ws_clients, ws); end
+    q = Channel{String}(_WS_OUT_CAP)
+    lock(_ws_clients_lock) do; _ws_clients[ws] = q; end
+    Threads.@spawn _ws_client_sender(ws, q)   # per-client drain (see broadcast_ws)
     try
         while true
             raw = HTTP.WebSockets.receive(ws)
@@ -295,6 +294,7 @@ function handle_ws(ws)
         e isa HTTP.WebSockets.WebSocketError || @warn "WS error" exception = e
     finally
         lock(_ws_clients_lock) do; delete!(_ws_clients, ws); end
+        close(q)   # signal this client's sender task to exit
     end
 end
 
@@ -418,7 +418,6 @@ const _BOUND_HOST = Ref{String}("")
 
 function start(; host=HOST, port=PORT)
     _BOUND_HOST[] = string(host)
-    _ws_ensure_sender!()   # start the single WS broadcast drainer before we accept connections
     @info "CeceliaAPI starting" host port threads=Threads.nthreads() projects_dir=projects_dir()
     HTTP.listen(handle_stream, host, port)
 end

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -20,6 +20,27 @@ _repl(code) = _post(api_repl, Dict("code" => code))
     @test d.threads >= 1
     @test !isempty(String(d.julia))
     @test haskey(d, :replAvailable) && haskey(d, :loopback) && haskey(d, :replEnabled)
+    # installed-build provenance (.cecelia-version at the install root); a source checkout has no
+    # such file → the fallback string. Either way the field must be present and non-empty.
+    @test haskey(d, :version) && !isempty(String(d.version))
+end
+
+@testset "API: packages" begin
+    st, body = api_packages(HTTP.Request("GET", "/api/diagnostics/packages"))
+    @test st == 200
+    d = JSON3.read(body)
+    @test haskey(d, :julia) && haskey(d, :python) && haskey(d, :pythonError)
+    # Julia list is in-process (Pkg.dependencies) → always populated & well-formed; the server dep set
+    # includes HTTP.
+    @test !isempty(d.julia)
+    @test all(p -> haskey(p, :name) && haskey(p, :version), d.julia)
+    @test any(p -> p.name == "HTTP", d.julia)
+    # Python list comes from `pixi list`; it's populated when pixi is on PATH (it is under
+    # `pixi run test-api`) and otherwise reports pythonError rather than throwing.
+    if d.pythonError === nothing
+        @test !isempty(d.python)
+        @test all(p -> haskey(p, :name) && haskey(p, :version) && haskey(p, :kind), d.python)
+    end
 end
 
 @testset "API: debug console gating" begin

--- a/docs/API.md
+++ b/docs/API.md
@@ -69,7 +69,8 @@ Settings → Debug console UI shows a note to this effect.
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/api/health` | liveness |
-| GET | `/api/diagnostics` | server health: threads, Julia version, memory, bound host/port, projects dir, debug-console state — powers Settings → Diagnostics |
+| GET | `/api/diagnostics` | server health: threads, Julia version, **installed version** (`.cecelia-version`), memory, bound host/port, projects dir, debug-console state — powers Settings → Diagnostics |
+| GET | `/api/diagnostics/packages` | installed-package inventory: `{julia, python, pythonError}` — Julia via in-process `Pkg.dependencies()`, Python via `pixi list --json` (lazy; backs the Settings → Diagnostics "Packages…" dialog) |
 | POST | `/api/repl` | `{code}` — evaluate Julia in the server's `Main` (value + captured stdout/stderr + error). **Gated**: only when the debug console is toggled on AND the server is loopback-bound; a `0.0.0.0` bind always refuses it. Localhost-only dev tool (`repl_api.jl`) |
 | POST | `/api/repl/config` | `{enabled}` — flip the runtime debug-console toggle (Settings → Developer). Not a security boundary; eval is still loopback-gated |
 | GET | `/api/projects`, POST `/api/projects/{list,create,load,save,rename}` | project CRUD |
@@ -90,12 +91,16 @@ Task execution + status flow over **WS** (`task:run`/`task:status`/…), not HTT
 are **broadcast to every connected client** (`_broadcast_task` → `broadcast_ws`), not sent point-to-point
 to the launching socket — so a second GUI tab and the read-only **task console** (`api/task_console.jl`,
 `pixi run console`) both see live progress. (They're keyed by `taskId`, so clients filter to what they
-care about. Chain events already broadcast.) Broadcast is **decoupled from the caller**: `broadcast_ws`
-enqueues a pre-serialised frame onto a bounded, drop-on-full channel that a single background task
-drains and writes to each client (pruning any that error). This is deliberate — task events fan out on
-every log/progress line from many worker threads, so writing sockets inline would let concurrent
-threads corrupt a shared socket and let one slow/half-open client block a worker (which strands a pool
-slot → tasks stuck at `queued`). Workers must never block on WS I/O. `handle_task_run` forwards
+care about. Chain events already broadcast.) Broadcast is **decoupled from the caller, per client**:
+each connected socket has its own bounded, drop-on-full queue drained by its own background task, and
+`broadcast_ws` enqueues a pre-serialised frame onto every client's queue (non-blocking; it skips a
+client whose queue is full). This is deliberate — task events fan out on every log/progress line from
+many worker threads, so writing sockets inline would let concurrent threads corrupt a shared socket
+and let one slow/half-open client block a worker (which strands a pool slot → tasks stuck at `queued`).
+Workers must never block on WS I/O. The **per-client** queue (rather than one shared drainer) also
+means a single stuck client only ever loses *its own* frames — it can't head-of-line-block delivery to
+the other tabs or the console. WS telemetry is lossy-safe: the console reconciles the authoritative
+state from `GET /api/tasks`, so a dropped frame self-heals. `handle_task_run` forwards
 `queued`/`running` **and
 `cancelled`** from `on_status_change` immediately (cancel has no result to order before it), so
 cancelling a task — especially a still-**queued** one — reflects at once instead of only when a worker

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -147,7 +147,9 @@ Node are not in Pixi*.) The multi-GB Pixi env is cached across re-runs, so a dev
 re-downloads the few-MB source and rebuilds the frontend (seconds), not the environment.
 
 **Provenance.** Both channels write `<install>/.cecelia-version` — the tag for stable, `dev @ <branch>
-<sha>` for dev (the SHA resolved via the commits API) — so a bug report can name the exact state.
+<sha>` for dev (the SHA resolved via the commits API) — so a bug report can name the exact state. The
+server reads it back via `GET /api/diagnostics` (`_installed_version()`; a plain source checkout with no
+such file reports `dev (source checkout)`) and it shows as the **Version** row in Settings → Diagnostics.
 
 The branch archive wraps everything in one `<repo>-<branch>/` dir, so the dev extraction uses
 `tar --strip-components=1`; the flat release bundle must not (it would hoist `api/`'s contents to the

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -66,6 +66,50 @@ the "old-school inputs look inconsistent" bug). Keep only layout in scoped style
 
 ---
 
+## Modals & dialogs — always use `BaseModal`
+
+**Every centred modal/dialog is built on `frontend/src/components/BaseModal.vue`. Never hand-roll an
+overlay (`position:fixed; inset:0`) again** — that copy-paste is how we ended up with four near-identical
+shells (`ProjectPanel`, `PhysicalSizeDialog`, `FileBrowser`, …). We do **not** use PrimeVue Dialog.
+
+`BaseModal` provides the dimmed overlay, the centred surface box, the header (icon + title + ✕), and
+close-on-✕ / click-outside / **Escape**. You provide the content via slots.
+
+- **Props:** `title` (string), `icon` (a PrimeIcons class, e.g. `pi-box`), `width` (CSS, default
+  `480px`), `height` (optional fixed CSS height; omit to size to content, capped at `90vh`).
+- **Slots:** default = the scrolling **body**; `#footer` = pinned action row; `#toolbar` = a pinned row
+  under the header (search bars, tabs, breadcrumbs); `#title` = override the whole title area (e.g. to
+  add an info-dot tooltip). The body scrolls; header/toolbar/footer stay pinned.
+- **Emits:** `close` — the host owns visibility (`v-if` + `@close`).
+
+Minimal dialog — copy this:
+
+```vue
+<script setup lang="ts">
+import BaseModal from './BaseModal.vue'
+const emit = defineEmits<{ (e: 'close'): void }>()
+</script>
+
+<template>
+  <BaseModal title="My dialog" icon="pi-cog" width="520px" @close="emit('close')">
+    <div style="padding: 1rem">…body…</div>            <!-- scrolls -->
+    <template #footer>
+      <span style="flex:1" />                            <!-- push buttons right -->
+      <button class="btn-ghost btn-sm" @click="emit('close')">Cancel</button>
+      <button class="btn-primary btn-sm" @click="…">Save</button>
+    </template>
+  </BaseModal>
+</template>
+```
+
+Host it with `v-if`: `<MyDialog v-if="show" @close="show = false" />`. Put dialog-specific CSS in the
+child's scoped `<style>`; the shell (overlay/box/header/footer) is BaseModal's — don't restyle it.
+Working examples: `PackagesDialog.vue` (toolbar + body), `PhysicalSizeDialog.vue` (`#title` slot +
+footer), `FileBrowser.vue` (toolbar + footer). *(An in-canvas overlay like `GateOverlay` is a
+different thing — that's `position:absolute` inside a plot, not a modal.)*
+
+---
+
 ## Pinia array reactivity
 
 Use `splice()` to mutate arrays in place inside setup stores.
@@ -238,8 +282,8 @@ Apply/Fill-flagged. Shown on every module page — the icon isn't gated behind `
 
 **Physical size & timing editor** (`frontend/src/components/PhysicalSizeDialog.vue`) is a modal,
 not a sidebar section — the first version crammed six fields + long explanatory paragraphs into
-the 280px `MetadataPanel` sidebar and was unreadable. Follows the `ProjectPanel.vue` hand-rolled
-modal shell (`.pp-overlay`/`.pp-modal` — no PrimeVue Dialog). Explanatory text lives in tooltips
+the 280px `MetadataPanel` sidebar and was unreadable. Built on the shared `BaseModal` shell (see
+*Modals & dialogs* above — no PrimeVue Dialog). Explanatory text lives in tooltips
 (the header's `pi-info-circle`, per-field labels, button tooltips), not inline paragraphs.
 Actions all write only the toggled fields (X/Y/Z/Δt chips — untick what's already correct so a fix
 to one axis doesn't also rewrite ones that are fine): **Apply** (to the selection it was opened

--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -1,0 +1,96 @@
+<!--
+  BaseModal — THE modal/dialog shell for this app. One hand-rolled convention (we don't use PrimeVue
+  Dialog): a fixed dimmed overlay, a centred surface box, a header (icon + title + close), and slots
+  for optional toolbar / body / footer. Closes on the ✕ button, on click-outside (overlay), and on
+  Escape. See docs/UI.md → "Modals & dialogs" for how to add a new one.
+
+  Every centred dialog should build on this instead of re-hand-rolling an overlay — the previous
+  copy-paste (pp-*/fb-* shells across ProjectPanel, PhysicalSizeDialog, FileBrowser, …) is exactly
+  the divergent re-implementation to avoid.
+
+  Slots:  #title (override the icon+text), #toolbar (fixed row under the header), default (scrolling
+          body), #footer (fixed action row). Props size the box; body scrolls, header/footer are pinned.
+-->
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount, computed } from 'vue'
+
+const props = withDefaults(defineProps<{
+  title?: string
+  icon?: string        // a PrimeIcons class, e.g. 'pi-box' (rendered as <i class="pi pi-box">)
+  width?: string       // CSS width, e.g. '480px'
+  height?: string      // optional fixed CSS height; omit to size to content (capped at max-height)
+}>(), { title: '', icon: '', width: '480px', height: '' })
+
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const boxStyle = computed(() => ({ width: props.width, ...(props.height ? { height: props.height } : {}) }))
+
+function onKey(e: KeyboardEvent) { if (e.key === 'Escape') emit('close') }
+onMounted(() => window.addEventListener('keydown', onKey))
+onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
+</script>
+
+<template>
+  <div class="cc-modal-overlay" @click.self="emit('close')">
+    <div class="cc-modal" :style="boxStyle">
+      <div class="cc-modal-header">
+        <span class="cc-modal-title">
+          <slot name="title"><i v-if="icon" :class="['pi', icon]" /> {{ title }}</slot>
+        </span>
+        <button class="cc-modal-close" @click="emit('close')" v-tooltip.left="'Close'">
+          <i class="pi pi-times" />
+        </button>
+      </div>
+
+      <slot name="toolbar" />
+
+      <div class="cc-modal-body"><slot /></div>
+
+      <div v-if="$slots.footer" class="cc-modal-footer"><slot name="footer" /></div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cc-modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.65);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 500;
+}
+.cc-modal {
+  background: var(--cc-surface-1);
+  border: 1px solid var(--cc-border);
+  border-radius: 0.6rem;
+  max-width: 96vw; max-height: 90vh;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 24px 48px rgba(0,0,0,0.5);
+}
+.cc-modal-header {
+  display: flex; align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--cc-border);
+  flex-shrink: 0;
+}
+.cc-modal-title {
+  flex: 1; font-size: 0.9rem; font-weight: 600; color: var(--cc-text);
+  display: flex; gap: 0.45rem; align-items: center;
+}
+.cc-modal-close {
+  background: none; border: none; cursor: pointer;
+  color: var(--cc-text-dim); font-size: 0.8rem;
+  padding: 0.2rem 0.4rem; border-radius: 0.25rem;
+}
+.cc-modal-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
+
+.cc-modal-body { flex: 1; overflow-y: auto; min-height: 0; }
+
+.cc-modal-footer {
+  display: flex; align-items: center; gap: 0.4rem;
+  padding: 0.65rem 1rem;
+  border-top: 1px solid var(--cc-border);
+  background: var(--cc-surface-1);
+  flex-shrink: 0;
+}
+</style>

--- a/frontend/src/components/FileBrowser.vue
+++ b/frontend/src/components/FileBrowser.vue
@@ -4,6 +4,7 @@
 -->
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import BaseModal from './BaseModal.vue'
 import { useLogStore } from '../stores/log'
 
 const emit = defineEmits<{
@@ -105,19 +106,10 @@ const breadcrumbs = computed(() => {
 </script>
 
 <template>
-  <div class="fb-overlay" @click.self="$emit('close')">
-    <div class="fb-modal">
+  <BaseModal title="Select images" width="680px" @close="$emit('close')">
 
-      <!-- header -->
-      <div class="fb-header">
-        <span class="fb-title">Select images</span>
-        <button class="fb-close" @click="$emit('close')"
-          v-tooltip.left="'Close without selecting.'">
-          <i class="pi pi-times" />
-        </button>
-      </div>
-
-      <!-- breadcrumbs -->
+    <!-- breadcrumbs -->
+    <template #toolbar>
       <div class="fb-breadcrumbs">
         <template v-for="(crumb, i) in breadcrumbs" :key="crumb.path">
           <span v-if="i > 0" class="crumb-sep">/</span>
@@ -127,6 +119,7 @@ const breadcrumbs = computed(() => {
           </button>
         </template>
       </div>
+    </template>
 
       <!-- body -->
       <div class="fb-body">
@@ -213,69 +206,33 @@ const breadcrumbs = computed(() => {
         </table>
       </div>
 
-      <!-- footer -->
-      <div class="fb-footer">
-        <span class="sel-count" v-if="selected.size > 0">
-          {{ selected.size }} file{{ selected.size > 1 ? 's' : '' }} selected
-        </span>
-        <span class="sel-count dim" v-else>No files selected</span>
+    <template #footer>
+      <span class="sel-count" v-if="selected.size > 0">
+        {{ selected.size }} file{{ selected.size > 1 ? 's' : '' }} selected
+      </span>
+      <span class="sel-count dim" v-else>No files selected</span>
 
-        <div class="footer-actions">
-          <button class="btn-ghost btn-sm" @click="$emit('close')"
-            v-tooltip.top="'Cancel and close the file browser.'">
-            Cancel
-          </button>
-          <button class="btn-primary btn-sm"
-            :disabled="selected.size === 0"
-            @click="confirm"
-            v-tooltip.top="selected.size > 0
-              ? `Add ${selected.size} selected file(s) to the set.`
-              : 'Select at least one image file first.'">
-            <i class="pi pi-plus" />
-            Add {{ selected.size > 0 ? selected.size : '' }} to set
-          </button>
-        </div>
+      <div class="footer-actions">
+        <button class="btn-ghost btn-sm" @click="$emit('close')"
+          v-tooltip.top="'Cancel and close the file browser.'">
+          Cancel
+        </button>
+        <button class="btn-primary btn-sm"
+          :disabled="selected.size === 0"
+          @click="confirm"
+          v-tooltip.top="selected.size > 0
+            ? `Add ${selected.size} selected file(s) to the set.`
+            : 'Select at least one image file first.'">
+          <i class="pi pi-plus" />
+          Add {{ selected.size > 0 ? selected.size : '' }} to set
+        </button>
       </div>
-
-    </div>
-  </div>
+    </template>
+  </BaseModal>
 </template>
 
 <style scoped>
-.fb-overlay {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.65);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 500;
-}
-
-.fb-modal {
-  background: var(--cc-surface-1);
-  border: 1px solid var(--cc-border);
-  border-radius: 0.6rem;
-  width: 680px;
-  max-width: 95vw;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  box-shadow: 0 24px 48px rgba(0,0,0,0.5);
-}
-
-/* header */
-.fb-header {
-  display: flex; align-items: center;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--cc-border);
-  flex-shrink: 0;
-}
-.fb-title { font-size: 0.9rem; font-weight: 600; color: var(--cc-text); flex: 1; }
-.fb-close {
-  background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.8rem;
-  padding: 0.2rem 0.4rem; border-radius: 0.25rem;
-}
-.fb-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
+/* Shell (overlay/box/header/footer) lives in BaseModal; only browser-specific styles remain here. */
 
 /* breadcrumbs */
 .fb-breadcrumbs {
@@ -295,8 +252,7 @@ const breadcrumbs = computed(() => {
 }
 .crumb:hover { background: var(--cc-surface-2); }
 
-/* body */
-.fb-body { flex: 1; overflow-y: auto; }
+/* body — BaseModal's cc-modal-body owns the scroll; .fb-body needs no shell styling. */
 
 .fb-state {
   display: flex; align-items: center; gap: 0.5rem;
@@ -343,13 +299,6 @@ const breadcrumbs = computed(() => {
 .fb-empty { text-align: center; padding: 2rem; color: var(--cc-text-dim); font-size: 0.8rem; }
 
 /* footer */
-.fb-footer {
-  display: flex; align-items: center; gap: 0.75rem;
-  padding: 0.65rem 1rem;
-  border-top: 1px solid var(--cc-border);
-  background: var(--cc-surface-1);
-  flex-shrink: 0;
-}
 .sel-count { font-size: 0.78rem; color: var(--cc-text); flex: 1; }
 .footer-actions { display: flex; gap: 0.4rem; }
 

--- a/frontend/src/components/PackagesDialog.vue
+++ b/frontend/src/components/PackagesDialog.vue
@@ -1,0 +1,141 @@
+<!--
+  Installed-package inventory — a read-only modal opened from Settings ▸ Diagnostics. Shows BOTH
+  ecosystems because they are provisioned separately and neither tool sees the other: the Python
+  analysis env (conda + pypi) from `pixi list`, and the Julia packages from the server's own
+  Pkg.dependencies() (docs/SHIPPING.md). Backs bug reports — "Copy" yields a plain-text manifest.
+  Built on the shared BaseModal shell (docs/UI.md → "Modals & dialogs").
+-->
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import BaseModal from './BaseModal.vue'
+
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+interface JlPkg { name: string; version: string }
+interface PyPkg { name: string; version: string; kind: string; explicit: boolean }
+interface PkgResp { julia: JlPkg[]; python: PyPkg[]; pythonError: string | null }
+
+const loading = ref(true)
+const error   = ref<string | null>(null)
+const data    = ref<PkgResp | null>(null)
+const q       = ref('')
+const copied  = ref(false)
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    const r = await fetch('/api/diagnostics/packages')
+    if (!r.ok) throw new Error(`HTTP ${r.status}`)
+    data.value = await r.json() as PkgResp
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+onMounted(load)
+
+const match = (name: string) => name.toLowerCase().includes(q.value.trim().toLowerCase())
+const py = computed(() => (data.value?.python ?? []).filter(p => match(p.name)))
+const jl = computed(() => (data.value?.julia  ?? []).filter(p => match(p.name)))
+
+function copyAll() {
+  const d = data.value
+  if (!d) return
+  const lines = [
+    '# Python (pixi: conda + pypi)',
+    ...d.python.map(p => `${p.name}\t${p.version}\t${p.kind}`),
+    '',
+    '# Julia',
+    ...d.julia.map(p => `${p.name}\t${p.version}`),
+  ]
+  navigator.clipboard.writeText(lines.join('\n'))
+  copied.value = true
+  setTimeout(() => { copied.value = false }, 1500)
+}
+</script>
+
+<template>
+  <BaseModal title="Installed packages" icon="pi-box" width="560px" height="76vh" @close="emit('close')">
+    <template #toolbar>
+      <div class="pk-toolbar">
+        <span class="search-wrap">
+          <i class="pi pi-search" />
+          <input class="search-input" v-model="q" placeholder="Filter by name…" />
+        </span>
+        <button class="mini-btn" :disabled="!data" @click="copyAll"
+          v-tooltip.bottom="'Copy the full list as text (for bug reports)'">
+          <i :class="['pi', copied ? 'pi-check' : 'pi-copy']" /> {{ copied ? 'Copied' : 'Copy' }}
+        </button>
+      </div>
+    </template>
+
+    <div class="pk-body">
+      <p v-if="loading" class="state-line"><i class="pi pi-spin pi-cog" /> Reading packages…</p>
+      <p v-else-if="error" class="state-line err"><i class="pi pi-times-circle" /> {{ error }}</p>
+
+      <template v-else-if="data">
+        <!-- Python env (pixi: conda + pypi) -->
+        <div class="grp-head">
+          Python env <span class="grp-sub">pixi · conda + pypi</span>
+          <span class="grp-count">{{ py.length }}</span>
+        </div>
+        <p v-if="data.pythonError" class="state-line warn">
+          <i class="pi pi-exclamation-triangle" /> {{ data.pythonError }}
+        </p>
+        <div v-else class="pkg-grid">
+          <template v-for="p in py" :key="'py-' + p.name">
+            <span class="pk-name">{{ p.name }}</span>
+            <span class="pk-ver mono">{{ p.version }}</span>
+            <span class="pk-kind" :class="p.kind">{{ p.kind }}</span>
+          </template>
+          <p v-if="!py.length" class="state-line dim">No matches.</p>
+        </div>
+
+        <!-- Julia (juliaup + Manifest — outside pixi) -->
+        <div class="grp-head">
+          Julia <span class="grp-sub">juliaup · Manifest</span>
+          <span class="grp-count">{{ jl.length }}</span>
+        </div>
+        <div class="pkg-grid">
+          <template v-for="p in jl" :key="'jl-' + p.name">
+            <span class="pk-name">{{ p.name }}</span>
+            <span class="pk-ver mono">{{ p.version }}</span>
+            <span class="pk-kind" />
+          </template>
+          <p v-if="!jl.length" class="state-line dim">No matches.</p>
+        </div>
+      </template>
+    </div>
+  </BaseModal>
+</template>
+
+<style scoped>
+.pk-toolbar { display: flex; gap: 0.5rem; align-items: center; padding: 0.6rem 1rem; border-bottom: 1px solid var(--cc-border); flex-shrink: 0; }
+.search-wrap { flex: 1; display: flex; align-items: center; gap: 0.4rem; background: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: 0.35rem; padding: 0.25rem 0.5rem; }
+.search-wrap .pi-search { font-size: 0.75rem; color: var(--cc-text-dim); }
+.search-input { flex: 1; background: none; border: none; outline: none; color: var(--cc-text); font-size: 0.8rem; }
+.mini-btn { display: flex; align-items: center; gap: 0.3rem; font-size: 0.75rem; padding: 0.3rem 0.6rem; border-radius: 0.35rem; border: 1px solid var(--cc-border); background: var(--cc-surface-2); color: var(--cc-text-dim); cursor: pointer; white-space: nowrap; }
+.mini-btn:hover:not(:disabled) { color: var(--cc-text); }
+.mini-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.pk-body { padding: 0.5rem 1rem 1rem; }
+
+.grp-head { display: flex; align-items: baseline; gap: 0.5rem; font-size: 0.8rem; font-weight: 600; color: var(--cc-text); margin: 0.85rem 0 0.4rem; position: sticky; top: 0; background: var(--cc-surface-1); padding: 0.2rem 0; }
+.grp-head:first-child { margin-top: 0.2rem; }
+.grp-sub { font-size: 0.68rem; font-weight: 400; color: var(--cc-text-dim); }
+.grp-count { margin-left: auto; font-size: 0.7rem; color: var(--cc-text-dim); background: var(--cc-surface-2); border-radius: 999px; padding: 0.05rem 0.5rem; }
+
+.pkg-grid { display: grid; grid-template-columns: 1fr auto auto; gap: 0.1rem 0.75rem; align-items: baseline; }
+.pk-name { font-size: 0.78rem; color: var(--cc-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pk-ver { font-size: 0.74rem; color: var(--cc-text-dim); }
+.pk-kind { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.03em; color: var(--cc-text-dim); min-width: 3.2rem; }
+.pk-kind.conda { color: #34d399; }
+.pk-kind.pypi  { color: #60a5fa; }
+
+.mono { font-variant-numeric: tabular-nums; }
+.state-line { display: flex; align-items: center; gap: 0.4rem; font-size: 0.78rem; color: var(--cc-text-dim); margin: 0.4rem 0; }
+.state-line.err  { color: #f87171; }
+.state-line.warn { color: #fbbf24; }
+.state-line.dim  { grid-column: 1 / -1; }
+</style>

--- a/frontend/src/components/PhysicalSizeDialog.vue
+++ b/frontend/src/components/PhysicalSizeDialog.vue
@@ -7,6 +7,7 @@
 -->
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import BaseModal from './BaseModal.vue'
 import { useProjectStore, type CciaImage } from '../stores/project'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useLogStore } from '../stores/log'
@@ -237,21 +238,14 @@ async function fillFlagged() {
 </script>
 
 <template>
-  <div class="pp-overlay" @click.self="emit('close')">
-    <div class="pp-modal">
+  <BaseModal width="480px" @close="emit('close')">
+    <template #title>
+      <i class="pi pi-ruler" /> Physical size &amp; timing
+      <i class="pi pi-info-circle info-dot"
+         v-tooltip.bottom="'Read from the file at import when possible. A flagged value means we couldn\'t find it, or it looked unusual — check Fiji (Image ▸ Properties) or your acquisition settings.'" />
+    </template>
 
-      <div class="pp-header">
-        <span class="pp-title">
-          <i class="pi pi-ruler" /> Physical size &amp; timing
-          <i class="pi pi-info-circle info-dot"
-             v-tooltip.bottom="'Read from the file at import when possible. A flagged value means we couldn\'t find it, or it looked unusual — check Fiji (Image ▸ Properties) or your acquisition settings.'" />
-        </span>
-        <button class="pp-close" @click="emit('close')" v-tooltip.left="'Close'">
-          <i class="pi pi-times" />
-        </button>
-      </div>
-
-      <div class="pp-body pp-form">
+      <div class="pp-form">
         <p v-if="focusedImg" class="focus-name">{{ focusedImg.name }}</p>
 
         <p v-if="focusedWarning" class="warn-line" v-tooltip.bottom="focusedWarning.long">
@@ -301,66 +295,31 @@ async function fillFlagged() {
         </div>
       </div>
 
-      <div class="pp-footer">
-        <button class="btn-ghost btn-sm" :disabled="propagating" @click="fillFlagged"
-          v-tooltip.top="'Fill this image\'s values into the OTHER selected images that are flagged — same-session acquisitions usually match exactly.'">
-          <i v-if="propagating" class="pi pi-spin pi-cog" /><i v-else class="pi pi-share-alt" />
-          Fill flagged
-        </button>
-        <button class="btn-ghost btn-sm" :disabled="copying" @click="copyToSelected"
-          v-tooltip.top="'Copy this image\'s values to the other selected images.'">
-          <i v-if="copying" class="pi pi-spin pi-cog" /><i v-else class="pi pi-copy" />
-          Copy to selected
-        </button>
-        <span class="footer-spacer" />
-        <button class="btn-ghost btn-sm" @click="emit('close')">Cancel</button>
-        <button class="btn-primary btn-sm" :disabled="saving" @click="apply"
-          v-tooltip.top="`Apply to ${targetUids.length} image(s). Doesn't retroactively recompute derived measures (e.g. track speed).`">
-          <i v-if="saving" class="pi pi-spin pi-cog" /><i v-else class="pi pi-check" />
-          Apply
-        </button>
-      </div>
-
-    </div>
-  </div>
+    <template #footer>
+      <button class="btn-ghost btn-sm" :disabled="propagating" @click="fillFlagged"
+        v-tooltip.top="'Fill this image\'s values into the OTHER selected images that are flagged — same-session acquisitions usually match exactly.'">
+        <i v-if="propagating" class="pi pi-spin pi-cog" /><i v-else class="pi pi-share-alt" />
+        Fill flagged
+      </button>
+      <button class="btn-ghost btn-sm" :disabled="copying" @click="copyToSelected"
+        v-tooltip.top="'Copy this image\'s values to the other selected images.'">
+        <i v-if="copying" class="pi pi-spin pi-cog" /><i v-else class="pi pi-copy" />
+        Copy to selected
+      </button>
+      <span class="footer-spacer" />
+      <button class="btn-ghost btn-sm" @click="emit('close')">Cancel</button>
+      <button class="btn-primary btn-sm" :disabled="saving" @click="apply"
+        v-tooltip.top="`Apply to ${targetUids.length} image(s). Doesn't retroactively recompute derived measures (e.g. track speed).`">
+        <i v-if="saving" class="pi pi-spin pi-cog" /><i v-else class="pi pi-check" />
+        Apply
+      </button>
+    </template>
+  </BaseModal>
 </template>
 
 <style scoped>
-.pp-overlay {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.65);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 500;
-}
-.pp-modal {
-  background: var(--cc-surface-1);
-  border: 1px solid var(--cc-border);
-  border-radius: 0.6rem;
-  width: 480px;
-  max-width: 96vw;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  box-shadow: 0 24px 48px rgba(0,0,0,0.5);
-}
-
-.pp-header {
-  display: flex; align-items: center;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--cc-border);
-  flex-shrink: 0;
-}
-.pp-title { flex: 1; font-size: 0.9rem; font-weight: 600; color: var(--cc-text); display: flex; gap: 0.45rem; align-items: center; }
+/* Shell (overlay/box/header/footer) lives in BaseModal; only dialog-specific styles remain here. */
 .info-dot { font-size: 0.72rem; color: var(--cc-text-dim); cursor: default; }
-.pp-close {
-  background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.8rem;
-  padding: 0.2rem 0.4rem; border-radius: 0.25rem;
-}
-.pp-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
-
-.pp-body { flex: 1; overflow-y: auto; }
 .pp-form { padding: 1rem 1.25rem; display: flex; flex-direction: column; gap: 0.75rem; }
 
 .focus-name { margin: 0; font-size: 0.82rem; font-weight: 600; color: var(--cc-text); }
@@ -404,13 +363,6 @@ async function fillFlagged() {
 .field-input.mixed { border: 1px dashed #60a5fa !important; background: #1e3a5f55; cursor: help; }
 .unit-input { flex: 0 0 4.2rem; }
 
-.pp-footer {
-  display: flex; align-items: center; gap: 0.4rem;
-  padding: 0.65rem 1rem;
-  border-top: 1px solid var(--cc-border);
-  background: var(--cc-surface-1);
-  flex-shrink: 0;
-}
 .footer-spacer { flex: 1; }
 
 .btn-sm {

--- a/frontend/src/components/ProjectPanel.vue
+++ b/frontend/src/components/ProjectPanel.vue
@@ -4,6 +4,7 @@
 -->
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
+import BaseModal from './BaseModal.vue'
 import { useProjectMetaStore, type ProjectType } from '../stores/projectMeta'
 
 const emit = defineEmits<{ (e: 'close'): void }>()
@@ -76,19 +77,10 @@ const typeColour: Record<ProjectType, string> = {
 </script>
 
 <template>
-  <div class="pp-overlay" @click.self="$emit('close')">
-    <div class="pp-modal">
+  <BaseModal title="Project Manager" icon="pi-folder-open" width="700px" @close="$emit('close')">
 
-      <!-- header -->
-      <div class="pp-header">
-        <span class="pp-title"><i class="pi pi-folder-open" /> Project Manager</span>
-        <button class="pp-close" @click="$emit('close')"
-          v-tooltip.left="'Close without changing the current project.'">
-          <i class="pi pi-times" />
-        </button>
-      </div>
-
-      <!-- tabs -->
+    <!-- tabs -->
+    <template #toolbar>
       <div class="pp-tabs">
         <button
           class="pp-tab"
@@ -107,6 +99,7 @@ const typeColour: Record<ProjectType, string> = {
           <i class="pi pi-plus" /> New project
         </button>
       </div>
+    </template>
 
       <!-- ── RECENT tab ─────────────────────────────────────────────────── -->
       <div v-if="tab === 'recent'" class="pp-body">
@@ -253,45 +246,11 @@ const typeColour: Record<ProjectType, string> = {
         </template>
       </div>
 
-    </div>
-  </div>
+  </BaseModal>
 </template>
 
 <style scoped>
-.pp-overlay {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.65);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 500;
-}
-
-.pp-modal {
-  background: var(--cc-surface-1);
-  border: 1px solid var(--cc-border);
-  border-radius: 0.6rem;
-  width: 700px;
-  max-width: 96vw;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  box-shadow: 0 24px 48px rgba(0,0,0,0.5);
-}
-
-/* header */
-.pp-header {
-  display: flex; align-items: center;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--cc-border);
-  flex-shrink: 0;
-}
-.pp-title { flex: 1; font-size: 0.9rem; font-weight: 600; color: var(--cc-text); display: flex; gap: 0.5rem; align-items: center; }
-.pp-close {
-  background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.8rem;
-  padding: 0.2rem 0.4rem; border-radius: 0.25rem;
-}
-.pp-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
+/* Shell (overlay/box/header) lives in BaseModal; only panel-specific styles remain here. */
 
 /* tabs */
 .pp-tabs {
@@ -311,8 +270,8 @@ const typeColour: Record<ProjectType, string> = {
 .pp-tab:hover { color: var(--cc-text); }
 .pp-tab.active { color: var(--cc-accent); border-bottom-color: var(--cc-accent); }
 
-/* body */
-.pp-body { flex: 1; overflow-y: auto; }
+/* body — BaseModal's cc-modal-body owns the scroll; the tab panes are plain flow. */
+.pp-body { display: flex; flex-direction: column; }
 
 .pp-empty {
   display: flex; flex-direction: column; align-items: center;

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -2,6 +2,9 @@
 import { ref, watch, onMounted } from 'vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
+import PackagesDialog from '../components/PackagesDialog.vue'
+
+const showPackages = ref(false)
 
 const projectMeta = useProjectMetaStore()
 const settings    = useSettingsStore()
@@ -79,7 +82,7 @@ onMounted(checkUpdates)
 
 // ── Diagnostics + debug console ──────────────────────────────────────────────
 interface Diag {
-  threads: number; julia: string; projectsDir: string
+  threads: number; julia: string; version: string; projectsDir: string
   memFreeGB: number; memTotalGB: number; gcLiveMB: number
   host: string; port: number; loopback: boolean
   replEnabled: boolean; replAvailable: boolean
@@ -246,6 +249,7 @@ onMounted(loadDiag)
       <h2 class="section-title">Diagnostics</h2>
 
       <div v-if="diag" class="diag-grid">
+        <span>Version</span><span class="mono">{{ diag.version }}</span>
         <span>Server threads</span><span class="mono">{{ diag.threads }}</span>
         <span>Julia</span><span class="mono">{{ diag.julia }}</span>
         <span>Memory</span><span class="mono">{{ diag.memFreeGB }} / {{ diag.memTotalGB }} GB free · GC live {{ diag.gcLiveMB }} MB</span>
@@ -253,9 +257,12 @@ onMounted(loadDiag)
         <span>Projects dir</span><span class="mono">{{ diag.projectsDir }}</span>
       </div>
 
-      <div class="field-row" style="margin-top:0.6rem">
+      <div class="field-row" style="margin-top:0.6rem; gap:0.5rem">
         <button class="save-btn" :disabled="diagBusy" @click="loadDiag" v-tooltip.right="'Re-read server diagnostics'">
           <i :class="['pi', diagBusy ? 'pi-spin pi-cog' : 'pi-refresh']" /> Refresh
+        </button>
+        <button class="save-btn" @click="showPackages = true" v-tooltip.right="'List every installed Python (pixi) and Julia package'">
+          <i class="pi pi-box" /> Packages…
         </button>
       </div>
       <span v-if="diag && diag.threads > 1" class="field-hint">Multithreaded API active ({{ diag.threads }} threads).</span>
@@ -314,6 +321,8 @@ onMounted(loadDiag)
 
     </div>
     </div>
+
+    <PackagesDialog v-if="showPackages" @close="showPackages = false" />
   </div>
 </template>
 

--- a/frontend/src/utils/id.test.ts
+++ b/frontend/src/utils/id.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { shortId, ID_CHARS, ID_LENGTH } from './id'
+
+// shortId is the shared client-side run-id generator (mirrors the backend gen_uid shape). It only
+// needs to hold two properties: the right shape, and no collisions at the volume a session produces.
+describe('shortId', () => {
+  it('is ID_LENGTH chars from the base62 alphabet by default', () => {
+    for (let i = 0; i < 100; i++) {
+      const id = shortId()
+      expect(id).toHaveLength(ID_LENGTH)
+      expect(id).toMatch(/^[a-zA-Z0-9]+$/)
+      for (const ch of id) expect(ID_CHARS).toContain(ch)
+    }
+  })
+
+  it('honours a custom length', () => {
+    expect(shortId(3)).toHaveLength(3)
+    expect(shortId(12)).toHaveLength(12)
+  })
+
+  it('is collision-free across a session-scale batch', () => {
+    // 2000 draws from 62^6 (~57e9): birthday-bound collision probability ~3e-5, negligible for a
+    // per-session correlation handle (task runs never approach this volume in one session).
+    const n = 2000
+    const seen = new Set<string>()
+    for (let i = 0; i < n; i++) seen.add(shortId())
+    expect(seen.size).toBe(n)
+  })
+})


### PR DESCRIPTION
## chore: post-session polish — WS hardening, diagnostics inventory, shared modal

Follow-up polish after the scheduler/chain-runs + dev-channel work. Five things, verified together.

### 1 · WS broadcast → per-client isolation (`api/src/server.jl`)
Each connected socket now gets its **own bounded, drop-on-full queue drained by its own task**,
instead of one shared sender. A slow/half-open client backs up *only its own* queue — it can neither
block a worker thread (which stalled the pool → tasks stuck at `queued`) **nor** head-of-line-block
event delivery to the other tabs and the console. WS telemetry stays lossy-safe (the console
reconciles from `GET /api/tasks`).

### 2 · Installed version in Diagnostics (`repl_api.jl`, `SettingsModule.vue`)
`GET /api/diagnostics` now returns `version` read from `.cecelia-version` at the install root (the
tag for a stable install, `dev @ <branch> <sha>` for the dev channel, `dev (source checkout)` when
absent). Shown as the **Version** row in Settings → Diagnostics — so a bug report can name the exact build.

### 3 · Package inventory viewer (`GET /api/diagnostics/packages`, `PackagesDialog.vue`)
A lazy endpoint returning `{julia, python, pythonError}` — **Julia** via in-process
`Pkg.dependencies()`, **Python** via `pixi list --json`. Both, because the two stacks are provisioned
separately and neither tool sees the other (Julia is juliaup+Manifest, outside Pixi). Behind a
**"Packages…"** button with a search filter and a **Copy** (plain-text manifest for bug reports).

### 4 · Generalised modal — `BaseModal` (`refactor(ui)`)
Extracted the one modal shell (overlay, box, header, close-on-✕/click-outside/**Escape**, +
`#toolbar`/body/`#footer`/`#title` slots) and migrated **all four** hand-rolled dialogs onto it —
`ProjectPanel`, `PhysicalSizeDialog`, `FileBrowser`, and the new `PackagesDialog` — deleting the
duplicated `pp-*`/`fb-*` overlays. We don't use PrimeVue Dialog. `docs/UI.md` gains a **"Modals &
dialogs"** section with a copy-paste example so the next dialog reuses it instead of hand-rolling a fifth.
*(In-canvas `GateOverlay` is `position:absolute` inside a plot — a different thing, left as-is.)*

### 5 · `shortId` tests (`id.test.ts`)
Shape, custom length, and collision-frhared client-side run-id generator.

### Docs
`docs/API.md` (both new routes + the per-client broadcast model), `docs/SHIPPING.md` (version
surfaced in Diagnostics), `docs/UI.md`

### Verification
API suite **25 pass** (diagnostics 5, packages 7, + rest) · Vitest **8 pass** · `vue-tsc` + `vite build`
clean · no orphaned modal shells remain overlay).

> ⚠️ `api/src/*.jl` aren't Revise-tracfor the broadcast/diagnostics changes.

🤖 Generated with [Claude Code](https: