### PR TITLE
docs: fix stale app/py path after the python/cecelia move

### DIFF
--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -216,7 +216,7 @@ for obs) are handled; sparse (`csr/csc`) raises rather than misreads.
 `HDF5.jl`). Categorical/string obs columns (HMM states are written numeric, but transitions like
 `"1_2"` and cluster ids are strings) need anndata's categorical encoding, so they go through
 `write_categorical_obs(path, columns; drop=…)` — a Python subprocess
-(`app/py/writers/write_categorical_obs_run.py`), the same "new encodings are Python's job" split as
+(`python/cecelia/writers/write_categorical_obs_run.py`), the same "new encodings are Python's job" split as
 new-file creation. The reader decodes categoricals
 transparently, so either write round-trips like any obs column.
 


### PR DESCRIPTION
## docs: fix stale `app/py` path after the `python/cecelia` move

`DATAMODEL.md` had a present-tense pointer to
`app/py/writers/write_categorical_obs_run.py`; that file now lives at
`python/cecelia/writers/write_categorical_obs_run.py`. Corrected it.

Swept the rest of the tracked docs for `app/py` — the remaining mentions are
intentional and left as-is:
- migration notes in `CLAUDE.md` / `ARCHITECTURE.md` ("moved from the old
  `app/py/` → `python/cecelia/`"),
- the historical parked-plan and audit docs under `docs/todo/`, which record the
  state at the time they were written.

(Working-dir cleanup, not in this PR: the leftover untracked `app/py/` dir —
only stale `__pycache__`, no source — was deleted locally. It was never tracked,
so there's nothing to commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)