### PR TITLE
Add Notebooks: pure-Julia Pluto downstream-analysis Playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ Thumbs.db
 *.swp
 
 # Manifest.toml is intentionally committed — this is an application, so deps are pinned.
+
+# Notebook Playground sysimage — a ~1.4 GB build artifact (rebuild with `pixi run notebooks-sysimage`).
+pluto/deps.so
+# Runtime Pluto session secret (written by pluto/launch.jl; read by the API to build authorized URLs).
+pluto/.plutosecret

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ See also:
 - [`docs/API.md`](docs/API.md) — HTTP/WS surface: routing conventions, binary responses, route index, gating routes (popmap/CRUD/plotdata/density/membership/stats)
 - [`docs/PLOTS.md`](docs/PLOTS.md) — summary-plot design: chart types × data source (one/multi/pooled) × measure type (numeric/categorical), encoding model, the agreed renderer spec
 - [`docs/ANALYSIS.md`](docs/ANALYSIS.md) — the Analysis board (`/analysis`): tabs + comic-plate layout + persistence keys, the registry-driven plot families (summary/interactive/cluster/image), the read-only cluster manager, the gating-strategy plot, and PDF/CSV export (light theme, shared hi-res raster path)
+- [`docs/NOTEBOOKS.md`](docs/NOTEBOOKS.md) — the Notebooks Playground (`/notebooks`): pure-Julia Pluto downstream analysis; the `pluto/` engine env, `CeceliaNb` helpers, per-project registry + snapshot/restore versioning, the deps/full sysimage, and the `/api/notebooks/*` routes
 - [`docs/FUTURE.md`](docs/FUTURE.md) — deliberately deferred optimisations (known-better alternatives set aside): what, why deferred, when to revisit
 - [`docs/ROADMAP.md`](docs/ROADMAP.md) — temporary forward goals: phases (behaviour/HMM → clustering → freeze v1.0 → packaging/distribution → self-update) + post-v1 backlog. Consult before starting a new phase.
 - [`docs/MILESTONES.md`](docs/MILESTONES.md) — durable, append-only ledger of what landed and how it was packaged (the counterpart to the throwaway roadmap). Add an entry at each freeze/release.
@@ -33,6 +34,7 @@ See also:
 | Scheduler, resource pools, barriers, event bus | `docs/SCHEDULER.md` |
 | UI patterns, components, design tokens | `docs/UI.md` |
 | Analysis board: tabs/layout, plot-hosting registries, board export | `docs/ANALYSIS.md` |
+| Notebooks Playground: Pluto engine, `CeceliaNb`, registry/versioning, sysimage, `/api/notebooks/*` | `docs/NOTEBOOKS.md` |
 | **Adding ANY plot (module page OR board)** — registry + `SummaryCanvas`, never a bespoke panel/route | `docs/PLOTS.md` → *Hosting*, `docs/ANALYSIS.md` |
 | Task JSON, registry, module pages, composite pattern | `docs/MODULES.md` |
 | Napari bridge, commands, OME-ZARR, contrast, layer props | `docs/NAPARI.md` |

--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -1,0 +1,407 @@
+# ── Notebook Playground (API layer) ─────────────────────────────────────────────
+# Launch / probe the Pluto notebook server (port 7660) and list a project's notebooks. The Pluto
+# server runs as its OWN Julia process (the pluto/ env, which path-sources Cecelia) — NOT this API
+# server. Lifecycle mirrors the napari bridge: lazy-launch on first request, adopt an already-running
+# server (e.g. one from `pixi run notebooks` or a survivor of a server restart) instead of spawning a
+# duplicate. Secret auth is disabled in pluto/launch.jl (localhost dev tool), so the URL is a plain
+# http://localhost:7660/. See docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md.
+
+const NOTEBOOKS_PORT = 7660
+const NOTEBOOKS_URL  = "http://localhost:$(NOTEBOOKS_PORT)/"
+
+# api/src → repo root → pluto/ (engine env + launch.jl) and notebooks/ (shipped examples).
+_pluto_root()          = abspath(joinpath(@__DIR__, "..", "..", "pluto"))
+_repo_notebooks_dir()  = abspath(joinpath(@__DIR__, "..", "..", "notebooks"))
+_project_notebooks_dir(uid::AbstractString) = joinpath(projects_dir(), uid, "notebooks")
+
+# Pluto's secret protection stays ON (see launch.jl). launch.jl writes the running session's secret
+# here; the frontend appends it to URLs (…/?secret=… and …/open?path=…&secret=…) so only this app can
+# drive the server. "" if not running / not yet written (frontend only uses URLs once running).
+_secret_path()      = joinpath(_pluto_root(), ".plutosecret")
+_notebook_secret()  = isfile(_secret_path()) ? String(strip(read(_secret_path(), String))) : ""
+
+const _nb_proc_ref  = Ref{Union{Base.Process,Nothing}}(nothing)
+const _nb_lock      = ReentrantLock()
+const _nb_starting  = Ref(false)
+const _nb_error     = Ref{Union{String,Nothing}}(nothing)   # last launch failure, surfaced in status
+
+const _SETUP_HINT = "Run `pixi run notebooks-instantiate` once to set up the notebook environment " *
+                    "(and optionally `pixi run notebooks-sysimage` for fast plots), then try again."
+
+# Is the pluto/ env provisioned? Heuristic: a resolved Manifest exists. A fresh clone has the committed
+# Manifest.toml but no downloaded/precompiled packages — that surfaces as a fast launch failure caught
+# below; this pre-check just gives the friendly hint before we even spawn when the Manifest is absent.
+_pluto_env_ready() = isfile(joinpath(_pluto_root(), "Manifest.toml"))
+
+# Alive = the Pluto HTTP server answers on the port. Any HTTP response (200 with secret disabled)
+# counts; a refused connection throws → not alive.
+function _notebook_server_alive()::Bool
+    try
+        HTTP.get(NOTEBOOKS_URL; retry = false, redirect = false,
+                 connect_timeout = 2, read_idle_timeout = 3, status_exception = false)
+        true
+    catch
+        false
+    end
+end
+
+# Ensure the Pluto server is up. Returns true if already serving, false if a launch was just kicked
+# off (still starting). `notebooks_dir` points Pluto's file picker at the active project's notebooks.
+function _ensure_notebook_server!(notebooks_dir::AbstractString)::Bool
+    lock(_nb_lock) do
+        _notebook_server_alive() && return true
+        _nb_starting[] && return false
+
+        pluto_root    = _pluto_root()
+        launch_script = joinpath(pluto_root, "launch.jl")
+        isfile(launch_script) || error("pluto/launch.jl not found at $launch_script")
+        # Friendly first-run guidance before spawning if the env clearly isn't set up.
+        _pluto_env_ready() || error("The notebook environment is not set up. $_SETUP_HINT")
+
+        julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
+        cmd = Cmd(`$julia_exe --project=$pluto_root $launch_script`)
+        cmd = addenv(cmd,
+            "CECELIA_NOTEBOOKS_DIR" => abspath(notebooks_dir),
+            "CECELIA_PLUTO_BROWSER" => "false")
+
+        @info "Launching Pluto notebook server..." notebooks_dir port = NOTEBOOKS_PORT
+        _nb_error[] = nothing
+        proc = run(pipeline(cmd; stdout = stdout, stderr = stderr), wait = false)
+        _nb_proc_ref[] = proc
+        _nb_starting[] = true
+        # Off the request path: wait for the port, OR detect the process dying during startup (the
+        # usual cause: env not instantiated → `using Pluto` fails) and surface a friendly hint.
+        @async begin
+            try
+                for _ in 1:120   # up to ~120 s cold start (first Pluto boot precompiles)
+                    _notebook_server_alive() && break
+                    if process_exited(proc) && !_notebook_server_alive()
+                        _nb_error[] = "The notebook server exited during startup. $_SETUP_HINT"
+                        break
+                    end
+                    sleep(1)
+                end
+            finally
+                lock(_nb_lock) do; _nb_starting[] = false; end
+            end
+        end
+        false
+    end
+end
+
+# POST /api/notebooks/launch  { projectUid }  → { url, starting }
+function api_notebooks_launch(body_bytes::Vector{UInt8})
+    body = JSON3.read(String(body_bytes))
+    uid  = String(get(body, :projectUid, ""))
+    isempty(uid) && return 400, JSON3.write((; error = "projectUid required"))
+    isdir(joinpath(projects_dir(), uid)) || return 404, JSON3.write((; error = "Project not found"))
+
+    nb_dir = _project_notebooks_dir(uid)
+    mkpath(nb_dir)
+    ready = try
+        _ensure_notebook_server!(nb_dir)
+    catch e
+        @warn "Pluto launch failed" exception = e
+        return 500, JSON3.write((; error = "Could not launch notebook server: $(sprint(showerror, e))"))
+    end
+    # 202 while starting (mirrors napari's starting response), 200 once serving.
+    (ready ? 200 : 202), JSON3.write((; url = NOTEBOOKS_URL, secret = _notebook_secret(), starting = !ready))
+end
+
+# GET /api/notebooks/status  → { running, starting, url, error }
+function api_notebooks_status(req::HTTP.Request)
+    running = _notebook_server_alive()
+    200, JSON3.write((; running = running, starting = _nb_starting[], url = NOTEBOOKS_URL,
+                        secret = _notebook_secret(), error = running ? nothing : _nb_error[]))
+end
+
+# Stop the Pluto server. We can only kill a server THIS process spawned (we hold its handle); killing
+# the launcher process terminates Pluto and its Malt workers follow (they exit when the parent drops).
+# An adopted/externally-launched one (e.g. `pixi run notebooks`) isn't ours → direct to stop-by-port.
+function _shutdown_notebook_server!()::Tuple{Bool,String}
+    lock(_nb_lock) do
+        proc = _nb_proc_ref[]
+        _nb_proc_ref[] = nothing
+        _nb_starting[] = false
+        _nb_error[]    = nothing
+        if proc !== nothing && process_running(proc)
+            kill(proc)
+            return true, "stopped"
+        end
+        _notebook_server_alive() &&
+            return false, "The notebook server is running but wasn't started by this app — stop it with `pixi run stop-notebooks`."
+        true, "not running"
+    end
+end
+
+# POST /api/notebooks/shutdown  → { ok, message }
+function api_notebooks_shutdown(body_bytes::Vector{UInt8})
+    ok, msg = _shutdown_notebook_server!()
+    (ok ? 200 : 409), JSON3.write((; ok = ok, message = msg))
+end
+
+# POST /api/notebooks/restart  { projectUid }  → { url, starting }  (relaunches after stopping)
+function api_notebooks_restart(body_bytes::Vector{UInt8})
+    ok, msg = _shutdown_notebook_server!()
+    ok || return 409, JSON3.write((; error = msg))
+    for _ in 1:20                        # let the port free before rebinding
+        _notebook_server_alive() || break
+        sleep(0.25)
+    end
+    api_notebooks_launch(body_bytes)
+end
+
+# Best-effort: take a server WE spawned down when this API process exits cleanly (so a normal server
+# shutdown doesn't orphan Pluto on :7660). Won't fire on SIGKILL — `pixi run stop` also kills :7660.
+atexit() do
+    try
+        p = _nb_proc_ref[]
+        p !== nothing && process_running(p) && kill(p)
+    catch
+    end
+end
+
+# ── Registry (settings/notebooks.json) ──────────────────────────────────────────
+# Per-project notebook metadata (description + version), mirroring how chains/boards persist under
+# settings/ (routes.jl `_settings_dir_for_project`). Keyed by filename; only PROJECT-scope notebooks
+# are registered — shipped examples are read-only (versioned with the code).
+using Dates
+
+_registry_path(uid::AbstractString) = joinpath(_settings_dir_for_project(uid), "notebooks.json")
+
+function _read_registry(uid::AbstractString)::Dict{String,Any}
+    p = _registry_path(uid)
+    isfile(p) || return Dict{String,Any}()
+    try
+        Dict{String,Any}(String(k) => Dict{String,Any}(v)
+                         for (k, v) in JSON3.read(read(p, String), Dict{String,Any}))
+    catch
+        Dict{String,Any}()
+    end
+end
+
+function _write_registry!(uid::AbstractString, reg::AbstractDict)
+    mkpath(_settings_dir_for_project(uid))
+    open(_registry_path(uid), "w") do io; JSON3.write(io, reg); end
+end
+
+# Sanitise a user-supplied notebook name → a safe `*.jl` basename. Rejects (returns nothing) any
+# path-like input — separators or `..` — rather than silently stripping it, plus dotfiles.
+function _safe_nb_file(name)::Union{String,Nothing}
+    n = strip(String(name))
+    isempty(n) && return nothing
+    (occursin('/', n) || occursin('\\', n) || occursin("..", n)) && return nothing
+    endswith(n, ".jl") || (n = n * ".jl")
+    (startswith(n, ".") || !occursin(r"^[A-Za-z0-9._ -]+\.jl$", n)) && return nothing
+    n
+end
+
+_reg_desc(e) = String(get(e, "description", ""))
+# `current` = which snapshot version the LIVE notebook currently reflects (0 = never snapshotted).
+# This is what the UI shows, so a restore to v3 reads back as "v3" (not a monotonic counter).
+_reg_current(e) = Int(get(e, "current", 0))
+
+# Snapshot versions present on disk for a notebook (from .snapshots/<stem>@v<N>.jl). Names are ASCII
+# (_safe_nb_file), so the byte-slice between the "…@v" prefix and ".jl" is safe.
+function _snapshot_versions(uid::AbstractString, file::AbstractString)::Vector{Int}
+    snapdir = joinpath(_project_notebooks_dir(uid), ".snapshots")
+    prefix  = "$(splitext(file)[1])@v"
+    vs = Int[]
+    isdir(snapdir) || return vs
+    for f in readdir(snapdir)
+        (startswith(f, prefix) && endswith(f, ".jl")) || continue
+        v = tryparse(Int, f[(length(prefix) + 1):(length(f) - 3)])
+        v === nothing || push!(vs, v)
+    end
+    vs
+end
+
+# Next snapshot number = one past the highest on disk (robust to manual snapshot edits).
+_next_snapshot_version(uid, file) = (vs = _snapshot_versions(uid, file); isempty(vs) ? 1 : maximum(vs) + 1)
+
+# GET /api/notebooks?projectUid=…  → { notebooks: [{ name, file, scope, description, version }] }
+# scope: "project" (this project's notebooks/, registry-tracked) or "example" (shipped, read-only).
+function api_notebooks_list(req::HTTP.Request)
+    query = HTTP.queryparams(HTTP.URI(req.target))
+    uid   = get(query, "projectUid", "")
+    isempty(uid) && return 400, JSON3.write((; error = "projectUid required"))
+    isdir(joinpath(projects_dir(), uid)) || return 404, JSON3.write((; error = "Project not found"))
+
+    reg = _read_registry(uid)
+    _files(dir) = isdir(dir) ?
+        sort([f for f in readdir(dir) if endswith(f, ".jl") && !startswith(f, ".")]) : String[]
+
+    pdir = _project_notebooks_dir(uid); edir = _repo_notebooks_dir()
+    proj = [(; name = splitext(f)[1], file = f, scope = "project", path = joinpath(pdir, f),
+             description = _reg_desc(get(reg, f, Dict())), version = _reg_current(get(reg, f, Dict())))
+            for f in _files(pdir)]
+    examples = [(; name = splitext(f)[1], file = f, scope = "example", path = joinpath(edir, f),
+                 description = "", version = 0)
+                for f in _files(edir)]
+    200, JSON3.write((; notebooks = vcat(proj, examples)))
+end
+
+# ── Notebook CRUD (project scope) ────────────────────────────────────────────────
+# All resolve the target strictly under {proj}/notebooks/ via _safe_nb_file, so examples (which live
+# in the repo, not the project dir) can't be mutated/deleted here — only duplicated into the project.
+
+# POST /api/notebooks/create  { projectUid, name, description? }  → { file }
+function api_notebooks_create(body_bytes::Vector{UInt8})
+    body = JSON3.read(String(body_bytes))
+    uid  = String(get(body, :projectUid, ""))
+    isempty(uid) && return 400, JSON3.write((; error = "projectUid required"))
+    isdir(joinpath(projects_dir(), uid)) || return 404, JSON3.write((; error = "Project not found"))
+    file = _safe_nb_file(get(body, :name, ""))
+    file === nothing && return 400, JSON3.write((; error = "Invalid notebook name"))
+
+    dir = _project_notebooks_dir(uid); mkpath(dir)
+    dest = joinpath(dir, file)
+    isfile(dest) && return 409, JSON3.write((; error = "Notebook already exists: $file"))
+    template = joinpath(_pluto_root(), "notebook_template.jl")
+    isfile(template) || return 500, JSON3.write((; error = "Template missing: $template"))
+    cp(template, dest)
+
+    reg = _read_registry(uid)
+    reg[file] = Dict{String,Any}("description" => String(get(body, :description, "")),
+                                 "current" => 0, "updatedAt" => string(Dates.now()))
+    _write_registry!(uid, reg)
+    200, JSON3.write((; ok = true, file = file))
+end
+
+# POST /api/notebooks/describe  { projectUid, file, description }  → { ok }
+function api_notebooks_describe(body_bytes::Vector{UInt8})
+    body = JSON3.read(String(body_bytes))
+    uid  = String(get(body, :projectUid, ""))
+    file = _safe_nb_file(get(body, :file, ""))
+    (isempty(uid) || file === nothing) && return 400, JSON3.write((; error = "projectUid + file required"))
+    isfile(joinpath(_project_notebooks_dir(uid), file)) || return 404, JSON3.write((; error = "Notebook not found"))
+
+    reg = _read_registry(uid)
+    e = get(reg, file, Dict{String,Any}("current" => 0))
+    e["description"] = String(get(body, :description, ""))
+    e["updatedAt"]   = string(Dates.now())
+    reg[file] = e
+    _write_registry!(uid, reg)
+    200, JSON3.write((; ok = true))
+end
+
+# POST /api/notebooks/delete  { projectUid, file }  → { ok }
+function api_notebooks_delete(body_bytes::Vector{UInt8})
+    body = JSON3.read(String(body_bytes))
+    uid  = String(get(body, :projectUid, ""))
+    file = _safe_nb_file(get(body, :file, ""))
+    (isempty(uid) || file === nothing) && return 400, JSON3.write((; error = "projectUid + file required"))
+    # Guard: Pluto owns an open notebook's file and can re-create it after deletion. If the server is
+    # up, require an explicit `force` (the UI's confirm supplies it) and tell the user to close it.
+    if get(body, :force, false) !== true && _notebook_server_alive()
+        return 409, JSON3.write((; error = "The notebook server is running — if \"$file\" is open there, close that tab first (an open notebook can be re-created after deletion), then confirm.", serverRunning = true))
+    end
+    dest = joinpath(_project_notebooks_dir(uid), file)
+    isfile(dest) && rm(dest)
+    reg = _read_registry(uid)
+    delete!(reg, file)
+    _write_registry!(uid, reg)
+    200, JSON3.write((; ok = true))
+end
+
+# POST /api/notebooks/duplicate  { projectUid, file, scope, newName? }  → { file }
+# Copies a project OR example notebook into this project's notebooks/ under a fresh name.
+function api_notebooks_duplicate(body_bytes::Vector{UInt8})
+    body  = JSON3.read(String(body_bytes))
+    uid   = String(get(body, :projectUid, ""))
+    file  = _safe_nb_file(get(body, :file, ""))
+    scope = String(get(body, :scope, "project"))
+    (isempty(uid) || file === nothing) && return 400, JSON3.write((; error = "projectUid + file required"))
+    isdir(joinpath(projects_dir(), uid)) || return 404, JSON3.write((; error = "Project not found"))
+
+    src = scope == "example" ? joinpath(_repo_notebooks_dir(), file) : joinpath(_project_notebooks_dir(uid), file)
+    isfile(src) || return 404, JSON3.write((; error = "Source notebook not found"))
+
+    dir = _project_notebooks_dir(uid); mkpath(dir)
+    base = something(_safe_nb_file(get(body, :newName, "")), splitext(file)[1] * "-copy.jl")
+    # Ensure uniqueness: name, name-2, name-3, …
+    stem, ext = splitext(base); dest = joinpath(dir, base); n = 2
+    while isfile(dest); dest = joinpath(dir, "$(stem)-$(n)$(ext)"); n += 1; end
+    cp(src, dest)
+
+    newfile = basename(dest)
+    reg = _read_registry(uid)
+    reg[newfile] = Dict{String,Any}("description" => "Copied from $(scope)/$(file)",
+                                    "current" => 0, "updatedAt" => string(Dates.now()))
+    _write_registry!(uid, reg)
+    200, JSON3.write((; ok = true, file = newfile))
+end
+
+# POST /api/notebooks/snapshot  { projectUid, file }  → { snapshot, version }
+# Freeze an immutable copy to notebooks/.snapshots/<name>@v<N>.jl (N = next number on disk) and set
+# the notebook's `current` to N. Answers "which version made Figure 3" without git/file-watching.
+function api_notebooks_snapshot(body_bytes::Vector{UInt8})
+    body = JSON3.read(String(body_bytes))
+    uid  = String(get(body, :projectUid, ""))
+    file = _safe_nb_file(get(body, :file, ""))
+    (isempty(uid) || file === nothing) && return 400, JSON3.write((; error = "projectUid + file required"))
+    dir  = _project_notebooks_dir(uid)
+    src  = joinpath(dir, file)
+    isfile(src) || return 404, JSON3.write((; error = "Notebook not found"))
+
+    v = _next_snapshot_version(uid, file)
+    snapdir = joinpath(dir, ".snapshots"); mkpath(snapdir)
+    snapname = "$(splitext(file)[1])@v$(v).jl"
+    cp(src, joinpath(snapdir, snapname); force = true)
+
+    reg = _read_registry(uid)
+    e   = get(reg, file, Dict{String,Any}())
+    e["current"]   = v                 # the live notebook now IS this snapshot
+    e["updatedAt"] = string(Dates.now())
+    reg[file] = e
+    _write_registry!(uid, reg)
+    200, JSON3.write((; ok = true, snapshot = snapname, version = v))
+end
+
+# List a notebook's snapshots (newest version first). GET /api/notebooks/snapshots?projectUid=&file=
+function api_notebooks_snapshots(req::HTTP.Request)
+    query = HTTP.queryparams(HTTP.URI(req.target))
+    uid   = get(query, "projectUid", "")
+    file  = _safe_nb_file(get(query, "file", ""))
+    (isempty(uid) || file === nothing) && return 400, JSON3.write((; error = "projectUid + file required"))
+
+    stem  = splitext(file)[1]
+    snaps = sort(_snapshot_versions(uid, file); rev = true)
+    200, JSON3.write((; snapshots = [(; version = v, file = "$(stem)@v$(v).jl") for v in snaps]))
+end
+
+# Restore a snapshot into the live notebook. POST /api/notebooks/restore { projectUid, file, version }
+# Plain overwrite of the live .jl with the chosen snapshot — it does NOT create a snapshot and does
+# NOT bump the version (Snapshot is the explicit way to freeze a version; restore just goes back).
+# Pluto auto-reloads the file (launch.jl `auto_reload_from_file`). The UI two-click-confirms to guard
+# against losing un-snapshotted edits.
+function api_notebooks_restore(body_bytes::Vector{UInt8})
+    body    = JSON3.read(String(body_bytes))
+    uid     = String(get(body, :projectUid, ""))
+    file    = _safe_nb_file(get(body, :file, ""))
+    version = get(body, :version, nothing)
+    (isempty(uid) || file === nothing || version === nothing) &&
+        return 400, JSON3.write((; error = "projectUid + file + version required"))
+    ver = version isa Integer ? Int(version) : tryparse(Int, string(version))
+    ver === nothing && return 400, JSON3.write((; error = "version must be an integer"))
+
+    dir    = _project_notebooks_dir(uid)
+    live   = joinpath(dir, file)
+    isfile(live) || return 404, JSON3.write((; error = "Notebook not found"))
+    chosen = joinpath(dir, ".snapshots", "$(splitext(file)[1])@v$(ver).jl")
+    isfile(chosen) || return 404, JSON3.write((; error = "Snapshot v$ver not found"))
+    # Guard: restoring overwrites the live file, which Pluto may have open (and could re-save its own
+    # copy over). If the server is up, require explicit `force` (UI confirm) and warn to close it.
+    if get(body, :force, false) !== true && _notebook_server_alive()
+        return 409, JSON3.write((; error = "The notebook server is running — if \"$file\" is open there, close that tab first (Pluto may re-save its copy over the restore), then confirm.", serverRunning = true))
+    end
+
+    cp(chosen, live; force = true)   # overwrite live with the chosen snapshot — no implicit snapshot
+    reg = _read_registry(uid)
+    e = get(reg, file, Dict{String,Any}())
+    e["current"]   = ver             # the live notebook now IS version `ver` → the table shows "v{ver}"
+    e["updatedAt"] = string(Dates.now())
+    reg[file] = e
+    _write_registry!(uid, reg)
+    200, JSON3.write((; ok = true, restoredFrom = ver, version = ver))
+end

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -16,6 +16,7 @@ include("plotting_api.jl")
 include("tracking_api.jl")
 include("update_api.jl")
 include("repl_api.jl")
