### PR TITLE
fix: gating on object measurements (NaN extent → plotmeta 500)

### DIFF
--- a/api/src/gating_api.jl
+++ b/api/src/gating_api.jl
@@ -359,6 +359,21 @@ function api_gating_membership(req::HTTP.Request)
     200, JSON3.write((; membership = Dict(String(p) => cells_in_pop(m, p) for p in pops)))
 end
 
+# Extrema over FINITE values only. Object/morphology measurements (volume, convex_hull_area,
+# surface_to_volume, …) carry NaN/Inf for degenerate or border objects; plain `extrema` would
+# propagate a single NaN into the extent, and JSON3 refuses to serialise NaN (→ 500, so the plot
+# never renders). Falls back when the column is empty or all-non-finite.
+function _finite_extrema(v, fallback::Tuple{Float64,Float64} = (0.0, 1.0))::Tuple{Float64,Float64}
+    lo = Inf; hi = -Inf
+    for x in v
+        xf = float(x)
+        isfinite(xf) || continue
+        xf < lo && (lo = xf)
+        xf > hi && (hi = xf)
+    end
+    lo <= hi ? (lo, hi) : fallback
+end
+
 # ── GET /api/gating/plotmeta ──────────────────────────────────────────────────
 # returns n + mode (scatter|density) + transformed extents + axis ticks
 function api_gating_plotmeta(req::HTTP.Request)
@@ -373,13 +388,13 @@ function api_gating_plotmeta(req::HTTP.Request)
     n = length(xv)
     density_threshold = parse(Int, get(q, "densityThreshold", "200000"))
     mode = n > density_threshold ? "density" : "scatter"
-    xext = isempty(xv) ? (0.0, 1.0) : extrema(xv)
-    yext = isempty(yv) ? (0.0, 1.0) : extrema(yv)
+    xext = _finite_extrema(xv)
+    yext = _finite_extrema(yv)
     # ticks use the raw extent (over the WHOLE dataset, not the pop subset) so labels read in data
     # units and selecting a population doesn't rescale the axis — track-aware via _plot_xy_raw.
     rxv, ryv = _plot_xy_raw(img, vn, get(q, "popType", "flow"), x, y, ROOT)
-    rxext = isempty(rxv) ? (0.0, 1.0) : extrema(rxv)
-    ryext = isempty(ryv) ? (0.0, 1.0) : extrema(ryv)
+    rxext = _finite_extrema(rxv)
+    ryext = _finite_extrema(ryv)
     # x0/y0=1 → "whole dataset" axis: origin at raw 0, upper bound = the FULL dataset max (rxext
     # is computed from all cells, not the pop subset), so selecting a population doesn't rescale
     # the axis (FlowJo behaviour). Autoscale (x0=0) fits the displayed population's extent.

