### PR TITLE
Feat/notebooks sysimage first run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ Thumbs.db
 
 # Notebook Playground sysimage — a ~1.4 GB build artifact (rebuild with `pixi run notebooks-sysimage`).
 pluto/deps.so
+pluto/deps.so.stamp
 # Runtime Pluto session secret (written by pluto/launch.jl; read by the API to build authorized URLs).
 pluto/.plutosecret

--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -3,8 +3,8 @@
 # server runs as its OWN Julia process (the pluto/ env, which path-sources Cecelia) — NOT this API
 # server. Lifecycle mirrors the napari bridge: lazy-launch on first request, adopt an already-running
 # server (e.g. one from `pixi run notebooks` or a survivor of a server restart) instead of spawning a
-# duplicate. Secret auth is disabled in pluto/launch.jl (localhost dev tool), so the URL is a plain
-# http://localhost:7660/. See docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md.
+# duplicate. Secret auth stays ON (see launch.jl); launch.jl publishes the session secret to
+# pluto/.plutosecret and the frontend appends it to URLs. See docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md.
 
 const NOTEBOOKS_PORT = 7660
 const NOTEBOOKS_URL  = "http://localhost:$(NOTEBOOKS_PORT)/"
@@ -112,7 +112,102 @@ end
 function api_notebooks_status(req::HTTP.Request)
     running = _notebook_server_alive()
     200, JSON3.write((; running = running, starting = _nb_starting[], url = NOTEBOOKS_URL,
-                        secret = _notebook_secret(), error = running ? nothing : _nb_error[]))
+                        secret = _notebook_secret(), sysimage = _sysimage_status(),
+                        error = running ? nothing : _nb_error[]))
+end
+
+# ── Fast-plot sysimage (pluto/deps.so), built on first run ───────────────────────
+# The deps-only sysimage (PackageCompiler) cuts Makie's ~20 s time-to-first-plot to a few seconds. It
+# can't be shipped prebuilt (native code tied to this platform + Julia/package versions), so on first
+# use we build it here in the BACKGROUND while notebooks stay usable (slow first plot until it lands).
+# The freshly-built image is picked up by launch.jl on the NEXT server launch — we don't restart a
+# running server out from under an open session. Mirrors the server lifecycle above (one tracked proc,
+# atexit cleanup). See docs/NOTEBOOKS.md and TODO #00070.
+_sysimage_path()  = joinpath(_pluto_root(), "deps.so")
+_sysimage_stamp() = _sysimage_path() * ".stamp"
+# Fingerprint of the resolved pluto deps — mirrors pluto/sysimage_stamp.jl (`hash(Manifest.toml)`), so
+# a package update that re-resolves the Manifest invalidates the stamp.
+_manifest_hash() = (m = joinpath(_pluto_root(), "Manifest.toml"); isfile(m) ? string(hash(read(m, String))) : "")
+
+const _nb_build_proc  = Ref{Union{Base.Process,Nothing}}(nothing)
+const _nb_build_error = Ref{Union{String,Nothing}}(nothing)
+
+# Does the on-disk stamp match this Julia + the current Manifest? (Same two fields the build writes.)
+function _stamp_matches(stamp::Union{String,Nothing}, julia::AbstractString, manifest::AbstractString)::Bool
+    stamp === nothing && return false
+    try
+        d = JSON3.read(stamp)
+        String(get(d, :julia, "")) == julia && String(get(d, :manifest, "")) == manifest
+    catch
+        false
+    end
+end
+
+# Pure classifier (testable, no IO): given whether deps.so exists, its stamp contents (or nothing),
+# whether a build is running, whether the last build errored, and the current Julia + Manifest hash →
+# one of: "ready" (fresh image), "stale" (image exists but built for a different Julia/package set —
+# rebuild), "building", "error", "absent". The frontend auto-rebuilds on "absent" OR "stale".
+function _classify_sysimage(exists::Bool, stamp::Union{String,Nothing}, building::Bool, errored::Bool,
+                            julia::AbstractString, manifest::AbstractString)::String
+    if exists
+        _stamp_matches(stamp, julia, manifest) && return "ready"
+        return building ? "building" : "stale"
+    end
+    building && return "building"
+    errored  && return "error"
+    "absent"
+end
+
+function _sysimage_status()::String
+    p = _nb_build_proc[]
+    building = p !== nothing && process_running(p)
+    stamp = isfile(_sysimage_stamp()) ? read(_sysimage_stamp(), String) : nothing
+    _classify_sysimage(isfile(_sysimage_path()), stamp, building, _nb_build_error[] !== nothing,
+                       string(VERSION), _manifest_hash())
+end
+
+# Kick off the background build if the image isn't already fresh or being built. Idempotent; returns
+# the resulting status. Rebuilds over a STALE image too (create_sysimage overwrites deps.so). Errors
+# (env not set up / script missing) propagate to the caller as a 500.
+function _ensure_sysimage_build!()::String
+    lock(_nb_lock) do
+        _sysimage_status() == "ready" && return "ready"
+        p = _nb_build_proc[]
+        (p !== nothing && process_running(p)) && return "building"
+
+        pluto_root   = _pluto_root()
+        build_script = joinpath(pluto_root, "build_sysimage.jl")
+        isfile(build_script) || error("pluto/build_sysimage.jl not found at $build_script")
+        _pluto_env_ready() || error("The notebook environment is not set up. $_SETUP_HINT")
+
+        julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
+        cmd = Cmd(`$julia_exe --project=$pluto_root $build_script`)
+        @info "Building the notebook fast-plot sysimage in the background (first run, ~10 min)..." out = _sysimage_path()
+        _nb_build_error[] = nothing
+        proc = run(pipeline(cmd; stdout = stdout, stderr = stderr), wait = false)
+        _nb_build_proc[] = proc
+        # Watch for completion off the request path: success = the file now exists (PackageCompiler
+        # can exit 0 without writing on some failures, so trust the file, not the code).
+        @async begin
+            wait(proc)
+            lock(_nb_lock) do
+                _nb_build_error[] = isfile(_sysimage_path()) ? nothing :
+                    "The fast-plot sysimage build failed — notebooks still work (slower first plot). Retry, or run `pixi run notebooks-sysimage`."
+            end
+        end
+        "building"
+    end
+end
+
+# POST /api/notebooks/build-sysimage  → { status }   (status as _sysimage_status)
+function api_notebooks_build_sysimage(body_bytes::Vector{UInt8})
+    status = try
+        _ensure_sysimage_build!()
+    catch e
+        @warn "Could not start sysimage build" exception = e
+        return 500, JSON3.write((; error = "Could not start the fast-plot build: $(sprint(showerror, e))"))
+    end
+    200, JSON3.write((; status = status))
 end
 
 # Stop the Pluto server. We can only kill a server THIS process spawned (we hold its handle); killing
