### PR TITLE
feat(gating): read-only channel-pairs matrix (R pairs) on the gating …

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -68,6 +68,13 @@ montage (⚙ toggle) from `popmap` + gate stats — the read-only counterpart of
 `GatePlotPanel`. Ports the old R `plot_gating` lineage. **The gating page itself is intentionally NOT
 registry-hosted** (it is a write-capable gate-drawing workspace, the opposite of this contract).
 
+It owns ONLY the selectors and the tree→tiles logic (`PanelDef[]`); the fetch + render + export of
+those tiles is the shared **`components/plots/GateMontage.vue`** (a grid of read-only `GateScatterCell`
+tiles, `mode="off"`). The channel-pairs matrix on the gating page (`GatePairsPanel`, see
+[`docs/POPULATION.md`](POPULATION.md)) feeds the SAME `GateMontage` with channel-product tiles — one
+montage renderer, two tile producers (`feedback_use_existing_framework`). `GateMontage` also carries
+the transpose reuse (mirror tiles share one fetch) and the optional coloured population overlays.
+
 ### Image / napari-screenshot slot
 `ImageStripView` shows an image filmstrip with a caption overlay (size slider in its ⚙). Napari-screenshot
 slots capture the live viewer via `/api/napari/screenshot` (backend restart to activate).

--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -296,6 +296,15 @@ now includes `membership_sig`, so resizing the selection shape refreshes the hig
   (`listeningToGating`) so server pushes don't re-emit gate mutations; multiple
   simultaneous panels; hierarchical population tree (generic for all 3 types). **No
   Plotly** for gating.
+- **Channel-pairs matrix (read-only)**: the gating page's `+ Pairs` button (`GatingPlots`) adds a
+  `GatePairsPanel` — the single plot's X/Y generalised to a *list* of channels, rendered as the full
+  N×N matrix of every channel-vs-channel scatter (R `pairs()`), for choosing the best two channels to
+  gate a population on. It draws NO gates, but shows the displayed population's child gate outlines on
+  the matching tiles and honours the SAME highlight pipeline as a normal plot (manager "eye" pops +
+  transient napari cell-selection light up every tile). Shared with both flow and track gating (one
+  `GatingPlots` host, keyed by `popType`). It reuses the shared `GateMontage` renderer (see
+  [`docs/UI.md`](UI.md) → *Gate scatters*); the pure tile builder is `plots/pairsMatrix.ts`
+  (`buildPairDefs`, unit-tested). Channel count is capped (8 → 64 tiles) with a visible hint.
 
 ## Scale
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,19 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00074** — **Channel-pairs matrix on the gating pages (R `pairs()`)** (2026-07-09)
+A `+ Pairs` button on the gating workspace (`GatingPlots`, so both flow AND track gating) adds a
+read-only `GatePairsPanel`: the single plot's X/Y generalised to a *list* of channels, rendered as the
+full N×N matrix of every channel-vs-channel scatter — for picking the best two channels to gate a
+population on. No gate drawing, but it shows the displayed population's child-gate outlines on the
+matching tiles and honours the same highlight pipeline as a normal plot (manager "eye" pops + transient
+napari cell-selection). Generalised, not duplicated: extracted the montage renderer/fetcher out of
+`GatingStrategyView` into the shared `components/plots/GateMontage.vue` (transpose reuse for mirror
+tiles, optional coloured pop overlays, PNG/PDF export); the strategy plot now consumes it too. Pure tile
+builder `plots/pairsMatrix.ts` (`buildPairDefs`) + `plots/montage.ts` are unit-tested; channel count
+capped at 8 (64 tiles) with a visible hint. See `docs/POPULATION.md` → *Channel-pairs matrix* and
+`docs/UI.md` → *Gate scatters*.
+
 **#00073** — **Napari region cell-selection over-selected on timelapses (ignored the t axis)** (2026-07-09)
 `_on_selection_changed` (`napari/napari_bridge.py`) point-in-polygons cell centroids in the displayed
 XY dims and filtered z (in slice mode) but never filtered **t** — so on a timelapse a drawn region

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -470,10 +470,19 @@ panel reads as "frozen". But a spinner that flashes on every quick plot is worse
   never blocks the plot underneath, and honours `prefers-reduced-motion`.
 
 Do **not** hand-roll per-plot "…" text or an immediate spinner. **Small/embedded plots stay out**: the
-gating-strategy montage tiles (compact `GateScatterCell`) keep an unobtrusive dot, not a wheel per tile
-— gate the overlay on `!compact` (or equivalent). Wired today in `SummaryPanel` and the full-size
-`GateScatterCell` (Gate page); `UmapView` has its own empty-state wheel. New heavy plots: reuse these
-two primitives.
+gate montage tiles (compact `GateScatterCell`, rendered by `GateMontage`) keep an unobtrusive dot, not a
+wheel per tile — gate the overlay on `!compact` (or equivalent). Wired today in `SummaryPanel` and the
+full-size `GateScatterCell` (Gate page); `UmapView` has its own empty-state wheel. New heavy plots: reuse
+these two primitives.
+
+**Gate scatters — one renderer, three hosts.** `components/plots/GateScatterCell.vue` is the ONE
+scatter+gate body (WebGL points + contour/pop-colour layer + canvas2D gate overlay). The interactive
+Gate page (`GatePlotPanel`, `mode` = rectangle/polygon) and every read-only montage tile (`mode="off"`)
+share it. Montages of tiles go through `components/plots/GateMontage.vue` — a grid of `GateScatterCell`
+tiles that owns the per-tile fetch (`plotmeta`/`plotdata`/`stats`), transpose reuse, optional coloured
+population overlays (`highlight`), and PNG/PDF export. It has two tile producers: `GatingStrategyView`
+(tree-derived, responsive wrap) and `GatePairsPanel` (channel-product N×N matrix, `cols` set). Add a new
+gate-montage view by building `PanelDef[]` and rendering `<GateMontage>` — never a second gate renderer.
 
 ### Generic plot-integration interface (reuse across surfaces)
 

