### PR TITLE
fix(gating): pairs-matrix follow-ups — heavy-load warning, axis toggl…

### DIFF
--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -303,8 +303,13 @@ now includes `membership_sig`, so resizing the selection shape refreshes the hig
   the matching tiles and honours the SAME highlight pipeline as a normal plot (manager "eye" pops +
   transient napari cell-selection light up every tile). Shared with both flow and track gating (one
   `GatingPlots` host, keyed by `popType`). It reuses the shared `GateMontage` renderer (see
-  [`docs/UI.md`](UI.md) → *Gate scatters*); the pure tile builder is `plots/pairsMatrix.ts`
-  (`buildPairDefs`, unit-tested). Channel count is capped (8 → 64 tiles) with a visible hint.
+  [`docs/UI.md`](UI.md) → *Gate scatters*); the pure tile builders are `plots/pairsMatrix.ts`
+  (`buildPairDefs` / `reconcileChannels` / `estimateMatrixLoad`, unit-tested). It honours the manager's
+  **Axis** toggle (whole-dataset origin-0 vs autoscale-to-population) — alignment holds because a tile's
+  x-range depends only on (x-channel, pop) and its y-range only on (y-channel, pop). Channel count is
+  capped (8 → 64 tiles); above an estimated point-load threshold (pairs × population cell-count) a
+  brief amber warning shows, with the numbers + the fix in its tooltip. The selection is pruned to the
+  current segmentation's columns on a value_name switch (reseeding defaults if it empties).
 
 ## Scale
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,20 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00075** — **Channel-pairs matrix follow-ups (reservations from #00074)** (2026-07-09)
+Three refinements to the pairs plot flagged as reservations when #00074 merged:
+- **Heavy-load warning** — a brief amber strip on `GatePairsPanel` when the estimated point load
+  (off-diagonal pairs × population cell-count) is large, so a user selecting many channels / a huge
+  population is warned before the fetch burst. Numbers + the fix live in the tooltip. Pure
+  `estimateMatrixLoad` (unit-tested).
+- **Axis toggle no longer a no-op** — the manager's Axis (whole-dataset vs autoscale) toggle now
+  works on pairs panels: `axisFromZero` is threaded through `GateMontage` → `plotQ` (`x0`/`y0`).
+  Alignment still holds (a tile's x-range depends only on its x-channel + pop, not the other axis).
+- **Stale-channel pruning** — on a segmentation (value_name) switch, the persisted channel selection
+  is pruned to the new columns (reseeding defaults if empty), mirroring the single plot; previously a
+  stale channel produced broken/empty tiles. Pure `reconcileChannels` (unit-tested). Also centralised
+  `--cc-warn`/`--cc-danger` as real design tokens (were only inlined as `var()` fallbacks).
+
 **#00074** — **Channel-pairs matrix on the gating pages (R `pairs()`)** (2026-07-09)
 A `+ Pairs` button on the gating workspace (`GatingPlots`, so both flow AND track gating) adds a
 read-only `GatePairsPanel`: the single plot's X/Y generalised to a *list* of channels, rendered as the

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -18,6 +18,8 @@ All tokens live in `frontend/src/style.css` under `.cc-dark` (always applied at 
 | `--cc-text-dim` | `#7d8590` | Secondary text, labels |
 | `--cc-border` | `#30363d` | All borders |
 | `--cc-accent` | `#a78bfa` | Active elements, buttons, links |
+| `--cc-warn` | `#f59e0b` | Amber warnings (e.g. heavy-load hints) |
+| `--cc-danger` | `#ef4444` | Destructive / error state (delete, invalid) |
 | `--cc-mono` | system monospace stack | Log output, code |
 | `--cc-header-h` | `40px` | Fixed header height |
 | `--cc-sidebar-w` | `190px` | Fixed sidebar width |

--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -34,12 +34,16 @@ const props = withDefaults(defineProps<{
   highlight?: { path: string; colour: string }[]
   // null → responsive wrap (gating-strategy montage); N → strict N-column matrix (channel pairs)
   cols?: number | null
+  // true (default) → whole-dataset axis (x0=1), tiles align on a fixed scale; false → autoscale each
+  // axis to the population. The gating-strategy montage always wants the fixed scale (tiles have
+  // different parents), so it leaves this at the default; the pairs matrix honours the page's toggle.
+  axisFromZero?: boolean
   // bump to force a data refresh when tiles are unchanged but membership moved (ancestor gate edit,
   // napari selection) — the parent's point cloud can change without any def changing.
   reloadKey?: string | number
 }>(), {
   renderMode: 'points', gateLabels: true, gateLineWidth: 1.5,
-  highlight: () => [], cols: null, reloadKey: 0,
+  highlight: () => [], cols: null, axisFromZero: true, reloadKey: 0,
 })
 
 const montageId = computed<MontageId>(() => ({
@@ -71,7 +75,7 @@ async function loadPanels() {
   // meta uses the whole-dataset axis (x0=1 in plotQ) → pop-independent range; cache by canonical pair.
   const metaFor = (o: ReturnType<typeof canonicalOrient>, pop: string) => {
     if (!metaCache.has(o.groupKey)) metaCache.set(o.groupKey, (async () => {
-      const m = await (await fetch(`/api/gating/plotmeta?${plotQ(id, pop, o.a, o.b, o.ta, o.tb)}`)).json() as {
+      const m = await (await fetch(`/api/gating/plotmeta?${plotQ(id, pop, o.a, o.b, o.ta, o.tb, props.axisFromZero)}`)).json() as {
         xExtent: [number, number]; yExtent: [number, number]; xTicks: Tick[]; yTicks: Tick[] }
       return { extents: { xMin: m.xExtent[0], xMax: m.xExtent[1], yMin: m.yExtent[0], yMax: m.yExtent[1] },
                xTicks: m.xTicks, yTicks: m.yTicks }
@@ -81,7 +85,7 @@ async function loadPanels() {
   const ptsFor = (o: ReturnType<typeof canonicalOrient>, pop: string) => {
     const key = `${pop}|${o.groupKey}`
     if (!ptsCache.has(key)) ptsCache.set(key, (async () =>
-      new Float32Array(await (await fetch(`/api/gating/plotdata?${plotQ(id, pop, o.a, o.b, o.ta, o.tb)}`)).arrayBuffer()))())
+      new Float32Array(await (await fetch(`/api/gating/plotdata?${plotQ(id, pop, o.a, o.b, o.ta, o.tb, props.axisFromZero)}`)).arrayBuffer()))())
     return ptsCache.get(key)!
   }
   const labelFor = async (c: PanelChild): Promise<string> => {
@@ -127,7 +131,7 @@ const sig = computed(() => JSON.stringify({
   id: montageId.value,
   defs: props.defs.filter(d => !d.diagonal).map(d =>
     ({ k: d.key, p: d.parentPath, x: d.xChan, y: d.yChan, xt: d.xt, yt: d.yt, c: d.children.map(c => [c.path, c.gate]) })),
-  hl: props.highlight, rk: props.reloadKey,
+  hl: props.highlight, rk: props.reloadKey, fz: props.axisFromZero,
 }))
 watch(sig, loadPanels, { immediate: true })
 

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -14,7 +14,7 @@ import { useGatingStore } from '../../stores/gating'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import GateMontage from '../../components/plots/GateMontage.vue'
-import { buildPairDefs } from '../../plots/pairsMatrix'
+import { buildPairDefs, reconcileChannels, estimateMatrixLoad } from '../../plots/pairsMatrix'
 import { downloadDataUrl } from '../../plots/export'
 
 type Kind = 'linear' | 'log' | 'asinh' | 'logicle'
@@ -69,14 +69,31 @@ function toggleChannel(c: string) {
 }
 function clearChannels() { channels.value = [] }
 
-// seed a sensible default selection the first time (like GatePlotPanel.ensureChannels): the first few
-// intensity channels for flow, else the first gateable columns for track.
-function ensureChannels() {
-  if (channels.value.length || !g.columns.length) return
-  const src = g.channels.length ? g.channels : g.columns
-  channels.value = src.slice(0, Math.min(4, src.length))
+// Keep the selection valid for the current segmentation: a value_name switch changes the columns, so
+// prune any channel that no longer exists (reseeding if that empties it) — the pure reconcileChannels,
+// same intent as the single plot's ensureChannels. Only assign on a real content change (a bare filter
+// returns a new array each time → would loop). Flow → intensity channels; track → gateable columns.
+function syncChannels() {
+  const defaults = g.channels.length ? g.channels : g.columns
+  const next = reconcileChannels(channels.value, g.columns, defaults)
+  const changed = next.length !== channels.value.length || next.some((c, i) => c !== channels.value[i])
+  if (changed) channels.value = next
 }
-watch([() => g.columns, () => g.imageUid, () => g.valueName], ensureChannels, { immediate: true })
+watch([() => g.columns, () => g.imageUid, () => g.valueName], syncChannels, { immediate: true })
+
+// ── heavy-matrix warning ────────────────────────────────────────────────────────────────────────
+// N×N grows fast, and every off-diagonal pair fetches the population's cells. Warn (before loading)
+// when the estimated point load is large — tiles alone don't tell the story (a few channels on a
+// millions-of-cells root is still heavy), so fold in the population's cell count when we know it.
+const parentCount = computed(() => g.stats[parent.value]?.count ?? null)
+const load = computed(() => estimateMatrixLoad(channels.value.length, parentCount.value))
+const heavy = computed(() => load.value.heavy)
+const fmtN = (n: number) => n >= 1e6 ? `${(n / 1e6).toFixed(1)}M` : n >= 1e3 ? `${Math.round(n / 1e3)}k` : `${n}`
+const heavyTip = computed(() => {
+  const n = channels.value.length
+  const pts = load.value.estPoints != null ? `, ~${fmtN(load.value.estPoints)} points` : ''
+  return `${n}×${n} = ${load.value.tiles} plots (${load.value.fetches} fetches${pts}). Pick fewer channels or a smaller population to speed up.`
+})
 
 const montageRef = useTemplateRef<{ exportImage(bg?: string, light?: boolean): Promise<string | null> }>('montageRef')
 function exportPng() {
@@ -139,10 +156,15 @@ function exportPng() {
       </div>
     </div>
 
+    <div v-if="heavy" class="pairs-warn" v-tooltip.bottom="heavyTip">
+      <i class="pi pi-exclamation-triangle" /> Large matrix — may be slow to load
+    </div>
+
     <GateMontage ref="montageRef" :project-uid="g.projectUid()" :image-uid="g.imageUid ?? ''"
                  :value-name="g.valueName" :pop-type="g.popType" :defs="defs" :col-label="g.colLabel"
                  :render-mode="renderMode" :gate-labels="props.gateLabels" :gate-line-width="props.gateLineWidth"
-                 :highlight="highlightPops" :cols="channels.length || 1" :reload-key="reloadKey">
+                 :highlight="highlightPops" :cols="channels.length || 1" :axis-from-zero="props.axisFromZero"
+                 :reload-key="reloadKey">
       <template #empty>Pick channels above to compare them against each other.</template>
     </GateMontage>
   </CanvasPanel>
@@ -151,6 +173,10 @@ function exportPng() {
 <style scoped>
 .ro-tag { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-text-dim);
   border: 1px solid var(--cc-border); border-radius: 3px; padding: 1px 5px; }
+/* heavy-matrix warning strip (brief; numbers + the fix live in the tooltip) */
+.pairs-warn { display: flex; align-items: center; gap: 6px; padding: 4px 10px; font-size: 11px;
+  color: var(--cc-warn, #f59e0b); background: color-mix(in srgb, var(--cc-warn, #f59e0b) 12%, transparent);
+  border-bottom: 1px solid var(--cc-border); cursor: help; }
 .ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
 .panel-ctrl { display: flex; flex-direction: column; gap: 6px; padding: 6px 8px;
   border-bottom: 1px solid var(--cc-border); font-size: 12px; }

--- a/frontend/src/plots/montage.ts
+++ b/frontend/src/plots/montage.ts
@@ -32,9 +32,15 @@ export function axisQ(p: 'x' | 'y', ts: TransformSpec): string {
 export function idQ(id: MontageId): string {
   return `projectUid=${id.projectUid}&imageUid=${id.imageUid}&valueName=${encodeURIComponent(id.valueName)}&popType=${id.popType}`
 }
-// x0=1&y0=1 → fixed whole-dataset axis per side, so the parent density + child gates align across tiles
-export function plotQ(id: MontageId, pop: string, xc: string, yc: string, xt: TransformSpec, yt: TransformSpec): string {
-  return `${idQ(id)}&x=${encodeURIComponent(xc)}&y=${encodeURIComponent(yc)}&pop=${encodeURIComponent(pop)}${axisQ('x', xt)}${axisQ('y', yt)}&x0=1&y0=1`
+// fromZero (default true) → x0=1/y0=1: fixed whole-dataset axis per side, so the parent density + child
+// gates align across tiles. false → x0=0/y0=0: autoscale each axis to the population. Alignment holds
+// either way because a tile's x-range depends only on (x-channel, pop) and its y-range only on
+// (y-channel, pop) — never on the OTHER axis — so a matrix column (shared x) and row (shared y) still
+// line up when autoscaled. Mirrors GatePlotPanel's axisFromZero → x0/y0 flag.
+export function plotQ(id: MontageId, pop: string, xc: string, yc: string, xt: TransformSpec, yt: TransformSpec,
+                      fromZero = true): string {
+  const z = fromZero ? 1 : 0
+  return `${idQ(id)}&x=${encodeURIComponent(xc)}&y=${encodeURIComponent(yc)}&pop=${encodeURIComponent(pop)}${axisQ('x', xt)}${axisQ('y', yt)}&x0=${z}&y0=${z}`
 }
 
 // ── Transpose reuse ─────────────────────────────────────────────────────────────────────────────

--- a/frontend/src/plots/pairsMatrix.test.ts
+++ b/frontend/src/plots/pairsMatrix.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { buildPairDefs, pairTransform } from './pairsMatrix'
-import { canonicalOrient, transposePoints, transposeExt } from './montage'
+import { buildPairDefs, pairTransform, reconcileChannels, estimateMatrixLoad } from './pairsMatrix'
+import { canonicalOrient, transposePoints, transposeExt, plotQ } from './montage'
 import type { FlatPop, GateSpec } from '../stores/gating'
 
 const rect = (xc: string, yc: string): GateSpec => ({
@@ -78,5 +78,52 @@ describe('transpose reuse (mirror tiles share one fetch)', () => {
 
   it('transposeExt swaps the x and y ranges', () => {
     expect(transposeExt({ xMin: 0, xMax: 1, yMin: 2, yMax: 3 })).toEqual({ xMin: 2, xMax: 3, yMin: 0, yMax: 1 })
+  })
+})
+
+describe('reconcileChannels (segmentation switch)', () => {
+  it('drops channels missing from the new columns', () => {
+    expect(reconcileChannels(['A', 'X', 'B'], ['A', 'B', 'C'], ['A'])).toEqual(['A', 'B'])
+  })
+  it('reseeds defaults when the prune empties the selection', () => {
+    expect(reconcileChannels(['X', 'Y'], ['A', 'B', 'C'], ['A', 'B', 'C'])).toEqual(['A', 'B', 'C'])
+  })
+  it('caps the reseed at max', () => {
+    expect(reconcileChannels([], ['A', 'B', 'C', 'D', 'E'], ['A', 'B', 'C', 'D', 'E'], 4)).toEqual(['A', 'B', 'C', 'D'])
+  })
+  it('returns the selection untouched while columns are still loading', () => {
+    expect(reconcileChannels(['A', 'X'], [], ['A'])).toEqual(['A', 'X'])
+  })
+})
+
+describe('estimateMatrixLoad (heavy warning)', () => {
+  it('counts tiles (N²) and off-diagonal fetches (N(N-1)/2)', () => {
+    const l = estimateMatrixLoad(4, 1000)
+    expect(l.tiles).toBe(16)
+    expect(l.fetches).toBe(6)
+    expect(l.estPoints).toBe(6000)
+  })
+  it('never flags a tiny matrix (<2 channels)', () => {
+    expect(estimateMatrixLoad(1, 10_000_000).heavy).toBe(false)
+  })
+  it('flags on estimated points when the count is known', () => {
+    expect(estimateMatrixLoad(3, 500_000).heavy).toBe(true)    // 3 fetches × 500k = 1.5M ≥ 1M
+    expect(estimateMatrixLoad(3, 100_000).heavy).toBe(false)   // 300k < 1M
+  })
+  it('falls back to a channel-count heuristic when the count is unknown (root)', () => {
+    expect(estimateMatrixLoad(5, null).heavy).toBe(true)
+    expect(estimateMatrixLoad(4, null).heavy).toBe(false)
+    expect(estimateMatrixLoad(5, null).estPoints).toBeNull()
+  })
+})
+
+describe('plotQ axis origin (from-zero toggle)', () => {
+  const id = { projectUid: 'p', imageUid: 'i', valueName: 'v', popType: 'flow' }
+  const t = { kind: 'linear' as const }
+  it('defaults to whole-dataset axes (x0=1,y0=1)', () => {
+    expect(plotQ(id, 'root', 'A', 'B', t, t)).toContain('&x0=1&y0=1')
+  })
+  it('autoscales to the population when fromZero is false (x0=0,y0=0)', () => {
+    expect(plotQ(id, 'root', 'A', 'B', t, t, false)).toContain('&x0=0&y0=0')
   })
 })

--- a/frontend/src/plots/pairsMatrix.ts
+++ b/frontend/src/plots/pairsMatrix.ts
@@ -16,6 +16,29 @@ import type { PanelDef, PanelChild } from './montage'
 export const pairTransform = (k: TransformSpec['kind']): TransformSpec =>
   k === 'logicle' ? { kind: k, T: 262144, W: 0.5, M: 4.5, A: 0 } : { kind: k }
 
+// Reconcile a persisted channel selection with the current segmentation's columns: drop any channel
+// that no longer exists (a value_name switch changes the columns — else buildPairDefs would ask
+// plotdata for a missing column → broken tiles), and if that empties the list, seed the first few
+// defaults. Pure so the segmentation-switch pruning is unit-tested; mirrors the single plot's prune.
+export function reconcileChannels(selected: string[], columns: string[], defaults: string[], max = 4): string[] {
+  if (!columns.length) return selected
+  const valid = selected.filter(c => columns.includes(c))
+  return valid.length ? valid : defaults.slice(0, Math.min(max, defaults.length))
+}
+
+// Estimate the fetch/render load of an N×N matrix so the panel can warn before a heavy load. Each
+// off-diagonal channel PAIR fetches the population's cells once (mirror tiles share it), so the point
+// load ≈ pairs × population cell-count. `parentCount` is null when unknown (e.g. 'root') → fall back to
+// a tile-count heuristic. Pure + unit-tested.
+export interface MatrixLoad { tiles: number; fetches: number; estPoints: number | null; heavy: boolean }
+export function estimateMatrixLoad(nChannels: number, parentCount: number | null, heavyPoints = 1_000_000): MatrixLoad {
+  const tiles = nChannels * nChannels
+  const fetches = (nChannels * (nChannels - 1)) / 2
+  const estPoints = parentCount != null ? fetches * parentCount : null
+  const heavy = nChannels < 2 ? false : (estPoints != null ? estPoints >= heavyPoints : nChannels >= 5)
+  return { tiles, fetches, estPoints, heavy }
+}
+
 export function buildPairDefs(
   channels: string[], parentPath: string, kind: TransformSpec['kind'], children: FlatPop[],
 ): PanelDef[] {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -16,6 +16,10 @@
   --cc-border:     #30363d;
   --cc-accent:     #a78bfa;
 
+  /* status colours (amber warning / red danger) — previously only inlined as var() fallbacks */
+  --cc-warn:       #f59e0b;
+  --cc-danger:     #ef4444;
+
   /* monospace */
   --cc-mono: ui-monospace, 'Cascadia Code', Consolas, monospace;
 


### PR DESCRIPTION
## Channel-pairs matrix follow-ups (reservations from #79)

Addresses the three reservations flagged when the pairs matrix (#79) merged.

### 1. Heavy-load warning (fetch volume)
An N×N matrix fires a burst of `plotdata` fetches. `GatePairsPanel` now shows a brief amber warning
strip when the matrix is heavy — estimated as **off-diagonal pairs × population cell-count** (so it
also catches "few channels on a millions-of-cells root", not just tile count). The numbers and the
fix ("pick fewer channels or a smaller population") live in the tooltip. Pure `estimateMatrixLoad`.

### 2. Axis toggle now works on pairs panels
The manager's **Axis** toggle (whole-dataset origin-0 vs autoscale-to-population) was a silent no-op
on pairs panels. `axisFromZero` is now threaded through `GateMontage` → `plotQ` (`x0`/`y0`). Row/column
alignment still holds because a tile's x-range depends only on (x-channel, pop) and its y-range only on
(y-channel, pop) — never on the other axis.

### 3. Stale-channel pruning on segmentation switch
Switching segmentation (value_name) changes the available columns; a persisted channel selection could
then point at a missing column → broken/empty tiles. `reconcileChannels` prunes the selection to the
current columns (reseeding defaults if it empties), mirroring the single plot's `ensureChannels`.

### Also
- Centralised `--cc-warn` / `--cc-danger` as real design tokens in `style.css` (were only inlined as
  `var()` fallbacks); documented in `docs/UI.md`.
- New pure helpers (`estimateMatrixLoad`, `reconcileChannels`) + `plotQ` axis-origin unit-tested — 49
  frontend tests pass. Typecheck + build green.
- Docs: `docs/POPULATION.md`, `docs/UI.md`, `docs/TODO.md` (#00075).

🤖 Generated with [Claude Code](https://claude.com/claude-code)