+include("notebooks_api.jl")
 
 # ── WS broadcast ──────────────────────────────────────────────────────────────
 
@@ -156,6 +157,12 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_chains_run(req)
         elseif path == "/api/napari/status"
             api_napari_status(req)
+        elseif path == "/api/notebooks"
+            api_notebooks_list(req)
+        elseif path == "/api/notebooks/status"
+            api_notebooks_status(req)
+        elseif path == "/api/notebooks/snapshots"
+            api_notebooks_snapshots(req)
         elseif path == "/api/gating/channels"
             api_gating_channels(req)
         elseif path == "/api/gating/popmap"
@@ -226,6 +233,24 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_chains_save(body_bytes)
         elseif path == "/api/chains/delete"
             api_chains_delete(body_bytes)
+        elseif path == "/api/notebooks/launch"
+            api_notebooks_launch(body_bytes)
+        elseif path == "/api/notebooks/create"
+            api_notebooks_create(body_bytes)
+        elseif path == "/api/notebooks/describe"
+            api_notebooks_describe(body_bytes)
+        elseif path == "/api/notebooks/delete"
+            api_notebooks_delete(body_bytes)
+        elseif path == "/api/notebooks/duplicate"
+            api_notebooks_duplicate(body_bytes)
+        elseif path == "/api/notebooks/snapshot"
+            api_notebooks_snapshot(body_bytes)
+        elseif path == "/api/notebooks/restore"
+            api_notebooks_restore(body_bytes)
+        elseif path == "/api/notebooks/shutdown"
+            api_notebooks_shutdown(body_bytes)
+        elseif path == "/api/notebooks/restart"
+            api_notebooks_restart(body_bytes)
         elseif path == "/api/napari/open"
             api_napari_open(body_bytes)
         elseif path == "/api/napari/close"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -91,3 +91,67 @@ end
     @test st == 200 && JSON3.read(body).replEnabled == true
     @test _repl("1+1")[1] == 200                      # enabled again
 end
+
+@testset "API: notebooks registry + versioning" begin
+    # Pure name sanitisation: reject path-like input + dotfiles, accept plain names.
+    @test _safe_nb_file("../evil") === nothing
+    @test _safe_nb_file("a/b")     === nothing
+    @test _safe_nb_file("a\\b")    === nothing
+    @test _safe_nb_file(".hidden") === nothing
+    @test _safe_nb_file("my nb")   == "my nb.jl"
+    @test _safe_nb_file("a.b.jl")  == "a.b.jl"
+
+    # Redirect projects_dir() → a temp dir so we never touch the real dev projects dir.
+    conf = cecelia_conf()
+    dirs = get!(conf, "dirs", Dict{String,Any}())
+    had  = haskey(dirs, "projects"); old = get(dirs, "projects", nothing)
+    tmp  = mktempdir()
+    dirs["projects"] = tmp
+    try
+        uid = "TESTNB"
+        mkpath(joinpath(tmp, uid))
+        list()  = JSON3.read(api_notebooks_list(HTTP.Request("GET", "/api/notebooks?projectUid=$uid"))[2]).notebooks
+        find(f) = (ns = filter(n -> n.file == f, list()); isempty(ns) ? nothing : ns[1])
+        snaps() = JSON3.read(api_notebooks_snapshots(HTTP.Request("GET", "/api/notebooks/snapshots?projectUid=$uid&file=nb1.jl"))[2]).snapshots
+
+        # create (+ duplicate-name 409, bad-name 400)
+        @test _post(api_notebooks_create, Dict("projectUid"=>uid, "name"=>"nb1", "description"=>"first"))[1] == 200
+        @test _post(api_notebooks_create, Dict("projectUid"=>uid, "name"=>"nb1"))[1] == 409
+        @test _post(api_notebooks_create, Dict("projectUid"=>uid, "name"=>"../x"))[1] == 400
+        nb = find("nb1.jl")
+        @test nb !== nothing && nb.version == 0 && nb.description == "first"   # fresh → v0
+
+        # snapshot advances the current-version pointer; number derived from disk
+        @test JSON3.read(_post(api_notebooks_snapshot, Dict("projectUid"=>uid,"file"=>"nb1.jl"))[2]).version == 1
+        @test JSON3.read(_post(api_notebooks_snapshot, Dict("projectUid"=>uid,"file"=>"nb1.jl"))[2]).version == 2
+        @test find("nb1.jl").version == 2
+        @test [s.version for s in snaps()] == [2, 1]
+
+        # restore: pointer back to 1, no new snapshot, repeatable (no churn), bad version 404
+        @test JSON3.read(_post(api_notebooks_restore, Dict("projectUid"=>uid,"file"=>"nb1.jl","version"=>1,"force"=>true))[2]).version == 1
+        @test find("nb1.jl").version == 1
+        @test _post(api_notebooks_restore, Dict("projectUid"=>uid,"file"=>"nb1.jl","version"=>1,"force"=>true))[1] == 200
+        @test [s.version for s in snaps()] == [2, 1]
+        @test _post(api_notebooks_restore, Dict("projectUid"=>uid,"file"=>"nb1.jl","version"=>99,"force"=>true))[1] == 404
+
+        # next snapshot after restore = max-on-disk + 1 (→ 3, not "current+1")
+        @test JSON3.read(_post(api_notebooks_snapshot, Dict("projectUid"=>uid,"file"=>"nb1.jl"))[2]).version == 3
+
+        # describe + duplicate
+        @test _post(api_notebooks_describe, Dict("projectUid"=>uid,"file"=>"nb1.jl","description"=>"updated"))[1] == 200
+        @test find("nb1.jl").description == "updated"
+        @test JSON3.read(_post(api_notebooks_duplicate, Dict("projectUid"=>uid,"file"=>"nb1.jl","scope"=>"project"))[2]).file == "nb1-copy.jl"
+        @test find("nb1-copy.jl") !== nothing
+
+        # delete (server not running in tests → guard doesn't require force)
+        @test _post(api_notebooks_delete, Dict("projectUid"=>uid,"file"=>"nb1.jl"))[1] == 200
+        @test find("nb1.jl") === nothing
+
+        # errors
+        @test api_notebooks_list(HTTP.Request("GET", "/api/notebooks?projectUid=NOPE"))[1] == 404
+        @test api_notebooks_list(HTTP.Request("GET", "/api/notebooks"))[1] == 400
+    finally
+        had ? (dirs["projects"] = old) : delete!(dirs, "projects")
+        rm(tmp; recursive = true, force = true)
+    end
+end

