### PR TITLE
fix(tasks): persist in-progress task-param drafts across navigation

### DIFF
--- a/frontend/src/stores/taskDrafts.test.ts
+++ b/frontend/src/stores/taskDrafts.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { taskDraftScope, taskDraftKey } from './taskDrafts'
+
+// The draft key must mirror how funParams are scoped (image → set) so an in-progress draft lives at
+// the same granularity the form loads/saves at. These pure helpers are the whole of that logic.
+describe('task draft scoping', () => {
+  it('scope is the driving image when one is selected, else the set', () => {
+    expect(taskDraftScope('img1', 'setA')).toBe('img1')   // single image selected
+    expect(taskDraftScope('', 'setA')).toBe('setA')       // multi/none → set-level
+    expect(taskDraftScope('', '')).toBe('')               // nothing known yet
+  })
+
+  it('key composes project|fun|scope, and is empty until all parts are known', () => {
+    expect(taskDraftKey('proj', 'cleanupImages.driftCorrect', 'img1'))
+      .toBe('proj|cleanupImages.driftCorrect|img1')
+    expect(taskDraftKey('', 'fun', 'scope')).toBe('')     // no project → no draft
+    expect(taskDraftKey('proj', '', 'scope')).toBe('')    // no fun → no draft
+    expect(taskDraftKey('proj', 'fun', '')).toBe('')      // no scope → no draft
+  })
+
+  it('per-image and per-set edits get distinct keys (the bug: A vs B vs set)', () => {
+    const fun = 'segment.cellpose'
+    const a   = taskDraftKey('p', fun, taskDraftScope('imgA', 'setA'))
+    const b   = taskDraftKey('p', fun, taskDraftScope('imgB', 'setA'))
+    const set = taskDraftKey('p', fun, taskDraftScope('', 'setA'))
+    expect(new Set([a, b, set]).size).toBe(3)
+  })
+})

--- a/frontend/src/stores/taskDrafts.ts
+++ b/frontend/src/stores/taskDrafts.ts
@@ -1,0 +1,32 @@
+import { defineStore } from 'pinia'
+import { reactive } from 'vue'
+import type { ParamValues } from '../tasks/types'
+
+// In-progress (un-run) task-param drafts, so typing params then navigating away and back doesn't
+// lose them (module pages except ChainModule unmount on navigation, and TaskRunner's paramValues is
+// otherwise a bare ref). Session-scoped/in-memory: survives navigation, resets on a full reload —
+// after a reload TaskRunner falls back to the server-saved funParams (persisted on Run).
+//
+// The draft is keyed to MIRROR how funParams are scoped (image → set): a draft lives at the same
+// granularity the form loads/saves at — per driving image when exactly one image is selected, else
+// per set. See TaskRunner.fetchSavedParams / api_task_fun_params / _remember_fun_params.
+
+// The scope a draft belongs to: the single selected image, else the set. Mirrors funparams resolution.
+export function taskDraftScope(drivingImageUid: string, setUid: string): string {
+  return drivingImageUid || setUid
+}
+
+// Stable draft key. Pure — unit-tested. Empty when project/fun/scope aren't known yet (no draft).
+export function taskDraftKey(projectUid: string, funName: string, scopeUid: string): string {
+  return (projectUid && funName && scopeUid) ? `${projectUid}|${funName}|${scopeUid}` : ''
+}
+
+export const useTaskDraftsStore = defineStore('taskDrafts', () => {
+  const drafts = reactive<Record<string, ParamValues>>({})
+
+  const get   = (key: string): ParamValues | undefined => key ? drafts[key] : undefined
+  const set   = (key: string, values: ParamValues) => { if (key) drafts[key] = values }
+  const clear = (key: string) => { if (key) delete drafts[key] }
+
+  return { drafts, get, set, clear }
+})

--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -9,6 +9,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import type { TaskDef, ParamValues } from './types'
+import { useTaskDraftsStore, taskDraftKey, taskDraftScope } from '../stores/taskDrafts'
 import ParamRenderer, { type ParamContext } from './ParamRenderer.vue'
 import TaskList from './TaskList.vue'
 import { useTaskStore } from '../stores/tasks'
