### PR TITLE
fix(zarr): stop data corruption in create_multiscales (da.store race)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
       - name: API tests
         run: pixi run test-api
 
+      # Python analysis-env tests (unittest-discovered app/py/tests/*) — e.g. the zarr writer
+      # regression. Runs in the Pixi env (needs numpy/dask/zarr); fixture-free.
+      - name: Python tests
+        run: pixi run test-py
+
       - name: Build frontend
         working-directory: frontend
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,14 +286,15 @@ Revise reloads function bodies on save. Struct/macro changes still need a restar
 
 ## Testing
 
-**Three test categories — one per layer. All three run in CI on every OS, and each has a `pixi run`
-task. Write AND run the matching category in the same change as the code:**
+**Four test categories — one per layer. All four run in CI on every OS, and each has a `pixi run`
+task that runs the whole suite. Write AND run the matching category in the same change as the code:**
 
 | You changed… | Write/run | Command |
 |---|---|---|
 | Julia package core (`app/`) — data model, persistence, task dispatch, param validation, scheduler/chain logic | package test (`app/test/runtests.jl`) | `pixi run test-pkg` |
 | An API handler/adapter (`api/src/*.jl`) with logic worth pinning | API test (`api/test/runtests.jl`, loaded with `CECELIA_NO_SERVE=1` — no socket) | `pixi run test-api` |
 | Frontend logic — first **extract it out of the `.vue` SFC into `frontend/src/utils/*.ts`**, then test that | Vitest (`*.test.ts` beside the module) | `pixi run test-frontend` |
+| Python analysis-env code (`app/py/**` — zarr/dask writers, correction/measure utils) | `unittest` `TestCase` in `app/py/tests/test_*.py` (stdlib, auto-discovered; no pytest dep) | `pixi run test-py` |
 
 Frontend scope is deliberately narrow: **pure logic in `src/utils/*` only — no component mounting,
 no jsdom/DOM/E2E.** Keep testable logic in plain `.ts`, not the component. Full conventions +

