### PR TITLE
feat: attribute + channel-name editing only on the Metadata page

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -373,6 +373,13 @@ lifecycle. Channel edits replace one index in the image's name list and re-send 
 (`channelEditable`). This is why the metadata panel's channel section has no "copy to all" button —
 naming is done per-cell in the table (bulk-assign-to-selection via the textarea remains).
 
+**Attribute + channel editing is Metadata-page-only.** The attr/channel columns are *shown*
+read-only on every page that sets `show-attrs` (so you can see the metadata in context), but they're
+only *editable* where `ModuleLayout` is given `:editable-meta="true"` — i.e. `MetadataModule`. This
+keeps metadata a single place to change (no accidental edits from the segment/track/cluster pages).
+The exclusion note + include/exclude toggle stay editable everywhere (excluding an image from
+processing is a per-page action, not metadata).
+
 ---
 
 ## TaskRunner component

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
   setUid: string
   module?: string      // when provided, shows a per-module status column
   showAttrs?: boolean  // show per-channel + attr columns
+  editableMeta?: boolean // allow inline editing of attr + channel-name cells (Metadata page only)
   allowDelete?: boolean
   filterUids?: string[] // when provided, restricts visible rows to these UIDs
   singleSelect?: boolean // radio-style: at most one image selected (e.g. gating)
@@ -617,33 +618,41 @@ onUnmounted(stopResize)
           </span>
         </td>
 
-        <td v-for="idx in channelIndices" :key="'ch-' + idx" class="col-resize" @click.stop>
-          <template v-if="channelEditable(img, idx)">
+        <!-- channel names: editable only on the Metadata page (editableMeta); read-only elsewhere -->
+        <td v-for="idx in channelIndices" :key="'ch-' + idx" class="col-resize">
+          <template v-if="editableMeta && channelEditable(img, idx)">
             <input v-if="isEditing(img.uid, 'ch:' + idx)"
-              class="attr-edit" v-model="editValue" :ref="focusEditInput"
+              class="attr-edit" v-model="editValue" :ref="focusEditInput" @click.stop
               @keyup.enter="commitEdit(img.uid, 'ch:' + idx, img.channelNames?.[idx - 1] ?? '', v => saveChannel(img, idx, v))"
               @keyup.esc="cancelEdit"
               @blur="commitEdit(img.uid, 'ch:' + idx, img.channelNames?.[idx - 1] ?? '', v => saveChannel(img, idx, v))" />
             <span v-else class="cell-text attr-cell"
               v-tooltip.right="img.channelNames?.[idx - 1] ? `${img.channelNames[idx - 1]} — click to edit` : `Name channel ${idx}`"
-              @click="startEdit(img.uid, 'ch:' + idx, img.channelNames?.[idx - 1] ?? '')">
+              @click.stop="startEdit(img.uid, 'ch:' + idx, img.channelNames?.[idx - 1] ?? '')">
               {{ img.channelNames?.[idx - 1] || '—' }}
             </span>
           </template>
+          <span v-else-if="img.channelNames?.[idx - 1]" class="cell-text"
+            v-tooltip.right="img.channelNames[idx - 1]">{{ img.channelNames[idx - 1] }}</span>
           <span v-else class="dim">—</span>
         </td>
 