--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -1,0 +1,209 @@
+<!--
+  The ONE gate-montage renderer: a grid of read-only GateScatterCell tiles, each showing a parent
+  population's cells as a density scatter on a channel pair with the child gate outlines that define
+  populations there. Extracted from GatingStrategyView so BOTH montage producers share it
+  (feedback_use_existing_framework):
+    • the gating-strategy plot (Analysis board) — tree-derived tiles, responsive wrap layout;
+    • the channel-pairs matrix (Gate/Tracking pages) — channel-product tiles, strict N×N matrix.
+  The host owns WHICH tiles to render (`defs`, built by tree walk or buildPairDefs); this owns the
+  per-tile fetch (plotmeta/plotdata/stats), the transpose reuse (mirror tiles share one fetch), the
+  optional coloured population overlays (`highlight` — the "show pops" / napari-brushing layers, same as
+  the normal gating plot), the layout, and PNG/PDF export. Store-agnostic (the board fetches its own
+  tree independent of the gating store), so all reactivity is driven by props.
+-->
+<script setup lang="ts">
+import { ref, computed, watch, useTemplateRef } from 'vue'
+import type { GateSpec } from '../../stores/gating'
+import { plotHostToImageURL } from '../../plots/export'
+import GateScatterCell from './GateScatterCell.vue'
+import type { PopLayer } from './PlotLayers.vue'
+import {
+  type PanelDef, type PanelChild, type MontageId, type Ext, type Tick,
+  idQ, plotQ, canonicalOrient, transposePoints, transposeExt,
+} from '../../plots/montage'
+
+const props = withDefaults(defineProps<{
+  projectUid: string; imageUid: string; valueName: string; popType: string
+  defs: PanelDef[]
+  colLabel: (col: string) => string
+  renderMode?: 'points' | 'contour'
+  gateLabels?: boolean
+  gateLineWidth?: number
+  // coloured population overlays drawn on every tile (the manager's "eye" pops + transient napari
+  // selection). Host resolves the colour; empty on the read-only board.
+  highlight?: { path: string; colour: string }[]
+  // null → responsive wrap (gating-strategy montage); N → strict N-column matrix (channel pairs)
+  cols?: number | null
+  // bump to force a data refresh when tiles are unchanged but membership moved (ancestor gate edit,
+  // napari selection) — the parent's point cloud can change without any def changing.
+  reloadKey?: string | number
+}>(), {
+  renderMode: 'points', gateLabels: true, gateLineWidth: 1.5,
+  highlight: () => [], cols: null, reloadKey: 0,
+})
+
+const montageId = computed<MontageId>(() => ({
+  projectUid: props.projectUid, imageUid: props.imageUid, valueName: props.valueName, popType: props.popType }))
+const single = computed(() => props.cols == null && props.defs.length === 1)
+const gridStyle = computed(() => props.cols ? { gridTemplateColumns: `repeat(${props.cols}, minmax(0, 1fr))` } : {})
+
+interface PanelData {
+  points: Float32Array; extents: Ext; xTicks: Tick[]; yTicks: Tick[]
+  gates: { path: string; colour: string; gate: GateSpec; label: string }[]
+  popLayers: PopLayer[]
+}
+const panelData = ref<Record<string, PanelData>>({})
+const loading = ref(false)
+const err = ref('')
+let loadTok = 0
+
+// per-run fetch memo → mirror tiles (a,b)/(b,a) and repeated highlight/stat lookups hit the network once.
+async function loadPanels() {
+  const defs = props.defs.filter(d => !d.diagonal)
+  if (!props.imageUid || !defs.length) { panelData.value = {}; err.value = ''; return }
+  const tok = ++loadTok
+  loading.value = true; err.value = ''
+  const id = montageId.value
+  const metaCache = new Map<string, Promise<{ extents: Ext; xTicks: Tick[]; yTicks: Tick[] }>>()
+  const ptsCache = new Map<string, Promise<Float32Array>>()
+  const statCache = new Map<string, Promise<number | undefined>>()
+
+  // meta uses the whole-dataset axis (x0=1 in plotQ) → pop-independent range; cache by canonical pair.
+  const metaFor = (o: ReturnType<typeof canonicalOrient>, pop: string) => {
+    if (!metaCache.has(o.groupKey)) metaCache.set(o.groupKey, (async () => {
+      const m = await (await fetch(`/api/gating/plotmeta?${plotQ(id, pop, o.a, o.b, o.ta, o.tb)}`)).json() as {
+        xExtent: [number, number]; yExtent: [number, number]; xTicks: Tick[]; yTicks: Tick[] }
+      return { extents: { xMin: m.xExtent[0], xMax: m.xExtent[1], yMin: m.yExtent[0], yMax: m.yExtent[1] },
+               xTicks: m.xTicks, yTicks: m.yTicks }
+    })())
+    return metaCache.get(o.groupKey)!
+  }
+  const ptsFor = (o: ReturnType<typeof canonicalOrient>, pop: string) => {
+    const key = `${pop}|${o.groupKey}`
+    if (!ptsCache.has(key)) ptsCache.set(key, (async () =>
+      new Float32Array(await (await fetch(`/api/gating/plotdata?${plotQ(id, pop, o.a, o.b, o.ta, o.tb)}`)).arrayBuffer()))())
+    return ptsCache.get(key)!
+  }
+  const labelFor = async (c: PanelChild): Promise<string> => {
+    if (!statCache.has(c.path)) statCache.set(c.path, (async () => {
+      try {
+        const s = await (await fetch(`/api/gating/stats?${idQ(id)}&pop=${encodeURIComponent(c.path)}`)).json() as { pctParent?: number }
+        return typeof s.pctParent === 'number' ? s.pctParent : undefined   // ALREADY a percentage (backend)
+      } catch { return undefined }
+    })())
+    const pct = await statCache.get(c.path)!
+    return pct == null ? c.name : `${c.name}  ${pct.toFixed(1)}%`
+  }
+
+  try {
+    const entries = await Promise.all(defs.map(async d => {
+      const o = canonicalOrient(d)
+      const [m, ptsRaw] = await Promise.all([metaFor(o, d.parentPath), ptsFor(o, d.parentPath)])
+      const gates = await Promise.all(d.children.map(async c =>
+        ({ path: c.path, colour: c.colour, gate: c.gate, label: await labelFor(c) })))
+      const popLayers = await Promise.all((props.highlight ?? []).map(async h => {
+        const raw = await ptsFor(o, h.path)
+        return { path: h.path, colour: h.colour, points: o.swap ? transposePoints(raw) : raw }
+      }))
+      const data: PanelData = {
+        points: o.swap ? transposePoints(ptsRaw) : ptsRaw,
+        extents: o.swap ? transposeExt(m.extents) : m.extents,
+        xTicks: o.swap ? m.yTicks : m.xTicks,
+        yTicks: o.swap ? m.xTicks : m.yTicks,
+        gates, popLayers,
+      }
+      return [d.key, data] as const
+    }))
+    if (tok === loadTok) panelData.value = Object.fromEntries(entries)
+  } catch (e) {
+    if (tok === loadTok) { err.value = e instanceof Error ? e.message : String(e); panelData.value = {} }
+  } finally { if (tok === loadTok) loading.value = false }
+}
+
+// One reactive signal covering everything that changes a tile's DATA (axes, transforms, parent, gate
+// specs, highlights, forced membership refresh). Tile keys alone miss transform/gate edits, so hash the
+// material fields — cheap for the tile counts a montage holds.
+const sig = computed(() => JSON.stringify({
+  id: montageId.value,
+  defs: props.defs.filter(d => !d.diagonal).map(d =>
+    ({ k: d.key, p: d.parentPath, x: d.xChan, y: d.yChan, xt: d.xt, yt: d.yt, c: d.children.map(c => [c.path, c.gate]) })),
+  hl: props.highlight, rk: props.reloadKey,
+}))
+watch(sig, loadPanels, { immediate: true })
+
+// ── export: plot-only image (single cell hi-res, or the whole grid on white for the board PDF) ──────
+const gridRef = useTemplateRef<HTMLElement>('gridRef')
+type CellExport = {
+  exportImage(bg?: string, light?: boolean): Promise<string | null>
+  hiRes(cv: HTMLCanvasElement, scale: number): Promise<CanvasImageSource | null>
+}
+const cellRefs = new Map<string, CellExport>()
+function setCellRef(key: string, el: unknown) { if (el) cellRefs.set(key, el as CellExport); else cellRefs.delete(key) }
+async function exportImage(bg = '#ffffff', light = true): Promise<string | null> {
+  const defs = props.defs.filter(d => !d.diagonal)
+  if (defs.length === 1) return (await cellRefs.get(defs[0].key)?.exportImage(bg, light)) ?? null
+  const el = gridRef.value
+  if (!el) return null
+  const cells = [...cellRefs.values()]
+  const hiRes = async (cv: HTMLCanvasElement, scale: number) => {
+    for (const c of cells) { const r = await c.hiRes?.(cv, scale); if (r) return r }
+    return null
+  }
+  const scale = Math.min(8, Math.max(4, Math.ceil(2800 / (el.clientWidth || 500))))
+  if (light) el.classList.add('cc-light')
+  try { return await plotHostToImageURL(el, bg, { hiRes, scale }) } finally { if (light) el.classList.remove('cc-light') }
+}
+defineExpose({ exportImage })
+
+const titleFor = (parentPath: string) => (parentPath === 'root' ? 'all events (root)' : parentPath)
+</script>
+
+<template>
+  <div ref="gridRef" class="gm-grid" :class="{ single, matrix: cols != null }" :style="gridStyle">
+    <div v-if="err" class="gm-msg">{{ err }}</div>
+    <div v-else-if="!defs.length" class="gm-msg"><slot name="empty">Nothing to show.</slot></div>
+    <template v-for="d in defs" :key="d.key">
+      <!-- diagonal (channel vs itself, pairs matrix): a labelled cell, R pairs()-style -->
+      <div v-if="d.diagonal" class="gm-cell gm-diag"><span>{{ colLabel(d.xChan) }}</span></div>
+      <div v-else class="gm-cell">
+        <div v-if="cols == null" class="gm-title" v-tooltip.top="`derived from ${titleFor(d.parentPath)}`">{{ titleFor(d.parentPath) }}</div>
+        <GateScatterCell v-if="panelData[d.key]" class="gm-plot" :ref="el => setCellRef(d.key, el)"
+                         :points="panelData[d.key].points" :extents="panelData[d.key].extents"
+                         :view-extents="panelData[d.key].extents"
+                         :x-ticks="panelData[d.key].xTicks" :y-ticks="panelData[d.key].yTicks"
+                         :gates="panelData[d.key].gates" :x-label="colLabel(d.xChan)" :y-label="colLabel(d.yChan)"
+                         :pop-layers="panelData[d.key].popLayers" :show-pops="(highlight?.length ?? 0) > 0"
+                         :render-mode="renderMode" mode="off" :gate-labels="gateLabels"
+                         :gate-line-width="gateLineWidth" :compact="!single" :readonly="true" />
+        <div v-else class="gm-loading">…</div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+/* Two layouts. WRAP (gating-strategy): responsive squares that fill the width and wrap. MATRIX
+   (channel pairs): a strict N-column grid (columns set inline) so every channel lines up in a row/col. */
+.gm-grid { flex: 1; min-height: 0; overflow: auto; padding: 6px; display: grid; gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); align-content: start; }
+.gm-grid.matrix { grid-auto-rows: max-content; }
+.gm-grid.single { grid-template-columns: 1fr; grid-template-rows: 1fr; overflow: hidden; }
+/* light theme for PDF export: dark ink on white */
+.gm-grid.cc-light { --cc-text: #111; --cc-text-dim: #555; --cc-border: #c9ccd1; --cc-bg: #fff; --cc-surface-2: #f0f0f3; }
+.gm-cell { display: flex; flex-direction: column; min-height: 0; border: 1px solid var(--cc-border);
+  border-radius: 5px; overflow: hidden; background: var(--cc-bg); }
+/* montage plot area is SQUARE. Cap the width in wrap mode so a wide column doesn't make it so tall the
+   x-axis label drops out of view; in matrix mode fill the column so the grid stays aligned. */
+.gm-plot { flex: none; width: 100%; max-width: 320px; aspect-ratio: 1; margin: 0 auto; }
+.gm-grid.matrix .gm-plot { max-width: none; }
+.gm-grid.single .gm-cell { container-type: size; }
+.gm-grid.single .gm-plot { flex: none; aspect-ratio: 1; min-height: 0; max-width: none;
+  width: min(100cqw, calc(100cqh - 26px)); margin: 0 auto; }
+/* diagonal label cell (matrix): channel name centred, matches the tile square */
+.gm-diag { align-items: center; justify-content: center; aspect-ratio: 1; background: var(--cc-surface-2);
+  color: var(--cc-text); font-weight: 700; font-size: 12px; padding: 4px; text-align: center; word-break: break-word; }
+.gm-title { flex-shrink: 0; font-size: 11px; font-weight: 700; padding: 3px 6px; color: var(--cc-text-dim);
+  border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.gm-loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--cc-text-dim); aspect-ratio: 1; }
+.gm-msg { grid-column: 1 / -1; padding: 16px; color: var(--cc-text-dim); font-size: 13px; }
+</style>

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -3,21 +3,21 @@
   interactiveViews.ts). READ-ONLY (project_analysis_canvas_readonly): it visualises an existing gating
   scheme, never edits it. Ports the old R `.flowPlotGatedRaster`: walk the population tree, group each
   parent's children by their gate's channel-pair, and for each group render the PARENT's cells as a