@@ -154,10 +249,12 @@ end
 # Best-effort: take a server WE spawned down when this API process exits cleanly (so a normal server
 # shutdown doesn't orphan Pluto on :7660). Won't fire on SIGKILL — `pixi run stop` also kills :7660.
 atexit() do
-    try
-        p = _nb_proc_ref[]
-        p !== nothing && process_running(p) && kill(p)
-    catch
+    for r in (_nb_proc_ref, _nb_build_proc)
+        try
+            p = r[]
+            p !== nothing && process_running(p) && kill(p)
+        catch
+        end
     end
 end
 

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -253,6 +253,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_notebooks_shutdown(body_bytes)
         elseif path == "/api/notebooks/restart"
             api_notebooks_restart(body_bytes)
+        elseif path == "/api/notebooks/build-sysimage"
+            api_notebooks_build_sysimage(body_bytes)
         elseif path == "/api/napari/open"
             api_napari_open(body_bytes)
         elseif path == "/api/napari/close"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -156,6 +156,32 @@ end
     end
 end
 
+@testset "API: notebooks sysimage status" begin
+    # status always carries a `sysimage` field, one of the valid states (machine-independent: deps.so
+    # may or may not exist here). Pins the response contract the frontend's first-run build reads.
+    d = JSON3.read(api_notebooks_status(HTTP.Request("GET", "/api/notebooks/status"))[2])
+    @test haskey(d, :sysimage)
+    @test String(d.sysimage) in ("ready", "building", "error", "absent", "stale")
+
+    # Pure staleness classifier — the update-safety logic, tested without touching disk.
+    stamp(j, m) = "{\"julia\":\"$j\",\"manifest\":\"$m\"}"
+    @test _classify_sysimage(false, nothing, false, false, "1.11", "abc") == "absent"
+    @test _classify_sysimage(false, nothing, true,  false, "1.11", "abc") == "building"
+    @test _classify_sysimage(false, nothing, false, true,  "1.11", "abc") == "error"
+    @test _classify_sysimage(true,  nothing, false, false, "1.11", "abc") == "stale"     # unstamped ⇒ rebuild
+    @test _classify_sysimage(true,  stamp("1.11","abc"), false, false, "1.11", "abc") == "ready"
+    @test _classify_sysimage(true,  stamp("1.10","abc"), false, false, "1.11", "abc") == "stale"  # Julia bumped
+    @test _classify_sysimage(true,  stamp("1.11","zzz"), false, false, "1.11", "abc") == "stale"  # Manifest changed
+    @test _classify_sysimage(true,  stamp("1.11","abc"), true,  false, "1.11", "abc") == "ready"  # fresh wins over building
+    @test _classify_sysimage(true,  stamp("1.10","abc"), true,  false, "1.11", "abc") == "building" # stale + rebuilding
+
+    # status wiring reads the right paths: "ready" on disk iff the image exists AND its stamp matches
+    # this Julia + Manifest (no build running in tests).
+    onstamp = isfile(_sysimage_stamp()) ? read(_sysimage_stamp(), String) : nothing
+    @test (_sysimage_status() == "ready") ==
+          (isfile(_sysimage_path()) && _stamp_matches(onstamp, string(VERSION), _manifest_hash()))
+end
+
 @testset "API: module-canvas persistence" begin
     # Redirect projects_dir() → temp so we don't touch the dev projects dir.
     conf = cecelia_conf(); dirs = get!(conf, "dirs", Dict{String,Any}())

--- a/docs/NOTEBOOKS.md
+++ b/docs/NOTEBOOKS.md
@@ -12,9 +12,9 @@ the work the old R Markdown vignettes did, now versioned and organised. Notebook
 - **From the app:** the **Notebooks** sidebar item (Analysis group). *Launch server* starts Pluto;
   *Open Notebooks* opens it in a new tab. The table below manages this project's notebooks.
 - **From the terminal:** `pixi run notebooks` (Pluto on **:7660**), `pixi run stop-notebooks`.
