### PR TITLE
feat: one consistent, collapse-persisted plot canvas across module pages

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -460,7 +460,7 @@ A set-scope task differs from an image-scope task in three places:
 
 **Composites can be set-scope too.** A composite with `"scope": "set"` (e.g. `behaviour.hmm` = `hmm_states` → `hmm_transitions`) runs each step's set-scope form over the image vector in sequence; `_run_task(::CompositeTask, imgs::Vector{CciaImage}, …)` handles this (no per-image ccid.json rewriting — set-scope behaviour tasks add obs columns rather than creating value_names).
 
-The module page hosts a set-scope task exactly like any other — `ModuleLayout` already allows multi-image selection; `TaskRunner` does the scope-aware submit. `BehaviourModule.vue` is the reference (TaskRunner in `#right`, plot canvas in `#below-table`).
+The module page hosts a set-scope task exactly like any other — `ModuleLayout` already allows multi-image selection; `TaskRunner` does the scope-aware submit. `BehaviourModule.vue` is the reference (TaskRunner in `#right`, plot canvas in the `#plots` slot).
 
 ---
 
@@ -585,10 +585,12 @@ To add a module-page plot:
    chartTypes, dataSource: { popType, granularity, measure, measureOptions }, scopeModes,
    whiteboardCompatible }`. Served via `GET /api/plots/definitions`. Data comes from the existing
    `POST /api/plot_data` (`plot_summary_data`) — no new route.
-2. Host it below the table with `SummaryCanvas` (the reference is `BehaviourModule.vue`):
+2. Host it in the `#plots` slot with `SummaryCanvas` (the reference is `BehaviourModule.vue`).
+   `ModuleLayout` wraps `#plots` in the shared, collapse-persisted section — do NOT add your own
+   `CollapsibleSection` (that's the divergence this replaced):
 
 ```vue
-<template #below-table="{ selectedUids }">
+<template #plots="{ selectedUids }">
   <SummaryCanvas :image-uids="selectedUids" module="<thisModule>" />
 </template>
 ```
@@ -596,7 +598,8 @@ To add a module-page plot:
 `whiteboardCompatible: true` also makes it available on the whiteboard — one definition, both places.
 
 `CollapsibleSection` (from `'../components/CollapsibleSection.vue'`) is only for **non-plot**
-supplementary panels (previews, tables, controls) — never wrap a bespoke chart in it.
+supplementary panels (previews, tables, controls) placed in the rare `#below-table` slot — never wrap
+a bespoke chart in it, and never hand-wrap the `#plots` canvas (ModuleLayout already does).
 
 ### RULE: persist every user-settable option (do NOT use a bare `ref()`)
 

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -168,31 +168,30 @@ const defs = useTaskDefs('segmentImages')
 
 - `#actions="{ hasSet }"` — items injected into the action bar before the image count (e.g. "Add images" button). `hasSet` is `true` when a set is active — use it to disable the button.
 - `#right="{ setUid, selectedUids, selectedNames }"` — the right-hand panel. All three slot props are computed inside `ModuleLayout`; the module page does not need its own refs for them.
-- `#below-table="{ setUid, selectedUids, selectedNames }"` — content rendered below the image table in the left column. Each piece should be wrapped in `<CollapsibleSection>` so users can toggle it independently. Multiple sections are supported.
+- `#plots="{ setUid, selectedUids, selectedNames, selectUids }"` — **the module's plot canvas.** `ModuleLayout` wraps it in ONE consistent, collapse-persisted `CollapsibleSection` (label via the `plotsLabel` prop, default `'Plots'`). **Do not wrap it yourself** — this is what makes every module page's plot canvas collapse the same way. This is the canonical place for the summary/gating/cluster canvas.
+- `#below-table="{ setUid, selectedUids, selectedNames, selectUids }"` — extra *custom* content below the plots (rare). Wrap each piece in `<CollapsibleSection>` yourself; multiple sections supported.
 
 If you need the active set in the module page itself (e.g. Import's file-browser guard), import `useProjectStore` and call `project.activeSet()` directly.
 
-### Adding plots below the image table
+### Adding the plot canvas below the image table
 
-Wrap each plot in `<CollapsibleSection>` and place it in the `#below-table` slot:
+Put the canvas in the `#plots` slot — nothing else. `ModuleLayout` gives it a consistent, collapsible, **collapse-persisted** section (per module, under `cc-plots-open:<module>`); pass `plots-label` to rename the header:
 
 ```vue
-<template #below-table>
-  <CollapsibleSection label="Intensity histogram">
-    <IntensityHistogram :before="histBefore" :after="histAfter" x-label="Pixel intensity" />
-  </CollapsibleSection>
-  <CollapsibleSection label="Channel correlation" :default-open="false">
-    <ChannelCorrelation :set-uid="setUid" />
-  </CollapsibleSection>
-</template>
+<ModuleLayout module="behaviourAnalysis" :show-attrs="true" plots-label="Plots">
+  <template #plots="{ selectedUids }">
+    <SummaryCanvas :image-uids="selectedUids" module="behaviourAnalysis" />
+  </template>
+</ModuleLayout>
 ```
 
-The image table itself is already in a `CollapsibleSection` ("Images") managed by `ModuleLayout`. All sections scroll together in the left panel; the panel collapses horizontally with the ‹/› button.
+Every module page uses this same slot, so the plot canvas collapses identically everywhere — don't hand-wrap a `CollapsibleSection` in the module (that's exactly the divergence this replaced: SegmentModule once rendered its canvas un-collapsible). The image table itself is in a `CollapsibleSection` ("Images") managed by `ModuleLayout`; all sections scroll together and the panel collapses horizontally with the ‹/› button.
 
 `CollapsibleSection` props:
 - `label` — section heading (uppercased in the toggle bar)
 - `defaultOpen` — whether open on mount (default: `true`)
 - `maxHeight` — CSS `max-height` for the body (default: `'320px'`; pass `'none'` to allow full growth)
+- `storageKey` — when set, the open/closed state persists in localStorage under this key (the `#plots` wrapper uses this so a collapsed canvas stays collapsed across navigation)
 
 ### 2 — Register the route
 
@@ -422,7 +421,7 @@ deduping so a multi-node chain run only sends one `chain:cancel`).
 
 Plots go either **in the left column** (below the image table, for compact summary visualizations) or **in the right panel** (alongside or instead of `TaskRunner`).
 