--- a/docs/NOTEBOOKS.md
+++ b/docs/NOTEBOOKS.md
@@ -1,0 +1,135 @@
+# Notebooks — the Pluto downstream-analysis Playground
+
+The **Notebooks** section is a home for structured, per-project, **pure-Julia** downstream analysis:
+load objects, pull cell tables via `pop_df`, plot with AlgebraOfGraphics + CairoMakie, export CSVs —
+the work the old R Markdown vignettes did, now versioned and organised. Notebooks run in
+[Pluto](https://plutojl.org/), reactive and reproducible, with no Python in the loop.
+
+> Origin/design history: `docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md`. This file is the durable reference.
+
+## Using it
+
+- **From the app:** the **Notebooks** sidebar item (Analysis group). *Launch server* starts Pluto;
+  *Open Notebooks* opens it in a new tab. The table below manages this project's notebooks.
+- **From the terminal:** `pixi run notebooks` (Pluto on **:7660**), `pixi run stop-notebooks`.
+- **First plot is slow (~20 s)** unless a sysimage is built — `pixi run notebooks-sysimage` (dev).
+  See *Sysimage* below.
+
+## Where things live
+
+```
+pluto/                       ← the notebook ENGINE (its own Julia env; path-sources Cecelia like api/)
+  Project.toml / Manifest    ← Pluto + CairoMakie + AlgebraOfGraphics + DataFrames + CSV + Cecelia + CeceliaNb
+  launch.jl                  ← starts Pluto (:7660), wires the sysimage + CECELIA_PLUTO_ENV
+  build_sysimage.jl          ← deps-only sysimage (dev)      → pluto/deps.so (git-ignored)
+  build_sysimage_full.jl     ← full sysimage (release)       → pluto/deps.so
+  notebook_template.jl       ← starter copied by "Add notebook"
+  CeceliaNb/                 ← small notebook-side helper package (aggregation + AoG plot shortcuts)
+notebooks/                   ← shipped EXAMPLE notebooks (UID-free, versioned with the code)
+  example_populations.jl · example_pop_df.jl · example_object_model.jl
+{project}/notebooks/         ← a project's own notebooks (created/managed from the UI)
+  .snapshots/<name>@v<N>.jl  ← version snapshots
+{project}/settings/notebooks.json  ← per-project registry: { file → {description, version, updatedAt} }
+```
+
+## Authoring a notebook
+
+The **first cell** activates the engine env (so the dev `Cecelia` + `CeceliaNb` resolve — Pluto's
+built-in package manager is registered-only and can't load them):
+
+```julia
+begin
+    import Pkg
+    Pkg.activate(get(ENV, "CECELIA_PLUTO_ENV", joinpath(@__DIR__, "..", "pluto")))
+end
+```
+
+Then the headless REPL contract is all available:
+
+```julia
+using Cecelia, DataFrames, CeceliaNb, AlgebraOfGraphics, CairoMakie, CSV
+Cecelia.init_cecelia!()
+img = init_object(proj_uid, uid)                       # a CciaImage / CciaSet (dispatches on class)
+df  = pop_df(img, "flow", ["/qc"]; value_name = "A")   # cell table (gates evaluated in-process)
+df  = label_props(img; value_name = "A") |> as_df      # or the raw segmentation table
+nb_hist(df, :volume; bins = 40)                        # CeceliaNb plot shortcut
+CSV.write(joinpath(projects_dir(), proj_uid, "exports", "cells.csv"), df)
+```
+
+`run_task(...)` also works — a notebook can re-run pipeline tasks (respect the project lock when
+mutating). Keep shipped examples **UID-free**: read the project/image from `CECELIA_EXAMPLE_*` env or
+editable top cells, never hard-code a UID.
+
+### `CeceliaNb` helpers
+
+Thin, deliberately minimal (grow from real use). `nb_count(df)` / `nb_summary(df, measure; by=…)`
+aggregate a `pop_df` table — **same numbers as the `/analysis` board** (both build on `pop_df`; only
+the rendering differs). `nb_hist` / `nb_box` / `nb_scatter` are one-liners over AlgebraOfGraphics.
+For anything more, use AoG directly: `data(df) * mapping(...) * visual(...) |> draw`.
+
+### Gotcha — `md"..."` interpolation
+
+Julia's single-quoted `md"..."` **cannot contain nested double-quotes inside `$(…)`** (e.g.
+`md"$(join(x, ", "))"` is a parse error). Use **triple-quoted** `md"""..."""` (nested `"` are safe
+there), or compute the string in plain code and interpolate a single variable. Backticks are fine.
+
+## Versioning — snapshots & restore
+
+Provenance without git or file-watching:
+- **Snapshot** (📷) freezes the current notebook to `.snapshots/<name>@v<N>.jl` (N = next number). This
+  is the **only** thing that creates a version.
+- **History** (🕘) opens a version dropdown; **Restore** overwrites the live notebook with the chosen
+  snapshot. It does **not** create a snapshot (so repeated restores don't pile up versions); a
+  two-click confirm guards un-snapshotted edits — snapshot first if you want to keep the current state.
+  Pluto auto-reloads the file (`auto_reload_from_file`), so an open notebook updates live.
+- The **Ver** column shows which snapshot the notebook currently reflects: a fresh notebook is `—`,
+  Snapshot advances it to the new number, and Restore sets it to the version you restored (restore v3
+  → the column reads `v3`). It is a *pointer to current state*, not a monotonic counter.
+
+## Sysimage (why the first plot isn't slow)
+
+Makie compiles plotting code on first use (~20 s cold). A PackageCompiler sysimage bakes that in
+(measured cold-start 32 s → 7.6 s). Built to `pluto/deps.so` (git-ignored, ~1.4 GB, ~10 min):
+`notebooks-sysimage` (dev, deps only — excludes Cecelia so Revise still hot-reloads it) /
+`notebooks-sysimage-full` (release, bakes Cecelia + CeceliaNb in). `launch.jl` picks up `deps.so`
+automatically and passes it to notebook workers; without it, notebooks still work, just slow-first-plot.
+Release packaging: see `docs/SHIPPING.md`.
+
+## API surface (`api/src/notebooks_api.jl`)
+
+The Pluto server is a separate process; lifecycle mirrors napari (probe :7660 → adopt or spawn).
+**Security:** Pluto's secret protection is left ON (its secure default) — Pluto is a browser-reachable
+code-execution surface, so without the secret any website you visit could drive it (CSRF/RCE). We do
+**not** disable it. `launch.jl` publishes the session secret to `pluto/.plutosecret` (git-ignored);
+`launch`/`status` return it and the frontend appends it to URLs (`…/?secret=…`, `…/open?path=…&secret=…`).
+Routes:
+
+| Route | Purpose |
+|---|---|
+| `POST /api/notebooks/launch` | ensure the server is up (202 while starting) → `{url}` |
+| `GET  /api/notebooks/status` | `{running, starting, url}` |
+| `GET  /api/notebooks?projectUid=` | list notebooks (project + example scopes) with description/version/path |
+| `POST /api/notebooks/create` | new notebook from the template |
+| `POST /api/notebooks/describe` | set a notebook's description |
+| `POST /api/notebooks/duplicate` | copy a project/example notebook into the project |
+| `POST /api/notebooks/delete` | delete a project notebook |
+| `POST /api/notebooks/snapshot` | freeze a version |
+| `GET  /api/notebooks/snapshots?projectUid=&file=` | list a notebook's snapshots |
+| `POST /api/notebooks/restore` | restore a snapshot into the live notebook |
+| `POST /api/notebooks/shutdown` | stop the server (only one this app spawned) |
+| `POST /api/notebooks/restart` | stop + relaunch |
+
+### Lifecycle & cleanup
+
+The server is spawned by the API server (`wait=false`) and is **not** bound to it — so it must be
+stopped explicitly, exactly like the napari bridge. Three ways: the **Shut down** / **Restart**
+buttons on the page, `pixi run stop-notebooks` (or `pixi run stop`, which also does :7660), and an
+`atexit` hook that kills a server *this* API process spawned when the server exits cleanly (won't fire
+on SIGKILL — that's what stop-by-port is for). Shutdown/restart can only kill a server this app
+spawned (it holds the process handle); one started by `pixi run notebooks` must be stopped by port.
+Destructive ops (`delete`/`restore`) require `force` when the server is up (the UI's confirm supplies
+it) — see *Versioning*. First-run: if the `pluto/` env isn't set up, launch fails with a hint to run
+`pixi run notebooks-instantiate`.
+
+Frontend: `modules/NotebooksModule.vue` (launch + status) + `components/NotebookTable.vue` (registry
+table, mirrors `ImageTable`). `api/src/*.jl` is **not** Revise-tracked — restart the server after edits.

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -244,6 +244,23 @@ CUDA-only and lives as a commented `[feature.gpu]` stub in `pixi.toml`; when un-
 separate env so non-CUDA platforms fall back to `leidenalg`. GPU is auto-detected at runtime, never a
 task param (`CLAUDE.md`). See `docs/todo/CLUSTERING_PLAN.md`.
 
+### Notebook Playground sysimage (`pluto/deps.so`)
+The Notebooks feature (`docs/NOTEBOOKS.md`) runs Pluto in its own Julia env (`pluto/`, separate from
+`app`/`api` — the API server must not carry the Makie plot stack). Makie's time-to-first-plot is
+~20 s cold; a **PackageCompiler sysimage kills it** (measured 32 s → 7.6 s cold-start). Two builds,
+both → `pluto/deps.so` (git-ignored, ~1.4 GB, ~10 min):
+- **Dev** — `pixi run notebooks-sysimage` — deps only (Makie/CairoMakie/AoG/DataFrames/HDF5/HTTP/CSV),
+  deliberately **excluding Cecelia** so Revise still hot-reloads it.
+- **Release** — `pixi run notebooks-sysimage-full` — also bakes in `Cecelia` + `CeceliaNb` (code is
+  frozen) for near-instant first plot AND first `pop_df`. **Wire this into the release bundle build**
+  (the bundle either ships `deps.so` or builds it on first run — it's too large to commit).
+
+The Pluto server keeps its **secret token ON** (Pluto's secure default): it's a browser-reachable
+code-execution surface, so the secret guards against other local sites/processes driving it (CSRF/RCE).
+`launch.jl` writes the session secret to `pluto/.plutosecret` (git-ignored) and the API threads it into
+the URLs. Do not bind it to a public host. Launched/stopped like napari: `pixi run notebooks` (port
+7660) / `pixi run stop-notebooks`, and the app launches it via `POST /api/notebooks/launch`.
+
 ---
 
 ## Roadmap

--- a/docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md
+++ b/docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md
@@ -1,0 +1,286 @@
+# Notebook Playground — Parked Plan
+
+> Status: **planned, not started.** Parked design (locked decisions + phased build + cross-file
+> architecture) for integrating **Pluto.jl** notebooks into the Cecelia UI as the structured home for
+> post-pipeline downstream analysis. Promote durable parts to a permanent `docs/NOTEBOOKS.md` once built.
+>
+> Origin: the `docs/todo/python-audit-report.md` *Notebooks* section + follow-up discussion. Grounded
+> in the real workflow it replaces — see Motivation.
+
+---
+
+## Motivation (why this is real, not speculative)
+
+The old R version's *actual* downstream analysis lived in ~60 R Markdown vignettes
+(`old-R-shiny-version/vignettes/`), per-experiment. Measured across them: **437 `initCciaObject`,
+170 `runTask`, 169 `popDT`, 806 `ggplot`, 664 `ggsave`, 196 `fwrite`.** This is where the paper
+figures and result tables actually got made — post-pipeline, per-experiment.
+
+Two facts from that corpus shape the whole design:
+1. **It is the primary output-generating workflow** — not exploratory scratch. 664 `ggsave` = these
+   notebooks produce publication figures. So **versioning is provenance** ("which notebook version
+   made Figure 3"), not a nicety.
+2. **It got messy for lack of structure** — 60 ad-hoc files, some 2700 lines, no per-experiment
+   isolation, no descriptions, one-giant-notebook-per-experiment. The structure here targets exactly
+   that.
+
+It is also **100% pure Julia, zero Python** (the Python `.ipynb` were only ever for *developing*
+cecelia's Python parts, never analysis). So this feature has no entanglement with the
+irreducible-Python boundary (`python-audit-report.md`) — it's the cleanest possible addition, and it
+is the **staging ground that makes "don't build a GUI module for every niche analysis" sustainable**:
+a user prototypes a niche analysis in a notebook against `Cecelia.jl`; only if broadly useful does it
+graduate to a GUI module.
+
+The workflow maps ~1:1 to Julia, and the foundation already exists:
+
+| R vignette | Julia | Status |
+|---|---|---|
+| `initCciaObject(pID, uID, versionID)` | `init_object(proj_uid, uid)` | ✅ exists |
+| `cciaObj$runTask(funName, funParams)` | `run_task(...)` | ✅ exists |
+| `cciaObj$popDT(popType, pops, …)` | `pop_df(obj, pop_type, pops; …)` | ✅ exists (documented accessor) |
+| `data.table` wrangling | `DataFrames.jl` | ✅ |
+| ggplot2 / tidyverse | **AoG + CairoMakie** (see Locked #2) | ⚠️ the one new piece |
+
+---
+
+## Locked decisions
+
+1. **Pluto.jl, not Jupyter/IJulia.** Reactive + reproducible (no hidden execution-order state in a
+   shipped artifact), notebooks are `.jl` (text-diffable, versions cleanly with the project — unlike
+   `.ipynb` JSON), Julia-only (no Jupyter/Python kernel stack to add). No `IJulia`/`jupyter` is in the
+   env today, so this adds Pluto rather than replacing anything.
+
+2. **Plotting: AlgebraOfGraphics.jl + CairoMakie.** The notebooks' figure stack — grammar-of-graphics
+   (familiar from ggplot2) with CairoMakie's publication-quality vector output (PDF/SVG/PNG), matching
+   the figure-export workflow. AoG over TidierPlots on maturity (AoG is the established GoG on Makie;
+   TidierPlots is the younger ggplot-syntax clone). Makie's one weakness — slow first plot (TTFP) — is
+   neutralized by the sysimage (Locked #6).
+   - *Out of scope for this plan:* GLMakie / interactive rendering / the future viewer, and the
+     browser-side `/analysis` canvas (Observable Plot + regl — settled, unchanged). Notebooks use
+     CairoMakie only.
+
+3. **Storage — per-project, versioned with the project.**
+   - User notebooks: `{projects_dir}/{proj_uid}/notebooks/*.jl` — isolated per experiment (a notebook
+     for experiment A never appears in B). Registry (path + description + version metadata) in the
+     project manifest `project.json` (written by `save!(proj::CciaProject)`; `docs/OBJECTMODEL.md`).
+   - Shipped **example** notebooks: repo `notebooks/` — versioned with the *code* so they track API
+     changes. **Must be UID-free** (lift hardcoded UIDs like `NRUBxU`/`jFWePN` to a top parameter
+     cell) or a "global example" is secretly dataset-bound.
+   - UI supports "duplicate this notebook into project X" so reuse across experiments doesn't fight
+     the isolation.
+
+4. **Pluto runs its OWN Julia session (`using Cecelia`), NOT the API server.** It is a full analysis
+   surface — **read + `run_task` + plot + export** (not read-only; the R workflow re-ran tasks 170×).
+   - **Concurrency note (not a prohibition):** a `run_task` from a notebook writes to disk directly;
+     if the GUI is concurrently open on the same project, it needs a refresh to see the change. The
+     notebook session must still respect the project lock (`with_transaction`/`.cecelia.lock`,
+     `docs/OBJECTMODEL.md`) when mutating.
+   - This is distinct from the debug console (which talks to the running server) — Pluto is
+     package-direct.
+
+5. **API surface = the existing headless REPL contract:** `init_object`, `run_task`, `pop_df`,
+   `label_props` (+ chain verbs). No new engine code needed for v1 — the notebook just calls these.
+
+6. **Cold-start: sysimage + persistent server, NOT DaemonMode.** (DaemonMode dispatches CLI scripts
+   to a daemon; Pluto manages its own workers and won't route through it — wrong tool.)
+   - **Dev:** a *deps-only* PackageCompiler sysimage (bundle Makie/CairoMakie + DataFrames + HDF5 +
+     HTTP — the stable heavy stuff), **not** Cecelia, so Revise still hot-reloads Cecelia.
+   - **Release:** a *full* sysimage (Cecelia + deps) baked into the Pixi/constructor flow
+     (`docs/SHIPPING.md`) → near-instant first plot.
+   - **Floor (interim):** a `PrecompileTools.@compile_workload` in Cecelia.jl exercising
+     `init_object → pop_df` so even without a sysimage the second launch onward is tolerable.
+   - **Persistent Pluto server** (one process, pointed at the active project's `notebooks/`) so
+     server-launch cost is paid once.
+
+7. **Process/lifecycle mirrors the napari bridge.** New `pixi run notebooks` task launching Pluto on a
+   dedicated port; add a stop-by-port entry to the `stop` task (Linux `lsof`/Windows PowerShell, per
+   the existing pattern in `pixi.toml`). Pick a fixed port (proposed **7660**; confirm free).
+
+8. **UI mirrors `ImageTable.vue` + `stores/project.ts`.** A Playground link launches Pluto; a notebook
+   table lists notebooks with add/remove + a **description/notes** field per row (same pattern as the
+   image table's exclusion notes) + version. Persist all table state per `useViewState` conventions
+   (`docs/UI.md`).
+
+9. **Shared helpers to prevent mess re-accreting.** Ship a few plot/summary helpers so users don't
+   re-roll ggplot boilerplate (the R side extracted `vignettes/app/*.R` for exactly this). Where
+   possible, expose the `pop_df → summary` aggregation so notebooks and the `/analysis` board compute
+   comparisons the same way (rendering differs — Makie vs Observable Plot — but the numbers shouldn't).
+
+---
+
+## Architecture summary
+
+```
+{projects_dir}/{proj_uid}/
+  project.json        ← + "notebooks": [{ file, description, version, … }]  (registry)
+  notebooks/          ← user notebooks (.jl, Pluto), versioned WITH the project
+  ...
+cecelia-pineapple/
+  notebooks/          ← shipped example notebooks (UID-free, track the API), versioned with code
+  pixi.toml           ← + `notebooks` task (Pluto on :7660) + stop-by-port entry
+  frontend/src/       ← Playground link + NotebookTable.vue (mirrors ImageTable.vue)
+  api/src/            ← routes: list/add/remove/describe notebooks; launch/status of Pluto server
+  app/src/            ← PrecompileTools workload; (later) shared plot/summary helpers
+  sysimage build      ← deps-only (dev) / full (release, docs/SHIPPING.md)
+```
+
+Data/render flow: **Vue Playground → launch Pluto (own session, `using Cecelia`) → notebook calls
+`init_object`/`pop_df`/`run_task` → AoG+CairoMakie plots + CSV export saved under the project dir.**
+No API-server round-trip (unlike the debug console).
+
+---
+
+## Phase 0 results (spike complete — 2026-07-08)
+
+**Verdict: the trio does NOT fight. All three friction points cleared; the UX assumption holds.**
+Spike was a throwaway env (Pluto 1.0.3, CairoMakie 0.15, AoG 0.13, Makie 0.24, Julia 1.12) with a
+`Pkg.develop`-tracked Cecelia, run headless against real data (`NRUBxU/KDIeEm`, 1201×45 `.h5ad`).
+
+1. **Dev-Cecelia in a Pluto worker — SOLVED.** Pluto's built-in package manager is registered-only
+   and cannot install an unregistered local dev package. The mechanism that works: the notebook's
+   **first cell does `import Pkg; Pkg.activate(<shared env>)`**, which makes Pluto *disable* its own
+   pkg management for that notebook and inherit the shared env (where Cecelia is dev-tracked). All 8
+   cells of a headless notebook ran clean (`SessionActions.open(...; run_async=false)`), `using
+   Cecelia` → `init_object` → `label_props |> as_df` → AoG/CairoMakie plot.
+2. **Sysimage plumbs through `compiler_options` — CONFIRMED.** `Pluto.Configuration.Options(compiler
+   = CompilerOptions(sysimage = "deps.so"))` reaches the worker; headless notebook run dropped
+   **45.4s → 24.3s**.
+3. **TTFP payoff — real and large** (standalone, warm):
+
+   | | cold (no sysimage) | deps-only sysimage |
+   |---|---|---|
+   | load plotting stack | 5.1s | **0.0s** |
+   | first plot render | **18.8s** | **3.9s** |
+   | total cold-start | 32.3s | **7.6s** |
+
+**Costs quantified (feed into Phase 5 / `docs/SHIPPING.md`):** the deps-only sysimage is **1.4 GB**
+and takes **~10 min** to build (Makie dominates both). One-time build/disk cost, not per-launch. The
+1.4 GB must either ship in the installer or be built on first run — a real shipping decision.
+
+**Resolved open questions:** deps-only sysimage (Makie/CairoMakie/AoG/DataFrames + **HDF5+HTTP as
+direct deps** — `PackageCompiler` requires named pkgs be direct, they're only transitive via Cecelia)
+builds cleanly and keeps Cecelia out so Revise still hot-reloads it (Locked #6 confirmed workable).
+Spike artifacts (throwaway): `scratchpad/nbspike/` — `setup.jl`, `ttfp.jl`, `build_sysimage.jl`,
+`run_pluto_headless.jl`, `spike_notebook.jl`.
+
+---
+
+## Phased build sequence
+
+- **Phase 0 — De-risk spike. ✅ DONE (2026-07-08).** See *Phase 0 results* above. Proved Pluto + a
+  `Pkg.develop`-tracked unregistered Cecelia.jl + a deps-only sysimage via `compiler_options`; TTFP
+  32.3s→7.6s standalone, 45.4s→24.3s in a Pluto worker. Trio does not fight.
+- **Phase 1 — Minimal launch slice. ✅ DONE (2026-07-08).** Shipped:
+  - `pluto/` engine dir (own Julia env, path-sources Cecelia like `api/`): `Project.toml` +
+    committed `Manifest.toml`, `launch.jl` (Pluto on **:7660**, detects `deps.so` → worker
+    `compiler_options`, exports `CECELIA_PLUTO_ENV`, points the file picker at the notebooks dir),
+    `build_sysimage.jl` + `precompile_workload.jl`.
+  - `notebooks/example_populations.jl` — **UID-free** parameterized example (data via editable cells
+    /`CECELIA_EXAMPLE_*` env, self-guiding when blank): `init_object` → `pop_df(img, "labels", [])`
+    (dataset-agnostic ungated accessor) → AoG/CairoMakie histogram → `CSV.write` to `{proj}/exports/`.
+  - `pixi.toml`: `notebooks` / `notebooks-sysimage` / `notebooks-instantiate` + `stop-notebooks`
+    (and :7660 added to `stop`, both linux + win-64). `.gitignore`: `pluto/deps.so`.
+  - **Verified end-to-end headless** against real data (`NRUBxU/KDIeEm`): all cells run clean, plot
+    renders, CSV lands (55 KB). `pixi run notebooks` serves on :7660 (HTTP 403 without secret = alive);
+    `pixi run stop-notebooks` kills it cleanly.
+  - **Gotcha found & fixed:** the `md"..."` macro **cannot take nested double-quotes inside `$(…)`**
+    interpolation (e.g. `md"$(join(x, ", "))"` → parse error). Build such strings in plain code and
+    interpolate a single variable. Backticks inside `md"..."` are fine.
+- **Phase 2 — Notebooks section in Vue. ✅ DONE (2026-07-08).** (Renamed **Playground → Notebooks** —
+  matches `pixi run notebooks`, `/api/notebooks`, the `notebooks/` dir.) Shipped:
+  - **Secret handling — REVISED (kept ON).** An earlier cut disabled Pluto's secret for a clean URL,
+    but `require_secret_for_open_links=false` is a real CSRF/RCE risk (any website could drive
+    localhost:7660 → arbitrary code). Reverted to Pluto's secure defaults; instead `launch.jl` writes
+    the session secret to `pluto/.plutosecret` (git-ignored) and the API returns it so the frontend
+    appends `?secret=…` / `&secret=…`. Verified: `open?path` without secret → 404 (blocked), with
+    secret → 302 (works).
+  - **Backend** `api/src/notebooks_api.jl` (mirrors napari lifecycle: probe :7660 → adopt or spawn
+    `julia --project=pluto launch.jl` pointed at the project's `notebooks/`): `api_notebooks_launch`
+    (POST, 202-while-starting/200), `api_notebooks_status` (GET), `api_notebooks_list` (GET, project +
+    shipped-example scopes). Registered in `server.jl` (GET `/api/notebooks`, `/api/notebooks/status`;
+    POST `/api/notebooks/launch`). **api/ isn't Revise-tracked → restart the server to pick these up.**
+  - **Frontend** `modules/NotebooksModule.vue` + route `/notebooks` (main.ts, lazy) + sidebar entry
+    (Analysis group, `pi-book`). Launch button ensures the server is up, then reveals an
+    `<a target=_blank>` **Open** link (popup-safe — no programmatic `window.open` after await).
+    Read-only notebook list with project/example badges. `vue-tsc -b` clean.
+  - **Verified**: handler direct-call test — launch spawns Pluto on :7660; status→running; list→example
+    (+400/404 error paths); bare URL→HTTP 200. (Did NOT bind a second :8080 — tested handlers directly
+    so the user's running dev server stayed untouched.)
+  - **Known Phase-2 limitation (fine per plan):** one persistent server; its file-picker dir is set at
+    first launch, so switching active project doesn't re-point a running server. `api_notebooks_list`
+    still reads the correct per-project dir regardless. Revisit under the "multi-project" open question.
+- **Phase 3 — Notebook management + versioning. ✅ DONE (2026-07-08).** Shipped:
+  - **Registry in `settings/notebooks.json`** (NOT `project.json` — followed the established
+    chains/boards `settings/` convention instead of adding a persistence-critical `CciaProject`
+    field; canonical-framework rule). Keyed by filename → `{description, version, updatedAt}`; tracks
+    project notebooks only (examples are read-only, versioned with code).
+  - **Backend** (`notebooks_api.jl` + `server.jl`): POST `create` (copies `pluto/notebook_template.jl`),
+    `describe`, `delete`, `duplicate` (project OR example → project, auto-unique name), `snapshot`.
+    `api_notebooks_list` now merges `description`+`version`+`path`. `_safe_nb_file` rejects path-like
+    input (separators/`..`/dotfiles), not just strips it.
+  - **Versioning = manual Snapshot** (chosen from the open-question options — lightest that delivers
+    provenance, no git/file-watching): freezes `notebooks/.snapshots/<name>@v<N>.jl` + bumps a version
+    counter. Answers "which version made Fig 3".
+  - **Frontend** `components/NotebookTable.vue` (mirrors `ImageTable` inline-edit for the description;
+    add / duplicate / snapshot / two-click-confirm delete; per-row Open link when server running) +
+    rewired `NotebooksModule.vue`.
+  - **Verified**: backend CRUD flow (create/dup-409/bad-name-400/list-merge/describe/snapshot×2/
+    duplicate-example/delete) direct-call test; `vue-tsc -b` clean; `pixi run test-api` green.
+- **Phase 4 — Shipped helpers + example port. ✅ DONE (2026-07-08).**
+  - `pluto/CeceliaNb` mini-package (dev-tracked): `nb_count`, `nb_summary` (aggregate a `pop_df`
+    table — **board-identical numbers**, both build on `pop_df`), `nb_hist`/`nb_box`/`nb_scatter` AoG
+    shortcuts. Kept minimal by design.
+  - Ported both **Julia** `.ipynb` demos to UID-free Pluto examples: `populations.ipynb` →
+    `example_pop_df.jl` (flow/live/pooled/tracked tutorial, adaptive to the dataset's gates),
+    `backend_model.ipynb` → `example_object_model.jl` (read-only load/inspect tour; dropped
+    create/import/napari). All three examples verified headless against real data (0 errored cells).
+  - Gotcha refined: single-quoted `md"..."` breaks on nested `"` in `$(…)`; **triple-quoted
+    `md"""..."""` is safe** (that's why one ported cell failed and the other didn't).
+- **Phase 5 — Release hardening. ✅ DONE (2026-07-08).**
+  - **Full sysimage** `build_sysimage_full.jl` + `pixi run notebooks-sysimage-full` (bakes Cecelia +
+    CeceliaNb in for release; dev build still deps-only for Revise). `docs/SHIPPING.md` note added
+    (1.4 GB, ship-or-build-on-first-run, no-secret localhost model).
+  - **Windows lifecycle** — `stop-notebooks` win-64 target already added in Phase 1.
+  - **Versioning completed with Restore** (gap found in testing: Snapshot had no reverse). Added
+    `GET /api/notebooks/snapshots` + `POST /api/notebooks/restore` + Pluto `auto_reload_from_file` so a
+    restore shows live; History → **version dropdown + Restore** (two-click confirm) in `NotebookTable.vue`.
+    Restore is a **plain overwrite** — it does NOT auto-snapshot or bump the version (an earlier
+    auto-snapshot-on-restore design piled up a version per click; removed). Snapshot is the only thing
+    that creates a version. Verified: repeated restores leave snapshots + version counter unchanged.
+  - **Promoted to permanent `docs/NOTEBOOKS.md`** + CLAUDE.md doc-index/table rows.
+  - **Post-build hardening (from testing/review):** (a) versioning "Ver" column now shows the *current*
+    version (restore v3 → v3), not a monotonic counter; restore is a plain overwrite (no version churn);
+    (b) **Shutdown/Restart** buttons + `POST /api/notebooks/{shutdown,restart}` + `atexit` cleanup (the
+    spawned Pluto isn't bound to the API server, so it needs explicit stop — like napari); (c) server-
+    running **guard** on delete/restore (require `force`; UI confirm supplies it) since Pluto owns an
+    open file; (d) friendly **first-run message** when the `pluto/` env isn't instantiated; (e) **API
+    tests** added (`api/test/runtests.jl` — 28 assertions over sanitisation + CRUD + versioning).
+
+---
+
+## Open questions (resolve during build, not blocking the plan)
+
+- **Versioning mechanism.** ✅ **Decided (Phase 3): manual Snapshot** — a `version` counter +
+  copy-to-`.snapshots/<name>@v<N>.jl` on demand. Lightest option that delivers provenance; no git, no
+  file-watching. Could later add auto-snapshot on significant edit or figure-stamping if wanted.
+- **Pluto server port** — ✅ **7660** confirmed free + wired (Phase 1). Still open: whether the backend
+  auto-launches it (like napari) or it stays a manual `pixi run notebooks`. Lean manual for v1.
+- **Windows lifecycle** — mirror the PowerShell stop-by-port pattern already in `pixi.toml`.
+- **Multi-project / concurrent sessions** — one persistent Pluto server serving whichever project is
+  active vs one per project. Start with one server, active-project-scoped.
+- **How much to expose as shared helpers** vs leave to example-notebook patterns (avoid over-building
+  a plotting API nobody asked for — start minimal, grow from real notebook usage).
+
+---
+
+## Cross-references
+
+- `docs/todo/python-audit-report.md` — Notebooks section (origin) + the Python-boundary context.
+- `docs/todo/julia-port-watchlist.md` — the porting discipline this feature complements.
+- `docs/FUTURE.md` — Julia-native viewer (the GLMakie half of the Makie house convention).
+- `docs/ANALYSIS.md`, `docs/PLOTS.md` — the `/analysis` canvas (browser-side; NOT this).
+- `docs/OBJECTMODEL.md` — `project.json`, disk layout, project lock.
+- `docs/SHIPPING.md` — where the release sysimage slots into packaging.
+- `docs/POPULATION.md` — `pop_df` accessor + the headless REPL contract.
+```
+```

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -47,6 +47,7 @@ const groups: { heading: string; items: NavItem[] }[] = [
       { to: '/clust-tracks', label: 'Cluster tracks', icon: 'pi-sitemap',      tip: 'Leiden cluster tracks (motility + HMM/behaviour), then define populations from clusters.', requiresProject: true },
       { to: '/spatial', label: 'Spatial', icon: 'pi-map',          tip: 'Spatial neighbourhood and proximity analysis.', disabled: true, soon: true },
       { to: '/analysis', label: 'Analysis board', icon: 'pi-clone', tip: 'Free-form canvas combining plots across modules, images and segmentations.', requiresProject: true },
+      { to: '/notebooks', label: 'Notebooks', icon: 'pi-book', tip: 'Pure-Julia downstream analysis in Pluto notebooks (load objects, pop_df, plot, export).', requiresProject: true },
     ],
   },
   {

--- a/frontend/src/components/NotebookTable.vue
+++ b/frontend/src/components/NotebookTable.vue
@@ -1,0 +1,326 @@
+<script setup lang="ts">
+// Per-project notebook registry table (Phase 3). Mirrors ImageTable's inline-edit pattern for the
+// description field. Project notebooks are managed (create/describe/snapshot/delete); shipped
+// examples are read-only (duplicate-into-project only). See docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md.
+import { ref, onMounted, watch } from 'vue'
+import { useLogStore } from '../stores/log'
+
+const props = defineProps<{
+  projectUid: string
+  serverUrl: string
+  serverSecret: string
+  serverRunning: boolean
+}>()
+
+const log = useLogStore()
+
+interface Notebook {
+  name: string; file: string; scope: 'project' | 'example'
+  path: string; description: string; version: number
+}
+const notebooks = ref<Notebook[]>([])
+const loading = ref(false)
+const newName = ref('')
+const busy = ref(false)
+
+async function post(path: string, body: Record<string, unknown>) {
+  const res = await fetch(path, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+  })
+  const d = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(d.error ?? `HTTP ${res.status}`)
+  return d
+}
+
+async function refresh() {
+  if (!props.projectUid) return
+  loading.value = true
+  try {
+    const res = await fetch(`/api/notebooks?projectUid=${encodeURIComponent(props.projectUid)}`)
+    const d = await res.json()
+    if (!res.ok) throw new Error(d.error ?? `HTTP ${res.status}`)
+    notebooks.value = d.notebooks ?? []
+  } catch (e) {
+    log.error(`Failed to list notebooks: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
+  } finally {
+    loading.value = false
+  }
+}
+
+async function createNotebook() {
+  const name = newName.value.trim()
+  if (!name || busy.value) return
+  busy.value = true
+  try {
+    await post('/api/notebooks/create', { projectUid: props.projectUid, name })
+    newName.value = ''
+    await refresh()
+    log.info(`Created notebook "${name}".`, { source: 'notebooks' })
+  } catch (e) {
+    log.error(`Create failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
+  } finally {
+    busy.value = false
+  }
+}
+
+async function duplicate(nb: Notebook) {
+  busy.value = true
+  try {
+    const d = await post('/api/notebooks/duplicate', { projectUid: props.projectUid, file: nb.file, scope: nb.scope })
+    await refresh()
+    log.info(`Duplicated to "${d.file}".`, { source: 'notebooks' })
+  } catch (e) {
+    log.error(`Duplicate failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
+  } finally {
+    busy.value = false
+  }
+}
+
+async function snapshot(nb: Notebook) {
+  busy.value = true
+  try {
+    const d = await post('/api/notebooks/snapshot', { projectUid: props.projectUid, file: nb.file })
+    await refresh()
+    if (expandedFile.value === nb.file) await loadSnapshots(nb.file)
+    log.info(`Snapshot ${d.snapshot} saved (now v${d.version}).`, { source: 'notebooks' })
+  } catch (e) {
+    log.error(`Snapshot failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
+  } finally {
+    busy.value = false
+  }
+}
+
+// Version history / restore.
+interface Snapshot { version: number; file: string }
+const expandedFile = ref<string | null>(null)
+const snapshots = ref<Snapshot[]>([])
+const snapsLoading = ref(false)
+const restoreVersion = ref<number | null>(null)   // the version chosen in the dropdown
+
+async function loadSnapshots(file: string) {
+  snapsLoading.value = true
+  confirmingRestore.value = null
+  try {
+    const res = await fetch(`/api/notebooks/snapshots?projectUid=${encodeURIComponent(props.projectUid)}&file=${encodeURIComponent(file)}`)
+    const d = await res.json()
+    if (!res.ok) throw new Error(d.error ?? `HTTP ${res.status}`)
+    snapshots.value = d.snapshots ?? []
+    restoreVersion.value = snapshots.value.length ? snapshots.value[0].version : null   // default: newest
+  } catch (e) {
+    log.error(`Failed to load history: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
+    snapshots.value = []
+    restoreVersion.value = null
+  } finally {
+    snapsLoading.value = false
+  }
+}
+
+function toggleHistory(nb: Notebook) {
+  if (expandedFile.value === nb.file) { expandedFile.value = null; return }
+  expandedFile.value = nb.file
+  loadSnapshots(nb.file)
+}
+
+// Two-click confirm (guards un-snapshotted edits; restore does NOT auto-snapshot).
+const confirmingRestore = ref<string | null>(null)
+async function restore(nb: Notebook) {
+  const version = restoreVersion.value
+  if (version == null) return
+  if (confirmingRestore.value !== nb.file) { confirmingRestore.value = nb.file; return }
+  confirmingRestore.value = null
+  busy.value = true
+  try {
+    await post('/api/notebooks/restore', { projectUid: props.projectUid, file: nb.file, version, force: true })
+    await refresh()
+    if (expandedFile.value === nb.file) await loadSnapshots(nb.file)
+    log.info(`Restored ${nb.file} to v${version}.`, { source: 'notebooks' })
+  } catch (e) {
+    log.error(`Restore failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
+  } finally {
+    busy.value = false
+  }
+}
+
+// Two-click delete confirm (no modal dependency).
+const confirmingDelete = ref<string | null>(null)
+async function remove(nb: Notebook) {
+  if (confirmingDelete.value !== nb.file) { confirmingDelete.value = nb.file; return }
+  confirmingDelete.value = null
+  busy.value = true
+  try {
+    // force: the two-click confirm IS the user's confirmation; satisfies the server-running guard.
+    await post('/api/notebooks/delete', { projectUid: props.projectUid, file: nb.file, force: true })
+    await refresh()
+    log.info(`Deleted notebook "${nb.file}".`, { source: 'notebooks' })
+  } catch (e) {
+    log.error(`Delete failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
+  } finally {
+    busy.value = false
+  }
+}
+
+// Inline description edit (mirrors ImageTable startEdit/commitEdit).
+const editingFile = ref<string | null>(null)
+const editValue = ref('')
+function startEdit(nb: Notebook) {
+  if (nb.scope !== 'project') return          // examples are read-only
+  editingFile.value = nb.file
+  editValue.value = nb.description
+}
+function cancelEdit() { editingFile.value = null }
+function focusEditInput(el: unknown) {
+  const i = el as HTMLInputElement | null
+  if (i && i !== document.activeElement) i.focus()
+}
+async function commitEdit(nb: Notebook) {
+  if (editingFile.value !== nb.file) return
+  editingFile.value = null
+  const val = editValue.value.trim()
+  if ((nb.description ?? '') === val) return
+  try {
+    await post('/api/notebooks/describe', { projectUid: props.projectUid, file: nb.file, description: val })
+    nb.description = val
+  } catch (e) {
+    log.error(`Save description failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
+  }
+}
+
+function openUrl(nb: Notebook) {
+  const s = props.serverSecret ? `&secret=${encodeURIComponent(props.serverSecret)}` : ''
+  return `${props.serverUrl}open?path=${encodeURIComponent(nb.path)}${s}`
+}
+
+onMounted(refresh)
+watch(() => props.projectUid, refresh)
+defineExpose({ refresh })
+</script>
+
+<template>
+  <div class="nbt">
+    <div class="nbt-add">
+      <input v-model="newName" type="text" placeholder="New notebook name…"
+             @keyup.enter="createNotebook" :disabled="busy" />
+      <button class="cc-btn cc-btn-primary" :disabled="busy || !newName.trim()" @click="createNotebook">
+        <i class="pi pi-plus" /> Add notebook
+      </button>
+      <button class="cc-btn cc-btn-ghost" :disabled="loading" @click="refresh">
+        <i class="pi pi-refresh" /> Refresh
+      </button>
+    </div>
+
+    <table class="nbt-table">
+      <thead>
+        <tr><th>Name</th><th>Description</th><th>Ver</th><th>Source</th><th class="nbt-actions-h">Actions</th></tr>
+      </thead>
+      <tbody>
+        <template v-for="nb in notebooks" :key="`${nb.scope}/${nb.file}`">
+        <tr>
+          <td class="nbt-name"><i class="pi pi-file" /> {{ nb.name }}</td>
+
+          <!-- Description: inline-editable for project notebooks -->
+          <td class="nbt-desc">
+            <input v-if="editingFile === nb.file" :ref="focusEditInput" v-model="editValue"
+                   type="text" @blur="commitEdit(nb)" @keyup.enter="commitEdit(nb)" @keyup.esc="cancelEdit" />
+            <span v-else :class="{ 'nbt-editable': nb.scope === 'project', 'nbt-muted': !nb.description }"
+                  @click="startEdit(nb)">
+              {{ nb.description || (nb.scope === 'project' ? 'Add a description…' : '—') }}
+            </span>
+          </td>
+
+          <td class="nbt-ver">{{ nb.scope === 'project' && nb.version ? `v${nb.version}` : '—' }}</td>
+          <td>
+            <span class="nb-badge" :class="`scope-${nb.scope}`">{{ nb.scope }}</span>
+          </td>
+
+          <td class="nbt-actions">
+            <a v-if="serverRunning" class="cc-btn cc-btn-ghost" :href="openUrl(nb)" target="_blank"
+               rel="noopener" v-tooltip.top="'Open in Pluto'"><i class="pi pi-external-link" /></a>
+            <button v-else class="cc-btn cc-btn-ghost" disabled
+                    v-tooltip.top="'Launch the server first'"><i class="pi pi-external-link" /></button>
+
+            <button class="cc-btn cc-btn-ghost" :disabled="busy" @click="duplicate(nb)"
+                    v-tooltip.top="'Duplicate into this project'"><i class="pi pi-copy" /></button>
+
+            <button v-if="nb.scope === 'project'" class="cc-btn cc-btn-ghost" :disabled="busy"
+                    @click="snapshot(nb)" v-tooltip.top="'Snapshot this version (provenance)'">
+              <i class="pi pi-camera" />
+            </button>
+
+            <button v-if="nb.scope === 'project'" class="cc-btn cc-btn-ghost"
+                    :class="{ 'nbt-active': expandedFile === nb.file }" :disabled="busy"
+                    @click="toggleHistory(nb)" v-tooltip.top="'Version history / restore'">
+              <i class="pi pi-history" />
+            </button>
+
+            <button v-if="nb.scope === 'project'"
+                    class="cc-btn cc-btn-ghost" :class="{ 'nbt-danger': confirmingDelete === nb.file }"
+                    :disabled="busy" @click="remove(nb)"
+                    v-tooltip.top="confirmingDelete === nb.file
+                      ? (serverRunning ? 'Server running — close this notebook in Pluto first, then click to confirm' : 'Click again to confirm')
+                      : 'Delete'">
+              <i class="pi" :class="confirmingDelete === nb.file ? 'pi-check' : 'pi-trash'" />
+            </button>
+          </td>
+        </tr>
+
+        <!-- Version history / restore panel -->
+        <tr v-if="expandedFile === nb.file" class="nbt-history-row">
+          <td colspan="5">
+            <div class="nbt-history">
+              <span v-if="snapsLoading" class="nbt-muted">Loading history…</span>
+              <span v-else-if="!snapshots.length" class="nbt-muted">
+                No snapshots yet — click <i class="pi pi-camera" /> to freeze this version.
+              </span>
+              <template v-else>
+                <label class="nbt-hist-label">Restore to version</label>
+                <select v-model.number="restoreVersion" :disabled="busy"
+                        @change="confirmingRestore = null">
+                  <option v-for="s in snapshots" :key="s.version" :value="s.version">v{{ s.version }}</option>
+                </select>
+                <button class="cc-btn" :class="confirmingRestore === nb.file ? 'cc-btn-primary' : 'cc-btn-ghost'"
+                        :disabled="busy || restoreVersion == null" @click="restore(nb)"
+                        v-tooltip.top="confirmingRestore === nb.file
+                          ? (serverRunning ? 'Server running — close this notebook in Pluto first, then confirm' : 'Click Confirm to overwrite the current notebook')
+                          : 'Overwrites the current notebook — snapshot first if you want to keep it'">
+                  <i class="pi pi-replay" /> {{ confirmingRestore === nb.file ? 'Confirm restore' : 'Restore' }}
+                </button>
+              </template>
+            </div>
+          </td>
+        </tr>
+        </template>
+        <tr v-if="!notebooks.length && !loading">
+          <td colspan="5" class="nbt-empty">No notebooks yet — add one, or duplicate an example.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<style scoped>
+.nbt-add { display: flex; align-items: center; gap: .5rem; margin-bottom: .75rem; }
+.nbt-add input { flex: 0 1 240px; }
+.nbt-table { width: 100%; border-collapse: collapse; font-size: .9rem; }
+.nbt-table th, .nbt-table td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--cc-border, #2a2a2a); }
+.nbt-table th { color: var(--cc-text-muted, #888); font-weight: 600; }
+.nbt-name { white-space: nowrap; }
+.nbt-desc input { width: 100%; }
+.nbt-editable { cursor: text; }
+.nbt-muted { color: var(--cc-text-muted, #888); font-style: italic; }
+.nbt-ver { white-space: nowrap; color: var(--cc-text-muted, #888); }
+.nbt-actions-h { text-align: right; }
+.nbt-actions { display: flex; gap: .3rem; justify-content: flex-end; }
+.nbt-actions .cc-btn { padding: .25rem .45rem; }
+.nbt-danger { color: #f85149; }
+.nbt-active { color: #58a6ff; }
+.nbt-empty { color: var(--cc-text-muted, #888); text-align: center; padding: 1rem; }
+.nbt-history-row td { background: var(--cc-surface-2, rgba(255,255,255,0.03)); }
+.nbt-history { display: flex; align-items: center; flex-wrap: wrap; gap: .5rem; font-size: .85rem; }
+.nbt-hist-label { color: var(--cc-text-muted, #888); }
+.nbt-snap { display: inline-flex; align-items: center; gap: .25rem; border: 1px solid var(--cc-border, #333); border-radius: 6px; padding: .1rem .1rem .1rem .5rem; }
+.nbt-snap-ver { font-variant-numeric: tabular-nums; }
+.nbt-snap .cc-btn { padding: .15rem .4rem; }
+.nb-badge { font-size: .72rem; padding: .1rem .45rem; border-radius: 999px; border: 1px solid var(--cc-border, #333); }
+.nb-badge.scope-project { color: #58a6ff; border-color: #58a6ff55; }
+.nb-badge.scope-example { color: #888; }
+</style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -27,6 +27,7 @@ const router = createRouter({
     { path: '/clust-cells',  component: () => import('./modules/ClusterCellsModule.vue'),  meta: { label: 'Cluster cells' } },
     { path: '/clust-tracks', component: () => import('./modules/ClusterTracksModule.vue'), meta: { label: 'Cluster tracks' } },
     { path: '/analysis',  component: () => import('./modules/AnalysisModule.vue'),      meta: { label: 'Analysis board' } },
+    { path: '/notebooks', component: () => import('./modules/NotebooksModule.vue'),     meta: { label: 'Notebooks' } },
     { path: '/tasks',     component: () => import('./modules/TasksModule.vue'),         meta: { label: 'Tasks' } },
     { path: '/chain',     component: () => import('./modules/ChainModule.vue'),         meta: { label: 'Whiteboard' } },
     { path: '/settings',  component: () => import('./modules/SettingsModule.vue'),      meta: { label: 'Settings' } },

--- a/frontend/src/modules/NotebooksModule.vue
+++ b/frontend/src/modules/NotebooksModule.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+// Notebooks — the Pluto notebook Playground: launch the (pure-Julia) notebook server and manage this
+// project's notebooks (add / describe / snapshot / delete + duplicate examples). The server runs as
+// its own process (api/src/notebooks_api.jl); this page launches/probes it and opens it in a new tab.
+// See docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md.
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useProjectMetaStore } from '../stores/projectMeta'
+import NotebookTable from '../components/NotebookTable.vue'
+
+const projectMeta = useProjectMetaStore()
+
+type ServerState = 'unknown' | 'stopped' | 'starting' | 'running'
+const server = ref<ServerState>('unknown')
+const url = ref('http://localhost:7660/')
+const secret = ref('')
+const errorMsg = ref('')
+
+// Pluto requires a secret (see launch.jl); append it so the browser is authorized.
+const homeUrl = computed(() => secret.value ? `${url.value}?secret=${encodeURIComponent(secret.value)}` : url.value)
+
+const projectUid = computed(() => projectMeta.current?.uid ?? '')
+const hasProject = computed(() => projectMeta.hasProject)
+const serverRunning = computed(() => server.value === 'running')
+
+let poll: number | undefined
+
+function stopPoll() { if (poll) { clearInterval(poll); poll = undefined } }
+
+function startPolling() {
+  stopPoll()
+  poll = window.setInterval(async () => {
+    await refreshStatus()
+    // stop once it's up OR a startup error surfaced (e.g. env not set up)
+    if (server.value === 'running' || errorMsg.value) {
+      stopPoll()
+      if (errorMsg.value) server.value = 'stopped'
+    }
+  }, 2000)
+}
+
+async function refreshStatus() {
+  try {
+    const d = await (await fetch('/api/notebooks/status')).json()
+    url.value = d.url ?? url.value
+    secret.value = d.secret ?? ''
+    server.value = d.running ? 'running' : (d.starting ? 'starting' : 'stopped')
+    if (d.error) errorMsg.value = d.error
+    else if (d.running) errorMsg.value = ''
+  } catch {
+    server.value = 'stopped'
+  }
+}
+
+async function launch() {
+  if (!projectUid.value) return
+  errorMsg.value = ''
+  server.value = 'starting'
+  try {
+    const res = await fetch('/api/notebooks/launch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid: projectUid.value }),
+    })
+    const d = await res.json().catch(() => ({}))
+    if (!res.ok) throw new Error(d.error ?? `HTTP ${res.status}`)
+    url.value = d.url ?? url.value
+    secret.value = d.secret ?? ''
+    if (!d.starting) { server.value = 'running'; return }
+    startPolling()
+  } catch (e) {
+    server.value = 'stopped'
+    errorMsg.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+async function restart() {
+  if (!projectUid.value) return
+  errorMsg.value = ''
+  server.value = 'starting'
+  try {
+    const res = await fetch('/api/notebooks/restart', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid: projectUid.value }),
+    })
+    const d = await res.json().catch(() => ({}))
+    if (!res.ok) throw new Error(d.error ?? `HTTP ${res.status}`)
+    url.value = d.url ?? url.value
+    secret.value = d.secret ?? ''
+    if (!d.starting) { server.value = 'running'; return }
+    startPolling()
+  } catch (e) {
+    server.value = 'stopped'
+    errorMsg.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+async function shutdown() {
+  stopPoll()
+  try {
+    const res = await fetch('/api/notebooks/shutdown', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+    })
+    const d = await res.json().catch(() => ({}))
+    if (!res.ok) errorMsg.value = d.error ?? `HTTP ${res.status}`
+  } catch (e) {
+    errorMsg.value = e instanceof Error ? e.message : String(e)
+  }
+  await refreshStatus()
+}
+
+onMounted(refreshStatus)
+onUnmounted(stopPoll)
+</script>
+
+<template>
+  <div class="notebooks-page">
+    <header class="nb-header">
+      <h1><i class="pi pi-book" /> Notebooks</h1>
+      <p class="nb-sub">
+        Pure-Julia downstream analysis with <strong>Pluto</strong> — load objects, pull cell tables
+        via <code>pop_df</code>, plot, and export. Runs in its own Julia session.
+      </p>
+    </header>
+
+    <div v-if="!hasProject" class="nb-empty">
+      <i class="pi pi-lock" /> Open or create a project first.
+    </div>
+
+    <template v-else>
+      <!-- Server launch / status -->
+      <section class="nb-section">
+        <div class="nb-server-row">
+          <span class="nb-status" :class="`is-${server}`">
+            <i class="pi" :class="server === 'running' ? 'pi-circle-fill'
+                                 : server === 'starting' ? 'pi-spin pi-spinner'
+                                 : 'pi-circle'" />
+            {{ server === 'running' ? 'Server running'
+             : server === 'starting' ? 'Starting…'
+             : server === 'stopped' ? 'Not running' : 'Checking…' }}
+          </span>
+
+          <button v-if="server !== 'running'" class="cc-btn cc-btn-primary"
+                  :disabled="server === 'starting'" @click="launch">
+            <i class="pi pi-play" /> Launch server
+          </button>
+
+          <template v-else>
+            <a class="cc-btn cc-btn-primary" :href="homeUrl" target="_blank" rel="noopener">
+              <i class="pi pi-external-link" /> Open Notebooks
+            </a>
+            <button class="cc-btn cc-btn-ghost" @click="restart" v-tooltip.top="'Stop and relaunch the notebook server'">
+              <i class="pi pi-refresh" /> Restart
+            </button>
+            <button class="cc-btn cc-btn-ghost" @click="shutdown" v-tooltip.top="'Stop the notebook server'">
+              <i class="pi pi-power-off" /> Shut down
+            </button>
+          </template>
+        </div>
+        <p v-if="server === 'starting'" class="nb-hint">
+          First launch precompiles — this can take up to a minute.
+        </p>
+        <p v-if="errorMsg" class="nb-error"><i class="pi pi-exclamation-triangle" /> {{ errorMsg }}</p>
+      </section>
+
+      <!-- Notebook registry (Phase 3: manage + version) -->
+      <section class="nb-section">
+        <h2>Notebooks</h2>
+        <NotebookTable :project-uid="projectUid" :server-url="url" :server-secret="secret" :server-running="serverRunning" />
+      </section>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.notebooks-page { padding: 1.25rem 1.5rem; max-width: 980px; }
+.nb-header h1 { display: flex; align-items: center; gap: .5rem; margin: 0 0 .25rem; font-size: 1.4rem; }
+.nb-sub { color: var(--cc-text-muted, #888); margin: 0 0 1rem; max-width: 640px; }
+.nb-empty { display: flex; align-items: center; gap: .5rem; color: var(--cc-text-muted, #888); padding: 2rem 0; }
+.nb-section { margin-bottom: 1.5rem; }
+.nb-section h2 { font-size: 1.05rem; margin: 0 0 .5rem; }
+.nb-server-row { display: flex; align-items: center; gap: 1rem; }
+.nb-status { display: inline-flex; align-items: center; gap: .4rem; font-size: .9rem; }
+.nb-status.is-running .pi { color: #3fb950; }
+.nb-status.is-stopped .pi, .nb-status.is-unknown .pi { color: var(--cc-text-muted, #888); }
+.nb-hint { color: var(--cc-text-muted, #888); font-size: .85rem; margin: .5rem 0 0; }
+.nb-error { color: #f0883e; font-size: .85rem; margin: .5rem 0 0; display: flex; align-items: center; gap: .4rem; }
+</style>

--- a/notebooks/example_object_model.jl
+++ b/notebooks/example_object_model.jl
@@ -1,0 +1,103 @@
+### A Pluto.jl notebook ###
+# v1.0.3
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ a1000000-0000-0000-0000-000000000000
+begin
+    import Pkg
+    Pkg.activate(get(ENV, "CECELIA_PLUTO_ENV", joinpath(@__DIR__, "..", "pluto")))
+end
+
+# ╔═╡ a2000000-0000-0000-0000-000000000000
+using Cecelia, DataFrames
+
+# ╔═╡ a0000000-0000-0000-0000-000000000000
+md"""
+# The object model — navigating a project (read-only)
+
+A quick tour of `load_project` / `init_object`: how a project, its sets, and its images fit together
+on disk, and how to reach the segmentations of an image. Read-only — it never writes. (Creating
+projects, importing images and opening Napari are done through the app UI, not notebooks.)
+Ported from the old `backend_model.ipynb`.
+"""
+
+# ╔═╡ a3000000-0000-0000-0000-000000000000
+Cecelia.init_cecelia!()
+
+# ╔═╡ b0000000-0000-0000-0000-000000000000
+proj_uid = get(ENV, "CECELIA_EXAMPLE_PROJ", "")   # ← your project UID
+
+# ╔═╡ b1000000-0000-0000-0000-000000000000
+md"## 1 · The project"
+
+# ╔═╡ b2000000-0000-0000-0000-000000000000
+proj = isempty(proj_uid) ? nothing : load_project(proj_uid)
+
+# ╔═╡ b3000000-0000-0000-0000-000000000000
+proj === nothing ? md"➡️ set `proj_uid` above (or `CECELIA_EXAMPLE_PROJ`)." :
+    md"**$(proj.name)** · kind `$(proj.kind)` · $(length(proj.set_uids)) set(s)"
+
+# ╔═╡ c0000000-0000-0000-0000-000000000000
+md"""
+## 2 · Sets and their images
+
+`init_object(projectUID, uid)` dispatches on the stored `class` field — a set UID returns a
+`CciaSet`, an image UID a `CciaImage`. Here we list each set and its member images.
+"""
+
+# ╔═╡ c1000000-0000-0000-0000-000000000000
+set_table = proj === nothing ? DataFrame() : let rows = NamedTuple[]
+    for suid in proj.set_uids
+        s = init_object(proj_uid, suid)
+        push!(rows, (; set = s.name, set_uid = suid, images = length(s.image_uids),
+                       image_uids = join(s.image_uids, ", ")))
+    end
+    DataFrame(rows)
+end
+
+# ╔═╡ d0000000-0000-0000-0000-000000000000
+md"## 3 · An image and its segmentations"
+
+# ╔═╡ d1000000-0000-0000-0000-000000000000
+# First image of the first set (or set CECELIA_EXAMPLE_UID to pick one).
+img_uid = let e = get(ENV, "CECELIA_EXAMPLE_UID", "")
+    !isempty(e) ? e :
+    (proj !== nothing && !isempty(proj.set_uids)) ?
+        (first(init_object(proj_uid, first(proj.set_uids)).image_uids)) : ""
+end
+
+# ╔═╡ d2000000-0000-0000-0000-000000000000
+img = (proj === nothing || isempty(img_uid)) ? nothing : init_object(proj_uid, img_uid)
+
+# ╔═╡ d3000000-0000-0000-0000-000000000000
+img === nothing ? md"_(no image resolved)_" :
+    md"""
+    **$(img.name)** (`$(img_uid)`)
+    - segmentations: **$(join([v for v in value_names(img.label_props) if v != "_active"], ", "))**
+    - active: **$(get(img.label_props, "_active", "—"))**
+    """
+
+# ╔═╡ d4000000-0000-0000-0000-000000000000
+md"""
+From here, `pop_df(img, pop_type, pops; value_name=…)` and `label_props(img; value_name=…) |> as_df`
+give you the cell tables — see `example_pop_df.jl` and `example_populations.jl`.
+"""
+
+# ╔═╡ Cell order:
+# ╟─a0000000-0000-0000-0000-000000000000
+# ╠═a1000000-0000-0000-0000-000000000000
+# ╠═a2000000-0000-0000-0000-000000000000
+# ╠═a3000000-0000-0000-0000-000000000000
+# ╠═b0000000-0000-0000-0000-000000000000
+# ╟─b1000000-0000-0000-0000-000000000000
+# ╠═b2000000-0000-0000-0000-000000000000
+# ╟─b3000000-0000-0000-0000-000000000000
+# ╟─c0000000-0000-0000-0000-000000000000
+# ╠═c1000000-0000-0000-0000-000000000000
+# ╟─d0000000-0000-0000-0000-000000000000
+# ╠═d1000000-0000-0000-0000-000000000000
+# ╠═d2000000-0000-0000-0000-000000000000
+# ╟─d3000000-0000-0000-0000-000000000000
+# ╟─d4000000-0000-0000-0000-000000000000

--- a/notebooks/example_pop_df.jl
+++ b/notebooks/example_pop_df.jl
@@ -1,0 +1,161 @@
+### A Pluto.jl notebook ###
+# v1.0.3
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ a1000000-0000-0000-0000-000000000000
+# Activate the Notebooks env (path-sources dev Cecelia + CeceliaNb helpers). Keep this first.
+begin
+    import Pkg
+    Pkg.activate(get(ENV, "CECELIA_PLUTO_ENV", joinpath(@__DIR__, "..", "pluto")))
+end
+
+# ╔═╡ a2000000-0000-0000-0000-000000000000
+using Cecelia, DataFrames, CeceliaNb
+
+# ╔═╡ a0000000-0000-0000-0000-000000000000
+md"""
+# Populations — the `pop_df` accessor
+
+How to pull populations out of an image with the unified `pop_df` accessor: gated cells of a
+segmentation (`flow`), several pooled into one table, and the **tracked** subset (`live`). `pop_df`
+reads the H5AD via the `label_props` chain, evaluates gates in-process, and pools across
+segmentations — see `docs/POPULATION.md`. Ported from the old `populations.ipynb`, now UID-free.
+"""
+
+# ╔═╡ a3000000-0000-0000-0000-000000000000
+Cecelia.init_cecelia!()
+
+# ╔═╡ b0000000-0000-0000-0000-000000000000
+md"## 1 · Load the image"
+
+# ╔═╡ b1000000-0000-0000-0000-000000000000
+proj_uid = get(ENV, "CECELIA_EXAMPLE_PROJ", "")   # ← your project UID
+
+# ╔═╡ b2000000-0000-0000-0000-000000000000
+uid = get(ENV, "CECELIA_EXAMPLE_UID", "")         # ← your image UID
+
+# ╔═╡ b3000000-0000-0000-0000-000000000000
+img = (isempty(proj_uid) || isempty(uid)) ? nothing : init_object(proj_uid, uid)
+
+# ╔═╡ b4000000-0000-0000-0000-000000000000
+# `label_props` keys are the segmentations (value_names); `_active` is the default one.
+segs = img === nothing ? String[] : [v for v in value_names(img.label_props) if v != "_active"]
+
+# ╔═╡ b5000000-0000-0000-0000-000000000000
+img === nothing ? md"➡️ set `proj_uid` + `uid` above (or `CECELIA_EXAMPLE_PROJ`/`_UID`)." :
+    md"""Loaded **$(img.name)** — segmentations: **$(join(segs, ", "))**"""
+
+# ╔═╡ c0000000-0000-0000-0000-000000000000
+md"""
+## 2 · What's gated on each segmentation?
+
+Each segmentation has its own gating sidecar `gating/{value_name}.json`. List the flow population
+paths per segmentation. Set `flow_pop` below to the leaf name you want to pull.
+"""
+
+# ╔═╡ c1000000-0000-0000-0000-000000000000
+gated = img === nothing ? DataFrame() :
+    DataFrame(value_name = segs,
+              pops = [join(pop_paths(load_pop_map(img; value_name = vn, pop_type = "flow")), ", ")
+                      for vn in segs])
+
+# ╔═╡ c2000000-0000-0000-0000-000000000000
+# Leaf name of the population to pull (must exist in the gated list above). Auto-picks the first
+# non-root population found if you leave it blank.
+flow_pop = let
+    override = get(ENV, "CECELIA_EXAMPLE_POP", "")
+    if !isempty(override)
+        override
+    elseif img === nothing
+        ""
+    else
+        leaves = String[]
+        for vn in segs, p in pop_paths(load_pop_map(img; value_name = vn, pop_type = "flow"))
+            p == "/" || push!(leaves, pop_name(p))
+        end
+        isempty(leaves) ? "" : first(unique(leaves))
+    end
+end
+
+# ╔═╡ d0000000-0000-0000-0000-000000000000
+md"""
+## 3 · Flow populations — one segmentation at a time
+
+A **leading-slash** path (`"/qc"`) is resolved *within* the `value_name` segmentation. Membership is
+computed by evaluating the gate in-process; intensity columns come back under their channel names.
+"""
+
+# ╔═╡ d1000000-0000-0000-0000-000000000000
+# Guarded pull — returns an empty frame (not an error) if the population isn't present.
+safe_pop_df(args...; kw...) = try pop_df(args...; kw...) catch; DataFrame() end
+
+# ╔═╡ d2000000-0000-0000-0000-000000000000
+per_seg = (img === nothing || isempty(flow_pop)) ? DataFrame() :
+    DataFrame(value_name = segs,
+              n = [nrow(safe_pop_df(img, "flow", ["/$(flow_pop)"]; value_name = vn)) for vn in segs])
+
+# ╔═╡ e0000000-0000-0000-0000-000000000000
+md"""
+## 4 · Pool all segmentations in one call
+
+A **prefixed** path (`"A/qc"`) names its own value_name, so one call pulls the population from
+several segmentations and `vcat`s them into a single table with a `value_name` column. `nb_count`
+(from `CeceliaNb`) tallies cells per `(value_name, pop)` — the same numbers the Analysis board shows.
+"""
+
+# ╔═╡ e1000000-0000-0000-0000-000000000000
+pooled = (img === nothing || isempty(flow_pop)) ? DataFrame() :
+    safe_pop_df(img, "flow", ["$(vn)/$(flow_pop)" for vn in segs])
+
+# ╔═╡ e2000000-0000-0000-0000-000000000000
+nb_count(pooled)
+
+# ╔═╡ f0000000-0000-0000-0000-000000000000
+md"""
+## 5 · Tracked (`live`) populations — the `_tracked` derived filter
+
+`_tracked` is a **derived filtered population**: the parent gate intersected with `track_id > 0`.
+For `pop_type="live"`, `pop_df` layers this filter on at read time (there is no `live` gating file).
+Tracked cells are a subset of the gated cells — the same cells, minus those that never got a track.
+"""
+
+# ╔═╡ f1000000-0000-0000-0000-000000000000
+tracked = (img === nothing || isempty(flow_pop)) ? DataFrame() :
+    safe_pop_df(img, "live", ["$(vn)/$(flow_pop)/_tracked" for vn in segs]; pop_cols = ["track_id"])
+
+# ╔═╡ f2000000-0000-0000-0000-000000000000
+nb_count(tracked)
+
+# ╔═╡ f3000000-0000-0000-0000-000000000000
+# gated vs tracked, side by side
+(isempty(pooled) || isempty(tracked)) ? md"_(no gated/tracked data yet)_" :
+    leftjoin(rename(nb_count(pooled), :n => :gated),
+             rename(select(nb_count(tracked), :value_name, :n), :n => :tracked),
+             on = :value_name)
+
+# ╔═╡ Cell order:
+# ╟─a0000000-0000-0000-0000-000000000000
+# ╠═a1000000-0000-0000-0000-000000000000
+# ╠═a2000000-0000-0000-0000-000000000000
+# ╠═a3000000-0000-0000-0000-000000000000
+# ╟─b0000000-0000-0000-0000-000000000000
+# ╠═b1000000-0000-0000-0000-000000000000
+# ╠═b2000000-0000-0000-0000-000000000000
+# ╠═b3000000-0000-0000-0000-000000000000
+# ╠═b4000000-0000-0000-0000-000000000000
+# ╟─b5000000-0000-0000-0000-000000000000
+# ╟─c0000000-0000-0000-0000-000000000000
+# ╠═c1000000-0000-0000-0000-000000000000
+# ╠═c2000000-0000-0000-0000-000000000000
+# ╟─d0000000-0000-0000-0000-000000000000
+# ╠═d1000000-0000-0000-0000-000000000000
+# ╠═d2000000-0000-0000-0000-000000000000
+# ╟─e0000000-0000-0000-0000-000000000000
+# ╠═e1000000-0000-0000-0000-000000000000
+# ╠═e2000000-0000-0000-0000-000000000000
+# ╟─f0000000-0000-0000-0000-000000000000
+# ╠═f1000000-0000-0000-0000-000000000000
+# ╠═f2000000-0000-0000-0000-000000000000
+# ╠═f3000000-0000-0000-0000-000000000000

--- a/notebooks/example_populations.jl
+++ b/notebooks/example_populations.jl
@@ -1,0 +1,149 @@
+### A Pluto.jl notebook ###
+# v1.0.3
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ a1000000-0000-0000-0000-000000000000
+# Activate the shared Playground env (path-sources the dev Cecelia). Doing Pkg ops here makes Pluto
+# disable its own registered-only package manager for this notebook — required for the local dev pkg.
+begin
+    import Pkg
+    Pkg.activate(get(ENV, "CECELIA_PLUTO_ENV", joinpath(@__DIR__, "..", "pluto")))
+end
+
+# ╔═╡ a2000000-0000-0000-0000-000000000000
+using Cecelia
+
+# ╔═╡ a3000000-0000-0000-0000-000000000000
+using DataFrames, AlgebraOfGraphics, CairoMakie, CSV
+
+# ╔═╡ a0000000-0000-0000-0000-000000000000
+md"""
+# Cecelia Playground — population summary (example)
+
+A **pure-Julia** downstream-analysis notebook. It loads a Cecelia image object, pulls its cell table
+through the documented `pop_df` accessor, plots a measurement with AlgebraOfGraphics + CairoMakie,
+and exports a CSV — the same shape of work the old R Markdown vignettes did, now structured and
+per-project.
+
+This example is **UID-free**: set the project/image below (or `CECELIA_EXAMPLE_PROJ` / `_UID` /
+`_VN`). Everything else is reactive — edit a cell and downstream cells recompute.
+"""
+
+# ╔═╡ a4000000-0000-0000-0000-000000000000
+Cecelia.init_cecelia!()
+
+# ╔═╡ b0000000-0000-0000-0000-000000000000
+md"## 1 · Choose your data"
+
+# ╔═╡ b1000000-0000-0000-0000-000000000000
+proj_uid = get(ENV, "CECELIA_EXAMPLE_PROJ", "")   # ← your project UID
+
+# ╔═╡ b2000000-0000-0000-0000-000000000000
+# Guide: available projects (shown when the field above is blank). The listing is built in plain
+# code — the `md"..."` macro can't take nested double-quotes inside `$(…)`, so only a single var
+# is interpolated.
+let
+    projs = isempty(proj_uid) ?
+        (try filter(d -> isdir(joinpath(projects_dir(), d)), readdir(projects_dir())) catch; String[] end) :
+        String[]
+    listing = isempty(projs) ? "none found" : join(projs, ", ")
+    isempty(proj_uid) ? md"➡️ Set `proj_uid`. Available projects: **$(listing)**" :
+                        md"✅ project `$(proj_uid)`"
+end
+
+# ╔═╡ b3000000-0000-0000-0000-000000000000
+uid = get(ENV, "CECELIA_EXAMPLE_UID", "")         # ← your image (or set) UID
+
+# ╔═╡ b4000000-0000-0000-0000-000000000000
+# Guide: available images/sets in the chosen project (dir names under {proj}/1/).
+let
+    show_objs = !isempty(proj_uid) && isempty(uid)
+    objs = show_objs ?
+        (try readdir(joinpath(projects_dir(), proj_uid, "1")) catch; String[] end) :
+        String[]
+    listing = isempty(objs) ? "none found" : join(objs, ", ")
+    if show_objs
+        md"➡️ Set `uid`. Objects in this project: **$(listing)**"
+    elseif isempty(uid)
+        md""
+    else
+        md"✅ object `$(uid)`"
+    end
+end
+
+# ╔═╡ b5000000-0000-0000-0000-000000000000
+value_name = get(ENV, "CECELIA_EXAMPLE_VN", "A")  # ← segmentation / value_name
+
+# ╔═╡ c0000000-0000-0000-0000-000000000000
+md"## 2 · Load the object and its cell table"
+
+# ╔═╡ c1000000-0000-0000-0000-000000000000
+# `nothing` until both UIDs are set — keeps the reactive graph clean instead of throwing.
+img = (isempty(proj_uid) || isempty(uid)) ? nothing : init_object(proj_uid, uid)
+
+# ╔═╡ c2000000-0000-0000-0000-000000000000
+# `pop_df` with pop_type "labels" = ALL cells of this segmentation, ungated (no gate names needed —
+# the dataset-agnostic entry point). Swap for ("root", […]) / ("live", […]) etc. for gated pops.
+df = img === nothing ? nothing : pop_df(img, "labels", String[]; value_name = value_name)
+
+# ╔═╡ c3000000-0000-0000-0000-000000000000
+df === nothing ? md"_(waiting for a project + image above)_" :
+    md"Loaded **$(nrow(df)) cells** × $(ncol(df)) columns from `$(value_name)`."
+
+# ╔═╡ d0000000-0000-0000-0000-000000000000
+md"## 3 · Plot a measurement"
+
+# ╔═╡ d1000000-0000-0000-0000-000000000000
+# Numeric columns available to plot (excludes the label id).
+numeric_cols = df === nothing ? String[] :
+    [n for n in names(df) if eltype(df[!, n]) <: Union{Missing,Real} && n != "label"]
+
+# ╔═╡ d2000000-0000-0000-0000-000000000000
+plot_col = isempty(numeric_cols) ? nothing : first(numeric_cols)   # ← pick any of `numeric_cols`
+
+# ╔═╡ d3000000-0000-0000-0000-000000000000
+if df !== nothing && plot_col !== nothing
+    draw(data(df) * mapping(plot_col) * AlgebraOfGraphics.histogram(bins = 40);
+         axis = (; title = "$(value_name): $(plot_col)"))
+else
+    md"_(no numeric column to plot yet)_"
+end
+
+# ╔═╡ e0000000-0000-0000-0000-000000000000
+md"## 4 · Export a CSV"
+
+# ╔═╡ e1000000-0000-0000-0000-000000000000
+if df !== nothing
+    outdir = joinpath(projects_dir(), proj_uid, "exports")
+    mkpath(outdir)
+    outpath = joinpath(outdir, "$(uid)_$(value_name)_cells.csv")
+    CSV.write(outpath, df)
+    md"💾 wrote `$(outpath)`"
+else
+    md"_(nothing to export yet)_"
+end
+
+# ╔═╡ Cell order:
+# ╟─a0000000-0000-0000-0000-000000000000
+# ╠═a1000000-0000-0000-0000-000000000000
+# ╠═a2000000-0000-0000-0000-000000000000
+# ╠═a3000000-0000-0000-0000-000000000000
+# ╠═a4000000-0000-0000-0000-000000000000
+# ╟─b0000000-0000-0000-0000-000000000000
+# ╠═b1000000-0000-0000-0000-000000000000
+# ╟─b2000000-0000-0000-0000-000000000000
+# ╠═b3000000-0000-0000-0000-000000000000
+# ╟─b4000000-0000-0000-0000-000000000000
+# ╠═b5000000-0000-0000-0000-000000000000
+# ╟─c0000000-0000-0000-0000-000000000000
+# ╠═c1000000-0000-0000-0000-000000000000
+# ╠═c2000000-0000-0000-0000-000000000000
+# ╟─c3000000-0000-0000-0000-000000000000
+# ╟─d0000000-0000-0000-0000-000000000000
+# ╠═d1000000-0000-0000-0000-000000000000
+# ╠═d2000000-0000-0000-0000-000000000000
+# ╠═d3000000-0000-0000-0000-000000000000
+# ╟─e0000000-0000-0000-0000-000000000000
+# ╠═e1000000-0000-0000-0000-000000000000

--- a/pixi.toml
+++ b/pixi.toml
@@ -103,6 +103,22 @@ napari = { cmd = "python3 napari_bridge.py", cwd = "napari" }
 # Reporting only (no run/cancel); safe alongside the GUI. `-- --stream` for append-only log output.
 console = { cmd = "julia --project task_console.jl", cwd = "api" }
 
+# Notebook Playground (Pluto, port 7660) — pure-Julia downstream analysis. Runs its OWN Julia
+# session (the pluto/ env path-sources Cecelia), NOT the API server. Point it at a project's
+# notebooks via CECELIA_NOTEBOOKS_DIR; defaults to the shipped examples in notebooks/. The server
+# launches WITHOUT a sysimage (it's just Pluto); notebook WORKERS pick up pluto/deps.so if built
+# (see notebooks-sysimage) — that's what kills Makie's ~20s time-to-first-plot. See
+# docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md.
+notebooks = { cmd = "julia --project launch.jl", cwd = "pluto" }
+# Build the deps-only sysimage (Makie/CairoMakie + AoG + DataFrames + HDF5 + HTTP; NOT Cecelia, so
+# Revise still hot-reloads it). ~10 min, ~1.4 GB, one-time; pluto/deps.so is git-ignored. DEV build.
+notebooks-sysimage = { cmd = "julia --project build_sysimage.jl", cwd = "pluto" }
+# RELEASE build: same, but also bakes in Cecelia + CeceliaNb (code frozen) for near-instant first
+# plot AND first pop_df. Wired into the packaging flow — see docs/SHIPPING.md. Also → pluto/deps.so.
+notebooks-sysimage-full = { cmd = "julia --project build_sysimage_full.jl", cwd = "pluto" }
+# Resolve/precompile the pluto env (its own manifest — like julia-instantiate for app/).
+notebooks-instantiate = { cmd = "julia --project -e 'using Pkg; Pkg.instantiate()'", cwd = "pluto" }
+
 # One-click launch (the desktop-shortcut entrypoint): start the prod server, wait for /api/health,
 # open the default browser at :8080. The Julia server serves the built frontend, so run `build` first.
 app = "python app.py"
@@ -117,15 +133,17 @@ julia-instantiate = "julia --project=app -e 'using Pkg; Pkg.instantiate()'"
 # Stop by PORT, not by process name — killing by name self-matches the task's own shell and was
 # orphaning the napari bridge (see docs/SHIPPING.md). `stop-napari` alone forces a fresh bridge
 # after editing napari_bridge.py (the backend otherwise adopts the running bridge on restart).
-stop         = "kill $(lsof -ti tcp:8080) 2>/dev/null ; kill $(lsof -ti tcp:5173) 2>/dev/null ; kill $(lsof -ti tcp:7655) 2>/dev/null ; echo 'stopped backend(8080)/frontend(5173)/napari(7655)'"
-stop-backend = "kill $(lsof -ti tcp:8080) 2>/dev/null ; echo 'stopped backend(8080)'"
-stop-napari  = "kill $(lsof -ti tcp:7655) 2>/dev/null ; echo 'stopped napari bridge(7655)'"
+stop           = "kill $(lsof -ti tcp:8080) 2>/dev/null ; kill $(lsof -ti tcp:5173) 2>/dev/null ; kill $(lsof -ti tcp:7655) 2>/dev/null ; kill $(lsof -ti tcp:7660) 2>/dev/null ; echo 'stopped backend(8080)/frontend(5173)/napari(7655)/notebooks(7660)'"
+stop-backend   = "kill $(lsof -ti tcp:8080) 2>/dev/null ; echo 'stopped backend(8080)'"
+stop-napari    = "kill $(lsof -ti tcp:7655) 2>/dev/null ; echo 'stopped napari bridge(7655)'"
+stop-notebooks = "kill $(lsof -ti tcp:7660) 2>/dev/null ; echo 'stopped notebooks(7660)'"
 
 # Windows: kill by listening port via PowerShell (lsof is unix-only). Untested on Windows hardware.
 [target.win-64.tasks]
-stop         = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 8080,5173,7655 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
-stop-backend = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 8080 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
-stop-napari  = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 7655 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
+stop           = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 8080,5173,7655,7660 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
+stop-backend   = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 8080 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
+stop-napari    = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 7655 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
+stop-notebooks = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 7660 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
 
 # --- GPU acceleration (PARKED) ----------------------------------------------------------------
 # RAPIDS-based GPU clustering is CUDA-only (Linux/Windows + NVIDIA). When un-parked, add it as a

--- a/pluto/CeceliaNb/Project.toml
+++ b/pluto/CeceliaNb/Project.toml
@@ -1,0 +1,13 @@
+name = "CeceliaNb"
+uuid = "cec0e11a-0000-4000-8000-000000000001"
+authors = ["Cecelia"]
+version = "0.1.0"
+
+# Thin notebook-side helpers (count/summary aggregation + AlgebraOfGraphics plot shortcuts) so Pluto
+# notebooks don't re-roll boilerplate. Dev-tracked in the pluto/ env. Kept deliberately small — grow
+# from real notebook usage, not speculatively. See docs/NOTEBOOKS.md.
+[deps]
+AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/pluto/CeceliaNb/src/CeceliaNb.jl
+++ b/pluto/CeceliaNb/src/CeceliaNb.jl
@@ -1,0 +1,89 @@
+"""
+    CeceliaNb
+
+Small notebook-side helper set for the Cecelia Notebooks (Pluto) Playground. Two jobs:
+
+1. **Aggregation** (`nb_count`, `nb_summary`) — tidy summaries of a `pop_df` DataFrame. These operate
+   on the SAME table the `/analysis` board builds from (both start from `Cecelia.pop_df`), so the
+   numbers match the board; only the rendering differs (AlgebraOfGraphics here vs Observable Plot there).
+2. **Plot shortcuts** (`nb_hist`, `nb_box`, `nb_scatter`) — one-liners over AlgebraOfGraphics +
+   CairoMakie for the plots notebooks reach for most, so users don't re-roll the grammar each time.
+
+Deliberately minimal — grow from real notebook usage. For anything beyond these, use
+AlgebraOfGraphics directly (`data(df) * mapping(...) * visual(...)` |> `draw`).
+"""
+module CeceliaNb
+
+using AlgebraOfGraphics, CairoMakie, DataFrames, Statistics
+
+export nb_count, nb_summary, nb_hist, nb_box, nb_scatter
+
+_sym(x) = x isa Symbol ? x : Symbol(x)
+
+# Grouping keys that `pop_df` adds (value_name / pop), when present — the natural summary axes.
+_pop_keys(df::DataFrame) = intersect([:value_name, :pop], propertynames(df))
+
+"""
+    nb_count(df) -> DataFrame
+
+Cell counts per `(value_name, pop)` when those columns are present (the usual `pop_df` shape), else
+a single total. The "how many cells landed where" summary.
+"""
+function nb_count(df::DataFrame)::DataFrame
+    isempty(df) && return DataFrame()
+    keys = _pop_keys(df)
+    isempty(keys) ? DataFrame(n = nrow(df)) : sort!(combine(groupby(df, keys), nrow => :n), keys)
+end
+
+"""
+    nb_summary(df, measure; by = value_name/pop) -> DataFrame
+
+Grouped `mean` / `median` / `sd` / `n` of a continuous `measure`. Defaults to grouping by whichever
+of `value_name`/`pop` are present. Missing/NaN are skipped.
+"""
+function nb_summary(df::DataFrame, measure; by = _pop_keys(df))::DataFrame
+    isempty(df) && return DataFrame()
+    m  = _sym(measure)
+    by = Symbol.(collect(by))
+    g  = isempty(by) ? df : groupby(df, by)
+    combine(g,
+        m => (x -> mean(skipmissing(x)))   => :mean,
+        m => (x -> median(skipmissing(x))) => :median,
+        m => (x -> std(skipmissing(x)))    => :sd,
+        m => (x -> count(!ismissing, x))   => :n)
+end
+
+# Optional grouping → an AoG `mapping` colour/dodge, or no extra visual channel.
+_maybe_color(col) = col === nothing ? mapping() : mapping(color = _sym(col))
+
+"""
+    nb_hist(df, col; bins = 40, color = nothing, kwargs...) -> figure
+
+Histogram of a continuous column, optionally split by `color` (overlaid). `kwargs` pass to `draw`.
+"""
+function nb_hist(df::DataFrame, col; bins::Int = 40, color = nothing, kwargs...)
+    layer = data(df) * mapping(_sym(col)) * _maybe_color(color) * AlgebraOfGraphics.histogram(bins = bins)
+    draw(layer; kwargs...)
+end
+
+"""
+    nb_box(df, group, value; color = nothing, kwargs...) -> figure
+
+Boxplot of `value` per category `group` (Tukey stats), e.g. compare a measure across `:value_name`.
+"""
+function nb_box(df::DataFrame, group, value; color = nothing, kwargs...)
+    layer = data(df) * mapping(_sym(group), _sym(value)) * _maybe_color(color) * visual(BoxPlot)
+    draw(layer; kwargs...)
+end
+
+"""
+    nb_scatter(df, x, y; color = nothing, kwargs...) -> figure
+
+Scatter of `y` vs `x`, optionally coloured by a third column.
+"""
+function nb_scatter(df::DataFrame, x, y; color = nothing, kwargs...)
+    layer = data(df) * mapping(_sym(x), _sym(y)) * _maybe_color(color) * visual(Scatter)
+    draw(layer; kwargs...)
+end
+
+end # module

--- a/pluto/Manifest.toml
+++ b/pluto/Manifest.toml
@@ -1,0 +1,2162 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.6"
+manifest_format = "2.0"
+project_hash = "54368e3eb49fae6457f3494db9460075caac075d"
+
+[[deps.AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "d92ad398961a3ed262d8bf04a1a2b8340f915fef"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "1.5.0"
+weakdeps = ["ChainRulesCore", "Test"]
+
+    [deps.AbstractFFTs.extensions]
+    AbstractFFTsChainRulesCoreExt = "ChainRulesCore"
+    AbstractFFTsTestExt = "Test"
+
+[[deps.AbstractTrees]]
+git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
+uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+version = "0.4.5"
+
+[[deps.Accessors]]
+deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
+git-tree-sha1 = "7063ad1083578215c7c4bf410368150abe8d5524"
+uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+version = "0.1.45"
+
+    [deps.Accessors.extensions]
+    AxisKeysExt = "AxisKeys"
+    IntervalSetsExt = "IntervalSets"
+    LinearAlgebraExt = "LinearAlgebra"
+    StaticArraysExt = "StaticArrays"
+    StructArraysExt = "StructArrays"
+    TestExt = "Test"
+    UnitfulExt = "Unitful"
+
+    [deps.Accessors.weakdeps]
+    AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "daa72978cd7a624246e894a4f4f067706d4e17e2"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "4.7.0"
+weakdeps = ["SparseArrays", "StaticArrays"]
+
+    [deps.Adapt.extensions]
+    AdaptSparseArraysExt = "SparseArrays"
+    AdaptStaticArraysExt = "StaticArrays"
+
+[[deps.AdaptivePredicates]]
+git-tree-sha1 = "7e651ea8d262d2d74ce75fdf47c4d63c07dba7a6"
+uuid = "35492f91-a3bd-45ad-95db-fcad7dcfedb7"
+version = "1.2.0"
+
+[[deps.AlgebraOfGraphics]]
+deps = ["Accessors", "Colors", "DataAPI", "Dates", "Dictionaries", "FileIO", "GLM", "GeoInterface", "GeometryBasics", "GridLayoutBase", "Isoband", "KernelDensity", "Loess", "Makie", "NaturalSort", "PlotUtils", "PolygonOps", "PooledArrays", "PrecompileTools", "RelocatableFolders", "StatsBase", "StructArrays", "Tables"]
+git-tree-sha1 = "46736ae99433e1489e009a564326adee46467bdd"
+uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
+version = "0.13.0"
+
+    [deps.AlgebraOfGraphics.extensions]
+    AlgebraOfGraphicsDynamicQuantitiesExt = "DynamicQuantities"
+    AlgebraOfGraphicsUnitfulExt = "Unitful"
+
+    [deps.AlgebraOfGraphics.weakdeps]
+    DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.AliasTables]]
+deps = ["PtrArrays", "Random"]
+git-tree-sha1 = "9876e1e164b144ca45e9e3198d0b689cadfed9ff"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.1.3"
+
+[[deps.Animations]]
+deps = ["Colors"]
+git-tree-sha1 = "e092fa223bf66a3c41f9c022bd074d916dc303e7"
+uuid = "27a7e980-b3e6-11e9-2bcd-0b925532e340"
+version = "0.4.2"
+
+[[deps.ArgCheck]]
+git-tree-sha1 = "f9e9a66c9b7be1ad7372bbd9b062d9230c30c5ce"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "2.5.0"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Automa]]
+deps = ["PrecompileTools", "TranscodingStreams"]
+git-tree-sha1 = "94eab0b3ccdcac361188cc661daf69d4433c1818"
+uuid = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
+version = "1.2.0"
+
+[[deps.AxisAlgorithms]]
+deps = ["LinearAlgebra", "Random", "SparseArrays", "WoodburyMatrices"]
+git-tree-sha1 = "01b8ccb13d68535d73d2b0c23e39bd23155fb712"
+uuid = "13072b0f-2c55-5437-9ae7-d433b7a33950"
+version = "1.1.0"
+
+[[deps.AxisArrays]]
+deps = ["Dates", "IntervalSets", "IterTools", "RangeArrays"]
+git-tree-sha1 = "4126b08903b777c88edf1754288144a0492c05ad"
+uuid = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+version = "0.4.8"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BaseDirs]]
+git-tree-sha1 = "8c290a1b223deaeea9aea44b235d24546da8eb98"
+uuid = "18cc8868-cbac-4acf-b575-c8ff214dc66f"
+version = "1.4.0"
+
+[[deps.BitFlags]]
+git-tree-sha1 = "bbe1079eecf9c9fbb52765193ad2bae27ae09bc8"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.10"
+
+[[deps.Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1b96ea4a01afe0ea4090c5c8039690672dd13f2e"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.9+0"
+
+[[deps.CEnum]]
+git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.5.0"
+
+[[deps.CRC32c]]
+uuid = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
+version = "1.11.0"
+
+[[deps.CRlibm]]
+deps = ["CRlibm_jll"]
+git-tree-sha1 = "66188d9d103b92b6cd705214242e27f5737a1e5e"
+uuid = "96374032-68de-5a5b-8d9e-752f78720389"
+version = "1.0.2"
+
+[[deps.CRlibm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "e329286945d0cfc04456972ea732551869af1cfc"
+uuid = "4e9b3aee-d8a1-5a3d-ad8b-7d824db253f0"
+version = "1.0.1+0"
+
+[[deps.CSV]]
+deps = ["CodecZlib", "Dates", "FilePathsBase", "InlineStrings", "Mmap", "Parsers", "PooledArrays", "PrecompileTools", "SentinelArrays", "Tables", "Unicode", "WeakRefStrings", "WorkerUtilities"]
+git-tree-sha1 = "8d8e0b0f350b8e1c91420b5e64e5de774c2f0f4d"
+uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+version = "0.10.16"
+
+[[deps.Cairo]]
+deps = ["Cairo_jll", "Colors", "Glib_jll", "Graphics", "Libdl", "Pango_jll"]
+git-tree-sha1 = "71aa551c5c33f1a4415867fe06b7844faadb0ae9"
+uuid = "159f3aea-2a34-519c-b102-8c37f9878175"
+version = "1.1.1"
+
+[[deps.CairoMakie]]
+deps = ["CRC32c", "Cairo", "Cairo_jll", "Colors", "FileIO", "FreeType", "GeometryBasics", "LinearAlgebra", "Makie", "PrecompileTools"]
+git-tree-sha1 = "80b2770813b42f80235ea57f4333de8ff3e1c342"
+uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+version = "0.15.12"
+
+[[deps.Cairo_jll]]
+deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "Libdl", "Pixman_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "1fa950ebc3e37eccd51c6a8fe1f92f7d86263522"
+uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
+version = "1.18.7+0"
+
+[[deps.Cecelia]]
+deps = ["DataFrames", "Dates", "DensityInterface", "Distributions", "HDF5", "HTTP", "HiddenMarkovModels", "JSON3", "LinearAlgebra", "Random", "SHA", "Statistics", "StatsAPI", "StructTypes", "TOML", "UUIDs"]
+path = "../app"
+uuid = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+version = "0.0.0"
+
+[[deps.CeceliaNb]]
+deps = ["AlgebraOfGraphics", "CairoMakie", "DataFrames", "Statistics"]
+path = "CeceliaNb"
+uuid = "cec0e11a-0000-4000-8000-000000000001"
+version = "0.1.0"
+
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra"]
+git-tree-sha1 = "12177ad6b3cad7fd50c8b3825ce24a99ad61c18f"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.26.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.ChainRulesCore.extensions]
+    ChainRulesCoreSparseArraysExt = "SparseArrays"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.8"
+
+[[deps.CodecZstd]]
+deps = ["TranscodingStreams", "Zstd_jll"]
+git-tree-sha1 = "da54a6cd93c54950c15adf1d336cfd7d71f51a56"
+uuid = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
+version = "0.8.7"
+
+[[deps.ColorBrewer]]
+deps = ["Colors", "JSON"]
+git-tree-sha1 = "07da79661b919001e6863b81fc572497daa58349"
+uuid = "a2cac450-b92f-5266-8821-25eda20663c8"
+version = "0.4.2"
+
+[[deps.ColorSchemes]]
+deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "PrecompileTools", "Random"]
+git-tree-sha1 = "b0fd3f56fa442f81e0a47815c92245acfaaa4e34"
+uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+version = "3.31.0"
+
+[[deps.ColorTypes]]
+deps = ["FixedPointNumbers", "Random"]
+git-tree-sha1 = "67e11ee83a43eb71ddc950302c53bf33f0690dfe"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.12.1"
+weakdeps = ["StyledStrings"]
+
+    [deps.ColorTypes.extensions]
+    StyledStringsExt = "StyledStrings"
+
+[[deps.ColorVectorSpace]]
+deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "Requires", "Statistics", "TensorCore"]
+git-tree-sha1 = "8b3b6f87ce8f65a2b4f857528fd8d70086cd72b1"
+uuid = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+version = "0.11.0"
+weakdeps = ["SpecialFunctions"]
+
+    [deps.ColorVectorSpace.extensions]
+    SpecialFunctionsExt = "SpecialFunctions"
+
+[[deps.Colors]]
+deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
+git-tree-sha1 = "37ea44092930b1811e666c3bc38065d7d87fcc74"
+uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
+version = "0.13.1"
+
+[[deps.CommonSolve]]
+git-tree-sha1 = "99ee296f88c12485402e37c2fd025f95ae097637"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.9"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.18.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.CompositionsBase]]
+git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.2"
+weakdeps = ["InverseFunctions"]
+
+    [deps.CompositionsBase.extensions]
+    CompositionsBaseInverseFunctionsExt = "InverseFunctions"
+
+[[deps.ComputePipeline]]
+deps = ["Observables", "Preferences"]
+git-tree-sha1 = "7bc84b769c1d384315e7b5c4ac03a6c303e6cf35"
+uuid = "95dc2771-c249-4cd0-9c9f-1f3b4330693c"
+version = "0.1.8"
+
+[[deps.ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "21d088c496ea22914fe80906eb5bce65755e5ec8"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.5.1"
+
+[[deps.Configurations]]
+deps = ["ExproniconLite", "OrderedCollections", "TOML"]
+git-tree-sha1 = "4358750bb58a3caefd5f37a4a0c5bfdbbf075252"
+uuid = "5218b696-f38b-4ac9-8b61-a12ec717816d"
+version = "0.17.6"
+
+[[deps.ConstructionBase]]
+git-tree-sha1 = "b4b092499347b18a015186eae3042f72267106cb"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.6.0"
+weakdeps = ["IntervalSets", "LinearAlgebra", "StaticArrays"]
+
+    [deps.ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
+
+[[deps.Contour]]
+git-tree-sha1 = "439e35b0b36e2e5881738abc8857bd92ad6ff9a8"
+uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
+version = "0.6.3"
+
+[[deps.CoreMath]]
+deps = ["CoreMath_jll"]
+git-tree-sha1 = "8c0480f92b1b1796239156a1b9b1bfb1b39499b4"
+uuid = "b7a15901-be09-4a0e-87d2-2e66b0e09b5a"
+version = "0.1.0"
+
+[[deps.CoreMath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a692a4c1dc59a4b8bc0b6403876eb3250fde2bc3"
+uuid = "a38c48d9-6df1-5ac9-9223-b6ada3b5572b"
+version = "0.1.0+0"
+
+[[deps.Crayons]]
+git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.1.1"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.16.0"
+
+[[deps.DataFrames]]
+deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "5fab31e2e01e70ad66e3e24c968c264d1cf166d6"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "1.8.2"
+
+[[deps.DataStructures]]
+deps = ["OrderedCollections"]
+git-tree-sha1 = "6fb53a69613a0b2b68a0d12671717d307ab8b24e"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.19.5"
+
+[[deps.DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.DelaunayTriangulation]]
+deps = ["AdaptivePredicates", "EnumX", "ExactPredicates", "Random"]
+git-tree-sha1 = "c55f5a9fd67bdbc8e089b5a3111fe4292986a8e8"
+uuid = "927a84f5-c5f4-47a5-9785-b46e178433df"
+version = "1.6.6"
+
+[[deps.DensityInterface]]
+deps = ["InverseFunctions", "Test"]
+git-tree-sha1 = "80c3e8639e3353e5d2912fb3a1916b8455e2494b"
+uuid = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+version = "0.4.0"
+
+[[deps.Dictionaries]]
+deps = ["Indexing", "Random", "Serialization"]
+git-tree-sha1 = "a55766a9c8f66cf19ffcdbdb1444e249bb4ace33"
+uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
+version = "0.4.6"
+
+[[deps.Distances]]
+deps = ["LinearAlgebra", "Statistics", "StatsAPI"]
+git-tree-sha1 = "c7e3a542b999843086e2f29dac96a618c105be1d"
+uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+version = "0.10.12"
+weakdeps = ["ChainRulesCore", "SparseArrays"]
+
+    [deps.Distances.extensions]
+    DistancesChainRulesCoreExt = "ChainRulesCore"
+    DistancesSparseArraysExt = "SparseArrays"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.11.0"
+
+[[deps.Distributions]]
+deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "Roots", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "cd3c5ac74cd3923c8945c6a81518c46abd0e73a3"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.25.129"
+
+    [deps.Distributions.extensions]
+    DistributionsChainRulesCoreExt = "ChainRulesCore"
+    DistributionsDensityInterfaceExt = "DensityInterface"
+    DistributionsSparseConnectivityTracerExt = "SparseConnectivityTracer"
+    DistributionsTestExt = "Test"
+
+    [deps.Distributions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+    SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.DocStringExtensions]]
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.5"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
+
+[[deps.EarCut_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "e3290f2d49e661fbd94046d7e3726ffcb2d41053"
+uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
+version = "2.2.4+0"
+
+[[deps.EnumX]]
+git-tree-sha1 = "c49898e8438c828577f04b92fc9368c388ac783c"
+uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
+version = "1.0.7"
+
+[[deps.ExactPredicates]]
+deps = ["IntervalArithmetic", "Random", "StaticArrays"]
+git-tree-sha1 = "83231673ea4d3d6008ac74dc5079e77ab2209d8f"
+uuid = "429591f6-91af-11e9-00e2-59fbe8cec110"
+version = "2.2.9"
+
+[[deps.ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "d36f682e590a83d63d1c7dbd287573764682d12a"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.11"
+
+[[deps.Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "c307cd83373868391f3ac30b41530bc5d5d05d08"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.8.1+0"
+
+[[deps.ExpressionExplorer]]
+git-tree-sha1 = "5f1c005ed214356bbe41d442cc1ccd416e510b7e"
+uuid = "21656369-7473-754a-2065-74616d696c43"
+version = "1.1.4"
+
+[[deps.ExproniconLite]]
+git-tree-sha1 = "c13f0b150373771b0fdc1713c97860f8df12e6c2"
+uuid = "55351af7-c7e9-48d6-89ff-24e801d99491"
+version = "0.10.14"
+
+[[deps.Extents]]
+git-tree-sha1 = "b309b36a9e02fe7be71270dd8c0fd873625332b4"
+uuid = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
+version = "0.1.6"
+
+[[deps.FFMPEG_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libva_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "7a58e45171b63ed4782f2d36fdee8713a469e6e0"
+uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
+version = "8.1.2+0"
+
+[[deps.FFTA]]
+deps = ["AbstractFFTs", "DocStringExtensions", "LinearAlgebra", "MuladdMacro", "Primes", "Random", "Reexport"]
+git-tree-sha1 = "65e55303b72f4a567a51b174dd2c47496efeb95a"
+uuid = "b86e33f2-c0db-4aa1-a6e0-ab43e668529e"
+version = "0.3.1"
+
+[[deps.FileIO]]
+deps = ["Pkg", "Requires", "UUIDs"]
+git-tree-sha1 = "8e9c059d6857607253e837730dbf780b6b151acd"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.19.0"
+weakdeps = ["HTTP"]
+
+    [deps.FileIO.extensions]
+    HTTPExt = "HTTP"
+
+[[deps.FilePaths]]
+deps = ["FilePathsBase", "MacroTools", "Reexport"]
+git-tree-sha1 = "a1b2fbfe98503f15b665ed45b3d149e5d8895e4c"
+uuid = "8fc22ac5-c921-52a6-82fd-178b2807b824"
+version = "0.9.0"
+
+    [deps.FilePaths.extensions]
+    FilePathsGlobExt = "Glob"
+    FilePathsURIParserExt = "URIParser"
+    FilePathsURIsExt = "URIs"
+
+    [deps.FilePaths.weakdeps]
+    Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
+    URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+    URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+
+[[deps.FilePathsBase]]
+deps = ["Compat", "Dates"]
+git-tree-sha1 = "3bab2c5aa25e7840a4b065805c0cdfc01f3068d2"
+uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
+version = "0.9.24"
+weakdeps = ["Mmap", "Test"]
+
+    [deps.FilePathsBase.extensions]
+    FilePathsBaseMmapExt = "Mmap"
+    FilePathsBaseTestExt = "Test"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.FillArrays]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "2f979084d1e13948a3352cf64a25df6bd3b4dca3"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "1.16.0"
+weakdeps = ["PDMats", "SparseArrays", "StaticArrays", "Statistics"]
+
+    [deps.FillArrays.extensions]
+    FillArraysPDMatsExt = "PDMats"
+    FillArraysSparseArraysExt = "SparseArrays"
+    FillArraysStaticArraysExt = "StaticArrays"
+    FillArraysStatisticsExt = "Statistics"
+
+[[deps.FixedPointNumbers]]
+deps = ["Random", "Statistics"]
+git-tree-sha1 = "59af96b98217c6ef4ae0dfe065ac7c20831d1a84"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.8.6"
+
+[[deps.Fontconfig_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Zlib_jll"]
+git-tree-sha1 = "f85dac9a96a01087df6e3a749840015a0ca3817d"
+uuid = "a3f928ae-7b40-5064-980b-68af3947d34b"
+version = "2.17.1+0"
+
+[[deps.Format]]
+git-tree-sha1 = "9c68794ef81b08086aeb32eeaf33531668d5f5fc"
+uuid = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+version = "1.3.7"
+
+[[deps.FreeType]]
+deps = ["CEnum", "FreeType2_jll"]
+git-tree-sha1 = "907369da0f8e80728ab49c1c7e09327bf0d6d999"
+uuid = "b38be410-82b0-50bf-ab77-7b57e271db43"
+version = "4.1.1"
+
+[[deps.FreeType2_jll]]
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "70329abc09b886fd2c5d94ad2d9527639c421e3e"
+uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
+version = "2.14.3+1"
+
+[[deps.FreeTypeAbstraction]]
+deps = ["BaseDirs", "ColorVectorSpace", "Colors", "FreeType", "GeometryBasics", "Mmap"]
+git-tree-sha1 = "4ebb930ef4a43817991ba35db6317a05e59abd11"
+uuid = "663a7486-cb36-511b-a19d-713bb74d65c9"
+version = "0.10.8"
+
+[[deps.FriBidi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "7a214fdac5ed5f59a22c2d9a885a16da1c74bbc7"
+uuid = "559328eb-81f9-559d-9380-de523a88c83c"
+version = "1.0.17+0"
+
+[[deps.Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+version = "1.11.0"
+
+[[deps.GLM]]
+deps = ["Distributions", "LinearAlgebra", "LogExpFunctions", "Printf", "Reexport", "SparseArrays", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsModels"]
+git-tree-sha1 = "c963639ae5b9aab54f543bdc7504f42f59880bec"
+uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
+version = "1.9.5"
+
+[[deps.Gamma]]
+git-tree-sha1 = "86f86b6168a016ed88e4ae4e64577b98c3b59e8e"
+uuid = "a0844989-3bd2-4988-8bea-c9407ab0941b"
+version = "1.1.0"
+
+[[deps.GeoFormatTypes]]
+git-tree-sha1 = "7528a7956248c723d01a0a9b0447bf254bf4da52"
+uuid = "68eda718-8dee-11e9-39e7-89f7f65f511f"
+version = "0.4.5"
+
+[[deps.GeoInterface]]
+deps = ["DataAPI", "Extents", "GeoFormatTypes"]
+git-tree-sha1 = "2b0312a0c06b4408773c6dc1829b472ea706f058"
+uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+version = "1.6.1"
+
+    [deps.GeoInterface.extensions]
+    GeoInterfaceMakieExt = ["Makie", "GeometryBasics"]
+    GeoInterfaceRecipesBaseExt = "RecipesBase"
+
+    [deps.GeoInterface.weakdeps]
+    GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+    Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+
+[[deps.GeometryBasics]]
+deps = ["EarCut_jll", "LinearAlgebra", "PrecompileTools", "Random", "StaticArrays"]
+git-tree-sha1 = "364685f5ffde25deb1bbcfd5bb278a5c6b7a9b37"
+uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+version = "0.5.11"
+weakdeps = ["Extents", "GeoInterface", "IntervalSets"]
+
+    [deps.GeometryBasics.extensions]
+    ExtentsExt = "Extents"
+    GeometryBasicsGeoInterfaceExt = "GeoInterface"
+    IntervalSetsExt = "IntervalSets"
+
+[[deps.GettextRuntime_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll"]
+git-tree-sha1 = "45288942190db7c5f760f59c04495064eedf9340"
+uuid = "b0724c58-0f36-5564-988d-3bb0596ebc4a"
+version = "0.22.4+0"
+
+[[deps.Giflib_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6570366d757b50fabae9f4315ad74d2e40c0560a"
+uuid = "59f7168a-df46-5410-90c8-f2779963d0ec"
+version = "5.2.3+0"
+
+[[deps.Glib_jll]]
+deps = ["Artifacts", "GettextRuntime_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "24f6def62397474a297bfcec22384101609142ed"
+uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
+version = "2.86.3+0"
+
+[[deps.Glob]]
+git-tree-sha1 = "246c628cec062230b7d183aab88841fa94fcabe9"
+uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
+version = "1.5.0"
+
+[[deps.GracefulPkg]]
+deps = ["Compat", "Pkg", "TOML"]
+git-tree-sha1 = "a854d6c0e9fb561b88cd20b4ad64f518cb1bfb8d"
+uuid = "828d9ff0-206c-6161-646e-6576656f7244"
+version = "2.4.3"
+
+[[deps.Graphics]]
+deps = ["Colors", "LinearAlgebra", "NaNMath"]
+git-tree-sha1 = "a641238db938fff9b2f60d08ed9030387daf428c"
+uuid = "a2bd30eb-e257-5431-a919-1863eab51364"
+version = "1.1.3"
+
+[[deps.Graphite2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "69ffb934a5c5b7e086a0b4fee3427db2556fba6e"
+uuid = "3b182d85-2403-5c21-9c21-1e1f0cc25472"
+version = "1.3.16+0"
+
+[[deps.GridLayoutBase]]
+deps = ["GeometryBasics", "InteractiveUtils", "Observables"]
+git-tree-sha1 = "93d5c27c8de51687a2c70ec0716e6e76f298416f"
+uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
+version = "0.11.2"
+
+[[deps.HDF5]]
+deps = ["Compat", "HDF5_jll", "Libdl", "MPIPreferences", "Mmap", "Preferences", "Printf", "Random", "Requires", "UUIDs"]
+git-tree-sha1 = "491ea627ac824619f34168e29a0427a9e00e3e40"
+uuid = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+version = "0.17.3"
+
+    [deps.HDF5.extensions]
+    MPIExt = "MPI"
+
+    [deps.HDF5.weakdeps]
+    MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+
+[[deps.HDF5_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "aws_c_s3_jll", "dlfcn_win32_jll", "libaec_jll", "mpif_jll"]
+git-tree-sha1 = "45337643a2d97262d5fe72ce1f13e8a662d13d62"
+uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
+version = "2.1.2+0"
+
+[[deps.HTTP]]
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "51059d23c8bb67911a2e6fd5130229113735fc7e"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "1.11.0"
+
+[[deps.HarfBuzz_jll]]
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
+git-tree-sha1 = "f923f9a774fcf3f5cb761bfa43aeadd689714813"
+uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
+version = "8.5.1+0"
+
+[[deps.HiddenMarkovModels]]
+deps = ["ArgCheck", "ChainRulesCore", "DensityInterface", "DocStringExtensions", "FillArrays", "LinearAlgebra", "ProgressLogging", "Random", "SparseArrays", "StatsAPI", "StatsFuns"]
+git-tree-sha1 = "9e1dc9da147a3af5622d863d6e94b78febf024a9"
+uuid = "84ca31d5-effc-45e0-bfda-5a68cd981f47"
+version = "0.7.1"
+weakdeps = ["Distributions"]
+
+    [deps.HiddenMarkovModels.extensions]
+    HiddenMarkovModelsDistributionsExt = "Distributions"
+
+[[deps.Hwloc_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "XML2_jll", "Xorg_libpciaccess_jll"]
+git-tree-sha1 = "c35847ca5b4997fc8418836354a56c459bcf48d8"
+uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
+version = "2.14.0+0"
+
+[[deps.HypergeometricFunctions]]
+deps = ["Gamma", "LinearAlgebra"]
+git-tree-sha1 = "18d7deab5fb0440dc6a7b6993c5c27b25420de10"
+uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
+version = "0.3.29"
+
+[[deps.HypertextLiteral]]
+deps = ["Tricks"]
+git-tree-sha1 = "d1a86724f81bcd184a38fd284ce183ec067d71a0"
+uuid = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
+version = "1.0.0"
+
+[[deps.ImageAxes]]
+deps = ["AxisArrays", "ImageBase", "ImageCore", "Reexport", "SimpleTraits"]
+git-tree-sha1 = "e12629406c6c4442539436581041d372d69c55ba"
+uuid = "2803e5a7-5153-5ecf-9a86-9b4c37f5f5ac"
+version = "0.6.12"
+
+[[deps.ImageBase]]
+deps = ["ImageCore", "Reexport"]
+git-tree-sha1 = "eb49b82c172811fd2c86759fa0553a2221feb909"
+uuid = "c817782e-172a-44cc-b673-b171935fbb9e"
+version = "0.1.7"
+
+[[deps.ImageCore]]
+deps = ["ColorVectorSpace", "Colors", "FixedPointNumbers", "MappedArrays", "MosaicViews", "OffsetArrays", "PaddedViews", "PrecompileTools", "Reexport"]
+git-tree-sha1 = "8c193230235bbcee22c8066b0374f63b5683c2d3"
+uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+version = "0.10.5"
+
+[[deps.ImageIO]]
+deps = ["FileIO", "IndirectArrays", "JpegTurbo", "LazyModules", "Netpbm", "OpenEXR", "PNGFiles", "QOI", "Sixel", "TiffImages", "UUIDs", "WebP"]
+git-tree-sha1 = "696144904b76e1ca433b886b4e7edd067d76cbf7"
+uuid = "82e4d734-157c-48bb-816b-45c225c6df19"
+version = "0.6.9"
+
+[[deps.ImageMetadata]]
+deps = ["AxisArrays", "ImageAxes", "ImageBase", "ImageCore"]
+git-tree-sha1 = "2a81c3897be6fbcde0802a0ebe6796d0562f63ec"
+uuid = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
+version = "0.9.10"
+
+[[deps.Imath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "dcc8d0cd653e55213df9b75ebc6fe4a8d3254c65"
+uuid = "905a6f67-0a94-5f89-b386-d35d92009cd1"
+version = "3.2.2+0"
+
+[[deps.Indexing]]
+git-tree-sha1 = "ce1566720fd6b19ff3411404d4b977acd4814f9f"
+uuid = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"
+version = "1.1.1"
+
+[[deps.IndirectArrays]]
+git-tree-sha1 = "012e604e1c7458645cb8b436f8fba789a51b257f"
+uuid = "9b13fd28-a010-5f03-acff-a1bbcff69959"
+version = "1.0.0"
+
+[[deps.Inflate]]
+git-tree-sha1 = "d1b1b796e47d94588b3757fe84fbf65a5ec4a80d"
+uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
+version = "0.1.5"
+
+[[deps.InlineStrings]]
+git-tree-sha1 = "8f3d257792a522b4601c24a577954b0a8cd7334d"
+uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
+version = "1.4.5"
+
+    [deps.InlineStrings.extensions]
+    ArrowTypesExt = "ArrowTypes"
+    ParsersExt = "Parsers"
+
+    [deps.InlineStrings.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+    Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+
+[[deps.IntegerMathUtils]]
+git-tree-sha1 = "4c1acff2dc6b6967e7e750633c50bc3b8d83e617"
+uuid = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
+version = "0.1.3"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.Interpolations]]
+deps = ["Adapt", "AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
+git-tree-sha1 = "48922d06068130f87e43edef52382e6a94305ae6"
+uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+version = "0.16.3"
+
+    [deps.Interpolations.extensions]
+    InterpolationsForwardDiffExt = "ForwardDiff"
+    InterpolationsUnitfulExt = "Unitful"
+
+    [deps.Interpolations.weakdeps]
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.IntervalArithmetic]]
+deps = ["CRlibm", "CoreMath", "MacroTools", "OpenBLASConsistentFPCSR_jll", "Printf", "Random", "RoundingEmulator"]
+git-tree-sha1 = "921d7e91687e15a2c7c269c226960491fc041832"
+uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+version = "1.0.9"
+
+    [deps.IntervalArithmetic.extensions]
+    IntervalArithmeticArblibExt = "Arblib"
+    IntervalArithmeticDiffRulesExt = "DiffRules"
+    IntervalArithmeticForwardDiffExt = "ForwardDiff"
+    IntervalArithmeticIntervalSetsExt = "IntervalSets"
+    IntervalArithmeticIrrationalConstantsExt = "IrrationalConstants"
+    IntervalArithmeticLinearAlgebraExt = "LinearAlgebra"
+    IntervalArithmeticRecipesBaseExt = "RecipesBase"
+    IntervalArithmeticSparseArraysExt = "SparseArrays"
+
+    [deps.IntervalArithmetic.weakdeps]
+    Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
+    DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.IntervalSets]]
+git-tree-sha1 = "79d6bd28c8d9bccc2229784f1bd637689b256377"
+uuid = "8197267c-284f-5f27-9208-e0e47529a953"
+version = "0.7.14"
+
+    [deps.IntervalSets.extensions]
+    IntervalSetsRandomExt = "Random"
+    IntervalSetsRecipesBaseExt = "RecipesBase"
+    IntervalSetsStatisticsExt = "Statistics"
+
+    [deps.IntervalSets.weakdeps]
+    Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.InverseFunctions]]
+git-tree-sha1 = "a779299d77cd080bf77b97535acecd73e1c5e5cb"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.17"
+weakdeps = ["Dates", "Test"]
+
+    [deps.InverseFunctions.extensions]
+    InverseFunctionsDatesExt = "Dates"
+    InverseFunctionsTestExt = "Test"
+
+[[deps.InvertedIndices]]
+git-tree-sha1 = "6da3c4316095de0f5ee2ebd875df8721e7e0bdbe"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.3.1"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.6"
+
+[[deps.Isoband]]
+deps = ["isoband_jll"]
+git-tree-sha1 = "f9b6d97355599074dc867318950adaa6f9946137"
+uuid = "f1662d9f-8043-43de-a69a-05efc1cc6ff4"
+version = "0.1.1"
+
+[[deps.IterTools]]
+git-tree-sha1 = "42d5f897009e7ff2cf88db414a389e5ed1bdd023"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.10.0"
+
+[[deps.IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "c89d196f5ffb64bfbf80985b699ea913b0d2c211"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "1.6.1"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JSON3]]
+deps = ["Dates", "Mmap", "Parsers", "PrecompileTools", "StructTypes", "UUIDs"]
+git-tree-sha1 = "411eccfe8aba0814ffa0fdf4860913ed09c34975"
+uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+version = "1.14.3"
+
+    [deps.JSON3.extensions]
+    JSON3ArrowExt = ["ArrowTypes"]
+
+    [deps.JSON3.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JpegTurbo]]
+deps = ["CEnum", "FileIO", "ImageCore", "JpegTurbo_jll", "TOML"]
+git-tree-sha1 = "9496de8fb52c224a2e3f9ff403947674517317d9"
+uuid = "b835a17e-a41a-41e7-81f0-2f016b05efe0"
+version = "0.1.6"
+
+[[deps.JpegTurbo_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1dae3057da6f2b9c857afef03177bbdc7c4afe92"
+uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
+version = "3.2.0+0"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.KernelDensity]]
+deps = ["Distributions", "DocStringExtensions", "FFTA", "Interpolations", "StatsBase"]
+git-tree-sha1 = "9eda8292dd3268b3b7ec9df21bbfac24e177ec52"
+uuid = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
+version = "0.6.12"
+
+[[deps.LAME_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "059aabebaa7c82ccb853dd4a0ee9d17796f7e1bc"
+uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
+version = "3.100.3+0"
+
+[[deps.LERC_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "17b94ecafcfa45e8360a4fc9ca6b583b049e4e37"
+uuid = "88015f11-f218-50d7-93a8-a6af411a945d"
+version = "4.1.0+0"
+
+[[deps.LLVMOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "3ac157462e1e800777cc97d0eafd1bdb5356a470"
+uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
+version = "21.1.8+0"
+
+[[deps.LRUCache]]
+git-tree-sha1 = "5519b95a490ff5fe629c4a7aa3b3dfc9160498b3"
+uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
+version = "1.6.2"
+weakdeps = ["Serialization"]
+
+    [deps.LRUCache.extensions]
+    SerializationExt = ["Serialization"]
+
+[[deps.LaTeXStrings]]
+git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.4.0"
+
+[[deps.LazilyInitializedFields]]
+git-tree-sha1 = "0f2da712350b020bc3957f269c9caad516383ee0"
+uuid = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
+version = "1.3.0"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
+
+[[deps.LazyModules]]
+git-tree-sha1 = "a560dd966b386ac9ae60bdd3a3d3a326062d3c3e"
+uuid = "8cdb02fc-e678-4876-92c5-9defec4f444e"
+version = "0.3.1"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.15.0+0"
+
+[[deps.LibGit2]]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.Libffi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "c8da7e6a91781c41a863611c7e966098d783c57a"
+uuid = "e9f186c6-92d2-5b65-8a66-fee21dc1b490"
+version = "3.4.7+0"
+
+[[deps.Libglvnd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll", "Xorg_libXext_jll"]
+git-tree-sha1 = "d36c21b9e7c172a44a10484125024495e2625ac0"
+uuid = "7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
+version = "1.7.1+1"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
+
+[[deps.Libmount_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "cc3ad4faf30015a3e8094c9b5b7f19e85bdf2386"
+uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
+version = "2.42.0+0"
+
+[[deps.Libtiff_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "aebd334d06cee9f24cea70bd19a39749daf73881"
+uuid = "89763e89-9b03-5906-acba-b20f662cd828"
+version = "4.7.3+0"
+
+[[deps.Libuuid_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "d620582b1f0cbe2c72dd1d5bd195a9ce73370ab1"
+uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
+version = "2.42.0+0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
+
+[[deps.Loess]]
+deps = ["Distances", "LinearAlgebra", "Statistics", "StatsAPI", "StatsFuns"]
+git-tree-sha1 = "aac61f60ed2b1561ae1bbef4e6d7b75c27f1f9e3"
+uuid = "4345ca2d-374a-55d4-8d30-97f9976e7612"
+version = "0.6.6"
+
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "13ca9e2586b89836fd20cccf56e57e2b9ae7f38f"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.29"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "f00544d95982ea270145636c181ceda21c4e2575"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.2.0"
+
+[[deps.MIMEs]]
+git-tree-sha1 = "c64d943587f7187e751162b3b84445bbbd79f691"
+uuid = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
+version = "1.1.0"
+
+[[deps.MPIABI_jll]]
+deps = ["Artifacts", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "9be143b6045719e8fb019d2b3bc2aebad1184fef"
+uuid = "b5ada748-db0f-5fc0-8972-9331c762740c"
+version = "0.1.5+0"
+
+[[deps.MPICH_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "07dbec8aab01696edc0151a401a6cdfe95b9b885"
+uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
+version = "5.0.1+0"
+
+[[deps.MPIPreferences]]
+deps = ["Libdl", "Preferences"]
+git-tree-sha1 = "8e98d5d80b87403c311fd51e8455d4546ba7a5f8"
+uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+version = "0.1.12"
+
+[[deps.MPItrampoline_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "675df097f8eeb28998b2cfe3b25655af73d5f7df"
+uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
+version = "5.5.6+0"
+
+[[deps.MacroTools]]
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.16"
+
+[[deps.Makie]]
+deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "ComputePipeline", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageBase", "ImageIO", "InteractiveUtils", "Interpolations", "IntervalSets", "InverseFunctions", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "PNGFiles", "Packing", "Pkg", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
+git-tree-sha1 = "efe001e1ee81b8eee0fe7da5a4328fcbbfd6b3aa"
+uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+version = "0.24.12"
+
+    [deps.Makie.extensions]
+    MakieDynamicQuantitiesExt = "DynamicQuantities"
+
+    [deps.Makie.weakdeps]
+    DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
+
+[[deps.Malt]]
+deps = ["Distributed", "Logging", "RelocatableFolders", "Serialization", "Sockets"]
+git-tree-sha1 = "c2335b4e291f2422e2be8abf8936ccad58a98992"
+uuid = "36869731-bdee-424d-aa32-cab38c994e3b"
+version = "1.4.1"
+
+[[deps.MappedArrays]]
+git-tree-sha1 = "0ee4497a4e80dbd29c058fcee6493f5219556f40"
+uuid = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
+version = "0.4.3"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MathTeXEngine]]
+deps = ["AbstractTrees", "Automa", "DataStructures", "FreeTypeAbstraction", "GeometryBasics", "LaTeXStrings", "REPL", "RelocatableFolders", "UnicodeFun"]
+git-tree-sha1 = "aa1078778be5a8e5259ff04fbc3d258b3e78d464"
+uuid = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
+version = "0.6.9"
+
+[[deps.MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
+git-tree-sha1 = "8785729fa736197687541f7053f6d8ab7fc44f92"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.1.10"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "ff69a2b1330bcb730b9ac1ab7dd680176f5896b8"
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.1010+0"
+
+[[deps.MicrosoftMPI_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "bc95bf4149bf535c09602e3acdf950d9b4376227"
+uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
+version = "10.1.4+3"
+
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.2.0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+[[deps.MosaicViews]]
+deps = ["MappedArrays", "OffsetArrays", "PaddedViews", "StackViews"]
+git-tree-sha1 = "7b86a5d4d70a9f5cdf2dacb3cbe6d251d1a61dbe"
+uuid = "e94cdb99-869f-56ef-bcf0-1ae2bcbe0389"
+version = "0.3.4"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2025.11.4"
+
+[[deps.MsgPack]]
+deps = ["Serialization"]
+git-tree-sha1 = "f5db02ae992c260e4826fe78c942954b48e1d9c2"
+uuid = "99f44e22-a591-53d1-9472-aa23ef4bd671"
+version = "1.2.1"
+
+[[deps.MuladdMacro]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "e8dcbeef032ba2f9051a44ac22b4e54e3a1a0099"
+uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
+version = "0.2.6"
+
+[[deps.NaNMath]]
+deps = ["OpenLibm_jll"]
+git-tree-sha1 = "dbd2e8cd2c1c27f0b584f6661b4309609c5a685e"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "1.1.4"
+
+[[deps.NaturalSort]]
+git-tree-sha1 = "eda490d06b9f7c00752ee81cfa451efe55521e21"
+uuid = "c020b1a1-e9b0-503a-9c33-f039bfc54a85"
+version = "1.0.0"
+
+[[deps.Netpbm]]
+deps = ["FileIO", "ImageCore", "ImageMetadata"]
+git-tree-sha1 = "d92b107dbb887293622df7697a2223f9f8176fcd"
+uuid = "f09324ee-3d7c-5217-9330-fc30815ba969"
+version = "1.1.1"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[deps.Observables]]
+git-tree-sha1 = "7438a59546cf62428fc9d1bc94729146d37a7225"
+uuid = "510215fc-4207-5dde-b226-833fc4488ee2"
+version = "0.5.5"
+
+[[deps.OffsetArrays]]
+git-tree-sha1 = "117432e406b5c023f665fa73dc26e79ec3630151"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.17.0"
+weakdeps = ["Adapt"]
+
+    [deps.OffsetArrays.extensions]
+    OffsetArraysAdaptExt = "Adapt"
+
+[[deps.Ogg_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "b6aa4566bb7ae78498a5e68943863fa8b5231b59"
+uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
+version = "1.3.6+0"
+
+[[deps.OpenBLASConsistentFPCSR_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "dafdaa3ff15f20ff703d909d3a6f574a5b0586f3"
+uuid = "6cdc7f73-28fd-5e50-80fb-958a8875b1af"
+version = "0.3.33+1"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
+
+[[deps.OpenEXR]]
+deps = ["Colors", "FileIO", "OpenEXR_jll"]
+git-tree-sha1 = "97db9e07fe2091882c765380ef58ec553074e9c7"
+uuid = "52e1d378-f018-4a11-a4be-720524705ac7"
+version = "0.3.3"
+
+[[deps.OpenEXR_jll]]
+deps = ["Artifacts", "Imath_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "0d621a4beb5e48d195f907c3c5b0bea285d9ff9d"
+uuid = "18a262bb-aa17-5467-a713-aee519bc75cb"
+version = "3.4.13+0"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.7+0"
+
+[[deps.OpenMPI_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]
+git-tree-sha1 = "6d6c0ca4824268c1a7dca1f4721c535ac63d9074"
+uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
+version = "5.0.11+0"
+
+[[deps.OpenSSL]]
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "NetworkOptions", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "1d1aaa7d449b58415f97d2839c318b70ffb525a0"
+uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
+version = "1.6.1"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.6+0"
+
+[[deps.Opus_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e2bb57a313a74b8104064b7efd01406c0a50d2ff"
+uuid = "91d4177d-7536-5919-b921-800302f37372"
+version = "1.6.1+0"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "94ba93778373a53bfd5a0caaf7d809c445292ff4"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.8.2"
+
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.44.0+1"
+
+[[deps.PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "26766d4b5f1a410c218a19b85a672c6edb693c65"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.11.40"
+weakdeps = ["StatsBase"]
+
+    [deps.PDMats.extensions]
+    StatsBaseExt = "StatsBase"
+
+[[deps.PNGFiles]]
+deps = ["Base64", "CEnum", "ImageCore", "IndirectArrays", "OffsetArrays", "libpng_jll"]
+git-tree-sha1 = "32b657a0d57c310a1a172bfc8c8cf68c5e674323"
+uuid = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
+version = "0.4.5"
+
+[[deps.PackageCompiler]]
+deps = ["Artifacts", "Glob", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs", "p7zip_jll"]
+git-tree-sha1 = "513193b976208b1b646ad4303323153e8bff0997"
+uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+version = "2.4.0"
+
+[[deps.Packing]]
+deps = ["GeometryBasics"]
+git-tree-sha1 = "bc5bf2ea3d5351edf285a06b0016788a121ce92c"
+uuid = "19eb6ba3-879d-56ad-ad62-d5c202156566"
+version = "0.5.1"
+
+[[deps.PaddedViews]]
+deps = ["OffsetArrays"]
+git-tree-sha1 = "0fac6313486baae819364c52b4f483450a9d793f"
+uuid = "5432bcbf-9aad-5242-b902-cca2824c8663"
+version = "0.5.12"
+
+[[deps.Pango_jll]]
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "58e5ed5e386e156bd93e86b305ebd21ac63d2d04"
+uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
+version = "1.57.1+0"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "32a4e09c5f29402573d673901778a0e03b0807b9"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.6"
+
+[[deps.Pixman_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
+git-tree-sha1 = "e4a6721aa89e62e5d4217c0b21bd714263779dda"
+uuid = "30392449-352a-5448-841d-b1acce4e97dc"
+version = "0.46.4+0"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.12.1"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.PkgVersion]]
+deps = ["Pkg"]
+git-tree-sha1 = "f9501cc0430a26bc3d156ae1b5b0c1b47af4d6da"
+uuid = "eebad327-c553-4316-9ea0-9fa01ccd7688"
+version = "0.3.3"
+
+[[deps.PlotUtils]]
+deps = ["ColorSchemes", "Colors", "Dates", "PrecompileTools", "Printf", "Random", "Reexport", "StableRNGs", "Statistics"]
+git-tree-sha1 = "26ca162858917496748aad52bb5d3be4d26a228a"
+uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
+version = "1.4.4"
+
+[[deps.Pluto]]
+deps = ["Base64", "Configurations", "Dates", "Downloads", "ExpressionExplorer", "FileWatching", "GracefulPkg", "HTTP", "HypertextLiteral", "InteractiveUtils", "LRUCache", "Logging", "LoggingExtras", "MIMEs", "Malt", "Markdown", "MsgPack", "Pkg", "PlutoDependencyExplorer", "PrecompileSignatures", "PrecompileTools", "REPL", "Random", "RegistryInstances", "RelocatableFolders", "SHA", "Scratch", "Sockets", "TOML", "Tables", "URIs", "UUIDs"]
+git-tree-sha1 = "fe7515cf6ddb62e738d924e4ca2dddaa60ff80ba"
+uuid = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+version = "1.0.3"
+
+[[deps.PlutoDependencyExplorer]]
+deps = ["ExpressionExplorer", "InteractiveUtils", "Markdown"]
+git-tree-sha1 = "c3e5073a977b1c58b2d55c1ec187c3737e64e6af"
+uuid = "72656b73-756c-7461-726b-72656b6b696b"
+version = "1.2.2"
+
+[[deps.PolygonOps]]
+git-tree-sha1 = "77b3d3605fc1cd0b42d95eba87dfcd2bf67d5ff6"
+uuid = "647866c9-e3ac-4575-94e7-e3d426903924"
+version = "0.1.2"
+
+[[deps.PooledArrays]]
+deps = ["DataAPI", "Future"]
+git-tree-sha1 = "36d8b4b899628fb92c2749eb488d884a926614d3"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "1.4.3"
+
+[[deps.PrecompileSignatures]]
+git-tree-sha1 = "18ef344185f25ee9d51d80e179f8dad33dc48eb1"
+uuid = "91cefc8d-f054-46dc-8f8c-26e11d7c5411"
+version = "3.0.3"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.PrettyTables]]
+deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
+git-tree-sha1 = "ebf455bb866ee6737030e3d3816bb6a0683c4325"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "3.4.0"
+
+    [deps.PrettyTables.extensions]
+    PrettyTablesExcelExt = "XLSX"
+    PrettyTablesTypstryExt = "Typstry"
+
+    [deps.PrettyTables.weakdeps]
+    Typstry = "f0ed7684-a786-439e-b1e3-3b82803b501e"
+    XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
+
+[[deps.Primes]]
+deps = ["IntegerMathUtils"]
+git-tree-sha1 = "25cdd1d20cd005b52fc12cb6be3f75faaf59bb9b"
+uuid = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
+version = "0.5.7"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.ProgressLogging]]
+deps = ["Logging", "SHA", "UUIDs"]
+git-tree-sha1 = "f0803bc1171e455a04124affa9c21bba5ac4db32"
+uuid = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
+version = "0.1.6"
+
+[[deps.ProgressMeter]]
+deps = ["Distributed", "Printf"]
+git-tree-sha1 = "fbb92c6c56b34e1a2c4c36058f68f332bec840e7"
+uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
+version = "1.11.0"
+
+[[deps.PtrArrays]]
+git-tree-sha1 = "4fbbafbc6251b883f4d2705356f3641f3652a7fe"
+uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
+version = "1.4.0"
+
+[[deps.QOI]]
+deps = ["ColorTypes", "FileIO", "FixedPointNumbers"]
+git-tree-sha1 = "472daaa816895cb7aee81658d4e7aec901fa1106"
+uuid = "4b34888f-f399-49d4-9bb3-47ed5cae4e65"
+version = "1.0.2"
+
+[[deps.QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "5e8e8b0ab68215d7a2b14b9921a946fee794749e"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.11.3"
+
+    [deps.QuadGK.extensions]
+    QuadGKEnzymeExt = "Enzyme"
+
+    [deps.QuadGK.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.RangeArrays]]
+git-tree-sha1 = "b9039e93773ddcfc828f12aadf7115b4b4d225f5"
+uuid = "b3c3ace0-ae52-54e7-9d0b-2c1406fd6b9d"
+version = "0.3.2"
+
+[[deps.Ratios]]
+deps = ["Requires"]
+git-tree-sha1 = "1342a47bf3260ee108163042310d26f2be5ec90b"
+uuid = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
+version = "0.4.5"
+weakdeps = ["FixedPointNumbers"]
+
+    [deps.Ratios.extensions]
+    RatiosFixedPointNumbersExt = "FixedPointNumbers"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.RegistryInstances]]
+deps = ["LazilyInitializedFields", "Pkg", "TOML", "Tar"]
+git-tree-sha1 = "ffd19052caf598b8653b99404058fce14828be51"
+uuid = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
+version = "0.1.0"
+
+[[deps.RelocatableFolders]]
+deps = ["SHA", "Scratch"]
+git-tree-sha1 = "ffdaf70d81cf6ff22c2b6e733c900c3321cab864"
+uuid = "05181044-ff0b-4ac5-8273-598c1e38db00"
+version = "1.0.1"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "62389eeff14780bfe55195b7204c0d8738436d64"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.1"
+
+[[deps.Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "5b3d50eb374cea306873b371d3f8d3915a018f0b"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.9.0"
+
+[[deps.Rmath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.5.1+0"
+
+[[deps.Roots]]
+deps = ["Accessors", "CommonSolve", "Printf"]
+git-tree-sha1 = "ed45bcc7cf3c8887595b973f2b1efbe91dcc50ec"
+uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+version = "3.0.1"
+
+    [deps.Roots.extensions]
+    RootsChainRulesCoreExt = "ChainRulesCore"
+    RootsForwardDiffExt = "ForwardDiff"
+    RootsIntervalRootFindingExt = "IntervalRootFinding"
+    RootsSymPyExt = "SymPy"
+    RootsSymPyPythonCallExt = "SymPyPythonCall"
+    RootsUnitfulExt = "Unitful"
+
+    [deps.Roots.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+    SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
+    SymPyPythonCall = "bc8888f7-b21e-4b7c-a06a-5d9c9496438c"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.RoundingEmulator]]
+git-tree-sha1 = "40b9edad2e5287e05bd413a38f61a8ff55b9557b"
+uuid = "5eaf0fd0-dfba-4ccb-bf02-d820a40db705"
+version = "0.2.1"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.SIMD]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "e24dc23107d426a096d3eae6c165b921e74c18e4"
+uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
+version = "3.7.2"
+
+[[deps.Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "9b81b8393e50b7d4e6d0a9f14e192294d3b7c109"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.3.0"
+
+[[deps.SentinelArrays]]
+deps = ["Dates", "Random"]
+git-tree-sha1 = "084c47c7c5ce5cfecefa0a98dff69eb3646b5a80"
+uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
+version = "1.4.10"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.ShaderAbstractions]]
+deps = ["ColorTypes", "FixedPointNumbers", "GeometryBasics", "LinearAlgebra", "Observables", "StaticArrays"]
+git-tree-sha1 = "818554664a2e01fc3784becb2eb3a82326a604b6"
+uuid = "65257c39-d410-5151-9873-9b3e5be5013e"
+version = "0.5.0"
+
+[[deps.SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+version = "1.11.0"
+
+[[deps.ShiftedArrays]]
+git-tree-sha1 = "503688b59397b3307443af35cd953a13e8005c16"
+uuid = "1277b4bf-5013-50f5-be3d-901d8477a67a"
+version = "2.0.0"
+
+[[deps.SignedDistanceFields]]
+deps = ["Statistics"]
+git-tree-sha1 = "3949ad92e1c9d2ff0cd4a1317d5ecbba682f4b92"
+uuid = "73760f76-fbc4-59ce-8f25-708e95d2df96"
+version = "0.4.1"
+
+[[deps.SimpleBufferStream]]
+git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.2.0"
+
+[[deps.SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools"]
+git-tree-sha1 = "7ddb0b49c109481b046972c0e4ab02b2127d6a75"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.9.6"
+
+[[deps.Sixel]]
+deps = ["Dates", "FileIO", "ImageCore", "IndirectArrays", "OffsetArrays", "REPL", "libsixel_jll"]
+git-tree-sha1 = "0494aed9501e7fb65daba895fb7fd57cc38bc743"
+uuid = "45858cf5-a6b0-47a3-bbea-62219f50df47"
+version = "0.1.5"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "13cd91cc9be159e3f4d95b857fa2aa383b53772a"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.2.3"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.12.0"
+
+[[deps.SpecialFunctions]]
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "6547cbdd8ce32efba0d21c5a40fa96d1a3548f9f"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.8.0"
+weakdeps = ["ChainRulesCore"]
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+[[deps.StableRNGs]]
+deps = ["Random"]
+git-tree-sha1 = "4f96c596b8c8258cc7d3b19797854d368f243ddc"
+uuid = "860ef19b-820b-49d6-a774-d7a799459cd3"
+version = "1.0.4"
+
+[[deps.StackViews]]
+deps = ["OffsetArrays"]
+git-tree-sha1 = "be1cf4eb0ac528d96f5115b4ed80c26a8d8ae621"
+uuid = "cae243ae-269e-4f55-b966-ac2d0dc13c15"
+version = "0.1.2"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
+git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.9.18"
+weakdeps = ["ChainRulesCore", "Statistics"]
+
+    [deps.StaticArrays.extensions]
+    StaticArraysChainRulesCoreExt = "ChainRulesCore"
+    StaticArraysStatisticsExt = "Statistics"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+[[deps.StatsAPI]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "178ed29fd5b2a2cfc3bd31c13375ae925623ff36"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.8.0"
+
+[[deps.StatsBase]]
+deps = ["AliasTables", "DataAPI", "DataStructures", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "e4d7a1a0edc20af42689ea6f4f3587a2175d50ee"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.34.12"
+
+[[deps.StatsFuns]]
+deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "91f091a8716a6bb38417a6e6f274602a19aaa685"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "1.5.2"
+weakdeps = ["ChainRulesCore", "InverseFunctions"]
+
+    [deps.StatsFuns.extensions]
+    StatsFunsChainRulesCoreExt = "ChainRulesCore"
+    StatsFunsInverseFunctionsExt = "InverseFunctions"
+
+[[deps.StatsModels]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Printf", "REPL", "ShiftedArrays", "SparseArrays", "StatsAPI", "StatsBase", "StatsFuns", "Tables"]
+git-tree-sha1 = "0db41c4e0d9f3fa195395a6401a8290752c9cd3d"
+uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
+version = "0.7.10"
+
+[[deps.StringManipulation]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "d05693d339e37d6ab134c5ab53c29fce5ee5d7d5"
+uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
+version = "0.4.4"
+
+[[deps.StructArrays]]
+deps = ["ConstructionBase", "DataAPI", "Tables"]
+git-tree-sha1 = "ad8002667372439f2e3611cfd14097e03fa4bccd"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.7.3"
+
+    [deps.StructArrays.extensions]
+    StructArraysAdaptExt = "Adapt"
+    StructArraysGPUArraysCoreExt = ["GPUArraysCore", "KernelAbstractions"]
+    StructArraysLinearAlgebraExt = "LinearAlgebra"
+    StructArraysSparseArraysExt = "SparseArrays"
+    StructArraysStaticArraysExt = "StaticArrays"
+
+    [deps.StructArrays.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.StructTypes]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "159331b30e94d7b11379037feeb9b690950cace8"
+uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+version = "1.11.0"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "82bee338d650aa515f31866c460cb7e3bcef90b8"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.2"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.8.3+2"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[deps.Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
+git-tree-sha1 = "0f38a06c83f0007bbab3cf911262841c9a0f07e0"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.13.0"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.TensorCore]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "1feb45f88d133a655e001435632f019a9a1bcdb6"
+uuid = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
+version = "0.1.1"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.TiffImages]]
+deps = ["CodecZstd", "ColorTypes", "DataStructures", "DocStringExtensions", "FileIO", "FixedPointNumbers", "IndirectArrays", "Inflate", "Mmap", "OffsetArrays", "PkgVersion", "PrecompileTools", "ProgressMeter", "SIMD", "UUIDs"]
+git-tree-sha1 = "9ca5f1f2d42f80df4b8c9f6ab5a64f438bbd9976"
+uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
+version = "0.11.9"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
+
+[[deps.Tricks]]
+git-tree-sha1 = "311349fd1c93a31f783f977a71e8b062a57d4101"
+uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
+version = "0.1.13"
+
+[[deps.TriplotBase]]
+git-tree-sha1 = "4d4ed7f294cda19382ff7de4c137d24d16adc89b"
+uuid = "981d1d27-644d-49a2-9326-4793e63143c3"
+version = "0.1.0"
+
+[[deps.URIs]]
+git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.6.1"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.UnicodeFun]]
+deps = ["REPL"]
+git-tree-sha1 = "53915e50200959667e78a92a418594b428dffddf"
+uuid = "1cfade01-22cf-5700-b092-accc4b62d6e1"
+version = "0.4.1"
+
+[[deps.Unitful]]
+deps = ["Dates", "LinearAlgebra", "Random"]
+git-tree-sha1 = "57e1b2c9de4bd6f40ecb9de4ac1797b81970d008"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.28.0"
+
+    [deps.Unitful.extensions]
+    ConstructionBaseUnitfulExt = "ConstructionBase"
+    ForwardDiffExt = "ForwardDiff"
+    InverseFunctionsUnitfulExt = "InverseFunctions"
+    LatexifyExt = ["Latexify", "LaTeXStrings"]
+    NaNMathExt = "NaNMath"
+    PrintfExt = "Printf"
+
+    [deps.Unitful.weakdeps]
+    ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+    LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+    Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+    NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+    Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.WeakRefStrings]]
+deps = ["DataAPI", "InlineStrings", "Parsers"]
+git-tree-sha1 = "0716e01c3b40413de5dedbc9c5c69f27cddfddfc"
+uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+version = "1.4.3"
+
+[[deps.WebP]]
+deps = ["CEnum", "ColorTypes", "FileIO", "FixedPointNumbers", "ImageCore", "libwebp_jll"]
+git-tree-sha1 = "aa1ca3c47f119fbdae8770c29820e5e6119b83f2"
+uuid = "e3aaa7dc-3e4b-44e0-be63-ffb868ccd7c1"
+version = "0.1.3"
+
+[[deps.WoodburyMatrices]]
+deps = ["LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "248a7031b3da79a127f14e5dc5f417e26f9f6db7"
+uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
+version = "1.1.0"
+
+[[deps.WorkerUtilities]]
+git-tree-sha1 = "cd1659ba0d57b71a464a29e64dbc67cfe83d54e7"
+uuid = "76eceee3-57b5-4d4a-8e66-0e911cebbf60"
+version = "1.6.1"
+
+[[deps.XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
+git-tree-sha1 = "80d3930c6347cfce7ccf96bd3bafdf079d9c0390"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.13.9+0"
+
+[[deps.XZ_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "b29c22e245d092b8b4e8d3c09ad7baa586d9f573"
+uuid = "ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
+version = "5.8.3+0"
+
+[[deps.Xorg_libX11_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
+git-tree-sha1 = "808090ede1d41644447dd5cbafced4731c56bd2f"
+uuid = "4f6342f7-b3d2-589e-9d20-edeb45f2b2bc"
+version = "1.8.13+0"
+
+[[deps.Xorg_libXau_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "aa1261ebbac3ccc8d16558ae6799524c450ed16b"
+uuid = "0c0b7dd1-d40b-584c-a123-a41640f87eec"
+version = "1.0.13+0"
+
+[[deps.Xorg_libXdmcp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "52858d64353db33a56e13c341d7bf44cd0d7b309"
+uuid = "a3789734-cfe1-5b06-b2d0-1dd0d9d62d05"
+version = "1.1.6+0"
+
+[[deps.Xorg_libXext_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "1a4a26870bf1e5d26cd585e38038d399d7e65706"
+uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
+version = "1.3.8+0"
+
+[[deps.Xorg_libXfixes_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "75e00946e43621e09d431d9b95818ee751e6b2ef"
+uuid = "d091e8ba-531a-589c-9de9-94069b037ed8"
+version = "6.0.2+0"
+
+[[deps.Xorg_libXrender_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "7ed9347888fac59a618302ee38216dd0379c480d"
+uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
+version = "0.9.12+0"
+
+[[deps.Xorg_libpciaccess_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "58972370b81423fc546c56a60ed1a009450177c3"
+uuid = "a65dc6b1-eb27-53a1-bb3e-dea574b5389e"
+version = "0.19.0+0"
+
+[[deps.Xorg_libxcb_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXau_jll", "Xorg_libXdmcp_jll"]
+git-tree-sha1 = "bfcaf7ec088eaba362093393fe11aa141fa15422"
+uuid = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
+version = "1.17.1+0"
+
+[[deps.Xorg_xtrans_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a63799ff68005991f9d9491b6e95bd3478d783cb"
+uuid = "c5fb5394-a638-5e4d-96e5-b29de1b5cf10"
+version = "1.6.0+0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.1+2"
+
+[[deps.Zstd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "446b23e73536f84e8037f5dce465e92275f6a308"
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.5.7+1"
+
+[[deps.aws_c_auth_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_cal_jll", "aws_c_http_jll", "aws_c_sdkutils_jll"]
+git-tree-sha1 = "8cab83c96af80a1be968251ce1a0548a7545484d"
+uuid = "2b3700d1-4306-52e2-a478-c162f0c514be"
+version = "0.9.6+0"
+
+[[deps.aws_c_cal_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_common_jll"]
+git-tree-sha1 = "22c0f42f4a1f0dc5dcfa8fd267c4ac407c455e7a"
+uuid = "70f11efc-bab2-57f1-b0f3-22aad4e67c4b"
+version = "0.9.13+0"
+
+[[deps.aws_c_common_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a759cb9bf456ad792cc7898a81ae333cce9ef02a"
+uuid = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
+version = "0.12.6+0"
+
+[[deps.aws_c_compression_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_common_jll"]
+git-tree-sha1 = "7910c72f45f44afd297c39fe43b99c56d5ed22ec"
+uuid = "73a04cd5-f3d7-5bac-9290-e8adb709f224"
+version = "0.3.2+0"
+
+[[deps.aws_c_http_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_compression_jll", "aws_c_io_jll"]
+git-tree-sha1 = "e358d5a001ef7afbd4f8c5225322512819cda2f2"
+uuid = "3254fc65-9028-534d-aa9d-d76d128babc6"
+version = "0.10.13+0"
+
+[[deps.aws_c_io_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_cal_jll", "aws_c_common_jll", "s2n_tls_jll"]
+git-tree-sha1 = "7e481d474b2087ee8bbf55b81bf9119f21e396d9"
+uuid = "13c41daa-f319-5298-b5eb-5754e0170d52"
+version = "0.26.3+0"
+
+[[deps.aws_c_s3_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_auth_jll", "aws_c_common_jll", "aws_c_http_jll", "aws_checksums_jll", "s2n_tls_jll"]
+git-tree-sha1 = "3e9917ab25114feba657e71be41cad068b9f6595"
+uuid = "bd1f34fb-993f-5903-a121-aaf302eed6d4"
+version = "0.11.5+0"
+
+[[deps.aws_c_sdkutils_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_common_jll"]
+git-tree-sha1 = "c43dfba2c1ab9ea9f02f2c80e86fa16f6460244e"
+uuid = "1282aa60-004d-510b-9f52-12498d409daa"
+version = "0.2.4+1"
+
+[[deps.aws_checksums_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_common_jll"]
+git-tree-sha1 = "2570c8e23f4771a087b12a47edcaaa670ac05a01"
+uuid = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
+version = "0.2.10+0"
+
+[[deps.dlfcn_win32_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e141d67ffe550eadfb5af1bdbdaf138031e4805f"
+uuid = "c4b69c83-5512-53e3-94e6-de98773c479f"
+version = "1.4.2+0"
+
+[[deps.isoband_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "51b5eeb3f98367157a7a12a1fb0aa5328946c03c"
+uuid = "9a68df92-36a6-505f-a73e-abb412b6bfb4"
+version = "0.2.3+0"
+
+[[deps.libaec_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "60f4792734488db6f42e2c7699f1d4594780bd03"
+uuid = "477f73a3-ac25-53e9-8cc3-50b2fa2566f0"
+version = "1.1.7+0"
+
+[[deps.libaom_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "850b06095ee71f0135d644ffd8a52850699581ed"
+uuid = "a4ae2306-e953-59d6-aa16-d00cac43593b"
+version = "3.13.3+0"
+
+[[deps.libass_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "125eedcb0a4a0bba65b657251ce1d27c8714e9d6"
+uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
+version = "0.17.4+0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"
+
+[[deps.libdrm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libpciaccess_jll"]
+git-tree-sha1 = "63aac0bcb0b582e11bad965cef4a689905456c03"
+uuid = "8e53e030-5e6c-5a89-a30b-be5b7263a166"
+version = "2.4.125+1"
+
+[[deps.libfdk_aac_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "646634dd19587a56ee2f1199563ec056c5f228df"
+uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
+version = "2.0.4+0"
+
+[[deps.libpng_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "e51150d5ab85cee6fc36726850f0e627ad2e4aba"
+uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
+version = "1.6.58+0"
+
+[[deps.libsixel_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "libpng_jll"]
+git-tree-sha1 = "c1733e347283df07689d71d61e14be986e49e47a"
+uuid = "075b6546-f08a-558a-be8f-8157d0f608a5"
+version = "1.10.5+0"
+
+[[deps.libva_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll", "Xorg_libXext_jll", "Xorg_libXfixes_jll", "libdrm_jll"]
+git-tree-sha1 = "7dbf96baae3310fe2fa0df0ccbb3c6288d5816c9"
+uuid = "9a156e7d-b971-5f62-b2c9-67348b8fb97c"
+version = "2.23.0+0"
+
+[[deps.libvorbis_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll"]
+git-tree-sha1 = "11e1772e7f3cc987e9d3de991dd4f6b2602663a5"
+uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
+version = "1.3.8+0"
+
+[[deps.libwebp_jll]]
+deps = ["Artifacts", "Giflib_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libglvnd_jll", "Libtiff_jll", "libpng_jll"]
+git-tree-sha1 = "4e4282c4d846e11dce56d74fa8040130b7a95cb3"
+uuid = "c5f90fcd-3b7e-5836-afba-fc50a0988cb2"
+version = "1.6.0+0"
+
+[[deps.mpif_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML"]
+git-tree-sha1 = "a8083ee0737c243c8f40a4ba86a0956997facb73"
+uuid = "9aeb927a-4695-514f-a259-621a69f20ec0"
+version = "0.1.7+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.64.0+1"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.7.0+0"
+
+[[deps.s2n_tls_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "64ae051c6f03044eb7d98027d1b552b4e21e650c"
+uuid = "cddc5d3d-934d-5d3a-9747-62fc12ea3f48"
+version = "1.7.3+0"
+
+[[deps.x264_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "14cc7083fc6dff3cc44f2bc435ee96d06ed79aa7"
+uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
+version = "10164.0.1+0"
+
+[[deps.x265_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e7b67590c14d487e734dcb925924c5dc43ec85f3"
+uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
+version = "4.1.0+0"

--- a/pluto/Project.toml
+++ b/pluto/Project.toml
@@ -1,0 +1,19 @@
+# Pluto notebook engine environment (Playground). Its own Julia env — deliberately separate from
+# `app/` (the Cecelia package) and `api/` (the WS server): the server must NOT carry the Makie
+# plotting stack. Cecelia is path-sourced from ../app (same pattern as api/), so notebooks call the
+# real headless REPL contract (init_object/pop_df/label_props). See docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md.
+[deps]
+AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Cecelia = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+CeceliaNb = "cec0e11a-0000-4000-8000-000000000001"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+
+[sources]
+Cecelia = {path = "../app"}
+CeceliaNb = {path = "CeceliaNb"}

--- a/pluto/build_sysimage.jl
+++ b/pluto/build_sysimage.jl
@@ -1,0 +1,19 @@
+# Build the DEPS-ONLY sysimage for the notebook Playground (pluto/deps.so).
+#
+#   pixi run notebooks-sysimage
+#
+# Deps-only (Locked #6): bakes the stable heavy stack — Makie/CairoMakie + AoG + DataFrames + HDF5 +
+# HTTP — but NOT Cecelia, so Revise still hot-reloads Cecelia in dev. For RELEASE, a full sysimage
+# (Cecelia included) is built in the packaging flow (docs/SHIPPING.md).
+#
+# Cost (Phase 0, Linux): ~10 min to build, ~1.4 GB on disk. One-time. deps.so is git-ignored.
+import Pkg
+Pkg.activate(@__DIR__)
+using PackageCompiler
+
+create_sysimage(
+    ["CairoMakie", "AlgebraOfGraphics", "DataFrames", "HDF5", "HTTP"];
+    sysimage_path = joinpath(@__DIR__, "deps.so"),
+    precompile_execution_file = joinpath(@__DIR__, "precompile_workload.jl"),
+)
+@info "sysimage built" path = joinpath(@__DIR__, "deps.so")

--- a/pluto/build_sysimage_full.jl
+++ b/pluto/build_sysimage_full.jl
@@ -1,0 +1,18 @@
+# Build the FULL (release) sysimage for the notebook Playground: deps + Cecelia + CeceliaNb baked in,
+# for near-instant first plot AND first `pop_df` on a shipped install.
+#
+#   pixi run notebooks-sysimage-full
+#
+# Difference from the deps-only build (build_sysimage.jl): that one deliberately EXCLUDES Cecelia so
+# Revise can hot-reload it in dev. This one bakes Cecelia + CeceliaNb in too — correct for a release
+# where the code is frozen. Wire this into the packaging flow (docs/SHIPPING.md); output is git-ignored.
+import Pkg
+Pkg.activate(@__DIR__)
+using PackageCompiler
+
+create_sysimage(
+    ["CairoMakie", "AlgebraOfGraphics", "DataFrames", "HDF5", "HTTP", "CSV", "Cecelia", "CeceliaNb"];
+    sysimage_path = joinpath(@__DIR__, "deps.so"),
+    precompile_execution_file = joinpath(@__DIR__, "precompile_workload_full.jl"),
+)
+@info "full sysimage built" path = joinpath(@__DIR__, "deps.so")

--- a/pluto/launch.jl
+++ b/pluto/launch.jl
@@ -1,0 +1,65 @@
+# Launch the persistent Pluto notebook server (the Playground engine).
+#
+#   pixi run notebooks                      # examples dir, opens a browser
+#   CECELIA_NOTEBOOKS_DIR=<proj>/notebooks pixi run notebooks   # a project's notebooks
+#
+# Design (see docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md):
+#   * Pluto runs its OWN Julia session (this `pluto/` env, which path-sources Cecelia) — NOT the API
+#     server. Notebooks are a full analysis surface: init_object / pop_df / run_task / plot / export.
+#   * A deps-only sysimage (pluto/deps.so, built by build_sysimage.jl) is passed to notebook WORKERS
+#     via compiler_options if present — kills Makie's time-to-first-plot (Phase 0: 18.8s → 3.9s).
+#     Optional: the server runs fine without it, just with a slow first plot.
+#   * CECELIA_PLUTO_ENV is exported so a notebook's first cell can `Pkg.activate` this env (which
+#     makes Pluto disable its own registered-only pkg manager and pick up the dev-tracked Cecelia).
+import Pkg
+Pkg.activate(@__DIR__)
+
+using Pluto
+
+const PLUTO_PORT = parse(Int, get(ENV, "CECELIA_PLUTO_PORT", "7660"))
+
+# Notebooks directory: explicit env override, else the repo's shipped examples (../notebooks).
+notebooks_dir = abspath(get(ENV, "CECELIA_NOTEBOOKS_DIR", joinpath(@__DIR__, "..", "notebooks")))
+isdir(notebooks_dir) || mkpath(notebooks_dir)
+
+# Export this env's path so notebooks activate it (workers inherit the server process's ENV).
+ENV["CECELIA_PLUTO_ENV"] = @__DIR__
+
+launch_browser = get(ENV, "CECELIA_PLUTO_BROWSER", "true") == "true"
+
+# Deps-only sysimage → worker compiler options (if built).
+sysimg = joinpath(@__DIR__, "deps.so")
+compiler = if isfile(sysimg)
+    @info "Pluto workers will use the deps sysimage (fast first plot)" sysimg
+    Pluto.Configuration.CompilerOptions(sysimage = sysimg)
+else
+    @warn "No pluto/deps.so — first plot in each notebook will be slow (~20s). Build it with: pixi run notebooks-sysimage"
+    Pluto.Configuration.CompilerOptions()
+end
+
+opts = Pluto.Configuration.Options(
+    server = Pluto.Configuration.ServerOptions(
+        port = PLUTO_PORT,
+        launch_browser = launch_browser,
+        notebook_path_suggestion = notebooks_dir * "/",
+        dismiss_update_notification = true,
+        # Reflect on-disk changes live — so a "Restore snapshot" from the app (which overwrites the
+        # .jl) shows up in an open notebook without a manual reload.
+        auto_reload_from_file = true,
+    ),
+    # Pluto's secret protection stays ON (its secure default). Pluto is a code-execution surface
+    # reachable from the browser, so without the secret ANY website you visit could drive
+    # localhost:7660 and run arbitrary code (CSRF/RCE) — that's why we do NOT disable it. Instead we
+    # publish the session secret to a runtime file (below) so the API server can build authorized URLs
+    # (…/?secret=… and …/open?path=…&secret=…).
+    compiler = compiler,
+    evaluation = Pluto.Configuration.EvaluationOptions(workspace_use_distributed = true),
+)
+
+session = Pluto.ServerSession(; options = opts)
+# Publish the secret for the API server to read (git-ignored). Written before run() (which blocks and
+# brings the port up), so by the time the port answers the secret is already available.
+write(joinpath(@__DIR__, ".plutosecret"), session.secret)
+
+@info "Starting Pluto Playground" port = PLUTO_PORT notebooks_dir env = @__DIR__
+Pluto.run(session)

--- a/pluto/notebook_template.jl
+++ b/pluto/notebook_template.jl
@@ -1,0 +1,43 @@
+### A Pluto.jl notebook ###
+# v1.0.3
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 10000000-0000-0000-0000-000000000001
+# Activate the Notebooks env (path-sources the dev Cecelia). Keep this as the first cell.
+begin
+    import Pkg
+    Pkg.activate(get(ENV, "CECELIA_PLUTO_ENV", joinpath(@__DIR__, "..", "pluto")))
+end
+
+# ╔═╡ 10000000-0000-0000-0000-000000000002
+using Cecelia
+
+# ╔═╡ 10000000-0000-0000-0000-000000000003
+using DataFrames, AlgebraOfGraphics, CairoMakie, CSV
+
+# ╔═╡ 10000000-0000-0000-0000-000000000004
+Cecelia.init_cecelia!()
+
+# ╔═╡ 10000000-0000-0000-0000-000000000005
+md"""
+# New notebook
+
+Set a project + image and go. Accessors: `init_object(proj_uid, uid)`, `pop_df(img, pop_type, pops;
+value_name=…)`, `label_props(img; value_name=…) |> as_df`. Plot with AlgebraOfGraphics + CairoMakie;
+export with `CSV.write`. See `example_populations.jl` for a worked example.
+"""
+
+# ╔═╡ 10000000-0000-0000-0000-000000000006
+# proj_uid = ""
+# uid = ""
+# img = init_object(proj_uid, uid)
+
+# ╔═╡ Cell order:
+# ╠═10000000-0000-0000-0000-000000000001
+# ╠═10000000-0000-0000-0000-000000000002
+# ╠═10000000-0000-0000-0000-000000000003
+# ╠═10000000-0000-0000-0000-000000000004
+# ╟─10000000-0000-0000-0000-000000000005
+# ╠═10000000-0000-0000-0000-000000000006

--- a/pluto/precompile_workload.jl
+++ b/pluto/precompile_workload.jl
@@ -1,0 +1,6 @@
+# Exercised during sysimage build so the compiled Makie plot methods get baked in (this is what
+# kills the time-to-first-plot tax). Mirrors the AoG+CairoMakie calls real notebooks make.
+using CairoMakie, AlgebraOfGraphics, DataFrames
+df = DataFrame(x = randn(500), g = rand(["a", "b"], 500))
+save(tempname() * ".png", draw(data(df) * mapping(:x) * AlgebraOfGraphics.histogram(bins=30)))
+save(tempname() * ".png", draw(data(df) * mapping(:x, color=:g) * AlgebraOfGraphics.density()))

--- a/pluto/precompile_workload_full.jl
+++ b/pluto/precompile_workload_full.jl
@@ -1,0 +1,10 @@
+# Precompile workload for the FULL (release) sysimage: exercises the whole notebook path so Cecelia,
+# CeceliaNb and the Makie plot methods all get baked in. Uses a synthetic DataFrame — NO real project
+# is assumed (this runs at build/CI time), so it loads + renders rather than reading a .h5ad.
+using Cecelia, CeceliaNb, DataFrames, AlgebraOfGraphics, CairoMakie
+Cecelia.init_cecelia!()   # bake the config/model load path
+df = DataFrame(x = randn(400), g = rand(["a", "b", "c"], 400))
+save(tempname() * ".png", nb_hist(df, :x; bins = 30))
+save(tempname() * ".png", nb_box(df, :g, :x))
+save(tempname() * ".png", nb_scatter(df, :x, :x; color = :g))
+nb_count(rename(df, :g => :value_name))


### PR DESCRIPTION
## Notebooks — pure-Julia Pluto downstream-analysis Playground

Adds a per-project **Notebooks** section: launch a Julia-only [Pluto](https://plutojl.org/)
notebook server from the UI and do downstream analysis (load objects, pull cell tables via
`pop_df`/`label_props`, plot with AlgebraOfGraphics + CairoMakie, export CSVs) — the work the old
R Markdown vignettes did, now structured, per-project, and versioned. Zero Python.

### Included
- **`pluto/` engine** — its own Julia env (path-sources `Cecelia` like `api/`, so the API server
  never carries the Makie stack): `launch.jl`, dev/full sysimage builds, the small `CeceliaNb`
  helper package, a notebook template.
- **`notebooks/` examples** — three UID-free Pluto notebooks (populations, `pop_df` tutorial,
  object-model tour), verified to run headless on real data.
- **Backend** `api/src/notebooks_api.jl` — launch/status/shutdown/restart (mirrors the napari
  lifecycle; `atexit` cleanup) + registry CRUD (create/describe/delete/duplicate) + snapshot/restore
  versioning. Pluto's secret stays **on**; the session secret is threaded via `pluto/.plutosecret`.
- **Frontend** — `NotebooksModule.vue` (launch/open/restart/shutdown) + `NotebookTable.vue`
  (mirrors `ImageTable` inline-edit; add/describe/duplicate/snapshot + version-history restore).
- **pixi** — `notebooks`, `notebooks-sysimage[-full]`, `notebooks-instantiate`, `stop-notebooks`
  (+ :7660 in `stop`), Linux + Windows.
- **Docs + tests** — `docs/NOTEBOOKS.md` (+ CLAUDE.md / SHIPPING.md), 28 API-test assertions.

### Review notes
- `api/src/*.jl` isn't Revise-tracked → restart the backend after pulling.
- First run needs `pixi run notebooks-instantiate` (+ optional `notebooks-sysimage` for fast first plot).
- Verified: `vue-tsc -b` clean, `pixi run test-api` green (incl. the notebooks suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)