-- **First plot is slow (~20 s)** until the fast-plot sysimage is built. The app builds it
-  automatically in the background on first open (and rebuilds after an update); `pixi run
-  notebooks-sysimage` is the manual/dev path. See *Sysimage* below.
+- **First plot is slow (~20 s)** until the fast-plot sysimage is built. Build it from the Notebooks
+  page — an **Enable fast plots** button (background, ~10 min); after an update it becomes a
+  **Rebuild** prompt. `pixi run notebooks-sysimage` is the manual/dev path. See *Sysimage* below.
 
 ## Where things live
 
@@ -99,18 +99,19 @@ Makie compiles plotting code on first use (~20 s cold). A PackageCompiler sysima
 being frozen (no Revise). `launch.jl` picks up `deps.so` and passes it to notebook workers; without
 it, notebooks still work, just slow-first-plot.
 
-**Built on first run, not by hand.** An end user never runs the `pixi` task. On first open of the
-Notebooks page the app POSTs `/api/notebooks/build-sysimage`, which builds `deps.so` in a **background
-process** while notebooks stay fully usable (a one-time banner explains the slow-first-plot until it
-lands). The fresh image is used from the **next** server launch — we never restart a running server
-out from under an open session. `pixi run notebooks-sysimage` remains the manual/dev path.
+**Built from a button, not by hand.** An end user never runs the `pixi` task. The Notebooks page shows
+an **Enable fast plots** button (→ `POST /api/notebooks/build-sysimage`) that builds `deps.so` in a
+**background process** while notebooks stay fully usable (a banner explains the slow-first-plot until
+it lands). The fresh image is used from the **next** server launch — we never restart a running server
+out from under an open session. The build is opt-in (a ~10 min, ~1.4 GB job shouldn't start on a
+stray click); `pixi run notebooks-sysimage` remains the manual/dev path.
 
 **Update-safe (the stamp).** A sysimage is native code tied to the exact Julia version + baked package
 versions, so it can't be shipped prebuilt as one universal artifact, and after an update the on-disk
 image goes **stale**. Each build writes a sidecar `deps.so.stamp` (`{julia, hash(Manifest.toml)}`, see
 `pluto/sysimage_stamp.jl`). Freshness = both fields match the current Julia + Manifest. `launch.jl`
 ignores a stale image (falls back to slow-first-plot rather than handing workers an incompatible one),
-and the status endpoint reports `stale` so the app rebuilds it automatically — same flow as first-run.
+and the status endpoint reports `stale` so the page shows a **Rebuild** button — same flow as first-run.
 `_classify_sysimage` (in `notebooks_api.jl`) is the pure, tested classifier: `ready` / `stale` /
 `building` / `error` / `absent`. Release packaging (ship a prebuilt image per platform vs. build on
 first run): see `docs/SHIPPING.md` and TODO #00070.

--- a/docs/NOTEBOOKS.md
+++ b/docs/NOTEBOOKS.md
@@ -12,8 +12,9 @@ the work the old R Markdown vignettes did, now versioned and organised. Notebook
 - **From the app:** the **Notebooks** sidebar item (Analysis group). *Launch server* starts Pluto;
   *Open Notebooks* opens it in a new tab. The table below manages this project's notebooks.
 - **From the terminal:** `pixi run notebooks` (Pluto on **:7660**), `pixi run stop-notebooks`.
-- **First plot is slow (~20 s)** unless a sysimage is built — `pixi run notebooks-sysimage` (dev).
-  See *Sysimage* below.
+- **First plot is slow (~20 s)** until the fast-plot sysimage is built. The app builds it
+  automatically in the background on first open (and rebuilds after an update); `pixi run
+  notebooks-sysimage` is the manual/dev path. See *Sysimage* below.
 
 ## Where things live
 
