### PR TITLE
perf(frontend): code-split routes + heavy libs; drop dead vega-embed

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -196,12 +196,25 @@ The image table itself is already in a `CollapsibleSection` ("Images") managed b
 
 ### 2 — Register the route
 
-`frontend/src/main.ts`:
+`frontend/src/main.ts` — **lazy-load the component** (see *Route-level code splitting* below); do **not**
+add a static `import` at the top:
 ```ts
-import SegmentModule from './modules/SegmentModule.vue'
-// ...
-{ path: '/segment', component: SegmentModule, meta: { label: 'Segment' } },
+{ path: '/segment', component: () => import('./modules/SegmentModule.vue'), meta: { label: 'Segment' } },
 ```
+
+#### Route-level code splitting
+
+Every module page uses `component: () => import('./modules/…')` so each becomes its own chunk fetched on
+navigation, not part of the initial `index` bundle. This matters: eagerly importing all pages once put
+the whole app (Chain whiteboard + `@vue-flow`, the plot stack, every modal) into a single ~1.2 MB chunk
+at boot; lazy routes cut the **initial** JS to ~240 KB (~54 KB gzip, an ~87% drop). A new page **must**
+follow the lazy form — a static top-of-file `import X from './modules/X.vue'` silently pulls that page
+(and its deps) back into the boot bundle.
+
+Same rule for a **heavy library used on one screen**: dynamic-import it at the call site rather than at
+module top, so it splits into its own on-demand chunk. Precedents: `@observablehq/plot`
+(`await import('@observablehq/plot')` in `PlotChart`/cluster panels) and `pdf-lib`
+(`await import('pdf-lib')` inside `plots/pdf.ts`'s export function — loads only when the user exports).
 
 ### 3 — Add the sidebar entry
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,6 @@
         "primeicons": "^7.0.0",
         "primevue": "^4.5.5",
         "regl-scatterplot": "^1.16.0",
-        "vega-embed": "^7.1.0",
         "vue": "^3.5.34",
         "vue-router": "^5.1.0"
       },
@@ -656,14 +655,8 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
@@ -1184,32 +1177,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1309,21 +1276,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/commander": {
@@ -1595,28 +1547,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-geo-projection": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
-      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "commander": "7",
-        "d3-array": "1 - 3",
-        "d3-geo": "1.12.0 - 3"
-      },
-      "bin": {
-        "geo2svg": "bin/geo2svg.js",
-        "geograticule": "bin/geograticule.js",
-        "geoproject": "bin/geoproject.js",
-        "geoquantize": "bin/geoquantize.js",
-        "geostitch": "bin/geostitch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-hierarchy": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
@@ -1830,13 +1760,6 @@
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
     },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -1855,16 +1778,6 @@
       "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
@@ -1886,12 +1799,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "license": "MIT"
-    },
-    "node_modules/fast-json-patch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
-      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -1923,29 +1830,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gl-matrix": {
@@ -2019,12 +1903,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/json-stringify-pretty-compact": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
-      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -2698,18 +2576,6 @@
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
       "license": "MIT"
     },