--- a/app/src/gating/density.jl
+++ b/app/src/gating/density.jl
@@ -29,15 +29,24 @@ function density_2d(xt::AbstractVector, yt::AbstractVector; bins::Int=256,
     yspan = ymax > ymin ? ymax - ymin : 1.0
     counts = zeros(Int, bins, bins)
     @inbounds for i in eachindex(xt)
-        bx = clamp(floor(Int, (float(xt[i]) - xmin) / xspan * bins) + 1, 1, bins)
-        by = clamp(floor(Int, (float(yt[i]) - ymin) / yspan * bins) + 1, 1, bins)
+        xi = float(xt[i]); yi = float(yt[i])
+        # object/morphology measures carry NaN/Inf for degenerate objects; skip them (else
+        # `floor(Int, NaN)` throws) — they simply don't contribute to any bin.
+        (isfinite(xi) && isfinite(yi)) || continue
+        bx = clamp(floor(Int, (xi - xmin) / xspan * bins) + 1, 1, bins)
+        by = clamp(floor(Int, (yi - ymin) / yspan * bins) + 1, 1, bins)
         counts[bx, by] += 1
     end
     Density2D(counts, xmin, xmax, ymin, ymax, bins)
 end
 
+# extrema over FINITE values only (NaN/Inf would poison the bin edges); falls back when the vector
+# is empty or all-non-finite.
 function extrema_or(v::AbstractVector, lo_default::Float64, hi_default::Float64)
-    isempty(v) && return (lo_default, hi_default)
-    mn, mx = extrema(v)
-    (float(mn), float(mx))
+    lo = Inf; hi = -Inf
+    for x in v
+        xf = float(x); isfinite(xf) || continue
+        xf < lo && (lo = xf); xf > hi && (hi = xf)
+    end
+    lo <= hi ? (lo, hi) : (lo_default, hi_default)
 end

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -1866,6 +1866,16 @@ end
         @test size(d.counts) == (10, 10)
         @test d.counts[1, 10] == 0                 # off-diagonal empty (x==y data)
         @test all(d.counts[i, i] >= 1 for i in 1:10)
+
+        # NaN/Inf (object/morphology measures on degenerate objects) must be skipped, not throw —
+        # extents come from the finite values, and a non-finite point contributes to no bin.
+        xn = [0.0, 0.5, 1.0, NaN, Inf, -Inf]
+        dn = density_2d(xn, xn; bins=10)
+        @test sum(dn.counts) == 3                  # only the 3 finite points counted
+        @test (dn.x_min, dn.x_max) == (0.0, 1.0)   # extents ignore NaN/Inf
+        # all-non-finite → falls back to the default extent and empty counts (no throw)
+        dz = density_2d([NaN, Inf], [NaN, Inf]; bins=4)
+        @test sum(dz.counts) == 0
     end
 
     # ── Population manager: paths, tree, persistence ──────────────────────────

--- a/frontend/src/components/plots/PlotLayers.vue
+++ b/frontend/src/components/plots/PlotLayers.vue
@@ -45,7 +45,9 @@ function densityGrid(points: Float32Array): Float32Array {
   const g = new Float32Array(G * G)
   const n = points.length / 2
   for (let i = 0; i < n; i++) {
-    let gx = Math.floor(((points[2 * i] - xMin) / xs) * G), gy = Math.floor(((points[2 * i + 1] - yMin) / ys) * G)
+    const px = points[2 * i], py = points[2 * i + 1]
+    if (!Number.isFinite(px) || !Number.isFinite(py)) continue   // NaN/Inf object measure → skip
+    let gx = Math.floor(((px - xMin) / xs) * G), gy = Math.floor(((py - yMin) / ys) * G)
     if (gx < 0 || gx > G - 1 || gy < 0 || gy > G - 1) continue
     g[gy * G + gx] += 1
   }

--- a/frontend/src/components/plots/ScatterGL.vue
+++ b/frontend/src/components/plots/ScatterGL.vue
@@ -110,8 +110,10 @@ function density(): Float32Array {
   const fx = new Float32Array(n), fy = new Float32Array(n)        // fractional grid coords
   const clampf = (v: number) => v < 0 ? 0 : v > G - 1 ? G - 1 : v
   for (let i = 0; i < n; i++) {
-    const gx = clampf(((p[2 * i] - xMin) / xs) * (G - 1))
-    const gy = clampf(((p[2 * i + 1] - yMin) / ys) * (G - 1))
+    const px = p[2 * i], py = p[2 * i + 1]
+    if (!Number.isFinite(px) || !Number.isFinite(py)) { fx[i] = 0; fy[i] = 0; continue }  // NaN/Inf → skip binning
+    const gx = clampf(((px - xMin) / xs) * (G - 1))
+    const gy = clampf(((py - yMin) / ys) * (G - 1))
     fx[i] = gx; fy[i] = gy
     grid[Math.floor(gy) * G + Math.floor(gx)] += 1
   }


### PR DESCRIPTION
## Fix: gating on object measurements (NaN extent → plotmeta 500)

### The bug
Object/morphology measurements (`volume`, `convex_hull_area`, `surface_to_volume`, …) carry **NaN/Inf** for degenerate or border objects. `extrema()` propagated a single NaN into `xExtent`/`yExtent`, and **JSON3 refuses to serialize NaN** → `GET /api/gating/plotmeta` **500'd** → the frontend never got axis extents → the plot never rendered or updated for **any** object measure. Fluorescence channels have no NaN, which is why gating worked there.

### Fixes
- **`api/src/gating_api.jl`** — `plotmeta` computes extents via a new `_finite_extrema` (ignores NaN/Inf; falls back when a column is empty/all-non-finite). This is the actual 500 fix.
- **`app/src/gating/density.jl`** — the density path had the same latent bug (`floor(Int, NaN)` would *throw*): `extrema_or` is now finite-only and the binning loop skips non-finite points. Test added.
- **`PlotLayers.vue` / `ScatterGL.vue`** — explicit finite guards so a NaN point never lands in `grid[NaN]` (contour + density-colour binning). The scatter itself already tolerated NaN (WebGL discards NaN vertices); these harden the contour path.

Net: NaN cells simply don't contribute to the plot / extent / contour; everything renders from the finite values.

**Verified**: `test-pkg` 766✓, `test-api` ✓, `vue-tsc` clean.

⚠️ **Server restart required** — `api/src/gating_api.jl` isn't Revise-tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)