--- a/app/py/tests/test_zarr_store.py
+++ b/app/py/tests/test_zarr_store.py
@@ -1,0 +1,50 @@
+"""Regression: create_multiscales must write pixel-exact data even when the source dask array's
+chunking does NOT match the per-plane destination grid.
+
+The per-plane-chunking change made the destination chunks (1 along T/C/Z, 512-tiled X/Y) differ from
+the source's own (auto) chunks, but kept `da.store(..., lock=False)`. When two source blocks map into
+one destination chunk, lock-free stores race on the zarr chunk file (read-modify-write) → scrambled
+planes, worst on EXPANDED outputs like drift correction. The fix rechunks the source to the dest grid
+first (one writer per chunk). This writes a deliberately misaligned, non-512-aligned (expanded-canvas-
+like) source and asserts an exact round-trip; the buggy pattern fails it (corrupts ~5/5 trials).
+
+Part of the Python (analysis-env) test suite — run with `pixi run test-py`.
+"""
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+import dask.array as da
+import zarr
+
+# app/ on the path so `py.utils.*` imports under `unittest discover` (mirrors rechunk_zarr.py).
+_APP_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+if _APP_DIR not in sys.path:
+    sys.path.insert(0, _APP_DIR)
+import py.utils.zarr_utils as zu  # noqa: E402
+
+
+class CreateMultiscalesStoreTest(unittest.TestCase):
+    def test_misaligned_source_roundtrips_exact(self):
+        rng = np.random.default_rng(0)
+        shape = (6, 2, 3, 730, 620)                 # [T,C,Z,Y,X] — Y/X NOT multiples of 512 (expanded case)
+        base = rng.integers(0, 65535, size=shape, dtype=np.uint16)
+        # source chunks span T/C with odd spatial blocks → misaligned vs the (1,1,1,512,512) dest grid
+        src = da.from_array(base, chunks=(3, 2, 3, 300, 400))
+
+        d = tempfile.mkdtemp()
+        try:
+            path = os.path.join(d, "out.ome.zarr")
+            zu.create_multiscales(src, path, nscales=1)
+            back = zarr.open_group(path, mode="r")["0"][:]
+            self.assertTrue(np.array_equal(back, base),
+                            "create_multiscales corrupted data on a misaligned source")
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/py/utils/zarr_utils.py
+++ b/app/py/utils/zarr_utils.py
@@ -217,13 +217,19 @@ def create_multiscales(im_array, filepath, dim_utils=None, im_chunks=None,
     if isinstance(im_array, dask.array.core.Array):
         # Write into the group so the sub-array inherits zarr v2 format. Chunk PER PLANE — NOT with the
         # dask array's own chunksize, which for a correction built via `chunks='auto'` spans the whole
-        # T/C axes (~128 MB chunks) and makes every napari plane access a full-timecourse read. `da.store`
-        # writes across the differing source chunking fine.
+        # T/C axes (~128 MB chunks) and makes every napari plane access a full-timecourse read.
         pchunks = plane_chunks(im_array.shape, dim_utils)
         dest = multiscales_zarr.create_array(
             "0", shape=im_array.shape, chunks=pchunks, dtype=im_array.dtype
         )
-        da.store(im_array, dest, lock=False)
+        # Rechunk the SOURCE to the destination grid before storing. `da.store(lock=False)` is only safe
+        # when each dest chunk has exactly one writer; im_array's own (auto) chunking does NOT align with
+        # the per-plane dest grid, so without this two source blocks can race on a shared dest chunk
+        # (zarr writes are read-modify-write per chunk file) → scrambled planes, worst on EXPANDED
+        # outputs like drift (non-512-aligned canvas). Aligning source→dest keeps it 1-writer-per-chunk,
+        # safe AND parallel (same pattern rechunk_zarr.py already uses). See docs/todo — regression from
+        # the per-plane-chunking change, which kept lock=False after making dest chunks differ from source.
+        da.store(im_array.rechunk(pchunks), dest, lock=False)
         im_chunks = list(pchunks)
     elif isinstance(im_array, zarr.Array):
         dest = multiscales_zarr.create_array("0", shape=im_array.shape, chunks=im_array.chunks, dtype=im_array.dtype)

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -86,7 +86,7 @@ git push -u origin feat/<short-slug>
 ## CI
 
 Every push/PR runs `.github/workflows/ci.yml` (smoke: fresh checkout → `pixi install` →
-`julia … instantiate` → API tests → frontend build → **frontend tests (Vitest)** → server serves
+`julia … instantiate` → API tests → **Python tests** → frontend build → **frontend tests (Vitest)** → server serves
 `/api/health` + the frontend). It runs the
 **full chain as a matrix on Linux, Windows and macOS-arm64** (`fail-fast: false`), so a
 platform-specific install/build/boot failure is caught in CI rather than by a tester — e.g. a PyPI
@@ -108,8 +108,8 @@ Rationale and the full packaging/update model live in [`docs/SHIPPING.md`](SHIPP
 
 ## Tests
 
-Three categories, one per language layer. **All three run in CI** (`.github/workflows/ci.yml`) on every
-OS in the matrix, and each has a `pixi run` task:
+Four categories, one per language layer. **All four run in CI** (`.github/workflows/ci.yml`) on every
+OS in the matrix, and each has a `pixi run` task that runs the whole suite:
 
 - **Package (headless Cecelia):** `pixi run test-pkg` (`app/test/runtests.jl`). The data model,
   persistence, task dispatch, scheduler + chain logic. Some testsets `@test_skip` when their
@@ -126,6 +126,14 @@ OS in the matrix, and each has a `pixi run` task:
   taken here. Vitest is zero-config on top of the existing Vite toolchain, so the category stays cheap.
   The convention this enforces: **keep testable logic in plain `.ts` modules, not the component**, so it
   can be unit-tested without mounting Vue.
+- **Python (analysis env):** `pixi run test-py` — the Pixi-env Python code Julia drives via `run_py`
+  (segmentation, measurement, corrections, the zarr/dask I/O layer): anywhere logic can silently produce
+  wrong data on disk. stdlib `unittest`, auto-discovered from `app/py/tests/test_*.py`
+  (`python -m unittest discover`) and run as one suite — add a `TestCase` whenever you touch `app/py/**`
+  data logic worth pinning; the suite grows with it. **Deliberately no `pytest` dependency** (it isn't in
+  the analysis env and shouldn't ship to users just for tests). Must run via `pixi run` so the env's
+  `python` + `numpy`/`dask`/`zarr` resolve. First member: `test_zarr_store.py` (the `create_multiscales`
+  chunk-aligned store round-trip).
 
 ## Diagnostics & debug console
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -84,11 +84,13 @@ torchvision = ">=0.21"
 dev  = { cmd = "julia --project -t auto -e 'using Revise; includet(\"src/server.jl\")'", cwd = "api" }  # hot-reload (development)
 prod = { cmd = "julia --project -t auto src/server.jl", cwd = "api" }                                    # plain include (production)
 
-# Tests. Package (headless Cecelia) + API adapters (loaded with CECELIA_NO_SERVE — no socket bound)
-# + frontend (Vitest — pure logic extracted from .vue into src/utils/*; no component/DOM/E2E).
+# Tests — one whole suite per layer. Package (headless Cecelia) + API adapters (loaded with
+# CECELIA_NO_SERVE — no socket bound) + frontend (Vitest, pure logic from src/utils/*) + Python
+# analysis-env (unittest-discovered app/py/tests/*, e.g. the zarr writer). All four run in CI.
 test-pkg      = { cmd = "julia --project test/runtests.jl", cwd = "app" }
 test-api      = { cmd = "julia --project test/runtests.jl", cwd = "api" }
 test-frontend = { cmd = "npm test", cwd = "frontend" }
+test-py       = { cmd = "python -m unittest discover -s app/py/tests -p 'test_*.py' -v" }
 
 # Frontend — Vite (port 5173).
 frontend = { cmd = "npm run dev", cwd = "frontend" }    # dev server, hot reload


### PR DESCRIPTION
## fix(zarr): stop data corruption in create_multiscales (da.store race)

A silent data-corruption regression in the correction writer. The per-plane-chunking change made the
destination chunks (1 along T/C/Z, 512-tiled X/Y) differ from the source dask array's own (auto)
chunks, but kept `da.store(..., lock=False)`. When two source blocks map into one destination chunk,
lock-free stores **race** on the zarr chunk file (read-modify-write) → scrambled planes.

- It bites **expanded** outputs (drift correction's non-512-aligned canvas); 512×512 AF outputs happen
  to tile cleanly and looked fine, so it slipped through.
- Reproduced: the old pattern corrupts **5/5 trials**; the fix round-trips pixel-exact.
- Symptom it caused: drift output = "chunks of image crops, no coherence", canvas ballooning
  (e.g. `[94,4,26,728,618]` → corrupted `[94,4,141,1038,950]`).

**Fix:** rechunk the source to the destination grid before storing, so each dest chunk has exactly one
writer — safe **and** still parallel (the same pattern `rechunk_zarr.py` already uses).

### Also: establishes the Python (analysis-env) test category
This bug slipped through for lack of one. Adds:
- `app/py/tests/test_zarr_store.py` — a `unittest` TestCase (misaligned-source round-trip). **stdlib
  `unittest`, no pytest dep** (it isn't in the analysis env and shouldn't ship to users for tests).
- `pixi run test-py` runs the whole suite via `unittest discover`.
- CI runs it on every OS alongside pkg/api/frontend.
- Documented as the 4th test category in `CLAUDE.md` + `docs/DEV.md`.

> ⚠️ Any drift/expanded correction written since the per-plane change is suspect and should be re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)