-    "node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2748,40 +2614,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
     },
     "node_modules/superjson": {
       "version": "2.2.6",
@@ -2838,33 +2670,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/topojson-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
-      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "commander": "2"
-      },
-      "bin": {
-        "topo2geo": "bin/topo2geo",
-        "topomerge": "bin/topomerge",
-        "topoquantize": "bin/topoquantize"
-      }
-    },
-    "node_modules/topojson-client/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -2921,504 +2732,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/vega": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-6.2.0.tgz",
-      "integrity": "sha512-BIwalIcEGysJdQDjeVUmMWB3e50jPDNAMfLJscjEvpunU9bSt7X1OYnQxkg3uBwuRRI4nWfFZO9uIW910nLeGw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-crossfilter": "~5.1.0",
-        "vega-dataflow": "~6.1.0",
-        "vega-encode": "~5.1.0",
-        "vega-event-selector": "~4.0.0",
-        "vega-expression": "~6.1.0",
-        "vega-force": "~5.1.0",
-        "vega-format": "~2.1.0",
-        "vega-functions": "~6.1.0",
-        "vega-geo": "~5.1.0",
-        "vega-hierarchy": "~5.1.0",
-        "vega-label": "~2.1.0",
-        "vega-loader": "~5.1.0",
-        "vega-parser": "~7.1.0",
-        "vega-projection": "~2.1.0",
-        "vega-regression": "~2.1.0",
-        "vega-runtime": "~7.1.0",
-        "vega-scale": "~8.1.0",
-        "vega-scenegraph": "~5.1.0",
-        "vega-statistics": "~2.0.0",
-        "vega-time": "~3.1.0",
-        "vega-transforms": "~5.1.0",
-        "vega-typings": "~2.1.0",
-        "vega-util": "~2.1.0",
-        "vega-view": "~6.1.0",
-        "vega-view-transforms": "~5.1.0",
-        "vega-voronoi": "~5.1.0",
-        "vega-wordcloud": "~5.1.0"
-      },
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
-      }
-    },
-    "node_modules/vega-canvas": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-2.0.0.tgz",
-      "integrity": "sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/vega-crossfilter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-5.1.0.tgz",
-      "integrity": "sha512-EmVhfP3p6AM7o/lPan/QAoqjblI19BxWUlvl2TSs0xjQd8KbaYYbS4Ixt3cmEvl0QjRdBMF6CdJJ/cy9DTS4Fw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-dataflow": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.1.0.tgz",
-      "integrity": "sha512-JxumGlODtFbzoQ4c/jQK8Tb/68ih0lrexlCozcMfTAwQ12XhTqCvlafh7MAKKTMBizjOfaQTHm4Jkyb1H5CfyQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-format": "^2.1.0",
-        "vega-loader": "^5.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-embed": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-7.1.0.tgz",
-      "integrity": "sha512-ZmEIn5XJrQt7fSh2lwtSdXG/9uf3yIqZnvXFEwBJRppiBgrEWZcZbj6VK3xn8sNTFQ+sQDXW5sl/6kmbAW3s5A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "fast-json-patch": "^3.1.1",
-        "json-stringify-pretty-compact": "^4.0.0",
-        "semver": "^7.7.2",
-        "tslib": "^2.8.1",
-        "vega-interpreter": "^2.0.0",
-        "vega-schema-url-parser": "^3.0.2",
-        "vega-themes": "3.0.0",
-        "vega-tooltip": "1.0.0"
-      },
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
-      },
-      "peerDependencies": {
-        "vega": "*",
-        "vega-lite": "*"
-      }
-    },
-    "node_modules/vega-encode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-5.1.0.tgz",
-      "integrity": "sha512-q26oI7B+MBQYcTQcr5/c1AMsX3FvjZLQOBi7yI0vV+GEn93fElDgvhQiYrgeYSD4Exi/jBPeUXuN6p4bLz16kA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^6.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-event-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
-      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/vega-expression": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.1.0.tgz",
-      "integrity": "sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.8",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-force": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.1.0.tgz",
-      "integrity": "sha512-wdnchOSeXpF9Xx8Yp0s6Do9F7YkFeOn/E/nENtsI7NOcyHpICJ5+UkgjUo9QaQ/Yu+dIDU+sP/4NXsUtq6SMaQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-force": "^3.0.0",
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-2.1.0.tgz",
-      "integrity": "sha512-i9Ht33IgqG36+S1gFDpAiKvXCPz+q+1vDhDGKK8YsgMxGOG4PzinKakI66xd7SdV4q97FgpR7odAXqtDN2wKqw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "d3-format": "^3.1.0",
-        "d3-time-format": "^4.1.0",
-        "vega-time": "^3.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-functions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-6.1.1.tgz",
-      "integrity": "sha512-Due6jP0y0FfsGMTrHnzUGnEwXPu7VwE+9relfo+LjL/tRPYnnKqwWvzt7n9JkeBuZqjkgYjMzm/WucNn6Hkw5A==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.1",
-        "vega-dataflow": "^6.1.0",
-        "vega-expression": "^6.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-scenegraph": "^5.1.0",
-        "vega-selections": "^6.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-time": "^3.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-geo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.1.0.tgz",
-      "integrity": "sha512-H8aBBHfthc3rzDbz/Th18+Nvp00J73q3uXGAPDQqizioDm/CoXCK8cX4pMePydBY9S6ikBiGJrLKFDa80wI20g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.1",
-        "vega-canvas": "^2.0.0",
-        "vega-dataflow": "^6.1.0",
-        "vega-projection": "^2.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-hierarchy": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.1.0.tgz",
-      "integrity": "sha512-rZlU8QJNETlB6o73lGCPybZtw2fBBsRIRuFE77aCLFHdGsh6wIifhplVarqE9icBqjUHRRUOmcEYfzwVIPr65g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-hierarchy": "^3.1.2",
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-interpreter": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-2.2.1.tgz",
-      "integrity": "sha512-o+4ZEme2mdFLewlpF76dwPWW2VkZ3TAF3DMcq75/NzA5KPvnN4wnlCM8At2FVawbaHRyGdVkJSS5ROF5KwpHPQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-label": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-2.1.0.tgz",
-      "integrity": "sha512-/hgf+zoA3FViDBehrQT42Lta3t8In6YwtMnwjYlh72zNn1p3c7E3YUBwqmAqTM1x+tudgzMRGLYig+bX1ewZxQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-canvas": "^2.0.0",
-        "vega-dataflow": "^6.1.0",
-        "vega-scenegraph": "^5.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-lite": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.4.3.tgz",
-      "integrity": "sha512-d/7hPjfz560UERaQuTmGgIVfXAe3g2hJWeC+igDeaGohUdEoNrHLXgR/yTOBT8vV/lIuuKnw+0/xWWblkDwkMQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "json-stringify-pretty-compact": "~4.0.0",
-        "tslib": "~2.8.1",
-        "vega-event-selector": "~4.0.0",
-        "vega-expression": "~6.1.0",
-        "vega-util": "~2.1.0",
-        "yargs": "~18.0.0"
-      },
-      "bin": {
-        "vl2pdf": "bin/vl2pdf",
-        "vl2png": "bin/vl2png",
-        "vl2svg": "bin/vl2svg",
-        "vl2vg": "bin/vl2vg"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
-      },
-      "peerDependencies": {
-        "vega": "^6.0.0"
-      }
-    },
-    "node_modules/vega-loader": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.1.0.tgz",
-      "integrity": "sha512-GaY3BdSPbPNdtrBz8SYUBNmNd8mdPc3mtdZfdkFazQ0RD9m+Toz5oR8fKnTamNSk9fRTJX0Lp3uEqxrAlQVreg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-dsv": "^3.0.1",
-        "topojson-client": "^3.1.0",
-        "vega-format": "^2.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.1.0.tgz",
-      "integrity": "sha512-g0lrYxtmYVW8G6yXpIS4J3Uxt9OUSkc0bLu5afoYDo4rZmoOOdll3x3ebActp5LHPW+usZIE+p5nukRS2vEc7Q==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-dataflow": "^6.1.0",
-        "vega-event-selector": "^4.0.0",
-        "vega-functions": "^6.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-projection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-2.1.0.tgz",
-      "integrity": "sha512-EjRjVSoMR5ibrU7q8LaOQKP327NcOAM1+eZ+NO4ANvvAutwmbNVTmfA1VpPH+AD0AlBYc39ND/wnRk7SieDiXA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-geo": "^3.1.1",
-        "d3-geo-projection": "^4.0.0",
-        "vega-scale": "^8.1.0"
-      }
-    },
-    "node_modules/vega-regression": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-2.1.0.tgz",
-      "integrity": "sha512-HzC7MuoEwG1rIxRaNTqgcaYF03z/ZxYkQR2D5BN0N45kLnHY1HJXiEcZkcffTsqXdspLjn47yLi44UoCwF5fxQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "vega-dataflow": "^6.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-runtime": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.1.0.tgz",
-      "integrity": "sha512-mItI+WHimyEcZlZrQ/zYR3LwHVeyHCWwp7MKaBjkU8EwkSxEEGVceyGUY9X2YuJLiOgkLz/6juYDbMv60pfwYA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-scale": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-8.1.0.tgz",
-      "integrity": "sha512-VEgDuEcOec8+C8+FzLcnAmcXrv2gAJKqQifCdQhkgnsLa978vYUgVfCut/mBSMMHbH8wlUV1D0fKZTjRukA1+A==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.1.0",
-        "vega-time": "^3.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-scenegraph": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.1.0.tgz",
-      "integrity": "sha512-4gA89CFIxkZX+4Nvl8SZF2MBOqnlj9J5zgdPh/HPx+JOwtzSlUqIhxFpFj7GWYfwzr/PyZnguBLPihPw1Og/cA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-path": "^3.1.0",
-        "d3-shape": "^3.2.0",
-        "vega-canvas": "^2.0.0",
-        "vega-loader": "^5.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-schema-url-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-3.0.2.tgz",
-      "integrity": "sha512-xAnR7KAvNPYewI3O0l5QGdT8Tv0+GCZQjqfP39cW/hbe/b3aYMAQ39vm8O2wfXUHzm04xTe7nolcsx8WQNVLRQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/vega-selections": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-6.1.2.tgz",
-      "integrity": "sha512-xJ+V4qdd46nk2RBdwIRrQm2iSTMHdlu/omhLz1pqRL3jZDrkqNBXimrisci2kIKpH2WBpA1YVagwuZEKBmF2Qw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "3.2.4",
-        "vega-expression": "^6.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-statistics": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-2.0.0.tgz",
-      "integrity": "sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4"
-      }
-    },
-    "node_modules/vega-themes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-3.0.0.tgz",
-      "integrity": "sha512-1iFiI3BNmW9FrsLnDLx0ZKEddsCitRY3XmUAwp6qmp+p+IXyJYc9pfjlVj9E6KXBPfm4cQyU++s0smKNiWzO4g==",
-      "license": "BSD-3-Clause",
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
-      },
-      "peerDependencies": {
-        "vega": "*",
-        "vega-lite": "*"
-      }
-    },
-    "node_modules/vega-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-3.1.0.tgz",
-      "integrity": "sha512-G93mWzPwNa6UYQRkr8Ujur9uqxbBDjDT/WpXjbDY0yygdSkRT+zXF+Sb4gjhW0nPaqdiwkn0R6kZcSPMj1bMNA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "d3-time": "^3.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-tooltip": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-1.0.0.tgz",
-      "integrity": "sha512-P1R0JP29v0qnTuwzCQ0SPJlkjAzr6qeyj+H4VgUFSykHmHc1OBxda//XBaFDl/bZgIscEMvjKSjZpXd84x3aZQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "vega-util": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
-      }
-    },
-    "node_modules/vega-transforms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-5.1.0.tgz",
-      "integrity": "sha512-mj/sO2tSuzzpiXX8JSl4DDlhEmVwM/46MTAzTNQUQzJPMI/n4ChCjr/SdEbfEyzlD4DPm1bjohZGjLc010yuMg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "vega-dataflow": "^6.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-time": "^3.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-typings": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.1.0.tgz",
-      "integrity": "sha512-zdis4Fg4gv37yEvTTSZEVMNhp8hwyEl7GZ4X4HHddRVRKxWFsbyKvZx/YW5Z9Ox4sjxVA2qHzEbod4Fdx+SEJA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@types/geojson": "7946.0.16",
-        "vega-event-selector": "^4.0.0",
-        "vega-expression": "^6.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/vega-view": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-6.1.0.tgz",
-      "integrity": "sha512-hmHDm/zC65lb23mb9Tr9Gx0wkxP0TMS31LpMPYxIZpvInxvUn7TYitkOtz1elr63k2YZrgmF7ztdGyQ4iCQ5fQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.4",
-        "d3-timer": "^3.0.1",
-        "vega-dataflow": "^6.1.0",
-        "vega-format": "^2.1.0",
-        "vega-functions": "^6.1.0",
-        "vega-runtime": "^7.1.0",
-        "vega-scenegraph": "^5.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-view-transforms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-5.1.0.tgz",
-      "integrity": "sha512-fpigh/xn/32t+An1ShoY3MLeGzNdlbAp2+HvFKzPpmpMTZqJEWkk/J/wHU7Swyc28Ta7W1z3fO+8dZkOYO5TWQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-dataflow": "^6.1.0",
-        "vega-scenegraph": "^5.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-voronoi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.1.0.tgz",
-      "integrity": "sha512-uKdsoR9x60mz7eYtVG+NhlkdQXeVdMr6jHNAHxs+W+i6kawkUp5S9jp1xf1FmW/uZvtO1eqinHQNwATcDRsiUg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-delaunay": "^6.0.4",
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
-      }
-    },
-    "node_modules/vega-wordcloud": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-5.1.0.tgz",
-      "integrity": "sha512-sSdNmT8y2D7xXhM2h76dKyaYn3PA4eV49WUUkfYfqHz/vpcu10GSAoFxLhQQTkbZXR+q5ZB63tFUow9W2IFo6g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-canvas": "^2.0.0",
-        "vega-dataflow": "^6.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -3739,34 +3052,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -3780,34 +3065,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,6 @@
     "primeicons": "^7.0.0",
     "primevue": "^4.5.5",
     "regl-scatterplot": "^1.16.0",
