### PR TITLE
Docs/commit reservations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,13 @@ opened, release tagging — are in [`docs/DEV.md`](docs/DEV.md). **Agents: ask b
 and before opening/pushing a PR — explicitly, each time; don't commit or push proactively** (a
 "go ahead" to do the work is not approval to commit it).
 
+**Agents: state your reservations BEFORE every commit.** When asked to commit/push (or asked for the
+PR url — that request itself calls the commit), first volunteer honest reservations about the change —
+what's unverified (e.g. never run in a browser, an untested regression surface), plus real
+limitations (perf, edge cases, silent no-ops) — as a short prioritized list. Don't reassure or wait
+to be asked "any reservations?". Surface the risk at the decision point, then commit on the go-ahead.
+See [`docs/DEV.md`](docs/DEV.md) → *Commits*.
+
 **Dev dir config — single source of truth:** `cecelia-pineapple/.env`
 ```
 CECELIA_DEV_DIR=~/cecelia-pineapple/dev

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -59,6 +59,24 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
 Ship the test in the same commit as the code (see `CLAUDE.md` → **Testing**), and update the
 relevant doc in the same change (see `CLAUDE.md` → the *Keep the docs current* table).
 
+### State reservations before committing (agents)
+
+Every time you're told to commit or push — **including** when Dom asks *"what's the PR url?"* (that
+request itself is the go-ahead to commit + push, so don't stall on extra `git status` round-trips) —
+**first volunteer your honest reservations about the change**, in the same turn, before running the
+commit. Not a reassurance; a short, prioritized list that separates:
+
+- **Unverified — "go look"**: what you did *not* actually exercise. The most common one: the change
+  was typechecked/tested/built but **never run in a browser / driven end-to-end**; also any shipped
+  component you refactored and didn't re-verify (a regression surface).
+- **Real limitations**: perf/fetch-volume concerns, edge cases you didn't handle, options that are
+  silent no-ops, stale-state paths.
+
+If any reservation is material, pause for Dom's call; if there are genuinely none, say "no
+reservations" and proceed. This is not the same as re-asking permission every turn — state the risk
+once, then act on the go-ahead. Dom added this rule after reservations surfaced only when he asked
+"any reservations?" *after* a merge — they belong at the decision point instead.
+
 ## Pull requests
 
 Open a PR against `main` for review; **Dom reviews and merges** (PR #1 merged this way). An agent

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -61,7 +61,7 @@ relevant doc in the same change (see `CLAUDE.md` → the *Keep the docs current*
 
 ### State reservations before committing (agents)
 
-Every time you're told to commit or push — **including** when Dom asks *"what's the PR url?"* (that
+Every time you're told to commit or push — **including** when Dominik asks *"what's the PR url?"* (that
 request itself is the go-ahead to commit + push, so don't stall on extra `git status` round-trips) —
 **first volunteer your honest reservations about the change**, in the same turn, before running the
 commit. Not a reassurance; a short, prioritized list that separates:
@@ -72,21 +72,21 @@ commit. Not a reassurance; a short, prioritized list that separates:
 - **Real limitations**: perf/fetch-volume concerns, edge cases you didn't handle, options that are
   silent no-ops, stale-state paths.
 
-If any reservation is material, pause for Dom's call; if there are genuinely none, say "no
+If any reservation is material, pause for Dominik's call; if there are genuinely none, say "no
 reservations" and proceed. This is not the same as re-asking permission every turn — state the risk
-once, then act on the go-ahead. Dom added this rule after reservations surfaced only when he asked
+once, then act on the go-ahead. Dominik added this rule after reservations surfaced only when he asked
 "any reservations?" *after* a merge — they belong at the decision point instead.
 
 ## Pull requests
 
-Open a PR against `main` for review; **Dom reviews and merges** (PR #1 merged this way). An agent
+Open a PR against `main` for review; **Dominik reviews and merges** (PR #1 merged this way). An agent
 **asks first** (see the golden rule) before pushing the branch or opening the PR.
 
 - The `gh` CLI is **not installed in the agent environment**. An agent therefore **pushes the
   branch and relays the PR-creation URL** (the `https://github.com/schienstockd/cecelia/pull/new/<branch>`
-  link printed by `git push`) for Dom to open — it does not attempt `gh pr create`.
+  link printed by `git push`) for Dominik to open — it does not attempt `gh pr create`.
 - **Always relay a complete, paste-ready PR body** — for *every* branch, not just large ones.