@@ -30,6 +31,7 @@ const log          = useLogStore()
 const ws           = useWsStore()
 const projectMeta  = useProjectMetaStore()
 const projectStore = useProjectStore()
+const drafts       = useTaskDraftsStore()
 
 // Selected image objects — looked up from the store so ParamRenderer gets filepath metadata
 const paramContext = computed<ParamContext>(() => ({
@@ -77,6 +79,12 @@ const paramValues = ref<ParamValues>({})
 const drivingImageUid = computed(() => props.selectedUids.length === 1 ? props.selectedUids[0] : '')
 const setUid = computed(() => projectStore.activeSet()?.uid ?? '')
 
+// Draft key mirrors how funParams are scoped (image → set): per driving image when exactly one is
+// selected, else per set. Empty until project/fun/scope are known (→ no draft).
+const currentDraftKey = computed(() => taskDraftKey(
+  projectMeta.current?.uid ?? '', taskDef.value?.fun_name ?? '',
+  taskDraftScope(drivingImageUid.value, setUid.value)))
+
 async function fetchSavedParams(def: TaskDef): Promise<ParamValues> {
   const projectUid = projectMeta.current?.uid ?? ''
   if (!projectUid) return {}
@@ -115,10 +123,21 @@ function buildParamValues(def: TaskDef, saved: ParamValues): ParamValues {
 let paramReqSeq = 0
 async function initParams(def: TaskDef | undefined) {
   if (!def) return
+  // Restore an in-progress draft for this exact scope first; only then fall back to server-saved
+  // params + defaults. (Drafts are written on user edits only, so this never masks a newer save.)
+  const draft = drafts.get(currentDraftKey.value)
+  if (draft) { paramValues.value = draft; return }
   const seq = ++paramReqSeq
   const saved = await fetchSavedParams(def)
   if (seq !== paramReqSeq) return
   paramValues.value = buildParamValues(def, saved)
+}
+
+// Persist a param edit as a draft (USER edits only — never on programmatic init) so navigating away
+// and back keeps it. Keyed to the current image→set scope.
+function onParamEdit(key: string, value: unknown) {
+  paramValues.value[key] = value
+  drafts.set(currentDraftKey.value, paramValues.value)
 }
 
 // Flatten top-level section params before sending — sections are UI containers only.
@@ -169,6 +188,9 @@ function run() {
 
   // params are persisted server-side on run (per image + set); just remember the last-used function
   localStorage.setItem(`cc-fn:${props.module}`, def.task)
+  // the in-progress draft is now the canonical saved value (server-side) — drop it so the next visit
+  // loads the freshly-saved params. Done before the set-scope early-return so both paths clear it.
+  drafts.clear(currentDraftKey.value)
 
   const projectUid = projectMeta.current?.uid ?? ''
 
@@ -346,7 +368,7 @@ onUnmounted(() => {
           :key="p.key"
           :param="p"
           :modelValue="paramValues[p.key]"
-          @update:modelValue="paramValues[p.key] = $event"
+          @update:modelValue="onParamEdit(p.key, $event)"
           :context="paramContext"
         />
       </div>


### PR DESCRIPTION
## fix(tasks): persist in-progress task-param drafts across navigation

Typing params on a module page then navigating away and back lost them: `TaskRunner` held edits in a
bare `ref`, and only ChainModule is kept-alive, so every other module page unmounts on navigation.
Params were only persisted server-side **on Run**, so unsaved edits vanished.

**Fix:** back the param form with a session Pinia store (`stores/taskDrafts`), keyed to **mirror the
funParams scope (image → set)** — per driving image when one image is selected, else per set (exactly
how params load/save today).
- `initParams` restores a draft for the current scope before falling back to server-saved params.
- Drafts are written **on user edits only** (never on programmatic load), so a draft can't mask a
  newer save.
- A successful **Run clears** the draft (the canonical values are now saved server-side).
- Lifetime: session (survives navigation — the reported bug; resets on full reload, after which the
  server-saved params load).

Vitest for the pure scope/key helpers. Frontend-only; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)