### PR TITLE
Fix/gating select after draw

### DIFF
--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -447,8 +447,9 @@ depth (`_z_axis_len() > 1`), so a 2D image opened with the set's 3D toggle on st
 `dims.ndisplay = 2` (you can't draw on a 3-D render). The layer carries the image's `scale` +
 `units` — so the polygon aligns with the cells and napari doesn't warn *"Inconsistent units
 across layers"*. When the user **closes a polygon**, the bridge automatically point-in-polygons
-the cell centroids (in the **currently displayed** dims — other dims like z/t are ignored, so it
-selects across slices) and POSTs the inside label IDs back (no key press / polling). The polygon
+the cell centroids (in the **currently displayed** dims; z scope is configurable below, and t —
+if present — is pinned to the current frame) and POSTs the inside label IDs back (no key press /
+polling). The polygon
 vertices are 2-D (in-plane) even on an N-D image, so they're indexed by their own columns, not the
 viewer dim indices (which would overflow). Mid-draw events (a polygon with <3 vertices) are ignored
 so the API isn't spammed with empty selections while clicking; clearing all shapes clears it.
@@ -461,8 +462,13 @@ when the polygon closes, so scrolling to a different slice before finishing sele
 toggle/stepper **re-evaluates the already-drawn polygon immediately** via `POST
 /api/napari/selection-scope` → `update_selection_scope` (updates `_sel_ctx` then re-runs
 `_on_selection_changed`), and the value is also picked up by the next `start_cell_selection`. No-op
-on images without a z axis, and when no selection is active. `t` is always ignored (selects across
-timepoints).
+on images without a z axis, and when no selection is active.
+
+**t scope.** On a timelapse the selection is **always** restricted to the currently displayed
+timepoint (read live, like z). A region drawn on the image means "these cells, at the frame you're
+looking at" — not every frame's detections in that XY tube. Ignoring t previously over-selected by
+the frame count (e.g. 64× on a 64-frame movie). No toggle: a whole-movie selection from one 2-D
+polygon isn't a meaningful linked-brushing target (each timepoint's detection is its own cell row).
 
 On `open_image` the viewer's **axis labels** are set to the dimension names (`t`/`z`/`y`/`x`, channel
 excluded) so the sliders read meaningfully instead of `-1`/`-2`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,32 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00073** — **Napari region cell-selection over-selected on timelapses (ignored the t axis)** (2026-07-09)