-  density scatter on those channels with the child gate outlines + "name  pct%" labels — a montage of
-  the whole gating strategy.
+  density scatter on those channels with the child gate outlines + "name  pct%" labels.
 
-  Reuse (feedback_use_existing_framework): each sub-panel is a read-only GateScatterCell (`mode='off'`)
-  — the SAME renderer as the Gate page — fed by the SAME stateless gating routes GatePlotPanel uses
-  (popmap / plotmeta / plotdata / stats). No second gate renderer, no store mutation.
+  Reuse (feedback_use_existing_framework): this owns ONLY the selectors + turning the population tree
+  into montage tiles (`PanelDef[]`). The fetch + render + export of those tiles is the shared
+  GateMontage (the SAME renderer the channel-pairs matrix uses), which in turn hosts the SAME read-only
+  GateScatterCell as the Gate page. No second gate renderer, no store mutation.
 -->
 <script setup lang="ts">
 import { ref, computed, watch, useTemplateRef, onMounted, onUnmounted } from 'vue'
 import type { GateSpec, TransformSpec, PopNode, PopTree } from '../../stores/gating'
 import { useDataRefresh } from '../../composables/useDataRefresh'
 import { orientGate } from '../../plots/gateGeometry'
-import { plotHostToImageURL } from '../../plots/export'
+import type { PanelDef } from '../../plots/montage'
 import type { VisProps } from '../../plots/plot'