-    "vega-embed": "^7.1.0",
     "vue": "^3.5.34",
     "vue-router": "^5.1.0"
   },

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,41 +8,29 @@ import 'primeicons/primeicons.css'
 import './style.css'
 import App from './App.vue'
 
-import ImportModule   from './modules/ImportModule.vue'
-import MetadataModule from './modules/MetadataModule.vue'
-import CleanupModule  from './modules/CleanupModule.vue'
-import SegmentModule  from './modules/SegmentModule.vue'
-import TasksModule    from './modules/TasksModule.vue'
-import SettingsModule from './modules/SettingsModule.vue'
-import TestModule     from './modules/TestModule.vue'
-import ChainModule    from './modules/ChainModule.vue'
-import GatingModule   from './modules/GatingModule.vue'
-import TrackingModule from './modules/TrackingModule.vue'
-import BehaviourModule from './modules/BehaviourModule.vue'
-import ClusterCellsModule  from './modules/ClusterCellsModule.vue'
-import ClusterTracksModule from './modules/ClusterTracksModule.vue'
-import AnalysisModule    from './modules/AnalysisModule.vue'
-
+// Module pages are lazy-loaded so each becomes its own chunk fetched on navigation, instead of one
+// giant eager `index` bundle at boot (the heavy ones — ChainModule pulls @vue-flow, the canvas pages
+// pull the plot stack — should not load until visited). See docs/UI.md → "Route-level code splitting".
 const pinia = createPinia()
 
 const router = createRouter({
   history: createWebHashHistory(),
   routes: [
     { path: '/',          redirect: '/import' },
-    { path: '/import',    component: ImportModule,   meta: { label: 'Import' } },
-    { path: '/metadata',  component: MetadataModule, meta: { label: 'Metadata' } },
-    { path: '/cleanup',   component: CleanupModule,  meta: { label: 'Cleanup' } },
-    { path: '/segment',   component: SegmentModule,  meta: { label: 'Segment' } },
-    { path: '/gate',      component: GatingModule,   meta: { label: 'Gate' } },
-    { path: '/track',     component: TrackingModule, meta: { label: 'Track' } },
-    { path: '/behaviour', component: BehaviourModule, meta: { label: 'Behaviour' } },
-    { path: '/clust-cells',  component: ClusterCellsModule,  meta: { label: 'Cluster cells' } },
-    { path: '/clust-tracks', component: ClusterTracksModule, meta: { label: 'Cluster tracks' } },
-    { path: '/analysis',  component: AnalysisModule,   meta: { label: 'Analysis board' } },
-    { path: '/tasks',     component: TasksModule,     meta: { label: 'Tasks' } },
-    { path: '/chain',     component: ChainModule,     meta: { label: 'Whiteboard' } },
-    { path: '/settings',  component: SettingsModule,  meta: { label: 'Settings' } },
-    { path: '/test',      component: TestModule,      meta: { label: 'Test Tasks' } },
+    { path: '/import',    component: () => import('./modules/ImportModule.vue'),        meta: { label: 'Import' } },
+    { path: '/metadata',  component: () => import('./modules/MetadataModule.vue'),      meta: { label: 'Metadata' } },
+    { path: '/cleanup',   component: () => import('./modules/CleanupModule.vue'),       meta: { label: 'Cleanup' } },
+    { path: '/segment',   component: () => import('./modules/SegmentModule.vue'),       meta: { label: 'Segment' } },
+    { path: '/gate',      component: () => import('./modules/GatingModule.vue'),        meta: { label: 'Gate' } },
+    { path: '/track',     component: () => import('./modules/TrackingModule.vue'),      meta: { label: 'Track' } },
+    { path: '/behaviour', component: () => import('./modules/BehaviourModule.vue'),     meta: { label: 'Behaviour' } },
+    { path: '/clust-cells',  component: () => import('./modules/ClusterCellsModule.vue'),  meta: { label: 'Cluster cells' } },
+    { path: '/clust-tracks', component: () => import('./modules/ClusterTracksModule.vue'), meta: { label: 'Cluster tracks' } },
+    { path: '/analysis',  component: () => import('./modules/AnalysisModule.vue'),      meta: { label: 'Analysis board' } },
+    { path: '/tasks',     component: () => import('./modules/TasksModule.vue'),         meta: { label: 'Tasks' } },
+    { path: '/chain',     component: () => import('./modules/ChainModule.vue'),         meta: { label: 'Whiteboard' } },
+    { path: '/settings',  component: () => import('./modules/SettingsModule.vue'),      meta: { label: 'Settings' } },
+    { path: '/test',      component: () => import('./modules/TestModule.vue'),          meta: { label: 'Test Tasks' } },
   ],
 })
 

