### PR TITLE
Notebooks: sync the status doc-comment with the sysimage/secret fields

### DIFF
--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -108,7 +108,8 @@ function api_notebooks_launch(body_bytes::Vector{UInt8})
     (ready ? 200 : 202), JSON3.write((; url = NOTEBOOKS_URL, secret = _notebook_secret(), starting = !ready))
 end
 
-# GET /api/notebooks/status  → { running, starting, url, error }
+# GET /api/notebooks/status  → { running, starting, url, secret, sysimage, error }
+# sysimage: "ready" | "stale" | "building" | "error" | "absent" (see _classify_sysimage below).
 function api_notebooks_status(req::HTTP.Request)
     running = _notebook_server_alive()
     200, JSON3.write((; running = running, starting = _nb_starting[], url = NOTEBOOKS_URL,


### PR DESCRIPTION
## Notebooks: sync the status doc-comment with the sysimage/secret fields

Comment-only. `api_notebooks_status`'s header comment still listed just
`{ running, starting, url, error }`, but it also returns `secret` and
`sysimage` (`ready`/`stale`/`building`/`error`/`absent`). Updated the comment
to match; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)