### PR TITLE
Delete a notebook's snapshots along with the notebook

### DIFF
--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -298,6 +298,17 @@ function api_notebooks_delete(body_bytes::Vector{UInt8})
     end
     dest = joinpath(_project_notebooks_dir(uid), file)
     isfile(dest) && rm(dest)
+    # Also drop this notebook's snapshots (.snapshots/<stem>@v<N>.jl) — otherwise deleting the
+    # notebook orphans its whole version history on disk.
+    snapdir = joinpath(_project_notebooks_dir(uid), ".snapshots")
+    prefix  = "$(splitext(file)[1])@v"
+    if isdir(snapdir)
+        for f in readdir(snapdir)
+            (startswith(f, prefix) && endswith(f, ".jl")) || continue
+            tryparse(Int, f[(length(prefix) + 1):(length(f) - 3)]) === nothing && continue
+            rm(joinpath(snapdir, f))
+        end
+    end
     reg = _read_registry(uid)
     delete!(reg, file)
     _write_registry!(uid, reg)

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -144,8 +144,10 @@ end
         @test find("nb1-copy.jl") !== nothing
 
         # delete (server not running in tests → guard doesn't require force)
+        @test !isempty(snaps())    # nb1 has snapshots on disk before delete
         @test _post(api_notebooks_delete, Dict("projectUid"=>uid,"file"=>"nb1.jl"))[1] == 200
         @test find("nb1.jl") === nothing
+        @test isempty(snaps())     # delete also removes the notebook's snapshot history
 
         # errors
         @test api_notebooks_list(HTTP.Request("GET", "/api/notebooks?projectUid=NOPE"))[1] == 404


### PR DESCRIPTION
## Delete a notebook's snapshots along with the notebook

Hitting **Delete** in the Notebooks GUI removed the live `.jl` and the
registry entry, but left every `.snapshots/<stem>@v<N>.jl` on disk — so a
deleted notebook orphaned its entire version history. (Reproduced: created
"3P HMM", took a few snapshots, deleted it → snapshots still in `.snapshots/`.)

`api_notebooks_delete` now also removes the notebook's snapshot files, using
the same prefix + version-parse discipline as `_snapshot_versions` (so it only
touches files matching `<stem>@v<N>.jl`, nothing else in the dir).

**Test:** the delete testset now asserts the notebook has snapshots on disk
before deletion and none after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)