### PR TITLE
Feat/qc framework

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -835,6 +835,9 @@ function _image_payload(img::CciaImage)
         filepaths       = fps,
         labels          = img.labels,
         attr            = img.attr,
+        # QC findings per "funName/valueName" (docs/todo/QC_PLAN.md) — advisory "output looks off"
+        # flags the GUI renders as a badge + tooltip. Empty dict when a task has emitted none.
+        qc              = read_all_qc(img),
     )
 end
 

--- a/app/py/tasks/cleanupImages/drift_correct_run.py
+++ b/app/py/tasks/cleanupImages/drift_correct_run.py
@@ -14,6 +14,8 @@ Parameter contract (JSON written by Julia):
   driftNormalisation - "phase" | "none"  (passed to skimage phase_cross_correlation)
 """
 
+import json
+
 # `py.*` resolves via PYTHONPATH=app/, set by the Julia launcher (app/src/py_runner.jl::run_py).
 import py.utils.zarr_utils as zarr_utils
 import py.utils.ome_xml_utils as ome_xml_utils
@@ -71,6 +73,23 @@ def run(params):
         changed_shape=drift_image.shape,
         dim_utils=dim_utils,
     )
+
+    # Persist the APPLIED drift so it's inspectable and drives QC (the Julia task reads this, computes
+    # findings, and writes the qc/ sidecar). shifts is [T, ndim] per-frame deltas; axes are Z,Y,X (3D)
+    # or Y,X (2D). See docs/todo/QC_PLAN.md.
+    qc_out_path = params.get('qcOutPath')
+    if qc_out_path:
+        n_axes = int(shifts.shape[1]) if shifts.ndim == 2 else len(shifts)
+        axes = ['Z', 'Y', 'X'] if n_axes == 3 else ['Y', 'X']
+        with open(qc_out_path, 'w') as f:
+            json.dump({
+                'dimOrder':    ''.join(dim_utils.im_dim_order),
+                'sourceShape': [int(x) for x in im_dat[0].shape],
+                'outputShape': [int(x) for x in drift_image.shape],
+                'shiftAxes':   axes,
+                'shifts':      [[float(v) for v in row] for row in shifts],
+            }, f)
+        log.log(f'>> saved drift/QC trajectory: {qc_out_path}')
 
     log.progress(4, 4)
     log.log('>> done')

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -22,6 +22,7 @@ export active, set_active!, value_names, img_filepath, img_zero_dir, img_physica
 export img_label_props_dir, img_label_props_path, img_track_props_path
 export read_module_fun_params, write_module_fun_params!
 export TRACK_PROPS_SUFFIX, is_reserved_value_name
+export write_qc, read_qc, read_all_qc, qc_finding, qc_canvas_expansion, qc_path
 export set_channel_names!, channel_names
 
 # ── Lockfile / transaction ────────────────────────────────────────────────────
@@ -100,6 +101,7 @@ include("py_runner.jl")
 include("helpers.jl")
 include("events.jl")
 include("model/image.jl")
+include("qc.jl")
 include("label_props.jl")
 include("gating/transforms.jl")
 include("gating/gates.jl")

--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -70,12 +70,11 @@ function qc_canvas_expansion(source_shape, output_shape, dim_order::AbstractStri
     pct(i) = source_shape[i] > 0 ? 100 * (output_shape[i] - source_shape[i]) / source_shape[i] : 0.0
     ye, xe = pct(yi), pct(xi); m = max(ye, xe)
     m > threshold_pct || return nothing
+    # Finding text: `short` = the problem (terse); `long` = what to DO (one imperative line). Numbers
+    # live in `detail`, not the prose. See docs/todo/QC_PLAN.md → "Finding text".
     qc_finding("warn", code,
         "Output canvas grew +$(round(Int, m))% in XY",
-        "The processed image's XY canvas grew by +$(round(Int, ye))%/$(round(Int, xe))% (Y/X), well " *
-        "beyond the ≤~15% typical of a good correction. That usually means the estimation went wrong " *
-        "(e.g. drift correction on a reference channel that didn't track) — check the output and " *
-        "consider re-running.";
+        "Larger than a clean correction — check the output and re-run this step if it looks wrong.";
         detail = Dict{String,Any}("yExpansionPct" => round(ye, digits = 1),
                                   "xExpansionPct" => round(xe, digits = 1)))
 end

--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -1,0 +1,81 @@
+# QC framework — general "we processed this, but the output looks off" findings.
+#
+# Convention (docs/todo/QC_PLAN.md): one JSON per (task, output) at
+#   1/{uid}/qc/{funName}/{valueName}.json
+# with a generic `findings` list the GUI renders verbatim (badge + tooltip on the image, the
+# MetadataPanel, and the chain whiteboard node). QC is ADVISORY — it never fails or gates a task.
+# The backend (this layer + each task) computes findings so thresholds live in one place; the GUI
+# only renders. This file is image-owned (like img_physical_sizes / pop_df) — any task emits QC the
+# same way via `write_qc`, rather than each task hand-rolling its own sidecar.
+
+const QC_DIRNAME = "qc"
+
+qc_root(img::CciaImage) = joinpath(img._dir, QC_DIRNAME)
+qc_fun_dir(img::CciaImage, fun_name::AbstractString) = joinpath(qc_root(img), string(fun_name))
+# A task with no output value_name falls back to the default versioned key so there's always a key.
+_qc_vn(value_name::AbstractString) = isempty(value_name) ? VERSIONED_DEFAULT_VAL : string(value_name)
+qc_path(img::CciaImage, fun_name::AbstractString, value_name::AbstractString = VERSIONED_DEFAULT_VAL) =
+    joinpath(qc_fun_dir(img, fun_name), _qc_vn(value_name) * ".json")
+
+# One finding. `level ∈ ("info","warn")` — "error" is reserved (QC never blocks). `code` is a stable
+# kebab/dotted slug (e.g. "drift.canvas_expansion") so the GUI can key styling/help off it.
+function qc_finding(level::AbstractString, code::AbstractString,
+                    short::AbstractString, long::AbstractString; detail = nothing)
+    f = Dict{String,Any}("level" => string(level), "code" => string(code),
+                         "short" => string(short), "long" => string(long))
+    isnothing(detail) || (f["detail"] = detail)
+    f
+end
+
+# Write (or clear) an image's QC for one (task, output). `findings` empty ⇒ still writes the file with
+# an empty list, so a clean re-run overwrites a previous warning rather than leaving it stale.
+function write_qc(img::CciaImage, fun_name::AbstractString, value_name::AbstractString,
+                  findings::AbstractVector; source = nothing, output = nothing, extras...)
+    dir = qc_fun_dir(img, fun_name); mkpath(dir)
+    doc = Dict{String,Any}("funName" => string(fun_name), "valueName" => _qc_vn(value_name),
+                           "findings" => collect(findings))
+    isnothing(source) || (doc["source"] = source)
+    isnothing(output) || (doc["output"] = output)
+    for (k, v) in extras; doc[string(k)] = v; end
+    path = qc_path(img, fun_name, value_name)
+    open(path, "w") do io; JSON3.write(io, doc); end
+    path
+end
+
+read_qc(img::CciaImage, fun_name::AbstractString, value_name::AbstractString = VERSIONED_DEFAULT_VAL) =
+    (p = qc_path(img, fun_name, value_name); isfile(p) ? JSON3.read(read(p, String)) : nothing)
+
+# All QC docs for an image, keyed "funName/valueName" → parsed doc. Powers the API image payload.
+function read_all_qc(img::CciaImage)
+    root = qc_root(img); out = Dict{String,Any}()
+    isdir(root) || return out
+    for fun in readdir(root)
+        fdir = joinpath(root, fun); isdir(fdir) || continue
+        for f in readdir(fdir)
+            endswith(f, ".json") || continue
+            out[string(fun, "/", f[1:end-5])] = JSON3.read(read(joinpath(fdir, f), String))
+        end
+    end
+    out
+end
+
+# Reusable spatial check — flag an output whose XY canvas grew abnormally vs its source. Shapes are in
+# `dim_order` (e.g. "TCZYX"). Generic across any spatially-transforming task (drift/AF correction, …);
+# returns a finding or `nothing`. Default threshold 25% (normal drift expands XY ≤~15%).
+function qc_canvas_expansion(source_shape, output_shape, dim_order::AbstractString;
+                             threshold_pct::Real = 25, code::AbstractString = "output.canvas_expansion")
+    order = collect(dim_order)
+    yi = findfirst(==('Y'), order); xi = findfirst(==('X'), order)
+    (isnothing(yi) || isnothing(xi)) && return nothing
+    pct(i) = source_shape[i] > 0 ? 100 * (output_shape[i] - source_shape[i]) / source_shape[i] : 0.0
+    ye, xe = pct(yi), pct(xi); m = max(ye, xe)
+    m > threshold_pct || return nothing
+    qc_finding("warn", code,
+        "Output canvas grew +$(round(Int, m))% in XY",
+        "The processed image's XY canvas grew by +$(round(Int, ye))%/$(round(Int, xe))% (Y/X), well " *
+        "beyond the ≤~15% typical of a good correction. That usually means the estimation went wrong " *
+        "(e.g. drift correction on a reference channel that didn't track) — check the output and " *
+        "consider re-running.";
+        detail = Dict{String,Any}("yExpansionPct" => round(ye, digits = 1),
+                                  "xExpansionPct" => round(xe, digits = 1)))
+end

--- a/app/src/tasks/cleanupImages/drift_correct.jl
+++ b/app/src/tasks/cleanupImages/drift_correct.jl
@@ -1,4 +1,35 @@
+using Statistics: median
+
 struct DriftCorrect <: CciaTask end
+
+# QC findings from the persisted drift trajectory (docs/todo/QC_PLAN.md). Two checks:
+#  • canvas expansion — XY grew far beyond the ≤~15% typical of a good correction (shape-only fallback)
+#  • drift jump — a single per-frame step dwarfs the trajectory's typical step (the actual cause: the
+#    reference channel briefly locked onto noise, e.g. fHqhyb jumping at T15→T16)
+function _drift_qc_findings(meta)
+    findings = Dict{String,Any}[]
+    src = collect(Int, meta["sourceShape"]); out = collect(Int, meta["outputShape"])
+    ce = qc_canvas_expansion(src, out, String(meta["dimOrder"]); code = "drift.canvas_expansion")
+    isnothing(ce) || push!(findings, ce)
+
+    shifts = meta["shifts"]                      # [T][ndim] per-frame deltas
+    if !isempty(shifts)
+        mags = [sqrt(sum(abs2, Float64.(row))) for row in shifts]
+        med  = median(mags); mx, ti = findmax(mags)
+        # relative (dwarfs the typical step) AND an absolute floor (px) so tiny, jittery trajectories
+        # don't trip it. ti is the 0-based frame index of the jump.
+        if med > 0 && mx > 4 * med && mx > 5
+            push!(findings, qc_finding("warn", "drift.jump",
+                "Large drift jump at T=$(ti - 1)",
+                "The applied drift jumps sharply at timepoint $(ti - 1) ($(round(mx, digits = 1)) px " *
+                "vs a typical $(round(med, digits = 1)) px step) — a sign the reference channel briefly " *
+                "locked onto noise instead of tracking real drift. Check the output / try another channel.";
+                detail = Dict{String,Any}("atT" => ti - 1, "jumpPx" => round(mx, digits = 1),
+                                          "medianPx" => round(med, digits = 1))))
+        end
+    end
+    findings, src, out
+end
 
 function _run_task(task::DriftCorrect, img::CciaImage, params::Dict{String,Any};
                    on_log::Function      = line -> println(line),
@@ -45,11 +76,14 @@ function _run_task(task::DriftCorrect, img::CciaImage, params::Dict{String,Any};
     on_log("[INFO] Output:      $im_correction_path")
     on_log("[INFO] Drift ch:    $drift_channel_idx")
 
+    qc_out_path = joinpath(task_run_dir(img._dir), "drift_shifts.json")
+
     ok = run_py("tasks/cleanupImages/drift_correct_run.py",
         (; imPath             = im_path,
            imCorrectionPath   = im_correction_path,
            driftChannel       = drift_channel_idx,
-           driftNormalisation = string(get(params, "driftNormalisation", "none"))),
+           driftNormalisation = string(get(params, "driftNormalisation", "none")),
+           qcOutPath          = qc_out_path),
         task_run_dir(img._dir);
         on_log = on_log, on_progress = on_progress, on_process = on_process)
     ok || return nothing
@@ -58,6 +92,21 @@ function _run_task(task::DriftCorrect, img::CciaImage, params::Dict{String,Any};
 
     out_value_name = _spec_output_value_name(task, "driftCorrected")
     out_filename   = "ccidDriftCorrected.ome.zarr"
+
+    # QC: read the persisted drift trajectory, compute findings, write the qc/ sidecar (advisory).
+    if isfile(qc_out_path)
+        try
+            qmeta = JSON3.read(read(qc_out_path, String))
+            findings, src, out = _drift_qc_findings(qmeta)
+            write_qc(img, "cleanupImages.driftCorrect", out_value_name, findings;
+                     source = Dict{String,Any}("shape" => src),
+                     output = Dict{String,Any}("shape" => out),
+                     trajectory = Dict{String,Any}("axes" => qmeta["shiftAxes"], "shifts" => qmeta["shifts"]))
+            isempty(findings) || on_log("[QC] $(length(findings)) finding(s) — see the image's QC badge.")
+        catch e
+            on_log("[QC] could not compute drift QC: $e")
+        end
+    end
 
     raw2 = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(ccid, String)))
     versioned_set_field!(raw2, "filepath", out_filename, out_value_name)

--- a/app/src/tasks/cleanupImages/drift_correct.jl
+++ b/app/src/tasks/cleanupImages/drift_correct.jl
@@ -19,11 +19,10 @@ function _drift_qc_findings(meta)
         # relative (dwarfs the typical step) AND an absolute floor (px) so tiny, jittery trajectories
         # don't trip it. ti is the 0-based frame index of the jump.
         if med > 0 && mx > 4 * med && mx > 5
+            # short = problem; long = the action. Figures go in detail (see docs/todo/QC_PLAN.md).
             push!(findings, qc_finding("warn", "drift.jump",
-                "Large drift jump at T=$(ti - 1)",
-                "The applied drift jumps sharply at timepoint $(ti - 1) ($(round(mx, digits = 1)) px " *
-                "vs a typical $(round(med, digits = 1)) px step) — a sign the reference channel briefly " *
-                "locked onto noise instead of tracking real drift. Check the output / try another channel.";
+                "Drift jumped sharply at T=$(ti - 1)",
+                "The reference channel likely lost tracking — re-run drift with a clearer/structural channel.";
                 detail = Dict{String,Any}("atT" => ti - 1, "jumpPx" => round(mx, digits = 1),
                                           "medianPx" => round(med, digits = 1))))
         end

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -3040,4 +3040,59 @@ end
         end
     end
 
+    @testset "QC framework" begin
+        @testset "sidecar round-trip" begin
+            img = CciaImage(; dir = mktempdir())
+            f = qc_finding("warn", "demo.code", "short text", "long text"; detail = Dict("k" => 1))
+            @test f["level"] == "warn" && f["code"] == "demo.code"
+
+            p = write_qc(img, "cleanupImages.driftCorrect", "driftCorrected", [f];
+                         source = Dict("shape" => [1, 2, 3]))
+            @test isfile(p)
+            @test occursin(joinpath("qc", "cleanupImages.driftCorrect", "driftCorrected.json"), p)
+
+            doc = read_qc(img, "cleanupImages.driftCorrect", "driftCorrected")
+            @test length(doc["findings"]) == 1
+            @test doc["findings"][1]["code"] == "demo.code"
+
+            all = read_all_qc(img)
+            @test haskey(all, "cleanupImages.driftCorrect/driftCorrected")
+
+            # no-value_name → falls back to the default key
+            write_qc(img, "some.task", "", Dict{String,Any}[])
+            @test isfile(qc_path(img, "some.task", VERSIONED_DEFAULT_VAL))
+        end
+
+        @testset "canvas-expansion check" begin
+            order = "TCZYX"
+            # fHqhyb: XY +42%/+21% → flagged; Z doubling is ignored
+            bad = qc_canvas_expansion([94, 4, 13, 512, 512], [94, 4, 26, 728, 618], order)
+            @test bad !== nothing && bad["code"] == "output.canvas_expansion"
+            # LUkCpP (normal): XY +6%/+3% → not flagged even though Z grew +46%
+            @test qc_canvas_expansion([64, 4, 13, 512, 512], [64, 4, 19, 541, 527], order) === nothing
+        end
+
+        @testset "drift findings" begin
+            base = Dict{String,Any}("dimOrder" => "TCZYX", "shiftAxes" => ["Z", "Y", "X"])
+            smooth = [[0.0, 1.0, 1.0] for _ in 1:20]
+            spiky  = copy(smooth); spiky[16] = [0.0, 120.0, 90.0]   # jump at frame 16
+
+            # bad ref: canvas ballooned AND a spike → both findings
+            meta_bad = merge(base, Dict("sourceShape" => [20, 4, 13, 512, 512],
+                                        "outputShape" => [20, 4, 26, 728, 618], "shifts" => spiky))
+            fb, _, _ = Cecelia._drift_qc_findings(meta_bad)
+            codes = Set(f["code"] for f in fb)
+            @test "drift.canvas_expansion" in codes
+            @test "drift.jump" in codes
+            jump = first(f for f in fb if f["code"] == "drift.jump")
+            @test jump["detail"]["atT"] == 15                       # 0-based frame index of the spike
+
+            # good ref: modest canvas, smooth trajectory → no findings
+            meta_ok = merge(base, Dict("sourceShape" => [20, 4, 13, 512, 512],
+                                       "outputShape" => [20, 4, 19, 541, 527], "shifts" => smooth))
+            fo, _, _ = Cecelia._drift_qc_findings(meta_ok)
+            @test isempty(fo)
+        end
+    end
+
 end

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,6 +111,28 @@ See [`docs/OBJECTMODEL.md`](OBJECTMODEL.md) for the full schema, versioned field
 
 ---
 
+## QC (quality-control) sidecars
+
+A task can exit 0 yet produce output that's quietly wrong (e.g. drift correction on a reference channel
+that didn't track → the canvas balloons). The **QC layer** (`app/src/qc.jl`, image-owned) lets any task
+emit **advisory** findings about the output it produced.
+
+- **Convention:** one JSON per (task, output) at `1/{uid}/qc/{funName}/{valueName}.json`
+  (no-value_name tasks → `"default"`). Written via `write_qc(img, fun_name, value_name, findings; …)`,
+  read via `read_qc` / `read_all_qc`.
+- **Contract:** each file has a generic `findings` list — `{level ("info"|"warn"), code, short, long,
+  detail?}`. `"error"` is reserved: **QC never fails or gates a task.**
+- **Boundary:** the **backend computes** findings (thresholds live in Julia — one source of truth); the
+  **GUI only renders** them (badge + tooltip). `api_images_meta`'s `_image_payload` exposes
+  `qc = read_all_qc(img)`; `frontend/src/lib/qc.ts` aggregates into a badge (ImageTable; MetadataPanel +
+  whiteboard are later phases).
+- **First producer:** `cleanupImages.driftCorrect` — persists the applied per-frame drift and flags a
+  large inter-frame jump (`drift.jump`) or abnormal XY canvas growth (`drift.canvas_expansion`).
+
+Full design + phased plan: [`docs/todo/QC_PLAN.md`](todo/QC_PLAN.md).
+
+---
+
 ## Napari
 
 See [`docs/NAPARI.md`](NAPARI.md) for the full bridge design, command protocol, OME-ZARR loading, contrast limits, and layer props.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -293,6 +293,14 @@ placeholder rather than a real per-slice calibration on real data. Clicking the 
 focused on that image with the current checkbox selection carried in as the target set for
 Apply/Fill-flagged. Shown on every module page — the icon isn't gated behind `showAttrs`/`module`.
 
+**QC badge.** Separate from the metadata warning (which is import-metadata-specific), a row shows a
+`pi-flag` **QC** badge when `qcSummary(img)` (`frontend/src/lib/qc.ts`) finds any QC finding on the
+image. QC is the general "we processed this, but the output looks off" layer: the **backend** computes
+findings per (task, output) into `1/{uid}/qc/{funName}/{valueName}.json` (see ARCHITECTURE → *QC
+sidecars* and `docs/todo/QC_PLAN.md`); `qc.ts` only aggregates + formats them. The badge hover shows
+the finding detail (e.g. drift correction's jump / canvas-expansion). It's **advisory** — never blocks.
+`warn` findings tint amber; `info` are neutral. (MetadataPanel + chain-whiteboard surfaces are later phases.)
+
 **Physical size & timing editor** (`frontend/src/components/PhysicalSizeDialog.vue`) is a modal,
 not a sidebar section — the first version crammed six fields + long explanatory paragraphs into
 the 280px `MetadataPanel` sidebar and was unreadable. Built on the shared `BaseModal` shell (see

--- a/docs/todo/QC_PLAN.md
+++ b/docs/todo/QC_PLAN.md
@@ -69,6 +69,25 @@ generalised across tasks.
 `findings` is the contract the frontend depends on; `trajectory`/`detail` are producer-specific extras.
 `level ∈ info | warn` (reserve `error` — QC never blocks). Worst level on an image drives the badge.
 
+## Finding text — clean, brief, ACTIONABLE (a hard rule)
+
+The user should read a flag and immediately know **what to do**. Every producer's findings follow this:
+
+- **`short`** — the *problem*, one terse line (≤ ~8 words). A single key figure is fine
+  (`"Drift jumped sharply at T=15"`, `"Output canvas grew +42% in XY"`). No mechanism, no paragraphs.
+- **`long`** — the *action*, ONE imperative sentence: what the user should do next
+  (`"Re-run drift with a clearer/structural channel."`). Not an explanation of *why*.
+- **Numbers / mechanism → `detail`** (structured), never prose. The tooltip renders `short` then `→ long`.
+
+Bad (verbose, explains the mechanism, no clear action): *"The applied drift jumps sharply at timepoint 15
+(137 px vs a typical 2 px step) — a sign the reference channel briefly locked onto noise instead of
+tracking real drift. Check the output / try another channel."*
+Good: short `"Drift jumped sharply at T=15"` · long `"The reference channel likely lost tracking — re-run
+drift with a clearer/structural channel."` · detail `{atT:15, jumpPx:137, medianPx:2}`.
+
+This mirrors the app-wide "keep info/warning UI text terse" rule — a flag is only useful if the next
+step is obvious.
+
 ## Architecture
 
 **Producer (Julia task layer).** New `app/src/qc.jl` — image-owned QC accessor (per the image-owned

--- a/docs/todo/QC_PLAN.md
+++ b/docs/todo/QC_PLAN.md
@@ -1,7 +1,7 @@
 # QC framework — plan
 
-Status: **proposed** (design locked with Dom, not yet built). Promote the durable parts into
-`docs/ARCHITECTURE.md` + `docs/UI.md` once Phase 1 lands.
+Status: **Phase 1 landed** (convention + drift producer + image badge). Phases 2–3 open. Durable
+parts summarised in `docs/ARCHITECTURE.md` (QC section) + `docs/UI.md` (QC badge).
 
 ## Motivation
 

--- a/docs/todo/QC_PLAN.md
+++ b/docs/todo/QC_PLAN.md
@@ -1,0 +1,116 @@
+# QC framework — plan
+
+Status: **proposed** (design locked with Dom, not yet built). Promote the durable parts into
+`docs/ARCHITECTURE.md` + `docs/UI.md` once Phase 1 lands.
+
+## Motivation
+
+A task can complete "successfully" (exit 0) yet produce output that is quietly wrong. The trigger
+case: **drift correction on the wrong reference channel**. `fHqhyb` (project `4kS67f`) drift-corrected
+against a channel that didn't track — the estimated per-timepoint shift jumped at T15→T16, so the
+output canvas ballooned to accommodate a spurious drift:
+
+| image | source `[Z,Y,X]` | drift `[Z,Y,X]` | ΔZ | ΔY | ΔX |
+|---|---|---|---|---|---|
+| LUkCpP (normal ref) | `[13,512,512]` | `[19,541,527]` | +46% | **+6%** | **+3%** |
+| …7 others (normal) | `[13,512,512]` | +8–69% Z | | **+2–15%** | **+2–15%** |
+| **fHqhyb (bad ref)** | `[13,512,512]` | `[26,728,618]` | +100% | **+42%** | **+21%** |
+
+**Z growing is expected** (drift expands the Z canvas too); the tells are the **XY canvas blow-out**
+(normal ≤15%, fHqhyb +42%) and, upstream of it, a **large inter-frame jump** in the applied drift.
+
+We want a general, reusable **QC layer**: any module task can emit QC findings for the output it
+produced; the GUI surfaces them as a non-blocking **"we processed this, but it looks off — check it"**
+badge + tooltip on the image, and on the chain whiteboard node that produced it. Same spirit as the
+physical/timing metadata warning (`imageMetadataWarnings.ts` → ImageTable icon + `PhysicalSizeDialog`),
+generalised across tasks.
+
+## Locked decisions (from discussion)
+
+1. **QC artifact convention** — one JSON per (task, output) under a `qc/` tree:
+   `1/{uid}/qc/{funName}/{valueName}.json` — e.g. `qc/cleanupImages.driftCorrect/driftCorrected.json`.
+   Image-scoped + durable (survives reload, readable by the whiteboard), keyed by the fully-qualified
+   `fun_name` then the output `value_name`. (`1/{uid}` is the per-image "task dir"; `task_run_dir`
+   still holds the raw run log.) A task with **no** output `value_name` falls back to
+   `VERSIONED_DEFAULT_VAL` (`"default"`) so the helper always has a key.
+2. **Drift task must persist the applied drift.** It currently computes per-T shifts and only *logs*
+   them (`drift_correct_run.py`: `log.log(f'shifts: {shifts}')`). Persist the trajectory so it's
+   inspectable and is the data QC reads.
+3. **General engine, two first checks:** an inter-frame **drift-jump** check (precise) and a general
+   **canvas-expansion** check (works for any spatially-transforming output). More checks per task
+   added as we go.
+4. **QC is advisory, never blocking.** It flags for a human; it never fails a task or gates a run.
+5. **Backend computes the findings; the frontend renders them.** Thresholds live in one place (Julia),
+   not duplicated in TS — the GUI just formats the QC findings into the badge + tooltip.
+6. **Surfaces:** (a) ImageTable row badge + tooltip, (b) MetadataPanel, (c) chain whiteboard node.
+
+## QC file schema (draft)
+
+```jsonc
+{
+  "funName":   "cleanupImages.driftCorrect",
+  "valueName": "driftCorrected",
+  "source":    { "shape": [94,4,13,512,512] },   // [T,C,Z,Y,X]
+  "output":    { "shape": [94,4,26,728,618] },
+  "findings": [                                    // generic; the engine renders these verbatim
+    { "level": "warn", "code": "drift.canvas_expansion",
+      "short": "Drift output canvas grew +42% in XY",
+      "long":  "Normal drift correction expands XY ≤~15%; this grew +42%/+21%, which usually means the reference channel didn't track. Re-run with a stronger/structural channel.",
+      "detail": { "xyExpansionPct": 42 } },
+    { "level": "warn", "code": "drift.jump",
+      "short": "Large drift jump at T=16",
+      "long":  "The applied drift jumps sharply between T15 and T16 (…px), far above the trajectory's typical step — a sign the correlation locked onto noise.",
+      "detail": { "atT": 16, "jumpPx": 137 } }
+  ],
+  "trajectory": { "shifts": [[z,y,x], …] }         // applied drift, per T (drift task only)
+}
+```
+
+`findings` is the contract the frontend depends on; `trajectory`/`detail` are producer-specific extras.
+`level ∈ info | warn` (reserve `error` — QC never blocks). Worst level on an image drives the badge.
+
+## Architecture
+
+**Producer (Julia task layer).** New `app/src/qc.jl` — image-owned QC accessor (per the image-owned
+accessors convention, not buried in a task): `write_qc(img, fun_name, value_name; source, output,
+findings, extras)` writes `qc/{fun}/{vn}.json`, and `read_qc(img[, fun][, vn])` reads it back. Each
+task computes its own findings after the run and calls `write_qc`. Drift: `drift_correct_run.py`
+returns/persists the shifts; `drift_correct.jl` computes jump + canvas-expansion findings and writes QC.
+
+**Live update.** `task:result` already carries `valueName`/`filename` in `meta` — add an optional
+`qc` summary (worst level + count, not the whole file) so the badge appears in-session without a reload
+(ARCHITECTURE.md → *task:result mandatory fields*). Durable state is the sidecar.
+
+**Exposure.** `api_images_meta` (or a dedicated `GET /api/images/qc`) includes per-image QC findings
+so the GUI can badge on load. `CciaImage` gains `qc?: Record<valueName, QcFinding[]>` (or keyed by
+`funName/valueName`).
+
+**Frontend engine.** `frontend/src/lib/qc.ts` — sibling of `imageMetadataWarnings.ts`; given an image's
+QC findings, returns the badge level + `{short, long}` tooltip lines. Pure renderer (no thresholds).
+ImageTable + MetadataPanel show a QC badge (distinct icon/colour from the metadata warning).
+
+**Whiteboard.** Chain live nodes render off `data.status` today; the chain→store bridge attaches a QC
+flag per (image, fun_name) so a produced node shows a QC dot + tooltip. Reuses the same findings.
+
+## Phased build sequence
+
+- **Phase 1 — convention + drift producer + image badge.** `qc.jl` (write/read), persist drift
+  shifts, compute drift findings, `qc/*` sidecar, expose on `CciaImage`, `qc.ts` renderer, ImageTable +
+  MetadataPanel badge/tooltip. Deliverable: `fHqhyb` shows a QC warning end-to-end. Tests: QC round-trip
+  + drift-finding thresholds (golden values from the table above).
+- **Phase 2 — whiteboard QC.** QC dot + tooltip on chain live nodes for images with findings.
+- **Phase 3 — more producers.** Segmentation (implausible object count / all-empty labels), tracking
+  (few/short tracks), cellpose-correct, etc. — one finding set per task as needed.
+
+## Resolved
+
+- **Storage root:** `1/{uid}/qc/{funName}/{valueName}.json` (the image metadata dir — Dom's "task
+  dir"). Durable, per-image, queryable on reload without run context.
+- **No-value_name tasks:** fall back to `VERSIONED_DEFAULT_VAL` (`"default"`) as the key.
+
+## Thresholds (initial, from the data above)
+
+- `drift.canvas_expansion`: warn when XY grows **> 25%** (normal ≤15%, bad = 42% — clean separation).
+- `drift.jump`: warn when the max single inter-frame step exceeds **N×** the median step (N ≈ 4–5;
+  tune once real trajectories are persisted). Prefer the jump check as the *primary* signal (it's the
+  cause); canvas-expansion is the robust shape-only fallback that needs no trajectory.

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -6,6 +6,7 @@ import { useLogStore } from '../stores/log'
 import { useTaskStore, type TaskStatus } from '../stores/tasks'
 import { useSettingsStore } from '../stores/settings'
 import { metadataWarning } from '../lib/imageMetadataWarnings'
+import { qcSummary } from '../lib/qc'
 import PhysicalSizeDialog from './PhysicalSizeDialog.vue'
 
 const props = defineProps<{
@@ -36,6 +37,11 @@ const physSizeDialogUid = ref<string | null>(null)
 function warnIconFor(img: CciaImage): { tip: string } | null {
   const w = metadataWarning(img)
   return w ? { tip: w.short } : null
+}
+// QC badge — advisory "we processed this but the output looks off" (docs/todo/QC_PLAN.md). Distinct
+// from the metadata warning: any module can emit it, and it's non-blocking (hover for detail).
+function qcFor(img: CciaImage): { short: string; long: string; level: 'info' | 'warn' } | null {
+  return qcSummary(img)
 }
 function pageIconFor(): { tip: string } | null {
   if (props.module === 'metadata' || props.module === 'import')
@@ -490,6 +496,10 @@ onUnmounted(stopResize)
               v-tooltip.right="warnIconFor(img)!.tip">
               <i class="pi pi-exclamation-triangle" />
             </button>
+            <span v-if="qcFor(img)" class="qc-badge" :class="qcFor(img)!.level"
+              v-tooltip.right="qcFor(img)!.long">
+              <i class="pi pi-flag" /> QC
+            </span>
             <span class="cell-text" v-tooltip.right="img.filepath ?? img.name">{{ img.name }}</span>
             <button v-if="pageIconFor()" class="row-icon-btn" @click.stop="physSizeDialogUid = img.uid"
               v-tooltip.right="pageIconFor()!.tip">
@@ -671,6 +681,17 @@ th:hover .resize-handle::after { opacity: 1; }
   color: #fbbf24; font-size: 0.75rem; padding: 0.1rem; line-height: 1;
 }
 .warn-icon-btn:hover { color: #fcd34d; }
+
+/* QC badge — advisory "output looks off" flag; distinct from the metadata warning icon. */
+.qc-badge {
+  flex-shrink: 0; display: inline-flex; align-items: center; gap: 0.2rem;
+  font-size: 0.6rem; font-weight: 700; letter-spacing: 0.04em;
+  padding: 0.05rem 0.3rem; border-radius: 0.25rem; cursor: help;
+  border: 1px solid transparent;
+}
+.qc-badge .pi { font-size: 0.62rem; }
+.qc-badge.warn { color: #fbbf24; background: #7c2d1233; border-color: #f59e0b55; }
+.qc-badge.info { color: var(--cc-text-dim); background: var(--cc-surface-2); border-color: var(--cc-border); }
 
 /* row-hover actions after the name: the "open editor" page icon + copy-UID — same look, one class */
 .row-icon-btn {

--- a/frontend/src/lib/qc.ts
+++ b/frontend/src/lib/qc.ts
@@ -40,6 +40,7 @@ export function qcSummary(img: CciaImage): QcSummary | null {
   if (!fs.length) return null
   const level = fs.some(f => f.level === 'warn') ? 'warn' : 'info'
   const short = fs.length === 1 ? fs[0].short : `${fs.length} QC issues — hover for detail`
-  const long = fs.map(f => `• ${f.long}`).join('\n\n')
+  // Tooltip: each finding as problem then the action (→). Brief; text convention in docs/todo/QC_PLAN.md.
+  const long = fs.map(f => `${f.short}\n→ ${f.long}`).join('\n\n')
   return { level, count: fs.length, short, long }
 }

--- a/frontend/src/lib/qc.ts
+++ b/frontend/src/lib/qc.ts
@@ -1,0 +1,45 @@
+// QC rendering — the frontend half of the QC framework (docs/todo/QC_PLAN.md). The BACKEND computes
+// the findings (thresholds live in Julia); this module only aggregates and formats them into a badge
+// + tooltip, mirroring imageMetadataWarnings.ts. Reused by ImageTable, MetadataPanel, and (later) the
+// chain whiteboard so all surfaces agree about the same image.
+import type { CciaImage } from '../stores/project'
+
+export interface QcFinding {
+  level: 'info' | 'warn'
+  code: string           // stable slug, e.g. "drift.canvas_expansion"
+  short: string
+  long: string
+  detail?: Record<string, unknown>
+}
+
+// One QC sidecar's parsed contents (1/{uid}/qc/{funName}/{valueName}.json). Only `findings` is relied
+// on here; producer-specific extras (source/output/trajectory) are ignored by the renderer.
+export interface QcDoc {
+  funName?: string
+  valueName?: string
+  findings?: QcFinding[]
+}
+
+export interface QcSummary {
+  level: 'info' | 'warn'
+  count: number
+  short: string   // one-line badge tooltip
+  long: string    // full detail (all findings)
+}
+
+// Every finding across all of an image's QC docs.
+export function qcFindings(img: CciaImage): QcFinding[] {
+  const qc = img.qc
+  if (!qc) return []
+  return Object.values(qc).flatMap(d => d?.findings ?? [])
+}
+
+// Worst-level summary for the badge, or null when the image has no QC findings. `warn` outranks `info`.
+export function qcSummary(img: CciaImage): QcSummary | null {
+  const fs = qcFindings(img)
+  if (!fs.length) return null
+  const level = fs.some(f => f.level === 'warn') ? 'warn' : 'info'
+  const short = fs.length === 1 ? fs[0].short : `${fs.length} QC issues — hover for detail`
+  const long = fs.map(f => `• ${f.long}`).join('\n\n')
+  return { level, count: fs.length, short, long }
+}

--- a/frontend/src/stores/project.ts
+++ b/frontend/src/stores/project.ts
@@ -25,6 +25,7 @@ export interface CciaImage {
   filepaths?: Record<string, string>      // valueName → filename (all versions, excludes _active)
   labels?: Record<string, string[]>        // valueName → [filename, …] (segmentation outputs)
   attr?: Record<string, string>           // user-defined metadata attributes
+  qc?: Record<string, import('../lib/qc').QcDoc>  // "funName/valueName" → QC doc (docs/todo/QC_PLAN.md)
 }
 
 export interface CciaSet {

--- a/frontend/src/stores/ws.ts
+++ b/frontend/src/stores/ws.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useLogStore } from './log'
 import { useTaskStore } from './tasks'
 import { useProjectStore } from './project'
+import { useProjectMetaStore } from './projectMeta'
 import { useTaskDefsStore } from './taskDefs'
 
 export type WsStatus = 'connecting' | 'connected' | 'disconnected' | 'error'
@@ -255,6 +256,19 @@ export const useWsStore = defineStore('ws', () => {
             if (meta.TimeIncrementUnit !== undefined) patch.timeIncrementUnit = String(meta.TimeIncrementUnit)
           }
           useProjectStore().updateImageMeta(imageUid, patch)
+
+          // QC findings are written to disk during the run but NOT carried in task:result, so pull the
+          // fresh image meta to surface the QC badge live (no full project reload). See docs/todo/QC_PLAN.md.
+          const projectUid = String((data.projectUid as string | undefined) ?? '')
+            || useProjectMetaStore().current?.uid || ''
+          if (projectUid) {
+            fetch(`/api/images/meta?projectUid=${projectUid}&imageUid=${imageUid}`)
+              .then(r => (r.ok ? r.json() : null))
+              .then(d => {
+                if (d?.image?.qc !== undefined) useProjectStore().updateImageMeta(imageUid, { qc: d.image.qc })
+              })
+              .catch(() => {})
+          }
         }
       }
 


### PR DESCRIPTION
## feat(qc): QC framework + drift correction producer (Phase 1)

A general **"we processed this, but the output looks off — check it"** layer. Advisory — QC **never
fails or gates a task**. Design doc: `docs/todo/QC_PLAN.md` (Phases 2–3 remain).

### Framework
- **`app/src/qc.jl`** (image-owned): `write_qc`/`read_qc`/`read_all_qc` + `qc_finding`, and a reusable
  `qc_canvas_expansion` check. Sidecars at **`1/{uid}/qc/{funName}/{valueName}.json`** with a generic
  `findings[]` contract. **Backend computes findings, GUI only renders** (thresholds live in Julia).
- `_image_payload` exposes `qc = read_all_qc(img)`; `frontend/src/lib/qc.ts` aggregates into a
  `pi-flag` **QC** badge in ImageTable (amber `warn` / neutral `info`).
- **Live:** on `task:result` the frontend refetches the image's `qc`, so the badge appears the moment a
  task finishes — no manual reload.

### Finding text — brief + actionable (a hard rule)
`short` = the problem (terse); `long` = the **action** (one imperative sentence); numbers in `detail`.
Tooltip renders `short → long`. Documented in `QC_PLAN.md` so every future producer follows it.

### Drift producer (`cleanupImages.driftCorrect`)
- `drift_correct_run.py` **persists the applied per-frame drift** (was only logged).
- `drift_correct.jl` computes findings → sidecar: **`drift.jump`** ("Drift jumped sharply at T=N →
  re-run with a clearer/structural channel") and **`drift.canvas_expansion`** (XY grew >25%; Z growth
  is expected and ignored).

### Tests / docs
Julia **756 pass** (+13: QC round-trip, canvas-expansion, drift-finding goldens). Vitest pass, build
clean. Docs: ARCHITECTURE (*QC sidecars*), UI (*QC badge*), `QC_PLAN.md`.

**Not in this phase:** whiteboard QC (Phase 2), more producers (Phase 3). Findings are computed at task
time, so existing outputs won't badge until re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)