-        <td v-for="key in attrKeys" :key="'attr-' + key" class="col-resize" @click.stop>
-          <input v-if="isEditing(img.uid, 'attr:' + key)"
-            class="attr-edit" v-model="editValue" :ref="focusEditInput"
-            @keyup.enter="commitEdit(img.uid, 'attr:' + key, img.attr?.[key] ?? '', v => saveAttr(img, key, v))"
-            @keyup.esc="cancelEdit"
-            @blur="commitEdit(img.uid, 'attr:' + key, img.attr?.[key] ?? '', v => saveAttr(img, key, v))" />
-          <span v-else class="cell-text attr-cell"
-            v-tooltip.right="img.attr?.[key] ? `${key}: ${img.attr[key]} — click to edit` : `Set ${key}`"
-            @click="startEdit(img.uid, 'attr:' + key, img.attr?.[key] ?? '')">
-            {{ img.attr?.[key] || '—' }}
-          </span>
+        <!-- attributes: editable only on the Metadata page (editableMeta); read-only elsewhere -->
+        <td v-for="key in attrKeys" :key="'attr-' + key" class="col-resize">
+          <template v-if="editableMeta">
+            <input v-if="isEditing(img.uid, 'attr:' + key)"
+              class="attr-edit" v-model="editValue" :ref="focusEditInput" @click.stop
+              @keyup.enter="commitEdit(img.uid, 'attr:' + key, img.attr?.[key] ?? '', v => saveAttr(img, key, v))"
+              @keyup.esc="cancelEdit"
+              @blur="commitEdit(img.uid, 'attr:' + key, img.attr?.[key] ?? '', v => saveAttr(img, key, v))" />
+            <span v-else class="cell-text attr-cell"
+              v-tooltip.right="img.attr?.[key] ? `${key}: ${img.attr[key]} — click to edit` : `Set ${key}`"
+              @click.stop="startEdit(img.uid, 'attr:' + key, img.attr?.[key] ?? '')">
+              {{ img.attr?.[key] || '—' }}
+            </span>
+          </template>
+          <span v-else class="cell-text"
+            v-tooltip.right="img.attr?.[key] ? `${key}: ${img.attr[key]}` : ''">{{ img.attr?.[key] || '—' }}</span>
         </td>
 
         <td v-if="!showAttrs" class="col-fixed col-ch">

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -10,6 +10,8 @@
     allowManage   bool      SetBar: show New/Rename/Delete set controls (default: false).
     allowDelete   bool      ImageTable: show per-image delete button (default: false).
     showAttrs     bool      ImageTable: show attr columns (default: false).
+    editableMeta  bool      ImageTable: allow inline attr/channel-name editing — Metadata page ONLY
+                            (default: false; every other page shows these read-only).
     showFilter    bool      Show the attr-value filter panel (default: true).
     noSetHint     string    Custom empty-state message.
 
@@ -43,6 +45,7 @@ const props = withDefaults(defineProps<{
   allowManage?: boolean
   allowDelete?: boolean
   showAttrs?:   boolean
+  editableMeta?: boolean
   showFilter?:  boolean
   singleSelect?: boolean   // radio-style image selection (e.g. gating works on one image)
   noSetHint?:   string
@@ -50,6 +53,7 @@ const props = withDefaults(defineProps<{
   allowManage: false,
   allowDelete: false,
   showAttrs:   false,
+  editableMeta: false,
   showFilter:  true,
   singleSelect: false,
   noSetHint:   'Select a set to get started.',
@@ -275,6 +279,7 @@ function selectUids(uids: string[]) {
               :selection-scope="selScope"
               :allow-delete="allowDelete"
               :show-attrs="showAttrs"
+              :editable-meta="editableMeta"
               :single-select="singleSelect"
               :filter-uids="filteredUids"
               @selectionChange="onSelectionChange"

--- a/frontend/src/modules/MetadataModule.vue
+++ b/frontend/src/modules/MetadataModule.vue
@@ -4,7 +4,7 @@ import MetadataPanel from './metadata/MetadataPanel.vue'
 </script>
 
 <template>
-  <ModuleLayout module="metadata" :show-attrs="true" :show-filter="false">
+  <ModuleLayout module="metadata" :show-attrs="true" :editable-meta="true" :show-filter="false">
     <template #right="{ setUid, selectedUids }">
       <MetadataPanel :setUid="setUid" :selectedUids="selectedUids" />
     </template>


### PR DESCRIPTION
## Attribute + channel-name editing only on the Metadata page

Inline editing of attribute and channel-name cells in the image table was live on **every** page that shows those columns (segment, track, cluster, …). Metadata should be a single place to change — not something you can do accidentally elsewhere.

### Change
- **`ImageTable` gains an `editableMeta` prop** (default `false`). When `false`, attr and channel cells render **read-only** (still shown, so you see the metadata in context); when `true` they are the existing click-to-edit cells.
- Threaded through `ModuleLayout` (`editableMeta` prop) — **only `MetadataModule` sets `:editable-meta="true"`**.
- The exclusion **note** + include/exclude toggle stay editable everywhere (excluding an image from processing is a per-page action, not metadata).

### Docs
- `UI.md` — ImageTable section notes the Metadata-only editing scope.

**Tests**: `vue-tsc` clean; `test-frontend` 30✓. Frontend-only — no server restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)