-**Left column** — use the `#below-table` slot with `<CollapsibleSection>` wrappers (see above). Best for histograms, intensity plots, and other per-run summaries that sit naturally next to the image list.
+**Left column** — put the plot canvas in the `#plots` slot (ModuleLayout wraps it in the shared collapsible section — see above); reserve `#below-table` for rare extra custom content. Best for summary/gating/cluster canvases that sit naturally next to the image list.
 
 **Right panel** — use the `#right` slot:
 
@@ -926,7 +925,7 @@ plot type = drop in a JSON, no new UI code. Current: `track_measures` (continuou
 ## Gating page (WebGL scatter + gate overlay)
 
 `frontend/src/modules/GatingModule.vue` — route `/gate`. Pick ONE image in the table; the
-gating workspace renders **below the table** (`#below-table` slot, wide left column),
+gating workspace renders **below the table** (`#plots` slot, wide left column),
 mirroring the old `flowPlotManager` layout. `gate/GatingPlots.vue` is the container:
 page-level **segmentation (value_name) select** + a **"+ Plot" button** + **Tile/Cascade** window-
 arrange icons (ImageJ-style: grid vs staggered), and a full-height **`.gp-canvas`** workspace
@@ -941,7 +940,7 @@ real segmentation). API: `docs/API.md` gating routes.
 
 **Track-property gating reuses the SAME canvas (`popType` prop) — no clone.** `GatingPlots` takes a
 `popType` prop (`'flow'` default | `'track'`); `TrackingModule.vue` (route `/track`) renders it in
