### PR TITLE
Napari: save layer props (incl. T/Z slider) live on change, not just …

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -54,6 +54,21 @@ function _try_load_layer_props!(v::NapariViewer, task_dir::String, zarr_path::St
     end
 end
 
+# Point the bridge's LIVE (debounced) autosave at the current image's props file and enable/disable it.
+# Sent after each open (layers are recreated per open → the bridge must reconnect to the fresh layers)
+# and on a live toggle. The bridge saves the moment the user changes contrast/colormap/T-Z, so the view
+# survives a crash — not just an image switch. Call after any load so it doesn't echo the load back.
+function _configure_autosave!(v::NapariViewer, task_dir::String, zarr_path::String, enabled::Bool)
+    try
+        props_file = _props_path(task_dir, zarr_path)
+        mkpath(dirname(props_file))
+        send(v, Dict{String,Any}("type" => "configure_autosave",
+                                 "path" => props_file, "enabled" => enabled))
+    catch e
+        @warn "Configure autosave failed" exception = e
+    end
+end
+
 function _viewer()::Union{NapariViewer,Nothing}
     _viewer_ref[]
 end
@@ -136,6 +151,8 @@ function _execute_pending_open()
         if hasproperty(pending, :auto_load_props) && pending.auto_load_props
             _try_load_layer_props!(v, task_dir, zarr_path)
         end
+        _configure_autosave!(v, task_dir, zarr_path,
+                             hasproperty(pending, :auto_save_props) ? pending.auto_save_props : false)
 
         @info "Napari opened image" image_uid=pending.image_uid zarr_path
         broadcast_ws(Dict{String,Any}("type" => "napari:opened", "imageUid" => pending.image_uid))
@@ -232,6 +249,7 @@ function api_napari_open(body_bytes::Vector{UInt8})
         lock(_viewer_lock) do
             _pending_open[] = (; proj_dir, image_uid,
                                  auto_load_props = auto_load,
+                                 auto_save_props = auto_save,
                                  show_3d, as_dask,
                                  show_labels     = show_labels_req,
                                  all_labels)
@@ -261,6 +279,8 @@ function api_napari_open(body_bytes::Vector{UInt8})
         if auto_load
             _try_load_layer_props!(v, task_dir, zarr_path)
         end
+        # Wire live autosave for this image (after the load, so the load isn't echoed back).
+        _configure_autosave!(v, task_dir, zarr_path, auto_save)
 
         @info "Opened image in Napari" image_uid zarr_path
         broadcast_ws(Dict{String,Any}("type" => "napari:opened", "imageUid" => image_uid))
@@ -284,6 +304,21 @@ function api_napari_close(body_bytes::Vector{UInt8})
         catch e
             500, JSON3.write((; error = sprint(showerror, e)))
         end
+    end
+end
+
+# POST /api/napari/configure-autosave  { enabled }  → toggle live layer-props autosave for the image
+# currently open in napari, without re-opening it. Lets the viewer-panel toggle take effect immediately.
+function api_napari_configure_autosave(body_bytes::Vector{UInt8})
+    data    = JSON3.read(String(body_bytes))
+    enabled = Bool(get(data, :enabled, false))
+    v = _viewer()
+    (isnothing(v) || !_viewer_alive()) && return 200, JSON3.write((; ok = false, message = "Napari not running"))
+    (isnothing(_current_zarr_path[]) || isnothing(_current_task_dir[])) &&
+        return 200, JSON3.write((; ok = false, message = "No image open"))
+    _with_viewer() do
+        _configure_autosave!(v, _current_task_dir[], _current_zarr_path[], enabled)
+        200, JSON3.write((; ok = true))
     end
 end
 

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -263,6 +263,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_napari_screenshot(body_bytes)
         elseif path == "/api/napari/restart"
             api_napari_restart(body_bytes)
+        elseif path == "/api/napari/configure-autosave"
+            api_napari_configure_autosave(body_bytes)
         elseif path == "/api/napari/show-labels"
             api_napari_show_labels(body_bytes)
         elseif path == "/api/napari/show-populations"

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -61,9 +61,10 @@ The full call chain for "eye button clicked":
 2. `api_napari_open` in `napari_api.jl`:
    - Resolves `zarr_path` via `versioned_get_field(raw, "filepath", value_name)`
    - Falls back to default channel names if the corrected value has no dedicated `imChannelNames` entry
-   - If auto-save is on, saves layer props for the currently open image before switching
+   - If auto-save is on, saves layer props for the currently open image before switching (a final flush)
    - Calls `_do_open!` → sends `set_task_dir` + `open_image` commands to bridge
    - If auto-load is on, sends `load_layer_props` after
+   - Sends `configure_autosave {path, enabled}` last → the bridge live-saves this image on change (see *Layer props persistence*)
 3. Bridge `open_image`: loads zarr, reads axes/scale/unit from metadata, calls `viewer.add_image`, sets contrast limits, optionally enters 3D mode
 
 ### Pending open
@@ -182,7 +183,7 @@ end
 
 ## Layer props persistence
 
-Auto-save/load stores napari layer visual properties (contrast limits, colormap, opacity, blending, visible, gamma) as a pickle file:
+Auto-save/load stores napari layer visual properties (contrast limits, colormap, opacity, blending, visible, gamma) **plus the viewer's T/Z slider position** (`dims.current_step`) as a pickle file:
 
 ```
 {task_dir}/data/{basename(zarr_path)}.pkl
@@ -190,9 +191,11 @@ Auto-save/load stores napari layer visual properties (contrast limits, colormap,
 
 Example: `projects/NRUBxU/1/KDIeEm/data/ccidImage.ome.zarr.pkl`
 
-The `data/` directory is created by `mkpath` in `_try_save_layer_props!` if it doesn't exist. Saving happens **before** the new image opens; loading happens **after**. Load is a no-op if the `.pkl` doesn't exist yet.
+The `data/` directory is created by `mkpath` if it doesn't exist. Only `Image` layers are saved/loaded (labels/points/tracks are not). On load, the T/Z step is **clamped** to the current image's `dims.nsteps` (a different segmentation/shape may have fewer slices) and only the saved axes are overridden.
 
-Only `Image` layers are saved/loaded. Labels, points, etc. are not included.
+**Saved live, not just on switch (debounced, in the bridge).** When auto-save is on, the bridge itself watches each Image layer's display-prop events and `dims.current_step`, and writes the `.pkl` ~500 ms after the last change (`configure_autosave` → `_schedule_autosave` → `_autosave_flush`). So an adjustment persists the moment you make it — surviving navigation **and** a crash/hard-kill — instead of only when you open another image. The write is **atomic** (tmp + `os.replace`, with `fsync`), so a kill mid-write never leaves a corrupt file. A load-guard (`_autosave_loading`) suppresses the write-back while applying loaded props.
+
+Wiring: the app enables it via `POST /api/napari/open` (`autoSaveProps`), which sends `configure_autosave {path, enabled}` **after** the load (so layers exist to connect to, and the load isn't echoed). Since layers are recreated per open, this reconnects each time. Toggling the viewer-panel button while an image is open takes effect immediately via `POST /api/napari/configure-autosave` (`api_napari_configure_autosave` → the current image's refs). The old on-switch save (`_try_save_layer_props!` before the next open) is kept as a belt-and-braces flush.
 
 ---
 

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -126,6 +126,18 @@ async function openInNapari(valueName: string) {
   }
 }
 
+// Toggling auto-save while an image is already open should take effect immediately (not only on the
+// next open), so tell the bridge to start/stop live-saving the current image. No-op if napari isn't
+// running — the flag still applies on the next open via /api/napari/open.
+watch(() => settings.napariAutoSaveLayerProps, async enabled => {
+  try {
+    await fetch('/api/napari/configure-autosave', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+    })
+  } catch { /* napari not running */ }
+})
+
 // Push a pop type's populations to napari as centroid points. When no `valueName` is given we send
 // BLANK so the server resolves the image's ACTIVE segmentation — the same one gating/clustering
 // (and the population manager's own napari toggle) write to. Defaulting to `labelNames[0]` was the
@@ -501,7 +513,7 @@ onUnmounted(() => {
       <button
         class="opt-btn" :class="{ active: settings.napariAutoSaveLayerProps }"
         @click="settings.napariAutoSaveLayerProps = !settings.napariAutoSaveLayerProps"
-        v-tooltip.bottom="'Auto-save layer props: save brightness/contrast and colormap when switching images, reload on next open'"
+        v-tooltip.bottom="'Auto-save layer props: save brightness/contrast, colormap and the T/Z slider the moment you change them (survives navigation and crashes); reload on next open'"
       ><i class="pi pi-bookmark" /></button>
 
       <button

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -66,6 +66,19 @@ class NapariState:
         self._colcol_cache = {}       # (value_name, column) → (labels, vals, is_cat) obs column read
         self._ts_handler = None       # timestamp slider callback, disconnected before reconnecting
 
+        # ── layer-props autosave (debounced, atomic) ────────────────────────────
+        # Save brightness/contrast/colormap + the T/Z slider position the moment the user changes
+        # them (coalesced ~500ms), so the view survives navigation AND a crash/hard-kill — the file
+        # is only ever written atomically. Off unless the app enables it per open (configure_autosave).
+        self._autosave_path = None     # target .pkl for the currently open image, or None
+        self._autosave_enabled = False
+        self._autosave_loading = False # True while applying loaded props → suppress the write-back
+        self._autosave_conns = []      # [(emitter, cb)] connected for the current image; dropped on reconnect
+        self._autosave_timer = QTimer()
+        self._autosave_timer.setSingleShot(True)
+        self._autosave_timer.setInterval(500)   # debounce window: one write ~500ms after the last change
+        self._autosave_timer.timeout.connect(self._autosave_flush)
+
     # ── Viewer lifecycle ───────────────────────────────────────────────────────
 
     def clear(self):
@@ -763,6 +776,57 @@ class NapariState:
 
     # ── Persistence ───────────────────────────────────────────────────────────
 
+    # ── Live autosave (debounced) ───────────────────────────────────────────────
+
+    def configure_autosave(self, path: str, enabled: bool):
+        """Point live autosave at `path` for the currently open image and (re)wire the change events.
+        Called by the app AFTER each open (layers are recreated per open, so we must reconnect to the
+        fresh layers), and again when the user toggles the setting while an image is open."""
+        self._autosave_path = path
+        self._autosave_enabled = bool(enabled)
+        self._reconnect_autosave()
+
+    def _reconnect_autosave(self):
+        # drop connections to the previous image's (now-destroyed) layers
+        for emitter, cb in self._autosave_conns:
+            try:
+                emitter.disconnect(cb)
+            except Exception:
+                pass
+        self._autosave_conns = []
+        self._autosave_timer.stop()
+        if not self._autosave_enabled:
+            return
+        cb = self._schedule_autosave
+        # per Image-layer display props …
+        for layer in self._viewer.layers:
+            if type(layer).__name__ == "Image":
+                for ev in (layer.events.contrast_limits, layer.events.gamma,
+                           layer.events.colormap, layer.events.opacity,
+                           layer.events.blending, layer.events.visible):
+                    ev.connect(cb)
+                    self._autosave_conns.append((ev, cb))
+        # … and the viewer's T/Z slider position
+        ev = self._viewer.dims.events.current_step
+        ev.connect(cb)
+        self._autosave_conns.append((ev, cb))
+
+    def _schedule_autosave(self, event=None):
+        # ignore changes we cause ourselves while applying loaded props
+        if not self._autosave_enabled or self._autosave_loading or not self._autosave_path:
+            return
+        self._autosave_timer.start()   # single-shot restart → coalesces a burst into one write
+
+    def _autosave_flush(self):
+        if not self._autosave_enabled or not self._autosave_path:
+            return
+        try:
+            self.save_layer_props(self._autosave_path)
+        except Exception:
+            pass
+
+    # ── Persistence (also used for the on-switch save/load) ──────────────────────
+
     def save_layer_props(self, filepath: str):
         props = {"Image": []}
         _keys = [
@@ -775,17 +839,46 @@ class NapariState:
                     k: getattr(layer, k).name if k == "colormap" else getattr(layer, k)
                     for k in _keys
                 })
-        with open(filepath, "wb") as f:
+        # viewer dims position (the T/Z slider) so the image reopens on the same frame/slice
+        try:
+            props["dims"] = {"current_step": list(self._viewer.dims.current_step)}
+        except Exception:
+            pass
+        # atomic write (tmp + os.replace) so a crash/kill never leaves a half-written props file —
+        # the image always reopens in a valid remembered state.
+        tmp = filepath + ".tmp"
+        with open(tmp, "wb") as f:
             pickle.dump(props, f, pickle.HIGHEST_PROTOCOL)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, filepath)
 
     def load_layer_props(self, filepath: str):
         with open(filepath, "rb") as f:
             data = pickle.load(f)
-        entries = list(reversed(data.get("Image", [])))
-        for layer in self._viewer.layers:
-            if type(layer).__name__ == "Image" and entries:
-                for k, v in entries.pop().items():
-                    setattr(layer, k, v)
+        self._autosave_loading = True   # applying these must not trigger a write-back
+        try:
+            entries = list(reversed(data.get("Image", [])))
+            for layer in self._viewer.layers:
+                if type(layer).__name__ == "Image" and entries:
+                    for k, v in entries.pop().items():
+                        setattr(layer, k, v)
+            # restore the T/Z slider, clamped to this image's dims (a different segmentation/shape
+            # may have fewer steps) — preserve current_step length, only override saved axes.
+            dims = data.get("dims") or {}
+            saved = dims.get("current_step")
+            if saved is not None:
+                try:
+                    cur = list(self._viewer.dims.current_step)
+                    nsteps = self._viewer.dims.nsteps
+                    for i in range(len(cur)):
+                        if i < len(saved) and i < len(nsteps):
+                            cur[i] = max(0, min(int(saved[i]), int(nsteps[i]) - 1))
+                    self._viewer.dims.current_step = tuple(cur)
+                except Exception:
+                    pass
+        finally:
+            self._autosave_loading = False
 
     # ── Screenshot ────────────────────────────────────────────────────────────
 
@@ -1081,6 +1174,9 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
 
         elif t == "load_layer_props":
             state.load_layer_props(cmd["path"])
+
+        elif t == "configure_autosave":
+            state.configure_autosave(cmd.get("path"), bool(cmd.get("enabled", False)))
 
         elif t == "save_screenshot":
             state.save_screenshot(cmd["path"], canvas_only=cmd.get("canvas_only", True))


### PR DESCRIPTION
## Napari: save layer props (incl. T/Z slider) live on change, not just on image switch

**Problem:** auto-save only fired when you opened *another* image — it flushed
the outgoing image's props on switch. Adjust contrast and then close napari,
close the app, or stay on the last image → the change was lost. And the T/Z
slider position was never saved at all, so images always reopened on the
default frame/slice.

**Now it saves the moment you change something**, and survives a crash.

### Bridge (`napari_bridge.py`)
- `configure_autosave(path, enabled)` wires a **debounced (~500 ms)** save to
  each Image layer's `contrast_limits / gamma / colormap / opacity / blending /
  visible` events **and** the viewer's `dims.current_step` (the T/Z slider). A
  burst (dragging a slider) coalesces into a single write — cost is a sub-ms
  write of a few-KB pickle, unnoticeable.
- `save_layer_props` now also stores `dims.current_step` and writes
  **atomically** (tmp + `fsync` + `os.replace`), so a crash/hard-kill never
  leaves a corrupt file — the image always reopens in a valid remembered state.
- `load_layer_props` restores the T/Z step, **clamped** to the image's
  `dims.nsteps` (a different segmentation/shape may have fewer slices), guarded
  so applying loaded props doesn't echo back as a save.

### API (`napari_api.jl` / `server.jl`)
- `_configure_autosave!` sent after each open (post-load, so layers exist and
  the load isn't echoed) on both the direct and pending-open paths.
- `POST /api/napari/configure-autosave` toggles it live for the open image.
- The old on-switch save is kept as a belt-and-braces final flush.

### Frontend (`ViewerPanel.vue`)
Toggling the auto-save button now reconfigures the open image immediately (not
only on the next open); tooltip updated.

### Docs
`NAPARI.md` — layer-props persistence + open-flow sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)