--- a/frontend/src/plots/pdf.ts
+++ b/frontend/src/plots/pdf.ts
@@ -1,5 +1,7 @@
-import { PDFDocument } from 'pdf-lib'
 import { downloadBlob } from './export'
+
+// pdf-lib is large and only needed when the user actually exports — dynamic-import it inside
+// exportTabsToPdf so it lands in its own chunk fetched on export, not the initial bundle.
 
 // Multipage PDF of the Analysis board: ONE page per tab, laid out as that tab's grid (each slot image
 // placed at its grid-area rectangle). Each summary plot's aggregated data can ride along as an embedded
@@ -27,6 +29,7 @@ function dataUrlToBytes(dataUrl: string): Uint8Array {
 const safe = (s: string) => s.replace(/[^\w.-]+/g, '_')
 
 export async function exportTabsToPdf(pages: PdfPage[], filename = 'analysis.pdf') {
+  const { PDFDocument } = await import('pdf-lib')
   const doc = await PDFDocument.create()
   for (const page of pages) {
     // A4, oriented to the board: wide (aspect ≥ 1) → landscape, tall → portrait


### PR DESCRIPTION
## perf(frontend): code-split routes + heavy libs; drop dead vega-embed

The whole app compiled into one **~1.2 MB eager `index` chunk** because `main.ts` statically imported
all 15 module pages. This splits it.

### Changes
- **Lazy route imports** — `component: () => import('./modules/…')` for every page. Each becomes its
  own chunk fetched on navigation. `@vue-flow` now rides `ChainModule`'s chunk (`/chain` only);
  `@observablehq/plot` + `regl-scatterplot` were already lazy.
- **`pdf-lib` dynamic-imported** inside `exportTabsToPdf` — its ~175 kB (gzip) loads only when the
  user exports, not at boot.
- **Removed `vega-embed`** — a dead dependency (no imports in `src`; the chart stack moved to
  Observable Plot). Lighter install + lockfile.
- **`docs/UI.md`** — new *Route-level code splitting* section: new pages must use the lazy form;
  heavy single-screen libs dynamic-import at the call site.

### Result (measured)
| | Before | After |
|---|---|---|
| Initial JS | 1,212 kB / **403.68 kB gzip** | 239 kB / **53.72 kB gzip** (**−87%**) |
| >500 kB warning | present | gone |
| JS chunks | 3 | 33 (on-demand) |

**Tradeoff:** total shipped bytes are ~3.5% higher *if* a user visits every page (chunk-split
overhead), but each session only downloads the pages it opens. First visit to a route fetches its
chunk — instant on localhost.

Build + `vue-tsc` clean · Vitest **8 pass** · no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)