-its `#below-table` slot as `<GatingPlots :image-uid pop-type="track" />` (active when exactly one
+its `#plots` slot as `<GatingPlots :image-uid pop-type="track" />` (active when exactly one
 image is selected, alongside the task runner in `#right`). `popType` only changes (a) the data source
 the store/API read — flow cells vs the per-track table, handled server-side (`docs/API.md` →
 `popType=track`) — and (b) the napari overlay: flow shows the cell-selection brush (linked brushing)
@@ -976,7 +975,7 @@ Two plot families share the canvas shell; the distinction matters for where a ne
 `modules/ClusterCellsModule.vue` (route `/clust-cells`, popType `clust`) and
 `modules/ClusterTracksModule.vue` (`/clust-tracks`, popType `trackclust`) — one page per granularity,
 mirroring the gate/track split. Each is `ModuleLayout` (multi-select — clustering is set-scope) +
-`TaskRunner` (`clustPops` / `clustTracks`) + a below-table **`modules/cluster/ClusterPlots.vue`**
+`TaskRunner` (`clustPops` / `clustTracks`) + a `#plots`-slot **`modules/cluster/ClusterPlots.vue`**
 canvas (the cluster analogue of `GatingPlots`: `useCanvasPanels` keyed `clust:${popType}` + a "+ Plot"
 picker + Tile/Cascade). The **"+ Plot"** picker lists every interactive view (`INTERACTIVE_VIEWS`) +
 the summary **Heatmap**; each panel is routed by family — interactive → `InteractivePanel` (e.g.
@@ -1008,9 +1007,9 @@ toggleable cluster-number labels at each cluster centroid), summary → **`Clust
     {features, partOf}}`), surfaced as `clusterMembers`. `ClusterPlots` writes only to the selected
     images in `partOf` and shows a banner naming any selected images that aren't in the run (and any
     run images not selected), with a **"Select clustered images"** button that sets the selection to
-    exactly the run's images. That button uses a `selectUids(uids)` callback `ModuleLayout` now exposes
-    on its `#below-table` slot — it writes the shared selection store, and `ImageTable` watches the
-    store and re-seeds its checkboxes (so below-table content can drive the selection generically).
+    exactly the run's images. That button uses a `selectUids(uids)` callback `ModuleLayout` exposes on
+    both the `#plots` and `#below-table` slots — it writes the shared selection store, and `ImageTable`
+    watches the store and re-seeds its checkboxes (so plot-canvas content can drive the selection generically).
   - **Highlight → overlays**: the manager's per-pop **eye** toggles a `highlighted` set (persisted in
     the canvas `shared` bag). `ClusterPlots` resolves it to `shownPops` ({path, name, colour,
     clusterIds}) and feeds it to the views:
@@ -1254,6 +1253,6 @@ These are deliberate shortcuts; know them before changing the plot components.
 
 The left panel has two collapse mechanisms:
 - **Horizontal** (‹/›) — shrinks the entire left panel to a 2.4rem strip. Useful for maximizing the right panel.
-- **Vertical** — each section within the panel (image table, plots) has its own toggle header. The image table is always in a "Images" `CollapsibleSection`; below-table content is whatever the module puts in `#below-table` slot (each wrapped in `<CollapsibleSection>`).
+- **Vertical** — each section within the panel (image table, plots) has its own toggle header. The image table is always in a "Images" `CollapsibleSection`; the plot canvas is the module's `#plots` slot, which `ModuleLayout` wraps in one consistent collapse-persisted `CollapsibleSection` (label via `plotsLabel`). Extra `#below-table` content is wrapped by the module itself.
 
 The whole left panel body scrolls vertically if sections together exceed available height. Collapsed state is local to the component and resets on navigation.

--- a/frontend/src/components/CollapsibleSection.vue
+++ b/frontend/src/components/CollapsibleSection.vue
@@ -5,20 +5,27 @@
     label       string   Heading text shown in the toggle bar.
     defaultOpen bool     Whether the section starts open (default: true).
     maxHeight   string   CSS max-height for the body div (default: '320px').
+    storageKey  string   When set, the open/closed state is remembered in localStorage under this
+                         key (so it survives navigation — see the "persist every option" rule).
 -->
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 const props = withDefaults(defineProps<{
   label:        string
   defaultOpen?: boolean
   maxHeight?:   string
+  storageKey?:  string
 }>(), {
   defaultOpen: true,
   maxHeight:   '320px',
 })
 
-const open = ref(props.defaultOpen)
+const stored = props.storageKey ? localStorage.getItem(props.storageKey) : null
+const open = ref(stored === null ? props.defaultOpen : stored === '1')
+watch(open, v => {
+  if (props.storageKey) { try { localStorage.setItem(props.storageKey, v ? '1' : '0') } catch { /* ignore */ } }
+})
 </script>
 
 <template>

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -1,7 +1,7 @@
 <!--
   Shared two-column module layout.
   Left column: SetBar + count bar + optional attr filter + collapsible ImageTable
-               + optional #below-table slot (module supplies CollapsibleSection wrappers).
+               + a consistent collapsible #plots canvas + optional #below-table slot.
   Right column: slot #right — TaskRunner, MetadataPanel, or a custom panel.
 
   Props