-import GateScatterCell from './GateScatterCell.vue'
+import GateMontage from './GateMontage.vue'
 
 const props = defineProps<{
   projectUid: string; imageUids: string[]; setUid: string | null
@@ -35,16 +35,10 @@ const rootPop = computed({ get: () => props.state.rootPop ?? 'root', set: v => (
 const renderMode = computed({ get: () => props.state.renderMode ?? 'points', set: v => (props.state.renderMode = v) })
 // DEFAULT: a single plot for the selected population (its defining gate). Toggling "show hierarchy"
 // walks the whole gating tree beneath the selected pop → the full montage (old .flowPlotGatedRaster).
-// Put a gating-strategy view in a 1×1 plate and turn this on to render the full strategy in one slot.
 const showHierarchy = computed({ get: () => props.state.showHierarchy ?? false, set: v => (props.state.showHierarchy = v) })
-// no size control — fit to the slot: the single plot fills it; the montage lays out responsive squares
-// that fit the slot width and wrap (grid columns set in CSS, so nothing to size manually).
-const single = computed(() => panelDefs.value.length === 1)
-const titleFor = (parentPath: string) => (parentPath === 'root' ? 'all events (root)' : parentPath)
 const setImageUid = (v: string) => (props.state.imageUid = v)
 
-// size + the hierarchy toggle live in a ⚙ popover (like the heatmap/state-plot panels) so the bar
-// never widens; close on an outside click.
+// size + the hierarchy toggle live in a ⚙ popover; close on an outside click.
 const optsOpen = ref(false)
 const optsRef = useTemplateRef<HTMLElement>('optsRef')
 function onDocClick(e: MouseEvent) { if (optsOpen.value && optsRef.value && !optsRef.value.contains(e.target as Node)) optsOpen.value = false }
@@ -61,20 +55,8 @@ function colLabel(col: string): string {
   return i >= 0 && channelNames.value[i] ? channelNames.value[i] : col
 }
 const tree = ref<PopTree | null>(null)
-const loading = ref(false)
-const err = ref('')
 
-// axis-transform → query params (mirrors GatePlotPanel.axisQ; logicle carries its shape)
-function axisQ(p: 'x' | 'y', ts: TransformSpec): string {
-  let q = `&${p}t=${ts.kind}`
-  if (ts.kind === 'logicle') q += `&${p}T=${ts.T ?? 262144}&${p}W=${ts.W ?? 0.5}&${p}M=${ts.M ?? 4.5}&${p}A=${ts.A ?? 0}`
-  return q
-}
 const idQ = () => `projectUid=${props.projectUid}&imageUid=${imageUid.value}&valueName=${encodeURIComponent(valueName.value)}&popType=${popType.value}`
-// x0=1&y0=1 → fixed whole-dataset axis per side, so the parent density + child gates align across panels
-function plotQ(pop: string, xc: string, yc: string, xt: TransformSpec, yt: TransformSpec) {
-  return `${idQ()}&x=${encodeURIComponent(xc)}&y=${encodeURIComponent(yc)}&pop=${encodeURIComponent(pop)}${axisQ('x', xt)}${axisQ('y', yt)}&x0=1&y0=1`
-}
 
 async function loadChannels() {
   if (!props.projectUid || !imageUid.value) { valueNames.value = []; return }
@@ -104,9 +86,7 @@ const flatPaths = computed<string[]>(() => {
   return out
 })
 
-// ── build the panel defs: for each parent, group its gated children by gate channel-pair ──────────
-interface PanelDef { key: string; parentPath: string; parentName: string; xChan: string; yChan: string
-  xt: TransformSpec; yt: TransformSpec; children: { path: string; name: string; colour: string; gate: GateSpec }[] }
+// ── build the montage tiles: for each parent, group its gated children by gate channel-pair ────────
 const pairKey = (a: string, b: string) => [a, b].sort().join('~~')
 function childrenAt(root: string): { nodes: PopNode[]; name: string } {
   if (root === 'root') return { nodes: tree.value?.populations ?? [], name: 'all events' }
@@ -118,7 +98,7 @@ function childrenAt(root: string): { nodes: PopNode[]; name: string } {
   const f = found as PopNode | null
   return { nodes: f?.children ?? [], name: f?.name ?? root }
 }
-// one LEVEL: group a parent's directly-gated children by their gate channel-pair → one panel each
+// one LEVEL: group a parent's directly-gated children by their gate channel-pair → one tile each
 function groupsAt(parentPath: string, parentName: string, nodes: PopNode[]): PanelDef[] {
   const acc: PanelDef[] = []
   const groups = new Map<string, PopNode[]>()
@@ -152,7 +132,7 @@ function nodeWithParent(target: string): { node: PopNode; parentPath: string; pa
   walk(tree.value?.populations ?? [], 'root', 'all events')
   return res
 }
-// FULL montage: recurse the tree beneath the selected pop, a panel per parent×channel-pair
+// FULL montage: recurse the tree beneath the selected pop, a tile per parent×channel-pair
 const hierarchyDefs = computed<PanelDef[]>(() => {
   const acc: PanelDef[] = []
   const collect = (parentPath: string, parentName: string, nodes: PopNode[]) => {
@@ -167,16 +147,15 @@ const hierarchyDefs = computed<PanelDef[]>(() => {
   return acc
 })
 // SINGLE plot: the plot that DEFINES the selected pop (its parent's density + this pop's own gate).
-// For root / an ungated pop, fall back to the first gated group directly beneath it.
 const singleDef = computed<PanelDef | null>(() => {
   const rp = rootPop.value
   if (rp !== 'root') {
     const nw = nodeWithParent(rp)
     if (nw?.node.gate) {
-      const g0 = nw.node.gate
+      const g0 = nw.node.gate as GateSpec
       return {
         key: `single::${rp}`, parentPath: nw.parentPath, parentName: nw.parentName,
-        xChan: g0.x_channel, yChan: g0.y_channel, xt: g0.x_transform, yt: g0.y_transform,
+        xChan: g0.x_channel, yChan: g0.y_channel, xt: g0.x_transform as TransformSpec, yt: g0.y_transform as TransformSpec,
         children: [{ path: rp, name: nw.node.name, colour: nw.node.colour,
                      gate: orientGate(g0, g0.x_channel, g0.y_channel) ?? g0 }],
       }
@@ -188,75 +167,14 @@ const singleDef = computed<PanelDef | null>(() => {
 const panelDefs = computed<PanelDef[]>(() =>
   showHierarchy.value ? hierarchyDefs.value : (singleDef.value ? [singleDef.value] : []))
 
-// ── fetch parent density + child stats per panel ─────────────────────────────────────────────────
-type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
-interface PanelData { points: Float32Array; extents: Ext; xTicks: { pos: number; label: string }[]
-  yTicks: { pos: number; label: string }[]; gates: { path: string; colour: string; gate: GateSpec; label: string }[] }
-const panelData = ref<Record<string, PanelData>>({})
-let loadTok = 0
-
-async function loadPanels() {
-  const defs = panelDefs.value
-  if (!defs.length) { panelData.value = {}; return }
-  const tok = ++loadTok
-  loading.value = true; err.value = ''
-  try {
-    const entries = await Promise.all(defs.map(async d => {
-      const q = plotQ(d.parentPath, d.xChan, d.yChan, d.xt, d.yt)
-      const meta = await (await fetch(`/api/gating/plotmeta?${q}`)).json() as {
-        xExtent: [number, number]; yExtent: [number, number]
-        xTicks: { pos: number; label: string }[]; yTicks: { pos: number; label: string }[] }
-      const points = new Float32Array(await (await fetch(`/api/gating/plotdata?${q}`)).arrayBuffer())
-      const gates = await Promise.all(d.children.map(async c => {
-        let label = c.name
-        try {
-          const s = await (await fetch(`/api/gating/stats?${idQ()}&pop=${encodeURIComponent(c.path)}`)).json() as { pctParent?: number }
-          // pctParent is ALREADY a percentage (backend pop_stats: 100 * cnt / pcnt) — don't ×100 again
-          if (typeof s.pctParent === 'number') label = `${c.name}  ${s.pctParent.toFixed(1)}%`
-        } catch { /* keep bare name */ }
-        return { path: c.path, colour: c.colour, gate: c.gate, label }
-      }))
-      const extents: Ext = { xMin: meta.xExtent[0], xMax: meta.xExtent[1], yMin: meta.yExtent[0], yMax: meta.yExtent[1] }
-      return [d.key, { points, extents, xTicks: meta.xTicks, yTicks: meta.yTicks, gates }] as const
-    }))
-    if (tok === loadTok) panelData.value = Object.fromEntries(entries)
-  } catch (e) {
-    if (tok === loadTok) { err.value = e instanceof Error ? e.message : String(e); panelData.value = {} }
-  } finally { if (tok === loadTok) loading.value = false }
-}
-
 watch([imageUid, popType], () => { loadChannels().then(loadTree) }, { immediate: true })
 watch([valueName], loadTree)
-// a task finishing on THIS image → gates/stats may have changed; reload the tree (cascades to panels)
+// a task finishing on THIS image → gates/stats may have changed; reload the tree (cascades to tiles)
 useDataRefresh(() => [imageUid.value], () => { loadChannels().then(loadTree) })
-watch(panelDefs, loadPanels, { immediate: true })
 
-// ── PDF export: a plot-only, LIGHT-theme image (no toolbar). Single plot → the one cell's hi-res
-// composite on white; montage → snapshot the grid on white with dark ink (`cc-light` flips the vars).
-const gsGridRef = useTemplateRef<HTMLElement>('gsGridRef')
-type CellExport = {
-  exportImage(bg?: string, light?: boolean): Promise<string | null>
-  hiRes(cv: HTMLCanvasElement, scale: number): Promise<CanvasImageSource | null>
-}
-const cellRefs = new Map<string, CellExport>()
-function setCellRef(key: string, el: unknown) { if (el) cellRefs.set(key, el as CellExport); else cellRefs.delete(key) }
-async function exportImage(): Promise<string | null> {
-  const defs = panelDefs.value
-  if (defs.length === 1) return (await cellRefs.get(defs[0].key)?.exportImage('#ffffff', true)) ?? null
-  // MONTAGE: capture the whole grid (titles + axes via the DOM overlay) but re-render each cell's canvases
-  // at export scale — a combined resolver routes each canvas to its owning cell's hiRes (else the whole
-  // montage would composite at screen resolution → soft).
-  const el = gsGridRef.value
-  if (!el) return null
-  const cells = [...cellRefs.values()]
-  const hiRes = async (cv: HTMLCanvasElement, scale: number) => {
-    for (const c of cells) { const r = await c.hiRes?.(cv, scale); if (r) return r }
-    return null
-  }
-  const scale = Math.min(8, Math.max(4, Math.ceil(2800 / (el.clientWidth || 500))))
-  el.classList.add('cc-light')
-  try { return await plotHostToImageURL(el, '#ffffff', { hiRes, scale }) } finally { el.classList.remove('cc-light') }
-}
+// PDF export: delegate to the shared montage renderer (single cell hi-res, or the whole grid on white).
+const montageRef = useTemplateRef<{ exportImage(bg?: string, light?: boolean): Promise<string | null> }>('montageRef')
+async function exportImage(): Promise<string | null> { return (await montageRef.value?.exportImage('#ffffff', true)) ?? null }
 defineExpose({ exportImage })
 </script>
 
@@ -293,24 +211,15 @@ defineExpose({ exportImage })
       </div>
     </div>
 
-    <div ref="gsGridRef" class="gs-grid" :class="{ single }">
-      <div v-if="err" class="gs-msg">{{ err }}</div>
-      <div v-else-if="!panelDefs.length" class="gs-msg">
+    <GateMontage ref="montageRef" :project-uid="projectUid" :image-uid="imageUid" :value-name="valueName"
+                 :pop-type="popType" :defs="panelDefs" :col-label="colLabel" :render-mode="renderMode"
+                 :gate-labels="true">
+      <template #empty>
         No gate to show for “{{ rootPop }}”.
         {{ showHierarchy ? 'No gated populations beneath it — draw gates on the Gate page first.'
                          : 'Select a gated population, or draw gates on the Gate page first.' }}
-      </div>
-      <div v-for="d in panelDefs" :key="d.key" class="gs-cell">
-        <div class="gs-title" v-tooltip.top="`derived from ${titleFor(d.parentPath)}`">{{ titleFor(d.parentPath) }}</div>
-        <GateScatterCell v-if="panelData[d.key]" class="gs-plot" :ref="el => setCellRef(d.key, el)"
-                         :points="panelData[d.key].points" :extents="panelData[d.key].extents"
-                         :view-extents="panelData[d.key].extents"
-                         :x-ticks="panelData[d.key].xTicks" :y-ticks="panelData[d.key].yTicks"
-                         :gates="panelData[d.key].gates" :x-label="colLabel(d.xChan)" :y-label="colLabel(d.yChan)"
-                         :render-mode="renderMode" mode="off" :gate-labels="true" :compact="!single" :readonly="true" />
-        <div v-else class="gs-loading">…</div>
-      </div>
-    </div>
+      </template>
+    </GateMontage>
   </div>
 </template>
 
@@ -319,42 +228,16 @@ defineExpose({ exportImage })
 .gs-bar { display: flex; align-items: center; gap: 6px; padding: 6px 8px; flex-wrap: wrap; flex-shrink: 0;
   border-bottom: 1px solid var(--cc-border); font-size: 12px; }
 .gs-bar select { font-size: 12px; max-width: 9rem; }
-/* fit to the slot — no size control. Montage: responsive squares that fill the slot width and wrap
-   (scroll if many). Single: one cell that fills the whole slot. */
-.gs-grid { flex: 1; min-height: 0; overflow-y: auto; padding: 6px; display: grid; gap: 8px;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); align-content: start; }
-.gs-grid.single { grid-template-columns: 1fr; grid-template-rows: 1fr; overflow: hidden; }
-/* light theme for PDF export: flip the ink/border vars so titles + axes read dark on white */
-.gs-grid.cc-light { --cc-text: #111; --cc-text-dim: #555; --cc-border: #c9ccd1; --cc-bg: #fff; --cc-surface-2: #f0f0f3; }
-.gs-cell { display: flex; flex-direction: column; min-height: 0; border: 1px solid var(--cc-border);
-  border-radius: 5px; overflow: hidden; background: var(--cc-bg); }
-/* montage: the plot area is SQUARE. Cap the width so a wide column doesn't make the square so TALL that
-   its bottom (the x-axis label) drops past the slot; centred when narrower than the column. */
-.gs-plot { flex: none; width: 100%; max-width: 320px; aspect-ratio: 1; margin: 0 auto; }
-/* single: keep the square aspect ratio but fit the slot — the largest square that fits the cell's
-   min(width, height − title), centred horizontally (title bar stays full-width). */
-.gs-grid.single .gs-cell { container-type: size; }
-/* min-height:0 overrides GateScatterCell's 218px floor so the square can shrink to fit a small slot */
-.gs-grid.single .gs-plot { flex: none; aspect-ratio: 1; min-height: 0; max-width: none;
-  width: min(100cqw, calc(100cqh - 26px)); margin: 0 auto; }
-/* ⚙ options popover (size + hierarchy toggle). margin-left:auto pins the gear to the far right of the
-   toolbar (even when it wraps to its own row), so the popover — anchored right:0 — always opens LEFTWARD
-   into the panel and is never clipped at the left edge. */
+/* ⚙ options popover (hierarchy toggle). margin-left:auto pins the gear to the far right so the popover —
+   anchored right:0 — always opens LEFTWARD into the panel and is never clipped at the left edge. */
 .gs-opts { position: relative; display: inline-flex; margin-left: auto; }
 .gs-gear { background: var(--cc-surface-2); color: var(--cc-text-dim); border: 1px solid var(--cc-border);
   border-radius: 5px; padding: 4px 8px; cursor: pointer; font-size: 12px; }
 .gs-gear.on { background: var(--cc-accent); color: #fff; border-color: var(--cc-accent); }
-/* opens leftward into the panel from the (right-pinned) gear; kept narrow so it fits a small slot */
 .gs-pop { position: absolute; top: calc(100% + 4px); right: 0; z-index: 20; width: 13rem;
   display: flex; flex-direction: column; gap: 8px; padding: 10px; background: var(--cc-surface-1);
   border: 1px solid var(--cc-border); border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,0.35); }
 .gs-check { display: flex; align-items: center; gap: 6px; color: var(--cc-text); font-size: 12px; }
-/* flex-shrink:0 so the title bar can never be squeezed to nothing by the plot in a short/constrained
-   cell (it's a flex-column child alongside the plot) */
-.gs-title { flex-shrink: 0; font-size: 11px; font-weight: 700; padding: 3px 6px; color: var(--cc-text-dim);
-  border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.gs-loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--cc-text-dim); }
-.gs-msg { grid-column: 1 / -1; padding: 16px; color: var(--cc-text-dim); font-size: 13px; }
 .seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
 .seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 4px 8px; cursor: pointer; font-size: 12px; }
 .seg button + button { border-left: 1px solid var(--cc-border); }

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -1,0 +1,184 @@
+<!--
+  A read-only "channel pairs" plot for the Gate / Tracking pages — the single gate plot's X/Y
+  generalised to a LIST of channels, rendered as the full N×N matrix of every channel-vs-channel
+  scatter (R pairs()). A sibling of GatePlotPanel: same free-floating CanvasPanel chrome, same page
+  (added via GatingPlots' "+ Pairs" button, so BOTH flow and track gating get it). It does NOT draw
+  gates — but it DOES show the gates that define the displayed population's children, and it honours the
+  SAME highlight pipeline as the normal plot: the manager's "eye" populations AND the transient napari
+  cell-selection light up across every tile (linked brushing). Rendering/fetching is the shared
+  GateMontage (feedback_use_existing_framework); the tiles come from the pure buildPairDefs.
+-->
+<script setup lang="ts">
+import { ref, computed, watch, useTemplateRef, onMounted, onUnmounted } from 'vue'
+import { useGatingStore } from '../../stores/gating'
+import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
+import type { ArrangeCmd } from '../../composables/useFloatingPanel'
+import GateMontage from '../../components/plots/GateMontage.vue'
+import { buildPairDefs } from '../../plots/pairsMatrix'
+import { downloadDataUrl } from '../../plots/export'
+
+type Kind = 'linear' | 'log' | 'asinh' | 'logicle'
+const TRANSFORMS: Kind[] = ['linear', 'log', 'asinh', 'logicle']
+const MAX_CHANNELS = 8            // N×N tiles grow fast — cap the selection and say so (no silent cut)
+
+const props = defineProps<{
+  index: number; active: boolean; parent: string; highlight: string[]
+  gateLineWidth: number; gateLabels: boolean; axisFromZero: boolean
+  // persisted per-plot config (owned by GatingPlots' PlotState): the channel list, the one shared
+  // transform, and the render mode. Read/written directly so they survive navigation.
+  ui: { channels?: string[]; xt?: Kind; renderMode?: 'points' | 'contour' }
+  arrange?: ArrangeCmd | null
+  persistKey?: string
+}>()
+const emit = defineEmits<{ activate: [number]; 'update:parent': [string]; remove: [] }>()
+const g = useGatingStore()
+
+// track properties → linear by default; flow intensities → logicle (FlowJo) — same rule as GatePlotPanel
+const defaultTransform: Kind = g.popType === 'track' ? 'linear' : 'logicle'
+const channels = computed<string[]>({ get: () => props.ui.channels ?? [], set: v => { props.ui.channels = v } })
+const transform = computed<Kind>({ get: () => props.ui.xt ?? defaultTransform, set: v => { props.ui.xt = v } })
+const renderMode = computed<'points' | 'contour'>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })
+const parent = computed({ get: () => props.parent, set: v => emit('update:parent', v) })
+const parentOptions = computed(() => ['root', ...g.flat.map(p => p.path)])
+
+// the displayed population's directly-gated children → their outlines appear on whichever tile matches
+// their channel-pair (buildPairDefs orients them). Mirrors GatePlotPanel's currentGates intent.
+const parentChildren = computed(() => g.flat.filter(p => p.parent === parent.value && p.gate))
+const defs = computed(() => buildPairDefs(channels.value, parent.value, transform.value, parentChildren.value))
+
+// coloured overlays: the pops highlighted for THIS panel (manager eye + napari transient), with colours
+// resolved from the store (GateMontage is store-agnostic).
+const highlightPops = computed(() => (props.highlight ?? []).map(path =>
+  ({ path, colour: g.flat.find(p => p.path === path)?.colour ?? '#22d3ee' })))
+// force a point refresh when membership moves without the tiles changing (ancestor gate edit, napari
+// selection re-evaluated) — the parent's / a highlighted pop's version bumps in the store.
+const reloadKey = computed(() =>
+  `${g.popVersion[parent.value] ?? 0}:${(props.highlight ?? []).map(p => g.popVersion[p] ?? 0).join(',')}`)
+
+// channel picker (compact popover)
+const pickOpen = ref(false)
+const pickRef = useTemplateRef<HTMLElement>('pickRef')
+function onDocClick(e: MouseEvent) { if (pickOpen.value && pickRef.value && !pickRef.value.contains(e.target as Node)) pickOpen.value = false }
+onMounted(() => document.addEventListener('mousedown', onDocClick))
+onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
+const atCap = computed(() => channels.value.length >= MAX_CHANNELS)
+function toggleChannel(c: string) {
+  const cur = channels.value
+  if (cur.includes(c)) channels.value = cur.filter(x => x !== c)
+  else if (!atCap.value) channels.value = [...cur, c]
+}
+function clearChannels() { channels.value = [] }
+
+// seed a sensible default selection the first time (like GatePlotPanel.ensureChannels): the first few
+// intensity channels for flow, else the first gateable columns for track.
+function ensureChannels() {
+  if (channels.value.length || !g.columns.length) return
+  const src = g.channels.length ? g.channels : g.columns
+  channels.value = src.slice(0, Math.min(4, src.length))
+}
+watch([() => g.columns, () => g.imageUid, () => g.valueName], ensureChannels, { immediate: true })
+
+const montageRef = useTemplateRef<{ exportImage(bg?: string, light?: boolean): Promise<string | null> }>('montageRef')
+function exportPng() {
+  const stem = `pairs_${channels.value.map(c => g.colLabel(c)).join('_')}`.replace(/[^\w.-]+/g, '_').slice(0, 80)
+  montageRef.value?.exportImage('#0d0b1a', false).then(url => url && downloadDataUrl(`${stem || 'pairs'}.png`, url))
+}
+</script>
+
+<template>
+  <CanvasPanel :index="index" :active="props.active" :arrange="props.arrange" :title="`Pairs ${channels.length}×${channels.length}`"
+               :persist-key="props.persistKey"
+               @activate="emit('activate', $event)" @remove="emit('remove')">
+    <template #actions>
+      <span class="ro-tag" v-tooltip.bottom="'Read-only — compare channels; draw gates on a single plot'">read-only</span>
+      <span class="ctrl-sep" />
+      <div class="seg" v-tooltip.bottom="'Render: pseudocolour points / density contour'">
+        <button :class="{ on: renderMode === 'points' }" @click="renderMode = 'points'"><i class="pi pi-circle-fill" /></button>
+        <button :class="{ on: renderMode === 'contour' }" @click="renderMode = 'contour'"><i class="pi pi-chart-line" /></button>
+      </div>
+    </template>
+    <template #footer>
+      <select class="gp-export" v-tooltip.top="'Export the matrix'" :disabled="!channels.length"
+              @change="($event.target as HTMLSelectElement).value === 'png' && exportPng(); ($event.target as HTMLSelectElement).value = ''">
+        <option value="">⤓ Export</option>
+        <option value="png">Image (PNG)</option>
+      </select>
+    </template>
+
+    <div class="panel-ctrl">
+      <label class="ax-row"><span class="ax-lbl">pop</span>
+        <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to compare; its gates are shown'">
+          <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select>
+      </label>
+      <div class="ax-row">
+        <span class="ax-lbl">chans</span>
+        <div ref="pickRef" class="chan-pick">
+          <button class="chan-btn" :class="{ on: pickOpen }" @click="pickOpen = !pickOpen"
+                  v-tooltip.bottom="'Choose the channels to plot against each other'">
+            {{ channels.length ? `${channels.length} selected` : 'select channels' }} <i class="pi pi-chevron-down" />
+          </button>
+          <div v-if="pickOpen" class="chan-pop">
+            <div class="chan-pop-head">
+              <span>{{ channels.length }}/{{ MAX_CHANNELS }}</span>
+              <button class="chan-clear" :disabled="!channels.length" @click="clearChannels">clear</button>
+            </div>
+            <div class="chan-list">
+              <label v-for="c in g.columns" :key="c" class="chan-item"
+                     :class="{ disabled: !channels.includes(c) && atCap }">
+                <input type="checkbox" :checked="channels.includes(c)"
+                       :disabled="!channels.includes(c) && atCap" @change="toggleChannel(c)" />
+                <span>{{ g.colLabel(c) }}</span>
+              </label>
+            </div>
+            <div v-if="atCap" class="chan-cap">Max {{ MAX_CHANNELS }} channels ({{ MAX_CHANNELS * MAX_CHANNELS }} tiles). Clear one to swap.</div>
+          </div>
+        </div>
+        <select class="tsel" v-model="transform" v-tooltip.bottom="'Axis transform (applied to every channel)'">
+          <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option>
+        </select>
+      </div>
+    </div>
+
+    <GateMontage ref="montageRef" :project-uid="g.projectUid()" :image-uid="g.imageUid ?? ''"
+                 :value-name="g.valueName" :pop-type="g.popType" :defs="defs" :col-label="g.colLabel"
+                 :render-mode="renderMode" :gate-labels="props.gateLabels" :gate-line-width="props.gateLineWidth"
+                 :highlight="highlightPops" :cols="channels.length || 1" :reload-key="reloadKey">
+      <template #empty>Pick channels above to compare them against each other.</template>
+    </GateMontage>
+  </CanvasPanel>
+</template>
+
+<style scoped>
+.ro-tag { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-text-dim);
+  border: 1px solid var(--cc-border); border-radius: 3px; padding: 1px 5px; }
+.ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
+.panel-ctrl { display: flex; flex-direction: column; gap: 6px; padding: 6px 8px;
+  border-bottom: 1px solid var(--cc-border); font-size: 12px; }
+.ax-row { display: flex; align-items: center; gap: 6px; }
+.ax-lbl { width: 2.6rem; color: var(--cc-text-dim); flex-shrink: 0; }
+.ax-chan { width: 12rem; flex: none; }
+.tsel { width: 5.5rem; flex-shrink: 0; }
+/* channel multiselect popover */
+.chan-pick { position: relative; flex: 1; min-width: 0; }
+.chan-btn { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 6px;
+  background: var(--cc-surface-2); color: var(--cc-text); border: 1px solid var(--cc-border);
+  border-radius: 5px; padding: 3px 8px; cursor: pointer; font-size: 12px; }
+.chan-btn.on { border-color: var(--cc-accent); }
+.chan-pop { position: absolute; top: calc(100% + 4px); left: 0; z-index: 30; width: 15rem; max-width: 80vw;
+  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.35); padding: 6px; }
+.chan-pop-head { display: flex; align-items: center; justify-content: space-between; padding: 2px 4px 6px;
+  color: var(--cc-text-dim); font-size: 11px; border-bottom: 1px solid var(--cc-border); }
+.chan-clear { background: none; border: none; color: var(--cc-accent); cursor: pointer; font-size: 11px; }
+.chan-clear:disabled { color: var(--cc-text-dim); cursor: default; }
+.chan-list { max-height: 220px; overflow-y: auto; padding: 4px 0; }
+.chan-item { display: flex; align-items: center; gap: 6px; padding: 3px 4px; cursor: pointer; color: var(--cc-text); }
+.chan-item:hover { background: var(--cc-surface-2); }
+.chan-item.disabled { color: var(--cc-text-dim); cursor: default; }
+.chan-cap { padding: 5px 4px 2px; font-size: 10px; color: var(--cc-text-dim); border-top: 1px solid var(--cc-border); }
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 3px 8px; cursor: pointer; font-size: 12px; }
+.seg button + button { border-left: 1px solid var(--cc-border); }
+.seg button.on { background: var(--cc-accent); color: #fff; }
+.gp-export { font-size: 12px; max-width: 7rem; }
+</style>

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -20,6 +20,7 @@ import { useWsStore } from '../../stores/ws'
 import { useCanvasPanels } from '../../composables/useCanvasPanels'
 import { useViewState } from '../../composables/useViewState'
 import GatePlotPanel from './GatePlotPanel.vue'
+import GatePairsPanel from './GatePairsPanel.vue'
 import PopulationManager from '../../components/canvas/PopulationManager.vue'
 
 const props = withDefaults(defineProps<{ imageUid: string | null; popType?: string }>(),
@@ -35,8 +36,10 @@ const ws = useWsStore()
 // per-plot copies also carry the axis config (channels/transforms/render mode) so those persist per
 // plot across navigation — like the summary panels' `ui` bag. Bare refs in the panel reset on remount.
 type GateKind = 'linear' | 'log' | 'asinh' | 'logicle'
-interface PlotState { parent: string; hl: string[]; lineWidth: number; labels: boolean; fromZero: boolean
-  x: string; y: string; xt: GateKind; yt: GateKind; renderMode: 'points' | 'contour' }
+// A panel is either a single gate scatter (default, drawable) or a read-only channel-pairs matrix.
+// `channels` is the pairs plot's selected list; the single plot ignores it (and vice-versa for x/y).
+interface PlotState { kind: 'single' | 'pairs'; parent: string; hl: string[]; lineWidth: number; labels: boolean; fromZero: boolean
+  x: string; y: string; xt: GateKind; yt: GateKind; renderMode: 'points' | 'contour'; channels: string[] }
 const canvasRef = useTemplateRef<HTMLElement>('canvasRef')
 // Per-image + segmentation: gating populations are per-value_name, so each (image, segmentation) keeps
 // its own plots/parents/highlights and the canvas rebinds when either the image or the segmentation
@@ -47,8 +50,10 @@ const ckey = computed(() => `gate:${props.popType}:${props.imageUid ?? 'none'}:$
 const defT: GateKind = props.popType === 'track' ? 'linear' : 'logicle'
 const { panels, activeId, activePanel, shared, add, remove, arrangeGrid, arrangeCascade } =
   useCanvasPanels<PlotState>(canvasRef, () =>
-    ({ parent: 'root', hl: [], lineWidth: 1.5, labels: true, fromZero: true,
-       x: '', y: '', xt: defT, yt: defT, renderMode: 'points' }), ckey)
+    ({ kind: 'single', parent: 'root', hl: [], lineWidth: 1.5, labels: true, fromZero: true,
+       x: '', y: '', xt: defT, yt: defT, renderMode: 'points', channels: [] }), ckey)
+// add a read-only channel-pairs matrix panel (same canvas, same shared options as a single plot)
+function addPairs() { const id = add(); const p = panels.value.find(x => x.id === id); if (p) p.state.kind = 'pairs' }
 
 // global-scope values live in the canvas `shared` bag via useViewState, so they PERSIST across
 // navigation with no per-field wiring (the highlighted pops were resetting on remount). Add an
@@ -138,6 +143,10 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
         <button class="cc-btn cc-btn-primary" v-tooltip.bottom="'Add a plot'" @click="add">
           <i class="pi pi-plus" /> Plot
         </button>
+        <button class="cc-btn cc-btn-ghost" v-tooltip.bottom="'Add a read-only channel-pairs matrix (R pairs): compare a set of channels against each other'"
+                @click="addPairs">
+          <i class="pi pi-th-large" /> Pairs
+        </button>
         <!-- FLOW: spatial cell-selection brush (linked brushing → transient cell pop). -->
         <div v-if="!isTrack" class="seg" v-tooltip.bottom="'Napari linked brushing'">
           <!-- showing populations in napari is the ViewerPanel's palette toggle (remembered);
@@ -169,11 +178,18 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
         <span class="gp-hint">drag plots by their title · resize from the corner</span>
       </div>
       <div ref="canvasRef" class="gp-canvas">
-        <GatePlotPanel v-for="(p, i) in panels" :key="`${ckey}:${p.id}`" :index="i" :arrange="p.arrange"
-                       :active="p.id === activeId" :parent="p.state.parent" :highlight="panelHL(p.state)"
-                       :gate-line-width="panelLineWidth(p.state)" :gate-labels="panelLabels(p.state)" :axis-from-zero="panelFromZero(p.state)"
-                       :ui="p.state" :persist-key="`${ckey}:${p.id}`"
-                       @activate="activeId = p.id" @update:parent="setParent(p.id, $event)" @remove="remove(p.id)" />
+        <template v-for="(p, i) in panels" :key="`${ckey}:${p.id}`">
+          <GatePairsPanel v-if="p.state.kind === 'pairs'" :index="i" :arrange="p.arrange"
+                          :active="p.id === activeId" :parent="p.state.parent" :highlight="panelHL(p.state)"
+                          :gate-line-width="panelLineWidth(p.state)" :gate-labels="panelLabels(p.state)" :axis-from-zero="panelFromZero(p.state)"
+                          :ui="p.state" :persist-key="`${ckey}:${p.id}`"
+                          @activate="activeId = p.id" @update:parent="setParent(p.id, $event)" @remove="remove(p.id)" />
+          <GatePlotPanel v-else :index="i" :arrange="p.arrange"
+                         :active="p.id === activeId" :parent="p.state.parent" :highlight="panelHL(p.state)"
+                         :gate-line-width="panelLineWidth(p.state)" :gate-labels="panelLabels(p.state)" :axis-from-zero="panelFromZero(p.state)"
+                         :ui="p.state" :persist-key="`${ckey}:${p.id}`"
+                         @activate="activeId = p.id" @update:parent="setParent(p.id, $event)" @remove="remove(p.id)" />
+        </template>
         <PopulationManager :selected="selected" :highlighted="activeHL" :scope="scope" :pop-type="props.popType"
                            :line-width="activeLineWidth" :gate-labels="activeLabels" :axis-from-zero="activeFromZero"
                            @update:selected="onPickPop" @update:scope="scope = $event" @toggle-highlight="toggleHighlight"

--- a/frontend/src/plots/montage.ts
+++ b/frontend/src/plots/montage.ts
@@ -1,0 +1,64 @@
+import type { GateSpec, TransformSpec } from '../stores/gating'
+
+// ── Gate MONTAGE model ────────────────────────────────────────────────────────────────────────────
+// A montage is a grid of read-only gate scatters. Each tile renders ONE parent population's cells as a
+// density scatter on a channel pair (xChan × yChan), with the child gate outlines that define
+// populations on that pair. This model + query builders are shared by the two montage producers — the
+// read-only gating-strategy plot (tree-derived tiles) and the channel-pairs matrix (channel-product
+// tiles) — so both feed the ONE renderer, GateMontage.vue (feedback_use_existing_framework). Kept as a
+// plain .ts (no Vue) so the pure logic — orientation/transpose reuse — is unit-tested (docs/DEV.md).
+
+export interface PanelChild { path: string; name: string; colour: string; gate: GateSpec }
+export interface PanelDef {
+  key: string                    // stable tile id (unique within a montage)
+  parentPath: string             // population whose cells are the density backdrop ('root' = all events)
+  parentName: string
+  xChan: string; yChan: string   // the tile's axes (raw column names)
+  xt: TransformSpec; yt: TransformSpec
+  children: PanelChild[]         // gate outlines already oriented to (xChan,yChan)
+  diagonal?: boolean             // xChan===yChan (pairs matrix): a labelled cell, no scatter fetch
+}
+
+export interface MontageId { projectUid: string; imageUid: string; valueName: string; popType: string }
+export interface Ext { xMin: number; xMax: number; yMin: number; yMax: number }
+export interface Tick { pos: number; label: string }
+
+// axis-transform → query params (mirrors GatePlotPanel.axisQ; logicle carries its shape)
+export function axisQ(p: 'x' | 'y', ts: TransformSpec): string {
+  let q = `&${p}t=${ts.kind}`
+  if (ts.kind === 'logicle') q += `&${p}T=${ts.T ?? 262144}&${p}W=${ts.W ?? 0.5}&${p}M=${ts.M ?? 4.5}&${p}A=${ts.A ?? 0}`
+  return q
+}
+export function idQ(id: MontageId): string {
+  return `projectUid=${id.projectUid}&imageUid=${id.imageUid}&valueName=${encodeURIComponent(id.valueName)}&popType=${id.popType}`
+}
+// x0=1&y0=1 → fixed whole-dataset axis per side, so the parent density + child gates align across tiles
+export function plotQ(id: MontageId, pop: string, xc: string, yc: string, xt: TransformSpec, yt: TransformSpec): string {
+  return `${idQ(id)}&x=${encodeURIComponent(xc)}&y=${encodeURIComponent(yc)}&pop=${encodeURIComponent(pop)}${axisQ('x', xt)}${axisQ('y', yt)}&x0=1&y0=1`
+}
+
+// ── Transpose reuse ─────────────────────────────────────────────────────────────────────────────
+// The pairs matrix renders BOTH (a,b) and (b,a) tiles. Their point clouds are the same data with the
+// two axes swapped, so we fetch ONE canonical orientation (channels in sorted order) per (parent,pair,
+// transforms) and TRANSPOSE it for the mirror tile — halving the fetches for the N×N matrix. The
+// gating-strategy montage has one def per sorted pair already, so it fetches exactly as before.
+
+// interleaved [x0,y0,x1,y1,…] → [y0,x0,y1,x1,…]
+export function transposePoints(pts: Float32Array): Float32Array {
+  const out = new Float32Array(pts.length)
+  for (let i = 0; i + 1 < pts.length; i += 2) { out[i] = pts[i + 1]; out[i + 1] = pts[i] }
+  return out
+}
+export const transposeExt = (e: Ext): Ext => ({ xMin: e.yMin, xMax: e.yMax, yMin: e.xMin, yMax: e.xMax })
+
+export interface Orient { a: string; b: string; ta: TransformSpec; tb: TransformSpec; swap: boolean; groupKey: string }
+// Canonical (sorted-channel) orientation for a tile + whether the tile is the mirror of it. `groupKey`
+// identifies the shared fetch: same parent + same unordered channel pair + same transforms → one fetch.
+export function canonicalOrient(d: Pick<PanelDef, 'parentPath' | 'xChan' | 'yChan' | 'xt' | 'yt'>): Orient {
+  const swap = d.xChan > d.yChan
+  const a = swap ? d.yChan : d.xChan
+  const b = swap ? d.xChan : d.yChan
+  const ta = swap ? d.yt : d.xt
+  const tb = swap ? d.xt : d.yt
+  return { a, b, ta, tb, swap, groupKey: `${d.parentPath}|${a}${axisQ('x', ta)}|${b}${axisQ('y', tb)}` }
+}

--- a/frontend/src/plots/pairsMatrix.test.ts
+++ b/frontend/src/plots/pairsMatrix.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { buildPairDefs, pairTransform } from './pairsMatrix'
+import { canonicalOrient, transposePoints, transposeExt } from './montage'
+import type { FlatPop, GateSpec } from '../stores/gating'
+
+const rect = (xc: string, yc: string): GateSpec => ({
+  kind: 'rectangle', x_channel: xc, y_channel: yc,
+  x_transform: { kind: 'linear' }, y_transform: { kind: 'linear' },
+  x_min: 0, x_max: 1, y_min: 2, y_max: 3,
+})
+const child = (name: string, gate?: GateSpec): FlatPop => ({
+  path: `/${name}`, name, parent: 'root', colour: '#fff', show: true, depth: 0, gate,
+})
+
+describe('buildPairDefs (channel-pairs matrix)', () => {
+  const chans = ['A', 'B', 'C']
+
+  it('produces the full N×N matrix (columns = X, rows = Y)', () => {
+    const defs = buildPairDefs(chans, 'root', 'linear', [])
+    expect(defs).toHaveLength(9)
+    // row-major: first row is y=A across x=A,B,C
+    expect(defs.slice(0, 3).map(d => [d.xChan, d.yChan])).toEqual([['A', 'A'], ['B', 'A'], ['C', 'A']])
+    expect(defs.every(d => d.parentPath === 'root' && d.parentName === 'all events')).toBe(true)
+  })
+
+  it('marks the diagonal (channel vs itself) and gives it no gate outlines', () => {
+    const defs = buildPairDefs(chans, 'root', 'linear', [child('P', rect('A', 'B'))])
+    const diag = defs.filter(d => d.diagonal)
+    expect(diag.map(d => d.xChan)).toEqual(['A', 'B', 'C'])
+    expect(diag.every(d => d.xChan === d.yChan && d.children.length === 0)).toBe(true)
+  })
+
+  it('attaches a child gate to its tile in EITHER channel order (orientGate)', () => {
+    const defs = buildPairDefs(chans, 'root', 'linear', [child('P', rect('A', 'B'))])
+    const ab = defs.find(d => d.xChan === 'A' && d.yChan === 'B')!
+    const ba = defs.find(d => d.xChan === 'B' && d.yChan === 'A')!
+    const ac = defs.find(d => d.xChan === 'A' && d.yChan === 'C')!
+    expect(ab.children.map(c => c.name)).toEqual(['P'])          // same order
+    expect(ba.children.map(c => c.name)).toEqual(['P'])          // swapped order — still matches
+    expect(ba.children[0].gate.x_channel).toBe('B')             // oriented to the tile's axes
+    expect(ac.children).toHaveLength(0)                         // unrelated pair → no gate
+  })
+
+  it('skips ungated children entirely', () => {
+    const defs = buildPairDefs(chans, 'root', 'linear', [child('nogate')])
+    expect(defs.every(d => d.children.length === 0)).toBe(true)
+  })
+
+  it('logicle transform carries its FlowJo shape; linear does not', () => {
+    expect(pairTransform('logicle')).toMatchObject({ kind: 'logicle', T: 262144, W: 0.5, M: 4.5, A: 0 })
+    expect(pairTransform('linear')).toEqual({ kind: 'linear' })
+    expect(buildPairDefs(['A'], 'root', 'logicle', [])[0].xt.kind).toBe('logicle')
+  })
+})
+
+describe('transpose reuse (mirror tiles share one fetch)', () => {
+  const d = (xc: string, yc: string) =>
+    ({ parentPath: '/P', xChan: xc, yChan: yc, xt: { kind: 'linear' as const }, yt: { kind: 'linear' as const } })
+
+  it('(a,b) and (b,a) resolve to the SAME canonical group, with swap flipped', () => {
+    const ab = canonicalOrient(d('A', 'B'))
+    const ba = canonicalOrient(d('B', 'A'))
+    expect(ab.groupKey).toBe(ba.groupKey)   // one fetch serves both
+    expect(ab.swap).toBe(false)
+    expect(ba.swap).toBe(true)
+    expect([ab.a, ab.b]).toEqual(['A', 'B'])
+  })
+
+  it('different parents never share a group', () => {
+    const p1 = canonicalOrient({ ...d('A', 'B'), parentPath: '/P1' })
+    const p2 = canonicalOrient({ ...d('A', 'B'), parentPath: '/P2' })
+    expect(p1.groupKey).not.toBe(p2.groupKey)
+  })
+
+  it('transposePoints swaps x/y of each interleaved point', () => {
+    expect([...transposePoints(new Float32Array([1, 2, 3, 4]))]).toEqual([2, 1, 4, 3])
+  })
+
+  it('transposeExt swaps the x and y ranges', () => {
+    expect(transposeExt({ xMin: 0, xMax: 1, yMin: 2, yMax: 3 })).toEqual({ xMin: 2, xMax: 3, yMin: 0, yMax: 1 })
+  })
+})

--- a/frontend/src/plots/pairsMatrix.ts
+++ b/frontend/src/plots/pairsMatrix.ts
@@ -1,0 +1,43 @@
+import type { FlatPop, GateSpec, TransformSpec } from '../stores/gating'
+import { orientGate } from './gateGeometry'
+import type { PanelDef, PanelChild } from './montage'
+
+// ── Channel-pairs matrix (R pairs()) ────────────────────────────────────────────────────────────
+// Turn a set of channels into the full N×N montage of every channel-vs-channel scatter for ONE
+// displayed population — the single gate plot's X/Y generalised to a list (the user's ask). Columns =
+// X channel, rows = Y channel. The diagonal (channel vs itself) is a labelled cell, not a scatter. On
+// each off-diagonal tile the displayed population's child gates whose channel-pair matches that tile —
+// in EITHER order (orientGate) — are attached as outlines, so the gates that define the populations
+// show, exactly as on the normal gating plot (but read-only). Pure + unit-tested (docs/DEV.md); the
+// tiles it returns feed the shared GateMontage renderer.
+
+// one transform applied to every axis (default logicle for flow, linear for track). Logicle carries its
+// FlowJo shape (matches GatePlotPanel.tspec) so the axis reads identically to the single plot.
+export const pairTransform = (k: TransformSpec['kind']): TransformSpec =>
+  k === 'logicle' ? { kind: k, T: 262144, W: 0.5, M: 4.5, A: 0 } : { kind: k }
+
+export function buildPairDefs(
+  channels: string[], parentPath: string, kind: TransformSpec['kind'], children: FlatPop[],
+): PanelDef[] {
+  const ts = pairTransform(kind)
+  const parentName = parentPath === 'root' ? 'all events' : parentPath
+  const gated = children.filter(c => c.gate)
+  const defs: PanelDef[] = []
+  for (const yc of channels) {               // rows
+    for (const xc of channels) {             // columns
+      const diagonal = xc === yc
+      const tileChildren: PanelChild[] = diagonal ? [] : gated
+        .map(c => {
+          const g = orientGate(c.gate as GateSpec, xc, yc)
+          return g ? { path: c.path, name: c.name, colour: c.colour, gate: g } : null
+        })
+        .filter((c): c is PanelChild => c !== null)
+      defs.push({
+        key: `${parentPath}::${xc}~~${yc}`,
+        parentPath, parentName, xChan: xc, yChan: yc, xt: ts, yt: ts,
+        children: tileChildren, diagonal,
+      })
+    }
+  }
+  return defs
+}


### PR DESCRIPTION
## Channel-pairs matrix on the gating pages (R `pairs()`)

Adds a `+ Pairs` button to the gating workspace that inserts a **read-only channel-pairs matrix**:
the single gate plot's X/Y generalised to a *list* of channels, rendered as the full N×N grid of
every channel-vs-channel scatter — for choosing the best two channels to gate a population on.
Available on **both** flow (Gate) and track (Tracking) gating, since both share the one
`GatingPlots` host (keyed by `popType`).

### Behaviour
- Read-only (`mode="off"`, read-only badge, no draw tools) — no gate drawing on these plots.
- Shows the displayed population's **child-gate outlines** on the tiles whose channel-pair matches
  (either order), so the gates that define the populations are visible.
- Honours the same highlight pipeline as a normal plot: the population manager's "eye" pops **and**
  the transient napari cell-selection colour every tile (linked brushing), reactive to gate edits.
- Single transform applied to all axes (logicle for flow, linear for track); render mode
  points/contour; diagonal cells are labelled (channel name); channel count capped at 8 (64 tiles)
  with a visible hint.

### Generalise, don't duplicate
Extracted the montage renderer/fetcher out of `GatingStrategyView` into a shared
`components/plots/GateMontage.vue` — a grid of read-only `GateScatterCell` tiles that owns the
per-tile `plotmeta`/`plotdata`/`stats` fetch, transpose reuse (mirror tiles share one fetch),
optional coloured population overlays, and PNG/PDF export. The gating-strategy plot now consumes it
too, so there is one montage renderer with two tile producers:
- `GatingStrategyView` — tree-derived tiles (responsive wrap);
- `GatePairsPanel` — channel-product N×N matrix (`plots/pairsMatrix.ts` `buildPairDefs`).

### Tests / docs
- Pure logic in `plots/pairsMatrix.ts` + `plots/montage.ts`; 9 new unit tests (matrix build, gate
  orientation, transpose reuse). Full frontend suite: 78 passing. Typecheck + build green.
- Docs: `docs/UI.md` (Gate scatters — one renderer, three hosts), `docs/ANALYSIS.md`,
  `docs/POPULATION.md`, `docs/TODO.md` (#00074).

🤖 Generated with [Claude Code](https://claude.com/claude-code)