+`_on_selection_changed` (`napari/napari_bridge.py`) point-in-polygons cell centroids in the displayed
+XY dims and filtered z (in slice mode) but never filtered **t** — so on a timelapse a drawn region
+selected every detection in that XY tube across *all* frames (e.g. 64× on the 64-frame `LUkCpP`), the
+"way too many cells" symptom. Now always restrict to the currently displayed timepoint (read live,
+like z), since each timepoint's detection is its own cell row and a whole-movie selection from one
+2-D polygon isn't a meaningful brushing target. Requires restarting the napari bridge (not
+Revise-tracked). See `docs/NAPARI.md` → *t scope*.
+
+**#00072** — **Gating plots didn't remember their axis config (channels / transforms / render mode)** (2026-07-09)
+The per-plot channels (`x`/`y`), transforms (`xt`/`yt`) and render mode were bare `ref()`s in
+`GatePlotPanel.vue`, so they reset to index-based defaults on every remount even though the canvas
+otherwise persists (parent/highlights/geometry already survived). Moved them into the persisted
+per-plot `PlotState` (`GatingPlots.vue`) and passed the bag down as `:ui`, read/written via
+`computed` get/set — the same pattern the summary panels use for their `ui` bag. The draw-tool
+`mode` stays a transient `ref` on purpose (reopening a plot shouldn't leave a tool armed).
+
+**#00071** — **Gate plot stayed in draw mode after drawing, so the new gate couldn't be adjusted** (2026-07-09)
+After drawing a rectangle/polygon the panel kept the draw tool armed, and since move/resize/vertex-edit
+only work in select (`off`) mode, the gate you'd just made couldn't be adjusted without toggling the
+tool button off. Kept the tool armed (so you can gate repeatedly) but added a **Shift-to-edit** modifier:
+holding Shift over the plot while a draw tool is armed grabs/moves/resizes the gate under the cursor
+(`GateOverlay.vue` `onDown`/`onMove` take the existing edit path when `e.shiftKey`; release Shift to keep
+drawing). Shift, not Alt — Alt reveals the menu bar in Firefox / is the menu-access key elsewhere. A
+brief muted hint ("hold Shift to adjust gates") shows top-right while a tool is armed.
+
 **#00069** — **Metadata resync silently reverted corrections; meta-edits missed napari's source of truth** (2026-07-04)
 Audit-driven cleanup of the physical-size/timing feature (#00064/#00065). Three coherence bugs, one
 root cause — the writer (`meta/set`) and the re-reader (`resync_ome_meta!`) disagreed about where

--- a/frontend/src/components/plots/GateOverlay.vue
+++ b/frontend/src/components/plots/GateOverlay.vue
@@ -6,6 +6,8 @@
       drag / insert (dbl-click edge) / delete (right-click vertex) polygon vertices. Live local
       redraw while dragging; emits `edit` with the new spec only on release (server recomputes +
       broadcasts → smooth cross-plot propagation). See docs/UI.md "rendering & UX hacks".
+      Holding Shift while a draw tool is armed enters this edit path too (grab the gate under the
+      cursor) without disarming the tool — release Shift to keep drawing.
 
   Everything is mapped data→px through the LIVE (zoom-synced) extents, so gates track pan/zoom.
 
@@ -129,6 +131,13 @@ let start: [number, number] | null = null
 let cur: [number, number] | null = null
 const polyPts = ref<[number, number][]>([])
 
+// while a draw tool is armed, holding Shift temporarily switches to edit: grab/move/resize any gate
+// under the cursor without disarming the tool. (Shift, not Alt — Alt opens the menu bar in Firefox
+// and is the menu-access key in other browsers.) `shiftEdit` = Shift held over the plot while armed →
+// show handles + edit cursors. An `editHandle` (mid-drag) counts too, so handles stay while resizing.
+const shiftEdit = ref(false)
+const editIntent = (e: MouseEvent) => props.mode !== 'off' && e.shiftKey && !props.readonly
+
 // ── render ──
 function strokeShape(g: GateSpec, colour: string, lw = props.lineWidth) {
   const c = ctx!; c.strokeStyle = colour; c.lineWidth = lw; c.beginPath()
@@ -197,7 +206,7 @@ function draw() {
   paintGates()
   // handles on the hovered / edited gate
   const active = editPath ? gateOf(editPath) : hover.value ? gateOf(hover.value.path) : undefined
-  if (active && props.mode === 'off') {
+  if (active && (props.mode === 'off' || shiftEdit.value || editHandle)) {
     const spec = active.path === editPath && draft.value ? draft.value : active.gate
     drawHandles(spec, active.colour || '#a78bfa')
   }
@@ -292,16 +301,27 @@ function onParentMove(e: MouseEvent) {
 
 // ── canvas handlers ──
 function onDown(e: MouseEvent) {
+  if (editIntent(e)) {                            // armed + Shift → edit the gate under the cursor, never draw
+    const h = hitTest(evtPx(e)); if (h) startEdit(h, evtPx(e))
+    return
+  }
   if (props.mode === 'rectangle') { dragging = true; start = evtPx(e); cur = start; return }
   if (props.mode === 'polygon') return
   const h = hover.value ?? hitTest(evtPx(e))      // off mode → begin editing
   if (h) startEdit(h, evtPx(e))
 }
 function onMove(e: MouseEvent) {
-  if (props.mode === 'off') return
-  cur = evtPx(e)
-  if (props.mode === 'rectangle' && !dragging) return
-  draw()
+  if (props.mode !== 'off') {                     // armed: Shift gives edit-hover feedback, else draw
+    if (editIntent(e) && !dragging && !editHandle) {   // (mid Shift-drag is driven by onEditMove)
+      shiftEdit.value = true
+      const h = hitTest(evtPx(e)); hover.value = h; cursor.value = h ? cursorFor(h) : 'crosshair'
+      return draw()
+    }
+    if (shiftEdit.value) { shiftEdit.value = false; hover.value = null; cursor.value = 'crosshair'; draw() }
+    cur = evtPx(e)
+    if (props.mode === 'rectangle' && !dragging) return
+    return draw()
+  }
 }
 function onUp() {
   if (props.mode === 'rectangle' && dragging && start && cur) {
@@ -312,7 +332,7 @@ function onUp() {
   }
 }
 function onClick(e: MouseEvent) {
-  if (props.mode !== 'polygon') return
+  if (props.mode !== 'polygon' || e.shiftKey) return   // Shift+click is an edit grab (onDown), not a vertex
   const p = evtPx(e)
   if (polyPts.value.length >= 3) {
     const [fx, fy] = polyPts.value[0]
@@ -350,7 +370,7 @@ function onKey(e: KeyboardEvent) {
 }
 
 // drawing modes always capture; off mode toggles via proximity
-watch(() => props.mode, m => { pe.value = m === 'off' ? 'none' : 'auto'; cursor.value = m === 'off' ? 'default' : 'crosshair' })
+watch(() => props.mode, m => { pe.value = m === 'off' ? 'none' : 'auto'; cursor.value = m === 'off' ? 'default' : 'crosshair'; shiftEdit.value = false })
 // authoritative gates arrived → drop the local draft (unless mid-drag)
 watch(() => props.gates, () => { if (!editHandle) { draft.value = null; editPath = null } draw() }, { deep: true })
 watch(() => [props.extents, props.viewTick, props.lineWidth, props.showLabels], draw, { deep: true })

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -25,6 +25,10 @@ import { downloadDataUrl } from '../../plots/export'
 const props = defineProps<{
   index: number; active: boolean; parent: string; highlight: string[]
   gateLineWidth: number; gateLabels: boolean; axisFromZero: boolean
+  // persisted per-plot axis config (owned by GatingPlots' PlotState) — channels, transforms, render
+  // mode. Read/written directly like the summary panels' `ui` bag so these survive navigation.
+  ui: { x?: string; y?: string; xt?: 'linear' | 'log' | 'asinh' | 'logicle'
+        yt?: 'linear' | 'log' | 'asinh' | 'logicle'; renderMode?: 'points' | 'contour' }
   // window-arrangement command (Tile/Cascade); seq bumps to force re-apply
   arrange?: ArrangeCmd | null
   persistKey?: string        // CanvasPanel geometry persistence key
@@ -37,15 +41,19 @@ const log = useLogStore()
 
 type Kind = 'linear' | 'log' | 'asinh' | 'logicle'
 const TRANSFORMS: Kind[] = ['linear', 'log', 'asinh', 'logicle']
-const xChan = ref(''); const yChan = ref('')
 // track properties (motility, per-track aggregates) are plain continuous values → linear by
 // default; flow intensities default to logicle (FlowJo). User can switch either per axis.
 const defaultTransform: Kind = g.popType === 'track' ? 'linear' : 'logicle'
-const xt = ref<Kind>(defaultTransform); const yt = ref<Kind>(defaultTransform)
+// axis config reads/writes the persisted `ui` bag (owned by GatingPlots) so it survives remount.
+const xChan = computed({ get: () => props.ui.x ?? '', set: v => { props.ui.x = v } })
+const yChan = computed({ get: () => props.ui.y ?? '', set: v => { props.ui.y = v } })
+const xt = computed<Kind>({ get: () => props.ui.xt ?? defaultTransform, set: v => { props.ui.xt = v } })
+const yt = computed<Kind>({ get: () => props.ui.yt ?? defaultTransform, set: v => { props.ui.yt = v } })
+const renderMode = computed<'points' | 'contour'>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })
 // displayed population is owned by GatingPlots (per-panel) so the manager can highlight it
 const parent = computed({ get: () => props.parent, set: v => emit('update:parent', v) })
+// draw tool is transient interaction state (not persisted): reopening a plot shouldn't leave a tool armed
 const mode = ref<'off' | 'rectangle' | 'polygon'>('off')
-const renderMode = ref<'points' | 'contour'>('points')
 // pop-colour overlay is driven by the populations checked for THIS panel in the manager
 const showPops = computed(() => (props.highlight?.length ?? 0) > 0)
 
@@ -140,8 +148,9 @@ async function loadPopLayers() {
 function onDraw(geom: Partial<GateSpec>) {
   pending.value = { ...geom, x_channel: xChan.value, y_channel: yChan.value,
                     x_transform: tspec(xt.value), y_transform: tspec(yt.value) }
-  // keep the draw tool armed (rectangle/polygon) so you can gate repeatedly without re-selecting it;
-  // it's only turned off explicitly (toggle the tool button, or cancel/Esc).
+  // keep the draw tool armed (rectangle/polygon) so you can gate repeatedly without re-selecting it.
+  // To adjust a gate without disarming, hold Shift over the plot — GateOverlay grabs/moves/resizes the
+  // gate under the cursor while armed (see its onDown/onMove); release Shift to keep drawing.
   newName.value = ''
 }
 const nameReserved = computed(() => isReservedPopName(newName.value))
@@ -233,6 +242,8 @@ watch(hlVersion, loadPopLayers)
                      :mode="mode" :gate-line-width="gateLineWidth" :gate-labels="gateLabels"
                      :view-tick="viewTick" :loading="loading"
                      @draw="onDraw" @edit="onEdit" @cancel="mode = 'off'">
+      <!-- brief affordance: the draw tool stays armed, hold Shift to grab/move/resize a gate -->
+      <div v-if="mode !== 'off' && !pending" class="gate-hint">hold <kbd>Shift</kbd> to adjust gates</div>
       <div v-if="pending" class="panel-name">
         <span>new {{ pending.kind }}</span>
         <input v-model="newName" placeholder="name…" autofocus
@@ -278,4 +289,10 @@ watch(hlVersion, loadPopLayers)
 .panel-name input { background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-border); border-radius: 3px; padding: 1px 5px; width: 90px; }
 .panel-name input.name-invalid { border-color: var(--cc-danger, #ef4444); }
 .name-hint { color: var(--cc-danger, #ef4444); font-size: 10px; max-width: 150px; line-height: 1.2; }
+/* subtle draw-mode affordance (top-right of the plot); mirrors .panel-name but muted and non-interactive */
+.gate-hint { position: absolute; top: 4px; right: 4px; pointer-events: none; display: flex; align-items: center; gap: 4px;
+  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 4px; padding: 2px 6px;
+  font-size: 10px; color: var(--cc-text-dim); }
+.gate-hint kbd { font: inherit; background: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: 3px;
+  padding: 0 3px; color: var(--cc-text); }
 </style>

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -32,15 +32,23 @@ const ws = useWsStore()
 // EVERY manager option (highlighted pops, gate labels, line width, axis) obeys this:
 // GLOBAL → one shared value applied to all plots; LOCAL → the active plot's own value.
 // per-plot copies of every scoped option (used when scope = 'local')
-interface PlotState { parent: string; hl: string[]; lineWidth: number; labels: boolean; fromZero: boolean }
+// per-plot copies also carry the axis config (channels/transforms/render mode) so those persist per
+// plot across navigation — like the summary panels' `ui` bag. Bare refs in the panel reset on remount.
+type GateKind = 'linear' | 'log' | 'asinh' | 'logicle'
+interface PlotState { parent: string; hl: string[]; lineWidth: number; labels: boolean; fromZero: boolean
+  x: string; y: string; xt: GateKind; yt: GateKind; renderMode: 'points' | 'contour' }
 const canvasRef = useTemplateRef<HTMLElement>('canvasRef')
 // Per-image + segmentation: gating populations are per-value_name, so each (image, segmentation) keeps
 // its own plots/parents/highlights and the canvas rebinds when either the image or the segmentation
 // (g.valueName) changes.
 const ckey = computed(() => `gate:${props.popType}:${props.imageUid ?? 'none'}:${g.valueName}`)
+// track properties → linear by default; flow intensities → logicle (FlowJo). Channels (x/y) start
+// empty and the panel picks index-based defaults once the store's columns load (see ensureChannels).
+const defT: GateKind = props.popType === 'track' ? 'linear' : 'logicle'
 const { panels, activeId, activePanel, shared, add, remove, arrangeGrid, arrangeCascade } =
   useCanvasPanels<PlotState>(canvasRef, () =>
-    ({ parent: 'root', hl: [], lineWidth: 1.5, labels: true, fromZero: true }), ckey)
+    ({ parent: 'root', hl: [], lineWidth: 1.5, labels: true, fromZero: true,
+       x: '', y: '', xt: defT, yt: defT, renderMode: 'points' }), ckey)
 
 // global-scope values live in the canvas `shared` bag via useViewState, so they PERSIST across
 // navigation with no per-field wiring (the highlighted pops were resetting on remount). Add an
@@ -164,7 +172,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
         <GatePlotPanel v-for="(p, i) in panels" :key="`${ckey}:${p.id}`" :index="i" :arrange="p.arrange"
                        :active="p.id === activeId" :parent="p.state.parent" :highlight="panelHL(p.state)"
                        :gate-line-width="panelLineWidth(p.state)" :gate-labels="panelLabels(p.state)" :axis-from-zero="panelFromZero(p.state)"
-                       :persist-key="`${ckey}:${p.id}`"
+                       :ui="p.state" :persist-key="`${ckey}:${p.id}`"
                        @activate="activeId = p.id" @update:parent="setParent(p.id, $event)" @remove="remove(p.id)" />
         <PopulationManager :selected="selected" :highlighted="activeHL" :scope="scope" :pop-type="props.popType"
                            :line-width="activeLineWidth" :gate-labels="activeLabels" :axis-from-zero="activeFromZero"

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -617,7 +617,11 @@ class NapariState:
 
         `z_mode="slice"` restricts the selection to cells whose z-centroid is within `z_window`
         slices of the **currently displayed** z (read live when the polygon is closed); `"stack"`
-        (default) ignores z and selects across the whole stack. No-op on images without a z axis."""
+        (default) ignores z and selects across the whole stack. No-op on images without a z axis.
+
+        On a timelapse (t axis) the selection is ALWAYS restricted to the currently displayed
+        timepoint — a drawn region means "these cells, at this frame", not every frame's cells in
+        that XY tube (which would over-select by the frame count)."""
         if self._task_dir is None:
             raise RuntimeError("call set_task_dir before start_cell_selection")
         self._sel_ctx = {"project_uid": project_uid, "image_uid": image_uid,
@@ -700,6 +704,20 @@ class NapariState:
             if z_now is not None:
                 win = int(self._sel_ctx.get("z_window", 0))
                 inside &= np.abs(np.round(C[:, axes.index("z")]) - z_now) <= win
+
+        # timelapse scope: a region drawn on the image means "these cells, at the frame you're
+        # looking at". The polygon test is in-plane only and ignores t, so WITHOUT this every
+        # detection in the XY tube across ALL timepoints is selected (e.g. 64× on a 64-frame movie)
+        # — the "way too many cells" symptom. Always restrict to the currently displayed timepoint
+        # (read live, like z above, so scrolling to another frame before closing selects on it).
+        if "t" in axes:
+            display_axes = self._display_axes()
+            try:
+                t_now = self._viewer.dims.current_step[display_axes.index("t")]
+            except (ValueError, IndexError):
+                t_now = None
+            if t_now is not None:
+                inside &= np.round(C[:, axes.index("t")]).astype(int) == int(t_now)
 
         self._post_selection([int(x) for x in labels[inside]])
 


### PR DESCRIPTION
## Gating-plot UX + napari selection fixes

Three related fixes reported while gating. Frontend type-checks (`vue-tsc --noEmit`);
the napari change is Python and needs a **bridge restart** (not Revise-tracked).

### 1. Adjust a gate without disarming the draw tool
After drawing, the tool stays armed so you can gate repeatedly — but the gate you'd
just made couldn't be adjusted, because move/resize/vertex-edit only run in select
(`off`) mode. Now **hold Shift** over the plot to grab/move/resize *any* gate under
the cursor while a tool is armed; release Shift to keep drawing. Reuses the existing
edit machinery (`GateOverlay` `onDown`/`onMove` take the edit path on `e.shiftKey`).
A muted hint ("hold Shift to adjust gates") shows top-right while armed.

**Shift, not Alt** — Alt reveals the menu bar in Firefox and is the menu-access key
in other browsers.

### 2. Gating plots remember their inputs
Per-plot channels (`x`/`y`), transforms (`xt`/`yt`) and render mode were bare
`ref()`s, so they reset to defaults on remount even though the canvas otherwise
persists (parent/highlights/geometry already survived). Moved them into the
persisted per-plot `PlotState` and passed the bag down as `:ui`, read/written via
`computed` get/set — the same pattern the summary panels use. The draw-tool `mode`
stays transient on purpose.

### 3. Napari region cell-selection over-selected on timelapses
`_on_selection_changed` point-in-polygoned centroids in the displayed XY dims and
filtered z (in slice mode) but **never filtered `t`** — so on a timelapse a drawn
region selected every detection in that XY tube across *all* frames (e.g. 64× on
the 64-frame `LUkCpP`), the "way too many cells" symptom. Now always restrict to
the currently displayed timepoint (read live, like z), since each timepoint's
detection is its own cell row and a whole-movie selection from one 2-D polygon
isn't a meaningful linked-brushing target.

### Files
- `frontend/src/components/plots/GateOverlay.vue` — Shift-to-edit while armed
- `frontend/src/modules/gate/GatePlotPanel.vue` — Shift edit, `:ui` axis config, hint
- `frontend/src/modules/gate/GatingPlots.vue` — axis config in persisted `PlotState`
- `napari/napari_bridge.py` — current-timepoint selection scope
- `docs/NAPARI.md`, `docs/TODO.md` (#00071–#00073)

### Testing
- `vue-tsc --noEmit` passes; `napari_bridge.py` parses.
- Not run in a live app/build here (no `node_modules` in this checkout) — worth a
  quick manual pass on the Shift-edit interaction and per-plot persistence.
- Restart the napari bridge to pick up the selection fix.