@@ -11,6 +11,7 @@
     allowDelete   bool      ImageTable: show per-image delete button (default: false).
     showAttrs     bool      ImageTable: show attr columns (default: false).
     showFilter    bool      Show the attr-value filter panel (default: true).
+    plotsLabel    string    Heading for the #plots section (default: 'Plots').
     noSetHint     string    Custom empty-state message.
 
   Slots
@@ -18,9 +19,15 @@
     #actions  { hasSet }                        — extra items in the action bar.
     #right    { setUid, selectedUids,
                 selectedNames }                 — the right-hand panel.
+    #plots    { setUid, selectedUids,
+                selectedNames, selectUids }     — the module's plot canvas. ModuleLayout wraps it in
+                                                  ONE consistent, collapse-persisted CollapsibleSection
+                                                  (labelled `plotsLabel`) — do NOT wrap it yourself.
+                                                  This is how every module page gets the SAME
+                                                  collapsible plot canvas.
     #below-table { setUid, selectedUids,
-                   selectedNames, selectUids }  — content below the image table.
-                                                  Wrap each piece in <CollapsibleSection>.
+                   selectedNames, selectUids }  — extra custom content below the plots (rare).
+                                                  Wrap each piece in <CollapsibleSection> yourself.
                                                   `selectUids(uids)` drives the image selection.
 
   Emits