-  Because `gh` is absent, GitHub receives **no** description automatically; the body is text Dom
+  Because `gh` is absent, GitHub receives **no** description automatically; the body is text Dominik
   pastes into the PR form. The commit message and the PR body serve different readers (reviewers
   skim the PR on GitHub), so a body is always worth giving — short for small branches, but never
   omitted. (Don't leave it to a per-branch judgement call; that produced inconsistent PRs.)

--- a/docs/todo/ANALYSIS_CANVAS_PLAN.md
+++ b/docs/todo/ANALYSIS_CANVAS_PLAN.md
@@ -315,7 +315,7 @@ pops it can't consume. (`useSummaryData`'s current single global `sel` becomes t
    run's cluster pops. Map cluster pops into the picker's group model (or generalise it); do not clone it.
 3. **Cluster heatmap is SVG (summary-family)** → crisp export via the SVG path (`SummaryPanel.exportImage`
    style), NOT the WebGL montage hi-res path. Only the UMAP is WebGL.
-4. **Migrate saved boards** — SKIPPED (no real boards exist yet, per Dom). The per-family bag
+4. **Migrate saved boards** — SKIPPED (no real boards exist yet, per Dominik). The per-family bag
    (`selByFamily`) can replace the flat `shared.sel` outright; no load-time shim needed.
 5. **No regression to summary toggling** — flow/live becomes one family; existing `useSummaryData`
    `gSel`/`toggleTarget` behaviour must be preserved exactly.
@@ -326,7 +326,7 @@ pops it can't consume. (`useSummaryData`'s current single global `sel` becomes t
 Investigation found cluster pops live in the **singleton `useGatingStore`** (loaded via
 `g.selectImage(uid, vn, popType)`) and are toggled through **`PopulationManager`** (tickable cluster IDs),
 not `SeriesPicker`. The store holds ONE active (popType, suffix) at a time — so independent per-slot
-cluster runs can't coexist. **Decision (Dom): enforce a single cluster run per board.**
+cluster runs can't coexist. **Decision (Dominik): enforce a single cluster run per board.**
 
 Consequences (keeps model C working for clusters):
 - The board carries a **board-level cluster context**: `clustPopType` + `clustSuffix`, stored in the

--- a/docs/todo/PY_PACKAGING_PLAN.md
+++ b/docs/todo/PY_PACKAGING_PLAN.md
@@ -63,7 +63,7 @@ contract. coastal has an interim `CECELIA_APP` env-var bootstrap
 1. **Rename the top-level import name away from `py`.** Recommended: **`cecelia`** (dist name
    `cecelia` or `cecelia-py`; import `cecelia`). Alternatives considered: `ccia` (matches the
    internal `Ccia*`/`ccid` naming but cryptic), `cecelia_py`. `py` is rejected outright (PyPI
-   collision). *Open sub-decision for Dom:* confirm the exact dist name + check PyPI availability
+   collision). *Open sub-decision for Dominik:* confirm the exact dist name + check PyPI availability
    before any publish; for a local editable install the name only needs to be unique in-env.
    The Julia module is also `Cecelia` — cross-language namespaces don't collide, but note it.
 2. **Ship as an installable package via `pyproject.toml`, installed editable into the pixi env.**

--- a/docs/todo/QC_PLAN.md
+++ b/docs/todo/QC_PLAN.md
@@ -123,7 +123,7 @@ flag per (image, fun_name) so a produced node shows a QC dot + tooltip. Reuses t
 
 ## Resolved
 
-- **Storage root:** `1/{uid}/qc/{funName}/{valueName}.json` (the image metadata dir — Dom's "task
+- **Storage root:** `1/{uid}/qc/{funName}/{valueName}.json` (the image metadata dir — Dominik's "task
   dir"). Durable, per-image, queryable on reload without run context.
 - **No-value_name tasks:** fall back to `VERSIONED_DEFAULT_VAL` (`"default"`) as the key.
 

--- a/docs/todo/julia-port-watchlist.md
+++ b/docs/todo/julia-port-watchlist.md
@@ -59,7 +59,7 @@ Recheck these periodically. When one lands (and is mature), the linked item(s) a
   implemented. cecelia doesn't use sharding either (it's deferred in `docs/FUTURE.md`; the `zarr>=3`
   pin is for the v3 API, not sharding), so this does not block the port — plain `Zarr.jl` covers the
   need. (`Zarrs.jl` has sharding but is a Rust crate wrapped via `zarrs_ffi`. Whether a precompiled
-  Rust dep behind a C FFI is acceptable is a *decision for Dom / ARCHITECTURE.md* — it's a transitive
+  Rust dep behind a C FFI is acceptable is a *decision for Dominik / ARCHITECTURE.md* — it's a transitive
   binary dep like the existing torch/HDF5/JVM deps, not "Rust in the maintained stack," and Rust has
   an existing carve-out (Tauri). Not needed here regardless, since we don't use sharding.)
 - **Decision note:** this is a real, non-trivial build (multiscale write + chunking + layout +


### PR DESCRIPTION
## Require agents to state reservations before committing (+ name normalization)

Two docs-only commits from a workflow-preference conversation.

### 1. `docs(dev)`: state reservations before committing
Codifies a rule in `CLAUDE.md` (Development) and `docs/DEV.md` (Commits → new *State reservations
before committing* subsection): every time an agent is told to commit/push — including when Dominik
asks *"what's the PR url?"* (that request is itself the go-ahead) — it must first volunteer honest
reservations about the change, before running the commit. A short prioritized list separating:
- **Unverified — "go look"**: what wasn't actually exercised (most commonly: typechecked/tested/built
  but never run in a browser / driven end-to-end; a refactored shipped component not re-verified).
- **Real limitations**: perf/fetch-volume, unhandled edge cases, silent no-op options, stale state.

Rationale: reservations were surfacing only when Dominik asked "any reservations?" *after* a merge —
they belong at the decision point.

### 2. `docs`: normalize Dom → Dominik
Word-boundary rename across `docs/DEV.md` and the parked plans under `docs/todo/` (Dominik prefers his
full name). No code or identifiers touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)