@@ -23,6 +24,7 @@ pluto/                       ← the notebook ENGINE (its own Julia env; path-so
   launch.jl                  ← starts Pluto (:7660), wires the sysimage + CECELIA_PLUTO_ENV
   build_sysimage.jl          ← deps-only sysimage (dev)      → pluto/deps.so (git-ignored)
   build_sysimage_full.jl     ← full sysimage (release)       → pluto/deps.so
+  sysimage_stamp.jl          ← writes/checks deps.so.stamp (Julia+Manifest) for update-staleness
   notebook_template.jl       ← starter copied by "Add notebook"
   CeceliaNb/                 ← small notebook-side helper package (aggregation + AoG plot shortcuts)
 notebooks/                   ← shipped EXAMPLE notebooks (UID-free, versioned with the code)
@@ -91,9 +93,27 @@ Provenance without git or file-watching:
 Makie compiles plotting code on first use (~20 s cold). A PackageCompiler sysimage bakes that in
 (measured cold-start 32 s → 7.6 s). Built to `pluto/deps.so` (git-ignored, ~1.4 GB, ~10 min):
 `notebooks-sysimage` (dev, deps only — excludes Cecelia so Revise still hot-reloads it) /
-`notebooks-sysimage-full` (release, bakes Cecelia + CeceliaNb in). `launch.jl` picks up `deps.so`
-automatically and passes it to notebook workers; without it, notebooks still work, just slow-first-plot.
-Release packaging: see `docs/SHIPPING.md`.
+`notebooks-sysimage-full` (release, bakes Cecelia + CeceliaNb in). Both run the same
+`create_sysimage`; the **only** difference is the package list — the `-full` build adds `CSV`,
+`Cecelia`, and `CeceliaNb`, so a release image also skips the first-`pop_df` compile, at the cost of
+being frozen (no Revise). `launch.jl` picks up `deps.so` and passes it to notebook workers; without
+it, notebooks still work, just slow-first-plot.
+
+**Built on first run, not by hand.** An end user never runs the `pixi` task. On first open of the
+Notebooks page the app POSTs `/api/notebooks/build-sysimage`, which builds `deps.so` in a **background
+process** while notebooks stay fully usable (a one-time banner explains the slow-first-plot until it
+lands). The fresh image is used from the **next** server launch — we never restart a running server
+out from under an open session. `pixi run notebooks-sysimage` remains the manual/dev path.
+
+**Update-safe (the stamp).** A sysimage is native code tied to the exact Julia version + baked package
+versions, so it can't be shipped prebuilt as one universal artifact, and after an update the on-disk
+image goes **stale**. Each build writes a sidecar `deps.so.stamp` (`{julia, hash(Manifest.toml)}`, see
+`pluto/sysimage_stamp.jl`). Freshness = both fields match the current Julia + Manifest. `launch.jl`
+ignores a stale image (falls back to slow-first-plot rather than handing workers an incompatible one),
+and the status endpoint reports `stale` so the app rebuilds it automatically — same flow as first-run.
+`_classify_sysimage` (in `notebooks_api.jl`) is the pure, tested classifier: `ready` / `stale` /
+`building` / `error` / `absent`. Release packaging (ship a prebuilt image per platform vs. build on
+first run): see `docs/SHIPPING.md` and TODO #00070.
 
 ## API surface (`api/src/notebooks_api.jl`)
 
@@ -107,7 +127,8 @@ Routes:
 | Route | Purpose |
 |---|---|
 | `POST /api/notebooks/launch` | ensure the server is up (202 while starting) → `{url}` |
-| `GET  /api/notebooks/status` | `{running, starting, url}` |
+| `GET  /api/notebooks/status` | `{running, starting, url, sysimage}` (`sysimage`: ready/stale/building/error/absent) |
+| `POST /api/notebooks/build-sysimage` | start the background fast-plot build (idempotent) → `{status}` |
 | `GET  /api/notebooks?projectUid=` | list notebooks (project + example scopes) with description/version/path |
 | `POST /api/notebooks/create` | new notebook from the template |
 | `POST /api/notebooks/describe` | set a notebook's description |

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -255,8 +255,18 @@ both → `pluto/deps.so` (git-ignored, ~1.4 GB, ~10 min):
 - **Dev** — `pixi run notebooks-sysimage` — deps only (Makie/CairoMakie/AoG/DataFrames/HDF5/HTTP/CSV),
   deliberately **excluding Cecelia** so Revise still hot-reloads it.
 - **Release** — `pixi run notebooks-sysimage-full` — also bakes in `Cecelia` + `CeceliaNb` (code is
-  frozen) for near-instant first plot AND first `pop_df`. **Wire this into the release bundle build**
-  (the bundle either ships `deps.so` or builds it on first run — it's too large to commit).
+  frozen) for near-instant first plot AND first `pop_df`.
+
+**End users never run either task.** The app builds `deps.so` in a background process on first open of
+Notebooks (a banner explains the one-time slow-first-plot), so the on-first-run path works with zero
+packaging effort — it's the baseline. A sysimage can't be committed or shipped as one universal
+artifact: it's native code tied to the exact **platform/arch + Julia + package versions**. So each
+build stamps `deps.so.stamp` (`{julia, hash(Manifest.toml)}`, `pluto/sysimage_stamp.jl`); after an
+update the image is detected **stale** and rebuilt automatically, and `launch.jl` refuses to hand a
+stale image to workers (a Julia-version mismatch would break them). *Optional* release optimisation
+(TODO #00070): build the `-full` image per platform in CI and ship it in the bundle so even the first
+open is instant — it falls through to the on-first-run build wherever no prebuilt image is present.
+Because the image is stamped, a shipped one that predates the user's Julia/deps still self-heals.
 
 The Pluto server keeps its **secret token ON** (Pluto's secure default): it's a browser-reachable
 code-execution surface, so the secret guards against other local sites/processes driving it (CSRF/RCE).

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -257,9 +257,10 @@ both → `pluto/deps.so` (git-ignored, ~1.4 GB, ~10 min):
 - **Release** — `pixi run notebooks-sysimage-full` — also bakes in `Cecelia` + `CeceliaNb` (code is
   frozen) for near-instant first plot AND first `pop_df`.
 
-**End users never run either task.** The app builds `deps.so` in a background process on first open of
-Notebooks (a banner explains the one-time slow-first-plot), so the on-first-run path works with zero
-packaging effort — it's the baseline. A sysimage can't be committed or shipped as one universal
+**End users never run either task.** An **Enable fast plots** button on the Notebooks page builds
+`deps.so` in a background process (a banner explains the one-time slow-first-plot), so the
+build-on-demand path works with zero packaging effort — it's the baseline. A sysimage can't be
+committed or shipped as one universal
 artifact: it's native code tied to the exact **platform/arch + Julia + package versions**. So each
 build stamps `deps.so.stamp` (`{julia, hash(Manifest.toml)}`, `pluto/sysimage_stamp.jl`); after an
 update the image is detected **stale** and rebuilt automatically, and `launch.jl` refuses to hand a

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -50,10 +50,11 @@ the move from commit-as-we-go to **versioned GitHub Releases** (SHIPPING.md Phas
 exist, the README's install section should point at the release installers, not a source checkout.
 
 **#00070** — **Ship a prebuilt Notebooks sysimage in the bundle** (release optimisation)
-(1) **DONE** — auto-build on first run: opening Notebooks builds `pluto/deps.so` in a background
-process, notebooks stay usable (slow-first-plot until it lands), and it's stamped so a package/Julia
-update marks it stale and rebuilds automatically (`build-sysimage` route, `_classify_sysimage`,
-`pluto/sysimage_stamp.jl`, `launch.jl` freshness gate). Self-contained, always correct, no CI needed.
+(1) **DONE** — build-on-demand: an **Enable fast plots** button on the Notebooks page builds
+`pluto/deps.so` in a background process, notebooks stay usable (slow-first-plot until it lands), and
+it's stamped so a package/Julia update marks it stale and surfaces a **Rebuild** button
+(`build-sysimage` route, `_classify_sysimage`, `pluto/sysimage_stamp.jl`, `launch.jl` freshness gate).
+Opt-in (a ~10 min build shouldn't auto-start). Self-contained, always correct, no CI needed.
 (2) **Remaining, optional** — once the constructor/pixi packaging pins Julia per platform, build the
 `-full` variant in CI and ship it in the bundle for the primary OSes so even the *first* open is
 instant. It falls through to (1) wherever no prebuilt image is present, and the stamp means a shipped

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -49,6 +49,17 @@ launcher (done), and the update path (`pixi run update` done; in-app button pend
 the move from commit-as-we-go to **versioned GitHub Releases** (SHIPPING.md Phase 3): once releases
 exist, the README's install section should point at the release installers, not a source checkout.
 
+**#00070** — **Ship a prebuilt Notebooks sysimage in the bundle** (release optimisation)
+(1) **DONE** — auto-build on first run: opening Notebooks builds `pluto/deps.so` in a background
+process, notebooks stay usable (slow-first-plot until it lands), and it's stamped so a package/Julia
+update marks it stale and rebuilds automatically (`build-sysimage` route, `_classify_sysimage`,
+`pluto/sysimage_stamp.jl`, `launch.jl` freshness gate). Self-contained, always correct, no CI needed.
+(2) **Remaining, optional** — once the constructor/pixi packaging pins Julia per platform, build the
+`-full` variant in CI and ship it in the bundle for the primary OSes so even the *first* open is
+instant. It falls through to (1) wherever no prebuilt image is present, and the stamp means a shipped
+image that predates the user's Julia/deps self-heals. Belongs with the packaging phase; not urgent —
+the on-first-run path already gives every user a fast cache after one build.
+
 **#00047** — **Temporal downsampling / overlapping tracklets for behaviour** (deferred)
 The old framework computed track measures on the fly, so HMM could push `skipTimesteps` /
 `subtrackOverlap` into celltrackR: a way to **downsample** tracks (e.g. treat 10s/frame data like

--- a/frontend/src/modules/NotebooksModule.vue
+++ b/frontend/src/modules/NotebooksModule.vue
@@ -15,6 +15,12 @@ const url = ref('http://localhost:7660/')
 const secret = ref('')
 const errorMsg = ref('')
 
+// Fast-plot sysimage (pluto/deps.so): built on first visit, in the background, so notebooks are
+// usable immediately (slow first plot until it lands). See api_notebooks_build_sysimage.
+// 'stale' = an image built for a different Julia/package set (after an update) — rebuilt like 'absent'.
+type SysimageState = 'unknown' | 'absent' | 'stale' | 'building' | 'ready' | 'error'
+const sysimage = ref<SysimageState>('unknown')
+
 // Pluto requires a secret (see launch.jl); append it so the browser is authorized.
 const homeUrl = computed(() => secret.value ? `${url.value}?secret=${encodeURIComponent(secret.value)}` : url.value)
 
@@ -23,8 +29,34 @@ const hasProject = computed(() => projectMeta.hasProject)
 const serverRunning = computed(() => server.value === 'running')
 
 let poll: number | undefined
+let buildPoll: number | undefined
 
 function stopPoll() { if (poll) { clearInterval(poll); poll = undefined } }
+function stopBuildPoll() { if (buildPoll) { clearInterval(buildPoll); buildPoll = undefined } }
+
+// Kick off the background build when the cache is missing ('absent') OR outdated after a package
+// update ('stale'). Non-fatal: if it can't start (env not set up), notebooks still launch — just
+// with a slow first plot.
+async function maybeBuildSysimage() {
+  if (sysimage.value !== 'absent' && sysimage.value !== 'stale') return
+  try {
+    const res = await fetch('/api/notebooks/build-sysimage', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+    })
+    const d = await res.json().catch(() => ({}))
+    if (res.ok) sysimage.value = d.status ?? 'building'
+  } catch { /* silent — the fallback (slow first plot) still works */ }
+  if (sysimage.value === 'building') startBuildPoll()
+}
+
+// Poll until the build finishes (~10 min) — slow cadence, it's a long job.
+function startBuildPoll() {
+  stopBuildPoll()
+  buildPoll = window.setInterval(async () => {
+    await refreshStatus()
+    if (sysimage.value === 'ready' || sysimage.value === 'error') stopBuildPoll()
+  }, 5000)
+}
 
 function startPolling() {
   stopPoll()
@@ -44,6 +76,7 @@ async function refreshStatus() {
     url.value = d.url ?? url.value
     secret.value = d.secret ?? ''
     server.value = d.running ? 'running' : (d.starting ? 'starting' : 'stopped')
+    sysimage.value = d.sysimage ?? 'unknown'
     if (d.error) errorMsg.value = d.error
     else if (d.running) errorMsg.value = ''
   } catch {
@@ -109,8 +142,8 @@ async function shutdown() {
   await refreshStatus()
 }
 
-onMounted(refreshStatus)
-onUnmounted(stopPoll)
+onMounted(async () => { await refreshStatus(); maybeBuildSysimage() })
+onUnmounted(() => { stopPoll(); stopBuildPoll() })
 </script>
 
 <template>
@@ -161,6 +194,21 @@ onUnmounted(stopPoll)
           First launch precompiles — this can take up to a minute.
         </p>
         <p v-if="errorMsg" class="nb-error"><i class="pi pi-exclamation-triangle" /> {{ errorMsg }}</p>
+
+        <!-- Fast-plot cache build (background): first run, or a rebuild after a package update -->
+        <div v-if="sysimage === 'building'" class="nb-note">
+          <i class="pi pi-spin pi-cog" />
+          <span>
+            <strong>Preparing notebooks — building the fast-plot cache (~10 min, in the background).</strong>
+            This runs once after install and again after an update. Keep working — notebooks are usable
+            now; only the <em>first</em> plot is slow until it finishes. The cache is picked up
+            automatically the next time the server launches.
+          </span>
+        </div>
+        <p v-else-if="sysimage === 'error'" class="nb-hint">
+          <i class="pi pi-info-circle" /> Couldn't build the fast-plot cache — notebooks still work,
+          just with a slower first plot.
+        </p>
       </section>
 
       <!-- Notebook registry (Phase 3: manage + version) -->
@@ -185,4 +233,10 @@ onUnmounted(stopPoll)
 .nb-status.is-stopped .pi, .nb-status.is-unknown .pi { color: var(--cc-text-muted, #888); }
 .nb-hint { color: var(--cc-text-muted, #888); font-size: .85rem; margin: .5rem 0 0; }
 .nb-error { color: #f0883e; font-size: .85rem; margin: .5rem 0 0; display: flex; align-items: center; gap: .4rem; }
+.nb-note {
+  display: flex; align-items: flex-start; gap: .55rem; margin: .75rem 0 0; padding: .65rem .8rem;
+  font-size: .85rem; line-height: 1.4; border-radius: 6px;
+  color: var(--cc-text, #cdd9e5); background: rgba(88, 166, 255, .08); border: 1px solid rgba(88, 166, 255, .25);
+}
+.nb-note .pi { margin-top: .1rem; color: #58a6ff; }
 </style>

--- a/frontend/src/modules/NotebooksModule.vue
+++ b/frontend/src/modules/NotebooksModule.vue
@@ -34,11 +34,10 @@ let buildPoll: number | undefined
 function stopPoll() { if (poll) { clearInterval(poll); poll = undefined } }
 function stopBuildPoll() { if (buildPoll) { clearInterval(buildPoll); buildPoll = undefined } }
 
-// Kick off the background build when the cache is missing ('absent') OR outdated after a package
-// update ('stale'). Non-fatal: if it can't start (env not set up), notebooks still launch — just
-// with a slow first plot.
-async function maybeBuildSysimage() {
-  if (sysimage.value !== 'absent' && sysimage.value !== 'stale') return
+// Build the fast-plot cache on demand (button). Used for a first build ('absent'), a rebuild after a
+// package update ('stale'), or a retry ('error'). Idempotent; notebooks work without it either way.
+async function buildSysimage() {
+  if (sysimage.value === 'building' || sysimage.value === 'ready') return
   try {
     const res = await fetch('/api/notebooks/build-sysimage', {
       method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
@@ -142,7 +141,8 @@ async function shutdown() {
   await refreshStatus()
 }
 
-onMounted(async () => { await refreshStatus(); maybeBuildSysimage() })
+// On open, learn the cache state (for the button) and resume watching a build already in progress.
+onMounted(async () => { await refreshStatus(); if (sysimage.value === 'building') startBuildPoll() })
 onUnmounted(() => { stopPoll(); stopBuildPoll() })
 </script>
 
@@ -195,19 +195,35 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
         </p>
         <p v-if="errorMsg" class="nb-error"><i class="pi pi-exclamation-triangle" /> {{ errorMsg }}</p>
 
-        <!-- Fast-plot cache build (background): first run, or a rebuild after a package update -->
+        <!-- Fast-plot cache: an optional compiled sysimage that makes the first plot fast. Built on
+             demand (this button); notebooks work without it, just slow-first-plot. -->
         <div v-if="sysimage === 'building'" class="nb-note">
           <i class="pi pi-spin pi-cog" />
           <span>
-            <strong>Preparing notebooks — building the fast-plot cache (~10 min, in the background).</strong>
-            This runs once after install and again after an update. Keep working — notebooks are usable
-            now; only the <em>first</em> plot is slow until it finishes. The cache is picked up
-            automatically the next time the server launches.
+            <strong>Building the fast-plot cache (~10 min, in the background).</strong>
+            Keep working — notebooks are usable now; only the <em>first</em> plot is slow until it
+            finishes. The cache is picked up automatically the next time the server launches.
           </span>
         </div>
-        <p v-else-if="sysimage === 'error'" class="nb-hint">
-          <i class="pi pi-info-circle" /> Couldn't build the fast-plot cache — notebooks still work,
-          just with a slower first plot.
+        <div v-else-if="sysimage === 'absent' || sysimage === 'stale' || sysimage === 'error'"
+             class="nb-build-row">
+          <button class="cc-btn cc-btn-ghost" @click="buildSysimage"
+                  v-tooltip.top="'Build a compiled image so the first plot renders fast (~10 min, runs in the background)'">
+            <i class="pi pi-bolt" />
+            {{ sysimage === 'stale' ? 'Rebuild fast-plot cache'
+             : sysimage === 'error' ? 'Retry fast-plot build'
+             : 'Enable fast plots' }}
+          </button>
+          <span class="nb-hint">
+            {{ sysimage === 'stale'
+              ? 'A package update outdated the cached image — rebuild to keep the first plot fast.'
+             : sysimage === 'error'
+              ? "Last build didn't finish — notebooks still work, just with a slow first plot."
+              : 'Optional: skip the ~20 s first-plot compile. Notebooks work without it.' }}
+          </span>
+        </div>
+        <p v-else-if="sysimage === 'ready'" class="nb-hint">
+          <i class="pi pi-bolt" /> Fast plots enabled.
         </p>
       </section>
 
@@ -239,4 +255,6 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
   color: var(--cc-text, #cdd9e5); background: rgba(88, 166, 255, .08); border: 1px solid rgba(88, 166, 255, .25);
 }
 .nb-note .pi { margin-top: .1rem; color: #58a6ff; }
+.nb-build-row { display: flex; align-items: center; gap: .75rem; margin: .75rem 0 0; flex-wrap: wrap; }
+.nb-build-row .nb-hint { margin: 0; }
 </style>

--- a/pluto/build_sysimage.jl
+++ b/pluto/build_sysimage.jl
@@ -10,10 +10,12 @@
 import Pkg
 Pkg.activate(@__DIR__)
 using PackageCompiler
+include(joinpath(@__DIR__, "sysimage_stamp.jl"))
 
 create_sysimage(
     ["CairoMakie", "AlgebraOfGraphics", "DataFrames", "HDF5", "HTTP"];
     sysimage_path = joinpath(@__DIR__, "deps.so"),
     precompile_execution_file = joinpath(@__DIR__, "precompile_workload.jl"),
 )
+write_sysimage_stamp(@__DIR__)   # record Julia + Manifest versions so a later update can detect staleness
 @info "sysimage built" path = joinpath(@__DIR__, "deps.so")

--- a/pluto/build_sysimage_full.jl
+++ b/pluto/build_sysimage_full.jl
@@ -9,10 +9,12 @@
 import Pkg
 Pkg.activate(@__DIR__)
 using PackageCompiler
+include(joinpath(@__DIR__, "sysimage_stamp.jl"))
 
 create_sysimage(
     ["CairoMakie", "AlgebraOfGraphics", "DataFrames", "HDF5", "HTTP", "CSV", "Cecelia", "CeceliaNb"];
     sysimage_path = joinpath(@__DIR__, "deps.so"),
     precompile_execution_file = joinpath(@__DIR__, "precompile_workload_full.jl"),
 )
+write_sysimage_stamp(@__DIR__)   # record Julia + Manifest versions so a later update can detect staleness
 @info "full sysimage built" path = joinpath(@__DIR__, "deps.so")

--- a/pluto/launch.jl
+++ b/pluto/launch.jl
@@ -27,13 +27,19 @@ ENV["CECELIA_PLUTO_ENV"] = @__DIR__
 
 launch_browser = get(ENV, "CECELIA_PLUTO_BROWSER", "true") == "true"
 
-# Deps-only sysimage → worker compiler options (if built).
+# Deps-only sysimage → worker compiler options — but ONLY if it's FRESH. A sysimage left over from a
+# previous Julia/package version is stale: at best slower, at worst a Julia-version mismatch that makes
+# workers reject it. So we use it only when its stamp matches (sysimage_stamp.jl); otherwise fall back
+# to a plain session (slow first plot) and let the app rebuild it. Never hand workers a stale image.
+include(joinpath(@__DIR__, "sysimage_stamp.jl"))
 sysimg = joinpath(@__DIR__, "deps.so")
-compiler = if isfile(sysimg)
+compiler = if sysimage_fresh(@__DIR__)
     @info "Pluto workers will use the deps sysimage (fast first plot)" sysimg
     Pluto.Configuration.CompilerOptions(sysimage = sysimg)
 else
-    @warn "No pluto/deps.so — first plot in each notebook will be slow (~20s). Build it with: pixi run notebooks-sysimage"
+    isfile(sysimg) ?
+        @warn("Ignoring a stale pluto/deps.so (built for a different Julia/package set) — the app will rebuild it. First plot slow (~20s) until then.") :
+        @warn("No pluto/deps.so — first plot in each notebook will be slow (~20s). Build it with: pixi run notebooks-sysimage")
     Pluto.Configuration.CompilerOptions()
 end
 

--- a/pluto/sysimage_stamp.jl
+++ b/pluto/sysimage_stamp.jl
@@ -1,0 +1,36 @@
+# Version stamp for the notebook sysimage (pluto/deps.so).
+#
+# A sysimage is native code tied to the EXACT Julia version + the baked package versions. After a
+# package or Julia update the on-disk image is STALE and must be rebuilt — a Julia-version mismatch
+# would make Pluto's workers reject it outright, not merely run slow. So we write a sidecar
+# `deps.so.stamp` at build time and check it before use (launch.jl) and to decide when to rebuild.
+#
+# Stamp format (hand-written JSON — no dep in the pluto env): {"julia":"<VERSION>","manifest":"<hash>"}
+# where <hash> fingerprints pluto/Manifest.toml (the resolved dep versions).
+#
+# The API server mirrors this same two-field classification in api/src/notebooks_api.jl
+# (_classify_sysimage) — kept trivially in sync; if you change the fields, change both.
+
+_sysimage_file(dir)  = joinpath(dir, "deps.so")
+_sysimage_stamp(dir) = joinpath(dir, "deps.so.stamp")
+_manifest_fingerprint(dir) = (m = joinpath(dir, "Manifest.toml"); isfile(m) ? string(hash(read(m, String))) : "")
+
+# Write the stamp next to a freshly-built deps.so. Call right after create_sysimage.
+function write_sysimage_stamp(dir)
+    open(_sysimage_stamp(dir), "w") do io
+        print(io, "{\"julia\":\"", VERSION, "\",\"manifest\":\"", _manifest_fingerprint(dir), "\"}")
+    end
+end
+
+# Fresh = the image exists AND its stamp matches this Julia + the current Manifest. A missing stamp
+# (e.g. an image from before stamping existed) counts as NOT fresh, so it gets rebuilt once and stamped.
+function sysimage_fresh(dir)::Bool
+    (isfile(_sysimage_file(dir)) && isfile(_sysimage_stamp(dir))) || return false
+    try
+        s = read(_sysimage_stamp(dir), String)
+        occursin("\"julia\":\"$(VERSION)\"", s) &&
+            occursin("\"manifest\":\"$(_manifest_fingerprint(dir))\"", s)
+    catch
+        false
+    end
+end


### PR DESCRIPTION
## Notebooks: build the fast-plot sysimage on demand, and rebuild it after updates

An end user should never type `pixi run notebooks-sysimage`. This wires the
fast-plot sysimage into the app, behind an explicit button, and makes it survive
updates.

### Build on demand (opt-in button)
The Notebooks page shows a control that builds `pluto/deps.so` in a **background
process** while notebooks stay fully usable (a banner explains the one-time
slow-first-plot until it lands). The fresh image is picked up from the **next**
server launch — we never restart a running server out from under an open session.
It's opt-in because a ~10 min, ~1.4 GB build shouldn't start on a stray click:
- **Enable fast plots** — no cache yet (`absent`)
- **Rebuild fast-plot cache** — a package/Julia update outdated it (`stale`)
- **Retry fast-plot build** — a previous build didn't finish (`error`)
- a muted **Fast plots enabled** once `ready`

### Update-safe (the stamp)
A sysimage is native code tied to the exact **Julia version + baked package
versions**, so it can't be shipped as one universal artifact and goes **stale**
after an update. Each build writes `deps.so.stamp` (`{julia,
hash(Manifest.toml)}`, `pluto/sysimage_stamp.jl`). Freshness = both fields match
the current Julia + Manifest:
- `launch.jl` uses `deps.so` **only when fresh** — a stale image would at best be
  slow, at worst a Julia-version mismatch that makes Pluto workers reject it.
  Otherwise it falls back to slow-first-plot.
- `GET /api/notebooks/status` reports `ready`/`stale`/`building`/`error`/`absent`
  via the pure, tested `_classify_sysimage`; the page shows the matching button.
  Stale is detected on page open (and during a build poll).

### `build_sysimage.jl` vs `build_sysimage_full.jl`
Same `create_sysimage`; the only difference is the package list. Dev is deps-only
and **excludes Cecelia** so Revise still hot-reloads it; `-full` also bakes in
`CSV` + `Cecelia` + `CeceliaNb` for a fast first `pop_df` too, at the cost of a
frozen image (release).

### Also
- Fixes a stale header comment (Pluto secret is ON, not disabled).

### Tests
9 `_classify_sysimage` cases (missing / matching / Julia-bumped / Manifest-changed
/ building), status-contract, and on-disk wiring. `api/test/runtests.jl` green
(28 / 12 / 9). Frontend typechecks.

### Docs
`NOTEBOOKS.md` (build-on-demand button + stamp + route), `SHIPPING.md`,
`TODO #00070` (part 1 done; a CI-built prebuilt image per platform remains as an
optional optimisation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)