@@ -45,6 +52,7 @@ const props = withDefaults(defineProps<{
   showAttrs?:   boolean
   showFilter?:  boolean
   singleSelect?: boolean   // radio-style image selection (e.g. gating works on one image)
+  plotsLabel?:  string
   noSetHint?:   string
 }>(), {
   allowManage: false,
@@ -52,6 +60,7 @@ const props = withDefaults(defineProps<{
   showAttrs:   false,
   showFilter:  true,
   singleSelect: false,
+  plotsLabel:  'Plots',
   noSetHint:   'Select a set to get started.',
 })
 
@@ -278,6 +287,19 @@ function selectUids(uids: string[]) {
               :single-select="singleSelect"
               :filter-uids="filteredUids"
               @selectionChange="onSelectionChange"
+            />
+          </CollapsibleSection>
+
+          <!-- Plot canvas — ONE consistent, collapse-persisted section for every module page.
+               ModuleLayout owns the wrapper so no module can forget it or diverge. -->
+          <CollapsibleSection v-if="$slots.plots && activeSet"
+            :label="plotsLabel" max-height="none"
+            :storage-key="`cc-plots-open:${module ?? 'default'}`">
+            <slot name="plots"
+              :set-uid="activeSet.uid"
+              :selected-uids="selectedUids"
+              :selected-names="selectedNames"
+              :select-uids="selectUids"
             />
           </CollapsibleSection>
 

--- a/frontend/src/modules/AnalysisModule.vue
+++ b/frontend/src/modules/AnalysisModule.vue
@@ -13,7 +13,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import ModuleLayout from '../components/ModuleLayout.vue'
-import CollapsibleSection from '../components/CollapsibleSection.vue'
 import TabbedCanvas from '../components/canvas/TabbedCanvas.vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
 
@@ -23,10 +22,8 @@ const projectUid = computed(() => meta.current?.uid ?? '')
 
 <template>
   <ModuleLayout module="analysis" :show-attrs="true" :show-filter="true">
-    <template #below-table="{ selectedUids }">
-      <CollapsibleSection label="Plots" :max-height="'none'">
-        <TabbedCanvas :key="projectUid" :image-uids="selectedUids" />
-      </CollapsibleSection>
+    <template #plots="{ selectedUids }">
+      <TabbedCanvas :key="projectUid" :image-uids="selectedUids" />
     </template>
   </ModuleLayout>
 </template>

--- a/frontend/src/modules/BehaviourModule.vue
+++ b/frontend/src/modules/BehaviourModule.vue
@@ -7,7 +7,6 @@
 -->
 <script setup lang="ts">
 import ModuleLayout from '../components/ModuleLayout.vue'
-import CollapsibleSection from '../components/CollapsibleSection.vue'
 import SummaryCanvas from '../components/canvas/SummaryCanvas.vue'
 import TaskRunner from '../tasks/TaskRunner.vue'
 import { useTaskDefs } from '../composables/useTaskDefs'
@@ -26,10 +25,8 @@ const { defs: behaviourDefs, reload: reloadDefs } = useTaskDefs('behaviour')
         :selected-names="selectedNames"
       />
     </template>
-    <template #below-table="{ selectedUids }">
-      <CollapsibleSection label="Plots" :max-height="'none'">
-        <SummaryCanvas :image-uids="selectedUids" module="behaviourAnalysis" />
-      </CollapsibleSection>
+    <template #plots="{ selectedUids }">
+      <SummaryCanvas :image-uids="selectedUids" module="behaviourAnalysis" />
     </template>
   </ModuleLayout>
 </template>

--- a/frontend/src/modules/ClusterCellsModule.vue
+++ b/frontend/src/modules/ClusterCellsModule.vue
@@ -5,12 +5,11 @@
    • below the table: explore clusters (heatmap + UMAP) and define populations by ticking cluster
      IDs into them (the `clust` pop type). [pop-manager + plots are filled in the next step]
 
-  Mirrors BehaviourModule (set-scope task + below-table canvas); the track counterpart is
+  Mirrors BehaviourModule (set-scope task + #plots canvas); the track counterpart is
   ClusterTracksModule.vue (gating/tracking-style split — one page per granularity).
 -->
 <script setup lang="ts">
 import ModuleLayout from '../components/ModuleLayout.vue'
-import CollapsibleSection from '../components/CollapsibleSection.vue'
 import TaskRunner from '../tasks/TaskRunner.vue'
 import ClusterPlots from './cluster/ClusterPlots.vue'
 import { useTaskDefs } from '../composables/useTaskDefs'
@@ -19,7 +18,7 @@ const { defs: clustDefs, reload: reloadDefs } = useTaskDefs('clustPops')
 </script>
 
 <template>
-  <ModuleLayout module="clustPops" :show-attrs="true" :show-filter="true">
+  <ModuleLayout module="clustPops" :show-attrs="true" :show-filter="true" plots-label="Clusters">
     <template #right="{ selectedUids, selectedNames }">
       <TaskRunner
         :defs="clustDefs"
@@ -29,10 +28,8 @@ const { defs: clustDefs, reload: reloadDefs } = useTaskDefs('clustPops')
         :selected-names="selectedNames"
       />
     </template>
-    <template #below-table="{ selectedUids, selectUids }">
-      <CollapsibleSection label="Clusters" :max-height="'none'">
-        <ClusterPlots :image-uids="selectedUids" :select-uids="selectUids" pop-type="clust" />
-      </CollapsibleSection>
+    <template #plots="{ selectedUids, selectUids }">
+      <ClusterPlots :image-uids="selectedUids" :select-uids="selectUids" pop-type="clust" />
     </template>
   </ModuleLayout>
 </template>

--- a/frontend/src/modules/ClusterTracksModule.vue
+++ b/frontend/src/modules/ClusterTracksModule.vue
@@ -10,7 +10,6 @@
 -->
 <script setup lang="ts">
 import ModuleLayout from '../components/ModuleLayout.vue'
-import CollapsibleSection from '../components/CollapsibleSection.vue'
 import TaskRunner from '../tasks/TaskRunner.vue'
 import ClusterPlots from './cluster/ClusterPlots.vue'
 import { useTaskDefs } from '../composables/useTaskDefs'
@@ -19,7 +18,7 @@ const { defs: clustDefs, reload: reloadDefs } = useTaskDefs('clustTracks')
 </script>
 
 <template>
-  <ModuleLayout module="clustTracks" :show-attrs="true" :show-filter="true">
+  <ModuleLayout module="clustTracks" :show-attrs="true" :show-filter="true" plots-label="Clusters">
     <template #right="{ selectedUids, selectedNames }">
       <TaskRunner
         :defs="clustDefs"
@@ -29,10 +28,8 @@ const { defs: clustDefs, reload: reloadDefs } = useTaskDefs('clustTracks')
         :selected-names="selectedNames"
       />
     </template>
-    <template #below-table="{ selectedUids, selectUids }">
-      <CollapsibleSection label="Clusters" :max-height="'none'">
-        <ClusterPlots :image-uids="selectedUids" :select-uids="selectUids" pop-type="trackclust" />
-      </CollapsibleSection>
+    <template #plots="{ selectedUids, selectUids }">
+      <ClusterPlots :image-uids="selectedUids" :select-uids="selectUids" pop-type="trackclust" />
     </template>
   </ModuleLayout>
 </template>

--- a/frontend/src/modules/GatingModule.vue
+++ b/frontend/src/modules/GatingModule.vue
@@ -5,16 +5,13 @@
 -->
 <script setup lang="ts">
 import ModuleLayout from '../components/ModuleLayout.vue'
-import CollapsibleSection from '../components/CollapsibleSection.vue'
 import GatingPlots from './gate/GatingPlots.vue'
 </script>
 
 <template>
-  <ModuleLayout module="gate" :show-attrs="true" :show-filter="true" :single-select="true">
-    <template #below-table="{ selectedUids }">
-      <CollapsibleSection label="Gating" :max-height="'none'">
-        <GatingPlots :image-uid="selectedUids[0] ?? null" />
-      </CollapsibleSection>
+  <ModuleLayout module="gate" :show-attrs="true" :show-filter="true" :single-select="true" plots-label="Gating">
+    <template #plots="{ selectedUids }">
+      <GatingPlots :image-uid="selectedUids[0] ?? null" />
     </template>
   </ModuleLayout>
 </template>

--- a/frontend/src/modules/SegmentModule.vue
+++ b/frontend/src/modules/SegmentModule.vue
@@ -22,7 +22,7 @@ const { defs: segmentDefs, reload: reloadDefs } = useTaskDefs('segment')
     <!-- Segmentation integrity (QC) plots: the canonical summary canvas, filtered to `segment` plot
          specs (segmentation_qc.json — cell count / morphology over the `labels` popType). One
          selectable population per segmentation value_name, so B/T plot side by side. -->
-    <template #below-table="{ selectedUids }">
+    <template #plots="{ selectedUids }">
       <SummaryCanvas :image-uids="selectedUids" module="segment" />
     </template>
   </ModuleLayout>

--- a/frontend/src/modules/TrackingModule.vue
+++ b/frontend/src/modules/TrackingModule.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import ModuleLayout from '../components/ModuleLayout.vue'
-import CollapsibleSection from '../components/CollapsibleSection.vue'
 import TaskRunner from '../tasks/TaskRunner.vue'
 import GatingPlots from './gate/GatingPlots.vue'
 import { useTaskDefs } from '../composables/useTaskDefs'
@@ -9,7 +8,7 @@ const { defs: trackingDefs, reload: reloadDefs } = useTaskDefs('tracking')
 </script>
 
 <template>
-  <ModuleLayout module="tracking" :show-attrs="true" :show-filter="true">
+  <ModuleLayout module="tracking" :show-attrs="true" :show-filter="true" plots-label="Track gating">
     <template #right="{ selectedUids, selectedNames }">
       <TaskRunner
         :defs="trackingDefs"
@@ -22,10 +21,8 @@ const { defs: trackingDefs, reload: reloadDefs } = useTaskDefs('tracking')
     <!-- Track-property gating: the SAME gating canvas as the Gate page, in track mode (one point
          per track; gate on motility / per-track aggregates). Active when exactly one image is
          selected. Reuses GatingPlots via popType — no track-specific component. -->
-    <template #below-table="{ selectedUids }">
-      <CollapsibleSection label="Track gating" :max-height="'none'">
-        <GatingPlots :image-uid="selectedUids.length === 1 ? selectedUids[0] : null" pop-type="track" />
-      </CollapsibleSection>
+    <template #plots="{ selectedUids }">
+      <GatingPlots :image-uid="selectedUids.length === 1 ? selectedUids[0] : null" pop-type="track" />
     </template>
   </ModuleLayout>
 </template>


### PR DESCRIPTION
Module pages diverged on the below-table plot canvas: SegmentModule rendered it un-collapsible (no wrapper), while the other six each hand-wrapped their own CollapsibleSection — and none persisted the open/closed state (reset on navigation).

- ModuleLayout now owns a dedicated `#plots` slot, wrapped in ONE consistent, collapse-persisted CollapsibleSection (label via `plotsLabel`, default "Plots"; state saved per module under `cc-plots-open:<module>`). Modules can't forget to wrap it or diverge.
- CollapsibleSection gains an optional `storageKey` so open/closed persists across navigation (closes the app-wide "collapse state resets" gap).
- Migrated all 7 plot-bearing modules (Segment, Behaviour, Analysis, Gating, Tracking, ClusterCells, ClusterTracks) to `#plots`, dropping their per-module CollapsibleSection. Labels preserved via `plots-label`.

Docs: UI.md (slots, module authoring, component sections) + MODULES.md updated (#below-table → #plots for the canvas). test-frontend (30) green; vue-tsc clean.