### PR TITLE
feat(settings): System control panel — status, start/stop/restart, qu…

### DIFF
--- a/api/dev.jl
+++ b/api/dev.jl
@@ -1,0 +1,27 @@
+# Dev supervisor for `pixi run dev`.
+#
+# Runs the API server as a child process and relaunches it whenever it exits with RESTART_EXIT_CODE
+# (42) — the sentinel POST /api/app/restart uses (Settings → System → Restart). Any other exit
+# (0 = Quit, Ctrl-C, crash) stops the loop. Staying the terminal-foreground parent is what lets the
+# fresh server reattach to THIS terminal — a detached relaunch can't. Prod's equivalent loop is in
+# app.py. See docs/todo/SERVICE_PANEL_PLAN.md.
+#
+# The child is the SAME command the dev task used before this supervisor existed: Revise-tracked
+# hot-reload, multithreaded. CECELIA_SUPERVISED (set by the pixi task) tells the server restart is
+# available; we keep it set for the child too.
+
+const RESTART_EXIT_CODE = 42
+
+julia = Base.julia_cmd().exec[1]   # this julia's executable; child gets its own flags (-t auto, Revise)
+child = `$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`
+
+while true
+    proc = try
+        run(ignorestatus(child); wait = true)      # inherits stdio + env (CECELIA_DEV/SUPERVISED)
+    catch e
+        e isa InterruptException && break           # Ctrl-C → stop supervising
+        rethrow()
+    end
+    proc.exitcode == RESTART_EXIT_CODE || break     # 0 / crash / signal → done
+    @info "[dev] restart requested — relaunching server…"
+end

--- a/api/src/app_api.jl
+++ b/api/src/app_api.jl
@@ -1,0 +1,61 @@
+# ── App lifecycle: global shutdown (+ restart, Phase 3) ─────────────────────────
+# Drives the Settings "System" panel's global controls. Per-component start/stop/restart reuse the
+# existing napari_api / notebooks_api endpoints; only the whole-app actions live here.
+
+# Stop the child processes THIS server owns, best-effort, before the process exits. napari has no
+# atexit hook (unlike the notebook server), so it must be closed explicitly here or the bridge is
+# orphaned on :7655. Called by the global shutdown (and, later, restart).
+function _stop_children_for_exit()
+    try
+        v = _viewer()
+        v !== nothing && close!(v)          # kills the napari bridge process
+    catch e
+        @warn "Shutdown: closing napari failed" exception = e
+    end
+    try
+        _shutdown_notebook_server!()        # stops a Pluto server we spawned (no-op otherwise)
+    catch e
+        @warn "Shutdown: stopping notebooks failed" exception = e
+    end
+    # belt-and-suspenders: also free the child ports by force, covering a bridge we only ADOPTED or
+    # that outlived a crash (no process handle to close!) — so shutdown/restart never leaves a zombie
+    # on :7655 / :7660. Mirrors `pixi run stop`. No-op when the graceful stop already freed the port.
+    try; Cecelia._kill_listeners_on_port(Cecelia.NAPARI_PORT); catch; end
+    try; Cecelia._kill_listeners_on_port(NOTEBOOKS_PORT);      catch; end
+end
+
+# POST /api/app/shutdown  → { ok, message }   — the global "Quit everything".
+# Stops children, answers 200, then exits the process from a detached task so the HTTP response
+# flushes first. In dev this ends `pixi run dev`; in the packaged app the server exit ends app.py.
+function api_app_shutdown(body_bytes::Vector{UInt8})
+    @info "Shutdown requested via /api/app/shutdown"
+    _stop_children_for_exit()
+    @async begin
+        sleep(0.3)      # give handle_stream time to write the response before the process dies
+        exit(0)
+    end
+    200, JSON3.write((; ok = true, message = "Shutting down Cecelia"))
+end
+
+# Backend restart works ONLY under a supervisor that relaunches the server when it exits with
+# RESTART_EXIT_CODE — the `dev.jl` loop in dev, or `app.py` in prod. Both set CECELIA_SUPERVISED so we
+# never "exit to nowhere" on a bare launch (`julia src/server.jl` directly). This replaces the earlier
+# detached-relauncher approach, which couldn't reattach a new server to a foreground terminal and
+# depended on `pixi` being on PATH. The UI offers restart dev-only (button gated on `diag.dev`).
+const RESTART_EXIT_CODE = 42
+_can_restart()::Bool = haskey(ENV, "CECELIA_SUPERVISED")
+
+# POST /api/app/restart  → { ok } | 409  — restart the backend itself.
+# Stop children, then exit with the sentinel; the supervisor relaunches in place (same terminal / app
+# window) — no detaching, no pixi-on-PATH dependency.
+function api_app_restart(body_bytes::Vector{UInt8})
+    _can_restart() || return 409, JSON3.write((;
+        error = "Restart unavailable — the server isn't running under a supervisor."))
+    @info "Restart requested via /api/app/restart"
+    _stop_children_for_exit()
+    @async begin
+        sleep(0.4)      # flush the HTTP response first, then exit with the restart sentinel
+        exit(RESTART_EXIT_CODE)
+    end
+    200, JSON3.write((; ok = true, message = "Restarting Cecelia"))
+end

--- a/api/src/repl_api.jl
+++ b/api/src/repl_api.jl
@@ -99,8 +99,16 @@ function api_diagnostics(::HTTP.Request)
         loopback    = _host_is_loopback(),
         replEnabled = _repl_on[],           # runtime toggle state
         replAvailable = _repl_available(),  # toggle on AND loopback-bound → console usable
+        dev         = _is_dev(),            # dev server (pixi run dev sets CECELIA_DEV); prod/app.py never does
+        napariPort    = Cecelia.NAPARI_PORT,  # child-service ports, surfaced so the panel shows which
+        notebooksPort = NOTEBOOKS_PORT,       # ports Cecelia occupies (backend `port` is above)
     ))
 end
+
+# Dev vs prod: the `dev` pixi task sets CECELIA_DEV=1; the packaged app (app.py / `pixi run app`) and
+# `pixi run prod` never do — so absence means prod, auto-detected with no installer involvement. Gates
+# dev-only controls (e.g. the planned backend restart) in Settings → System.
+_is_dev() = get(ENV, "CECELIA_DEV", "") ∉ ("", "0", "false")
 
 # Render a value the way the REPL would (text/plain), length-capped so a huge object can't flood the UI.
 function _repl_show(x)::String

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -1,6 +1,7 @@
 using Cecelia
 using HTTP
 using JSON3
+using Logging
 
 # ── Bootstrap ─────────────────────────────────────────────────────────────────
 
@@ -17,6 +18,7 @@ include("tracking_api.jl")
 include("update_api.jl")
 include("repl_api.jl")
 include("notebooks_api.jl")
+include("app_api.jl")
 
 # ── WS broadcast ──────────────────────────────────────────────────────────────
 
@@ -57,6 +59,53 @@ function broadcast_ws(msg::Dict)
         isopen(q) && Base.n_avail(q) < _WS_OUT_CAP && try; put!(q, json); catch; end
     end
     nothing
+end
+
+# ── Server-log tee → WS (the "pixi console" in the browser) ─────────────────────
+# The Settings console window streams the backend's OWN @info/@warn/@error (startup banner, napari
+# warnings, …), not just task logs. A global AbstractLogger forwards each record to the real console
+# logger AND broadcasts it as {type:"server:log"}, keeping a small ring buffer so a freshly-opened
+# console backfills recent lines via GET /api/logs/recent. Installed in `start()` only (never under
+# CECELIA_NO_SERVE) so the test harness keeps the plain logger.
+const _LOG_RING_CAP  = 500
+const _log_ring      = Vector{Dict{String,Any}}()
+const _log_ring_lock = ReentrantLock()
+
+function _push_log_ring(rec::Dict{String,Any})
+    lock(_log_ring_lock) do
+        push!(_log_ring, rec)
+        length(_log_ring) > _LOG_RING_CAP && popfirst!(_log_ring)
+    end
+end
+
+struct BroadcastLogger <: Logging.AbstractLogger
+    inner::Logging.AbstractLogger
+end
+Logging.min_enabled_level(l::BroadcastLogger) = Logging.min_enabled_level(l.inner)
+Logging.shouldlog(l::BroadcastLogger, level, _module, group, id) =
+    Logging.shouldlog(l.inner, level, _module, group, id)
+Logging.catch_exceptions(l::BroadcastLogger) = Logging.catch_exceptions(l.inner)
+function Logging.handle_message(l::BroadcastLogger, level, message, _module, group, id, file, line; kwargs...)
+    Logging.handle_message(l.inner, level, message, _module, group, id, file, line; kwargs...)
+    try
+        lvl = level >= Logging.Error ? "error" : level >= Logging.Warn ? "warn" : "info"
+        msg = string(message)
+        isempty(kwargs) || (msg *= "  " * join(("$k = $v" for (k, v) in kwargs), "  "))
+        rec = Dict{String,Any}("level" => lvl, "message" => msg)
+        _push_log_ring(rec)
+        broadcast_ws(Dict{String,Any}("type" => "server:log", "level" => lvl, "message" => msg))
+    catch
+        # a logging failure must never escape the logger
+    end
+    nothing
+end
+
+_install_log_tee!() = global_logger(BroadcastLogger(global_logger()))
+
+# GET /api/logs/recent → { logs: [{level,message}, …] } — backfill a freshly-opened console window
+function api_logs_recent()
+    logs = lock(_log_ring_lock) do; copy(_log_ring); end
+    200, JSON3.write((; logs = logs))
 end
 
 # ── Chain event → WS bridge ───────────────────────────────────────────────────
@@ -155,6 +204,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_chains_runs(req)
         elseif path == "/api/chains/run"
             api_chains_run(req)
+        elseif path == "/api/logs/recent"
+            api_logs_recent()
         elseif path == "/api/napari/status"
             api_napari_status(req)
         elseif path == "/api/notebooks"
@@ -255,6 +306,10 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_notebooks_restart(body_bytes)
         elseif path == "/api/notebooks/build-sysimage"
             api_notebooks_build_sysimage(body_bytes)
+        elseif path == "/api/app/shutdown"
+            api_app_shutdown(body_bytes)
+        elseif path == "/api/app/restart"
+            api_app_restart(body_bytes)
         elseif path == "/api/napari/open"
             api_napari_open(body_bytes)
         elseif path == "/api/napari/close"
@@ -451,6 +506,7 @@ const _BOUND_HOST = Ref{String}("")
 
 function start(; host=HOST, port=PORT)
     _BOUND_HOST[] = string(host)
+    _install_log_tee!()   # tee server logs to the WS console (only when actually serving)
     @info "CeceliaAPI starting" host port threads=Threads.nthreads() projects_dir=projects_dir()
     HTTP.listen(handle_stream, host, port)
 end

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -20,9 +20,33 @@ _repl(code) = _post(api_repl, Dict("code" => code))
     @test d.threads >= 1
     @test !isempty(String(d.julia))
     @test haskey(d, :replAvailable) && haskey(d, :loopback) && haskey(d, :replEnabled)
+    # service ports surfaced for the System panel
+    @test d.port > 0 && d.napariPort == 7655 && d.notebooksPort == 7660
     # installed-build provenance (.cecelia-version at the install root); a source checkout has no
     # such file → the fallback string. Either way the field must be present and non-empty.
     @test haskey(d, :version) && !isempty(String(d.version))
+end
+
+@testset "API: app lifecycle" begin
+    # dev detection + restart availability are pure env readers
+    withenv("CECELIA_DEV" => nothing) do; @test _is_dev() == false; end
+    withenv("CECELIA_DEV" => "1")     do; @test _is_dev() == true;  end
+    withenv("CECELIA_DEV" => "0")     do; @test _is_dev() == false; end
+    withenv("CECELIA_SUPERVISED" => nothing) do; @test _can_restart() == false; end
+    withenv("CECELIA_SUPERVISED" => "1")     do; @test _can_restart() == true;  end
+
+    # restart when NOT supervised → 409, and (crucially) must NOT exit the process.
+    # (We never call api_app_shutdown, nor restart while supervised — those call exit().)
+    st, body = withenv("CECELIA_SUPERVISED" => nothing) do
+        api_app_restart(Vector{UInt8}("{}"))
+    end
+    @test st == 409
+    @test haskey(JSON3.read(body), :error)
+
+    # the console backfill endpoint is a safe read
+    st2, body2 = api_logs_recent()
+    @test st2 == 200
+    @test haskey(JSON3.read(body2), :logs)
 end
 
 @testset "API: packages" begin

--- a/app.py
+++ b/app.py
@@ -80,34 +80,49 @@ def _apply_pending_update() -> None:
               file=sys.stderr)
 
 
+# The server exits with this code to ask its supervisor (us) to relaunch it — Settings → System →
+# Restart (POST /api/app/restart). Mirrors the dev.jl supervisor loop. Any other exit → we stop.
+RESTART_EXIT_CODE = 42
+
+
 def main() -> int:
     _apply_pending_update()
     # Production mode: plain include, no Revise. Inherits PATH from the activated env so the
-    # server's Python subprocesses use the same env.
-    proc = subprocess.Popen(
-        [_find_julia(), "--project", "src/server.jl"],
-        cwd=os.path.join(ROOT, "api"),
-    )
-    try:
-        print(f"Starting Cecelia… (waiting for {HEALTH})")
-        if _server_ready():
-            webbrowser.open(URL)
-            print(f"Cecelia is running at {URL} — close this window to stop.")
-        else:
-            print("Cecelia server did not become ready in time.", file=sys.stderr)
-            proc.terminate()
-            return 1
-        proc.wait()
-    except KeyboardInterrupt:
-        pass
-    finally:
-        if proc.poll() is None:
-            proc.terminate()
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-    return 0
+    # server's Python subprocesses use the same env. CECELIA_SUPERVISED tells the server that
+    # backend restart is available (we relaunch it on RESTART_EXIT_CODE).
+    env = {**os.environ, "CECELIA_SUPERVISED": "1"}
+    first = True
+    while True:
+        proc = subprocess.Popen(
+            [_find_julia(), "--project", "src/server.jl"],
+            cwd=os.path.join(ROOT, "api"),
+            env=env,
+        )
+        try:
+            print(f"Starting Cecelia… (waiting for {HEALTH})")
+            if _server_ready():
+                if first:
+                    webbrowser.open(URL)   # only pop a browser on the initial launch, not each restart
+                    first = False
+                print(f"Cecelia is running at {URL} — close this window to stop.")
+            else:
+                print("Cecelia server did not become ready in time.", file=sys.stderr)
+                proc.terminate()
+                return 1
+            rc = proc.wait()
+            if rc == RESTART_EXIT_CODE:
+                print("Restarting Cecelia…")
+                continue
+            return 0
+        except KeyboardInterrupt:
+            return 0
+        finally:
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
 
 
 if __name__ == "__main__":

--- a/app/src/tasks/scheduler.jl
+++ b/app/src/tasks/scheduler.jl
@@ -189,6 +189,28 @@ function _kill_tree(pid::Int)
     end
 end
 
+# Kill whatever process is LISTENING on a TCP port (+ its tree). Cross-platform, best-effort. Used to
+# guarantee a clean app shutdown even for a child we only ADOPTED or that outlived a crash (no process
+# handle to `kill`) — napari :7655, notebooks :7660 — mirroring `pixi run stop`. There is no libuv API
+# for port→pid, so we shell out per-OS; this is the one sanctioned place, alongside `_kill_tree`.
+function _kill_listeners_on_port(port::Integer)
+    pids = Int[]
+    try
+        out = Sys.iswindows() ?
+            readchomp(`powershell -NoProfile -Command "(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).OwningProcess"`) :
+            readchomp(`lsof -ti tcp:$port`)   # exits non-zero (throws) when nothing is listening → caught
+        for line in split(out, '\n'; keepempty=false)
+            p = tryparse(Int, strip(line))
+            isnothing(p) || push!(pids, p)
+        end
+    catch; end
+    for p in unique(pids)
+        p == getpid() && continue   # never kill ourselves
+        _kill_tree(p)
+    end
+    nothing
+end
+
 """
 Cancel a running task: marks it cancelled and kills any active subprocess.
 Safe to call multiple times or for an already-completed task.

--- a/docs/API.md
+++ b/docs/API.md
@@ -85,6 +85,9 @@ Settings → Debug console UI shows a note to this effect.
 | GET | `/api/chains/runs?projectUid` · `/api/chains/run?projectUid&runId` | list persisted run records / load one run's frozen template + per-node status (Live view run history; see `docs/SCHEDULER.md` → *Loading past runs*) |
 | GET | `/api/napari/status`, POST `/api/napari/{open,close,restart,show-labels,show-populations,start-selection,stop-selection,event}` | napari bridge + gating linked brushing |
 | POST | `/api/napari/screenshot` | `projectUid` | **binary** PNG of the current napari canvas (`canvas_only`) — `save_screenshot!` to a temp file → stream the bytes → delete. `400` if napari not running. Feeds the Analysis-canvas image / filmstrip slots. |
+| POST | `/api/app/shutdown` | the global "Quit everything" (Settings → System). Best-effort stops children (napari `close!`, notebook server) then `exit(0)` from a detached task so the response flushes first. Dev: ends `pixi run dev`; packaged: server exit ends `app.py`. (`api/src/app_api.jl`) |
+| POST | `/api/app/restart` | **dev-only** backend restart (button gated on `diag.dev`). Stops children then `exit(42)` (`RESTART_EXIT_CODE`); the **supervisor** relaunches in place — `api/dev.jl` in dev, `app.py`'s loop in prod. `409` when not supervised (no `CECELIA_SUPERVISED` — a bare `julia src/server.jl`). Replaced the old detached-relauncher, which couldn't reattach to a foreground terminal. |
+| GET | `/api/logs/recent` | `{logs: [{level,message}]}` — the server-log ring buffer (last 500), so a freshly-opened console **window** backfills recent lines. Fed by the `BroadcastLogger` tee that also emits the `server:log` WS event (see below). |
 | — | **Gating** (below) | population manager + gating |
 
 Task execution + status flow over **WS** (`task:run`/`task:status`/…), not HTTP — see
@@ -92,7 +95,11 @@ Task execution + status flow over **WS** (`task:run`/`task:status`/…), not HTT
 are **broadcast to every connected client** (`_broadcast_task` → `broadcast_ws`), not sent point-to-point
 to the launching socket — so a second GUI tab and the read-only **task console** (`api/task_console.jl`,
 `pixi run console`) both see live progress. (They're keyed by `taskId`, so clients filter to what they
-care about. Chain events already broadcast.) Broadcast is **decoupled from the caller, per client**:
+care about. Chain events already broadcast.) The server also tees its **own** logs (`@info`/`@warn`/
+`@error` — startup banner, napari warnings, …) to WS as **`server:log`** `{level, message}` via a global
+`BroadcastLogger` installed in `start()` (never under `CECELIA_NO_SERVE`), keeping a 500-line ring
+buffer (`GET /api/logs/recent`). This is what makes the Settings console window a real "pixi console",
+not just a task log. Broadcast is **decoupled from the caller, per client**:
 each connected socket has its own bounded, drop-on-full queue drained by its own background task, and
 `broadcast_ws` enqueues a pre-serialised frame onto every client's queue (non-blocking; it skips a
 client whose queue is full). This is deliberate — task events fan out on every log/progress line from

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,22 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00076** — **Settings → System: service control panel + sidebar Quit/Restart + console window** (2026-07-09)
+Made the runtime legible/controllable from the UI (was: no way to see or manage the moving parts; a
+stale napari bridge needed a terminal). New **System** section in `SettingsModule.vue` (aligned grid
+name·status·port·actions): live status pills for Application / Napari / Notebooks (polled ~4s) + their
+ports, a read-only Frontend (GUI) row so the full port picture (8080/5173/7655/7660) is visible,
+per-component start/stop/restart (reusing `/api/{napari,notebooks}/*`), a global **Quit** (`POST
+/api/app/shutdown`), and **Open console** — the existing `ErrorConsole` (`fill` prop) mounted
+full-window in a separate window (`bare` `/console` + `window.open('#/console')`), fed by a `server:log`
+WS logger tee + 500-line ring buffer (`GET /api/logs/recent`) → a real "pixi console". A sidebar footer
+mirrors Quit + (dev) Restart via the shared `appControl` store (one implementation). Backend **Restart**
+is dev-only: `POST /api/app/restart` → `exit(42)` + a supervisor (`api/dev.jl` in dev, `app.py` loop in
+prod) relaunches in place; Quit/Restart also free child ports by force (`_kill_listeners_on_port`) so no
+zombie napari/pluto survives an adopted/crashed bridge. Dev vs prod auto-detected via `CECELIA_DEV` (dev
+task only) → `diag.dev`. Tests: `serviceStatus` (Vitest), api app-lifecycle + diagnostics ports. See
+`docs/todo/SERVICE_PANEL_PLAN.md`.
+
 **#00075** — **Channel-pairs matrix follow-ups (reservations from #00074)** (2026-07-09)
 Three refinements to the pairs plot flagged as reservations when #00074 merged:
 - **Heavy-load warning** — a brief amber strip on `GatePairsPanel` when the estimated point load

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -37,6 +37,25 @@ CellProfiler is the reference for tooltip density — if a button does something
 All errors go to `useLogStore().error(msg, { source, detail })`.
 Task failures must never be silent — errors must reach the console bar visible to the user.
 
+The **console** is one component — `components/ErrorConsole.vue` over the `log` store — mounted in two
+places: the docked bar at the bottom of the app shell, and (with the `fill` prop) full-window in the
+standalone **console window**. Do not build a second console. The window is a `bare` route
+(`/console`, `meta.bare` → `App.vue` renders it without the shell) opened via
+`window.open(origin + pathname + '#/console', …)` from Settings → System → **Open console**; being a
+separate browser window it's a fresh app instance with its own WS, and it backfills recent lines from
+`GET /api/logs/recent` on open. The stream includes the backend's own logs (WS `server:log`, see
+`docs/API.md`), so it's a real "pixi console", not just task logs.
+
+## Settings → System (service control panel)
+
+`SettingsModule.vue` has a **System** section: one row per runtime component (Application / Napari /
+Notebooks) with a status pill (Running / Starting… / Stopped, polled every ~4 s from the existing
+`/api/{napari,notebooks}/status` endpoints — ephemeral UI state, a plain `ref`, NOT persisted) and
+start/stop/restart buttons that reuse the existing control endpoints, plus **Open console** and a
+global **Quit** (`POST /api/app/shutdown`, behind a confirm). Status→verb/label mapping is the pure,
+unit-tested `utils/serviceStatus.ts`. Backend self-restart is planned (see
+`docs/todo/SERVICE_PANEL_PLAN.md`, Phase 3).
+
 ---
 
 ## Button utilities

--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -44,6 +44,9 @@ If it fits in a paragraph and needs no design, it's a `docs/TODO.md` item, not a
   `pixi.toml`, `clustering_utils.py`, `clustPops`/`clustTracks` `cluster.jl`, `docs/SHIPPING.md`.
 - `ANALYSIS_CANVAS_PLAN.md` — multipage tabbed analysis board + gating-strategy plot + PDF export
   (branch `feat/multipage-analysis-canvas`).
+- `SERVICE_PANEL_PLAN.md` — Settings control panel: live status + start/stop/restart for backend /
+  napari / notebooks, global Quit, and a separate-window "pixi console" (reuses the existing log
+  console). Branch `feat/settings-service-panel`; phased (panel → console → backend restart).
 - `PY_PACKAGING_PLAN.md` — make `app/py` an installable package (rename `py` → `cecelia`,
   `pyproject.toml` + extras, editable pixi install) so external consumers (`coastal`) can
   `import cecelia.utils.*` without a `sys.path` hack. Touches `app/src/py_runner.jl` (1 line),

--- a/docs/todo/SERVICE_PANEL_PLAN.md
+++ b/docs/todo/SERVICE_PANEL_PLAN.md
@@ -1,0 +1,107 @@
+# Service control panel (Settings) — plan
+
+**Status:** in-progress — branch `feat/settings-service-panel`. Phases 1–2 verified live. Phase 3
+(backend restart) reworked from a detached relauncher (failed the live test) to a **supervisor +
+`exit(42)`** model (`api/dev.jl` in dev, `app.py` loop in prod) — pending a re-test of the restart
+button. Committed incrementally on the branch; final squash/PR at the end.
+
+## Goal
+
+A small **control panel in the Settings page** that (a) shows the live status of each runtime
+component (running / starting / stopped) for transparency — "what is actually running" — and (b)
+gives per-component **start / stop / restart**, plus one global **Quit everything** button and an
+**Open console** button (live backend/pixi console in a separate window).
+
+Trigger: a stale **napari bridge**. The bridge is a long-lived child that survives server restarts
+and isn't Revise-tracked, so edits to `napari_bridge.py` (and PR #78's `configure_autosave`) don't
+take effect until it's killed + relaunched — today that means a second terminal (`pixi run
+stop-napari` + reopen). The old R app had a shutdown button; the pineapple app had nothing.
+
+Components managed: **Application** (Julia backend :8080), **Napari bridge** (:7655), **Notebooks /
+Pluto** (:7660). Vite frontend is **excluded** (prod: backend serves the built UI; dev: it's serving
+the page you're on).
+
+## Decisions (locked)
+
+1. **Reuse existing endpoints for napari/notebooks.** napari `POST /api/napari/{restart,close}` +
+   `GET /api/napari/status {alive,starting}`; notebooks `POST /api/notebooks/{restart,shutdown,launch}`
+   + `GET /api/notebooks/status {running,starting,…}`. `launch`/`restart` need `projectUid`.
+2. **Global Quit / app shutdown is a new endpoint** `POST /api/app/shutdown`: best-effort stop
+   children (napari `close!`, `api_notebooks_shutdown`), respond `200`, then `@async` short delay +
+   `exit(0)` so the response flushes. Napari has **no** `atexit` (notebooks does) → it MUST be killed
+   explicitly. Dev: ends `pixi run dev`; packaged: server exit ends `app.py`.
+3. **Backend restart needs a supervisor** (revised after live test — a detached relauncher does NOT
+   work: it can't reattach a new server to a foreground terminal, and depended on `pixi` being on
+   PATH). `POST /api/app/restart` stops children then `exit(42)` (`RESTART_EXIT_CODE`); a **supervisor**
+   relaunches in place — `api/dev.jl` loops the Revise server in dev (the `dev` pixi task runs
+   `julia dev.jl`), and `app.py`'s loop does it in prod. Both set `CECELIA_SUPERVISED`; restart is
+   `409` without it (`_can_restart`), and the UI offers it dev-only (`diag.dev`).
+4. **ONE console implementation — no second task-tracking path.** The windowed console reuses the
+   existing `log` store (`frontend/src/stores/log.ts`) + `ErrorConsole.vue`; extract the log rendering
+   into a shared component if needed and mount it in BOTH the docked bar and the window. The window is
+   a second *mount point*, not a second console.
+5. **Console window = console-only mode of the same SPA** (no vue-router in this app). Button →
+   `window.open(origin + '#console', 'cecelia-console', …)`; on boot, `location.hash === '#console'`
+   renders the shared console full-window with its own WS connection.
+6. **Make it a real "pixi console":** add an `AbstractLogger` tee in `server.jl` that `broadcast_ws`es
+   backend `@info/@warn/@error` as `{type:"server:log",level,message,ts}` → pushed into the same `log`
+   store. Bounded server-side ring buffer + `GET /api/logs/recent` so a freshly-opened console
+   backfills the last N lines (mirrors how the task console reconciles from `GET /api/tasks`).
+7. **Status polling** is ephemeral UI state → plain `ref` + `setInterval(~4s)` cleared on unmount
+   (NOT persisted view state); refresh immediately after each action.
+8. **Dev vs prod is auto-detected**, no installer changes. The `dev` pixi task sets `CECELIA_DEV=1`;
+   the packaged app (`pixi run app` → `app.py` → `julia src/server.jl`) and `pixi run prod` never do,
+   so absence = prod. Exposed via `GET /api/diagnostics` → `dev`. End users (prod) see the whole
+   System panel — status, Quit, napari/notebooks controls, Open console — EXCEPT the backend
+   **Restart**, which is dev-only (gated on `diag.dev`). A small "dev" badge marks a dev server.
+
+## Phases
+
+- **Phase 1 (high value, low risk):** System section + status polling (all three) + napari & notebooks
+  Start/Stop/Restart (existing endpoints) + global **Quit** (`/api/app/shutdown`). Delivers the
+  transparency and the napari-reload win.
+- **Phase 2 (console window):** `server:log` tee + ring buffer + `GET /api/logs/recent`, shared console
+  component, `#console` window mode, "Open console" button.
+- **Phase 3 (fragile, cross-platform):** Application **Restart** — `/api/app/restart` + detached
+  relauncher + `CECELIA_RELAUNCH_CMD` in the pixi tasks (+ win-64 variants).
+
+## Files
+
+- `frontend/src/modules/SettingsModule.vue` — "System" section (grid rows: name·status·port·actions,
+  polling, Quit confirm, Open console, read-only Frontend/GUI row, ports). Status→verb logic →
+  `frontend/src/utils/serviceStatus.ts` (+ `.test.ts`).
+- `frontend/src/stores/appControl.ts` *(new)* — shared app-level actions (`quit`, `restartBackend`,
+  `dev`, `busy`) used by BOTH the Settings panel and the sidebar footer (one implementation).
+- `frontend/src/components/AppSidebar.vue` — bottom-left footer: Quit (all) + Restart backend (dev only).
+- `frontend/src/components/ErrorConsole.vue` — `fill` prop → the one reusable console (docked + window).
+- `frontend/src/App.vue` — `#console` full-window `bare` mode.
+- `frontend/src/stores/ws.ts` — handle `server:log` → `log` store.
+- `api/src/app_api.jl` *(new)* — `api_app_shutdown`, `api_app_restart` (exit-42 sentinel), `_can_restart`,
+  `_stop_children_for_exit` (graceful + kill-by-port fallback).
+- `api/dev.jl` *(new)* — dev supervisor loop (relaunch on exit 42). `app.py` — same loop for prod.
+- `app/src/tasks/scheduler.jl` — `_kill_listeners_on_port` (next to `_kill_tree`) → zombie-free Quit.
+- `api/src/server.jl` — includes + routes (`/api/app/{shutdown,restart}`, `GET /api/logs/recent`) +
+  `server:log` logger tee + ring buffer. `api/src/repl_api.jl` — `dev`/ports in `/api/diagnostics`.
+- `pixi.toml` — `dev` task runs `dev.jl` with `CECELIA_DEV` + `CECELIA_SUPERVISED`.
+- Docs: `docs/UI.md`, `docs/API.md`, `docs/TODO.md`. Tests: `serviceStatus.test.ts`,
+  `api/test/runtests.jl` (app lifecycle + diagnostics ports).
+
+## Non-goals
+
+- **Browser-close → quit. DECIDED AGAINST (2026-07-09).** Considered auto-shutdown when the last WS
+  client disconnects (a ~15s grace window survives refresh — the robust alternative to a footgun
+  `beforeunload`). Dom chose **explicit Quit only**: closing the browser just disconnects; the backend
+  keeps running. To stop the app: the Quit button, or closing `app.py`'s window in prod. Don't
+  re-raise without a new ask.
+- Frontend (Vite) *controls* — but its port IS shown (read-only "Frontend (GUI)" row) so the full
+  picture of occupied ports (8080/5173/7655/7660) is visible; Quit/Restart free the child ports by
+  force (`_kill_listeners_on_port`) so no zombies survive even an adopted/crashed bridge.
+
+## Verification
+
+Open Settings → pills reflect reality; kill the bridge → Napari flips to Stopped within ~4s → Start →
+Running. Edit `napari_bridge.py` → Restart → reopen image → new code live (timelapse selection
+respects the frame; no `configure_autosave` warning). Notebooks Start/Stop/Restart cycle. Open console
+→ separate window streams live logs incl. server `@info/@warn`; docked bar + window are the same
+component. Quit → server exits. Restart (Phase 3, via `pixi run dev`) → relauncher brings it back;
+disabled when the env var is absent. `pixi run test-frontend` + `test-api` green; `vue-tsc` clean.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { useWsStore } from './stores/ws'
 import AppHeader from './components/AppHeader.vue'
 import AppSidebar from './components/AppSidebar.vue'
@@ -7,10 +8,20 @@ import ErrorConsole from './components/ErrorConsole.vue'
 
 const ws = useWsStore()
 onMounted(() => ws.connect())
+
+// `bare` routes (e.g. the standalone console window) render full-window without the app shell
+// (header / sidebar / docked console). See the /console route in main.ts.
+const route = useRoute()
+const bare = computed(() => route.meta.bare === true)
 </script>
 
 <template>
-  <div class="cc-dark cc-shell">
+  <!-- bare: full-window single view (own window via window.open) -->
+  <div v-if="bare" class="cc-dark cc-bare">
+    <RouterView />
+  </div>
+  <!-- normal app shell -->
+  <div v-else class="cc-dark cc-shell">
     <AppHeader />
     <div class="cc-content">
       <AppSidebar />
@@ -44,5 +55,10 @@ onMounted(() => ws.connect())
   flex: 1;
   overflow-y: auto;
   background: var(--cc-bg);
+}
+
+.cc-bare {
+  height: 100vh;
+  overflow: hidden;
 }
 </style>

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -1,13 +1,22 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
+import { useAppControlStore } from '../stores/appControl'
 import ProjectPanel from './ProjectPanel.vue'
 import ViewerPanel from './ViewerPanel.vue'
 
 const projectMeta = useProjectMetaStore()
 const settings = useSettingsStore()
+const appCtl = useAppControlStore()
 const showPanel = ref(false)
+
+// quick app controls in the footer: Quit (everyone) + Restart backend (dev only). Same shared store
+// the Settings → System panel uses. Quit is destructive → confirm first.
+onMounted(() => appCtl.refreshDev())
+function onQuit() {
+  if (window.confirm('Quit Cecelia? This stops napari, notebooks and the backend.')) appCtl.quit()
+}
 
 // Track which groups are collapsed (all open by default)
 const collapsed = ref<Set<string>>(new Set())
@@ -138,6 +147,18 @@ function isNavDisabled(item: NavItem): boolean {
       <i :class="['pi', isOpen('Viewer') ? 'pi-chevron-up' : 'pi-chevron-down', 'group-chevron']" />
     </button>
     <ViewerPanel v-if="isOpen('Viewer')" />
+
+    <!-- ── Footer: quick app controls (bottom-left) ────────────────────────── -->
+    <div class="sidebar-footer">
+      <button class="footer-btn danger" :disabled="appCtl.busy" @click="onQuit"
+              v-tooltip.right="'Quit Cecelia — stop napari, notebooks and the backend'">
+        <i class="pi pi-power-off" />
+      </button>
+      <button v-if="appCtl.dev" class="footer-btn" :disabled="appCtl.busy" @click="appCtl.restartBackend()"
+              v-tooltip.right="'Restart the backend server (dev) — reconnects when it is back'">
+        <i :class="['pi', appCtl.busy ? 'pi-spin pi-cog' : 'pi-refresh']" />
+      </button>
+    </div>
 
   </nav>
 
@@ -277,5 +298,27 @@ function isNavDisabled(item: NavItem): boolean {
   letter-spacing: 0.05em;
 }
 .lock-badge { font-size: 0.68rem; color: var(--cc-text-dim); opacity: 0.7; }
+
+/* ── Footer: quick app controls, pinned to the bottom ──────────────────────── */
+.sidebar-footer {
+  margin-top: auto;                 /* push to the bottom of the flex column */
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.5rem 0.6rem 0.2rem;
+  border-top: 1px solid var(--cc-border);
+}
+.footer-btn {
+  background: var(--cc-surface-2);
+  border: 1px solid var(--cc-border);
+  color: var(--cc-text-dim);
+  border-radius: 0.35rem;
+  padding: 0.35rem 0.55rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.12s, color 0.12s;
+}
+.footer-btn:hover:not(:disabled) { color: var(--cc-text); background: var(--cc-surface-1); }
+.footer-btn.danger:hover:not(:disabled) { color: #fff; background: var(--cc-danger, #ef4444); border-color: var(--cc-danger, #ef4444); }
+.footer-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
 </style>

--- a/frontend/src/components/ErrorConsole.vue
+++ b/frontend/src/components/ErrorConsole.vue
@@ -2,6 +2,10 @@
 import { ref, computed, watch, nextTick } from 'vue'
 import { useLogStore, type LogLevel } from '../stores/log'
 
+// `fill`: render just the open panel filling its container (no docked collapse bar / toggle). Used by
+// the standalone console window (ConsoleView) so the docked bar and the window are the SAME component.
+const props = defineProps<{ fill?: boolean }>()
+
 const log = useLogStore()
 
 type Filter = LogLevel | 'all'
@@ -37,8 +41,8 @@ const filterCounts = computed(() => ({
 </script>
 
 <template>
-  <!-- collapsed bar -->
-  <div v-if="!log.consoleOpen" class="console-bar" @click="log.openConsole()">
+  <!-- collapsed bar (never in fill/window mode) -->
+  <div v-if="!fill && !log.consoleOpen" class="console-bar" @click="log.openConsole()">
     <span class="bar-toggle" v-tooltip.top="'Open error console'">
       <i class="pi pi-angle-up" />
       Console
@@ -55,16 +59,18 @@ const filterCounts = computed(() => ({
     </span>
   </div>
 
-  <!-- open panel -->
-  <div v-else class="console-panel">
+  <!-- open panel (always shown in fill/window mode) -->
+  <div v-if="fill || log.consoleOpen" class="console-panel" :class="{ fill }">
     <div class="console-toolbar">
       <button
+        v-if="!fill"
         class="bar-toggle"
         @click="log.closeConsole()"
         v-tooltip.top="'Collapse console'"
       >
         <i class="pi pi-angle-down" /> Console
       </button>
+      <span v-else class="bar-toggle"><i class="pi pi-desktop" /> Console</span>
 
       <div class="filter-tabs">
         <button
@@ -191,6 +197,8 @@ const filterCounts = computed(() => ({
   background: var(--cc-console-bg);
   flex-shrink: 0;
 }
+/* window/standalone mode: fill the whole container instead of the docked open-height */
+.console-panel.fill { height: 100%; border-top: none; }
 
 .console-toolbar {
   display: flex;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -31,6 +31,8 @@ const router = createRouter({
     { path: '/tasks',     component: () => import('./modules/TasksModule.vue'),         meta: { label: 'Tasks' } },
     { path: '/chain',     component: () => import('./modules/ChainModule.vue'),         meta: { label: 'Whiteboard' } },
     { path: '/settings',  component: () => import('./modules/SettingsModule.vue'),      meta: { label: 'Settings' } },
+    // bare = rendered full-window without the app shell (opened in its own window via window.open)
+    { path: '/console',   component: () => import('./modules/ConsoleView.vue'),         meta: { label: 'Console', bare: true } },
   ],
 })
 

--- a/frontend/src/modules/ConsoleView.vue
+++ b/frontend/src/modules/ConsoleView.vue
@@ -1,0 +1,36 @@
+<!--
+  Standalone console window (opened from Settings → System → Open console via window.open('#/console')).
+  It's a bare, full-window mount of the SAME ErrorConsole component the docked bar uses (one console
+  implementation, no second task-tracking path) — this popup is just a second mount point. Being a
+  separate browser window it's a fresh app instance with its own WS connection, so it streams
+  independently; on open it backfills the server's recent log lines from GET /api/logs/recent.
+-->
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import ErrorConsole from '../components/ErrorConsole.vue'
+import { useLogStore } from '../stores/log'
+
+const log = useLogStore()
+
+onMounted(async () => {
+  document.title = 'Cecelia — Console'
+  // backfill recent backend logs so the window isn't empty until the next line arrives
+  try {
+    const { logs } = await (await fetch('/api/logs/recent')).json() as { logs: { level: string; message: string }[] }
+    for (const l of logs) {
+      const level = (l.level === 'error' || l.level === 'warn') ? l.level : 'info'
+      log.push(level as any, l.message, { source: 'server' })
+    }
+  } catch { /* server may be down — the live stream fills in once it's up */ }
+})
+</script>
+
+<template>
+  <div class="console-window cc-dark">
+    <ErrorConsole fill />
+  </div>
+</template>
+
+<style scoped>
+.console-window { height: 100vh; width: 100vw; overflow: hidden; background: var(--cc-console-bg); }
+</style>

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
-import { ref, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import PackagesDialog from '../components/PackagesDialog.vue'
+import { napariState, notebooksState, stateInfo, type ServiceState } from '../utils/serviceStatus'
+import { useAppControlStore } from '../stores/appControl'
 
 const showPackages = ref(false)
 
 const projectMeta = useProjectMetaStore()
 const settings    = useSettingsStore()
+const appCtl      = useAppControlStore()
 
 const editName = ref(projectMeta.current?.name ?? '')
 const saving   = ref(false)
@@ -85,7 +88,8 @@ interface Diag {
   threads: number; julia: string; version: string; projectsDir: string
   memFreeGB: number; memTotalGB: number; gcLiveMB: number
   host: string; port: number; loopback: boolean
-  replEnabled: boolean; replAvailable: boolean
+  replEnabled: boolean; replAvailable: boolean; dev: boolean
+  napariPort: number; notebooksPort: number
 }
 const diag = ref<Diag | null>(null)
 const diagBusy = ref(false)
@@ -134,6 +138,71 @@ function replKeydown(e: KeyboardEvent) {
   if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); runRepl() }
 }
 onMounted(loadDiag)
+
+// ── System: service control panel ─────────────────────────────────────────────
+// Live status of the backend's child processes + per-component and global controls. Status is
+// ephemeral UI state (polled) → plain refs, not persisted view state. Pure status→state mapping
+// lives in utils/serviceStatus.ts (unit-tested); here we only poll, act, and pick which buttons show.
+const napariRaw = ref<{ alive?: boolean; starting?: boolean } | null>(null)
+const notebooksRaw = ref<{ running?: boolean; starting?: boolean } | null>(null)
+const napariSt = computed<ServiceState>(() => napariState(napariRaw.value))
+const notebooksSt = computed<ServiceState>(() => notebooksState(notebooksRaw.value))
+const projectUid = computed(() => projectMeta.current?.uid ?? '')
+// the port serving THIS window (Vite :5173 in dev; the backend :8080 in prod) — the GUI isn't a
+// controllable service, we just show it so the full picture of occupied ports is visible.
+const guiPort = computed(() => location.port || (location.protocol === 'https:' ? '443' : '80'))
+
+const svcBusy = ref('')     // which row's action is in flight ('napari' | 'notebooks' | 'app')
+const svcMsg = ref('')
+const showQuitConfirm = ref(false)
+
+async function pollServices() {
+  try { napariRaw.value = await (await fetch('/api/napari/status')).json() } catch { napariRaw.value = null }
+  try { notebooksRaw.value = await (await fetch('/api/notebooks/status')).json() } catch { notebooksRaw.value = null }
+}
+let svcTimer: number | undefined
+onMounted(() => { pollServices(); svcTimer = window.setInterval(pollServices, 4000) })
+onUnmounted(() => { if (svcTimer) window.clearInterval(svcTimer) })
+
+const svcPost = (url: string, body?: object) =>
+  fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body ?? {}) })
+
+async function napariAction(kind: 'restart' | 'stop') {
+  svcBusy.value = 'napari'; svcMsg.value = ''
+  try {
+    await svcPost(kind === 'restart' ? '/api/napari/restart' : '/api/napari/close')
+    svcMsg.value = kind === 'restart' ? 'Napari restarting — reopen the image to reload its layers.' : 'Napari stopped.'
+  } catch { svcMsg.value = 'Napari action failed.' }
+  finally { svcBusy.value = ''; setTimeout(pollServices, 500) }
+}
+async function notebooksAction(kind: 'start' | 'stop' | 'restart') {
+  svcBusy.value = 'notebooks'; svcMsg.value = ''
+  try {
+    if (kind === 'stop') await svcPost('/api/notebooks/shutdown')
+    else await svcPost(kind === 'start' ? '/api/notebooks/launch' : '/api/notebooks/restart', { projectUid: projectUid.value })
+    svcMsg.value = kind === 'stop' ? 'Notebooks stopped.' : kind === 'start' ? 'Notebooks starting…' : 'Notebooks restarting…'
+  } catch { svcMsg.value = 'Notebooks action failed.' }
+  finally { svcBusy.value = ''; setTimeout(pollServices, 500) }
+}
+// app-level actions (Quit / dev Restart) live in the shared appControl store — same logic the sidebar
+// footer uses. We mirror its status into svcMsg and refresh the pills once the backend is back.
+async function appRestart() {
+  svcMsg.value = 'Backend restarting…'
+  await appCtl.restartBackend()
+  svcMsg.value = appCtl.message
+  pollServices()
+}
+function openConsole() {
+  // hash-history route → the popup boots the same SPA, sees #/console, and renders the console
+  // full-window (App.vue bare mode) with its own WS connection.
+  const url = location.origin + location.pathname + '#/console'
+  window.open(url, 'cecelia-console', 'width=980,height=600')
+}
+async function quitApp() {
+  showQuitConfirm.value = false
+  await appCtl.quit()
+  svcMsg.value = appCtl.message
+}
 </script>
 
 <template>
@@ -243,6 +312,93 @@ onMounted(loadDiag)
 
     </div>
     <div class="settings-col">
+
+    <!-- ── System (service control panel) ──────────────────────────────── -->
+    <section class="settings-section">
+      <h2 class="section-title">System
+        <span v-if="diag?.dev" class="svc-tag" v-tooltip.top="'Development server (pixi run dev, Revise hot-reload)'">dev</span>
+      </h2>
+
+      <div class="svc-row">
+        <span class="svc-name">Application</span>
+        <span class="svc-pill ok"><span class="dot" /> Running</span>
+        <span class="svc-port" v-tooltip.top="'Backend HTTP/WS server'">:{{ diag?.port ?? '8080' }}</span>
+        <span class="svc-actions">
+          <button v-if="diag?.dev" class="save-btn" :disabled="appCtl.busy" @click="appRestart"
+                  v-tooltip.top="'Restart the backend server (dev): the supervisor relaunches it, page reconnects when it is back'">
+            <i :class="['pi', appCtl.busy ? 'pi-spin pi-cog' : 'pi-refresh']" /> Restart
+          </button>
+          <button class="save-btn danger" :disabled="appCtl.busy" @click="showQuitConfirm = true"
+                  v-tooltip.top="'Stop napari, notebooks and the backend, then exit Cecelia'">
+            <i class="pi pi-power-off" /> Quit
+          </button>
+        </span>
+      </div>
+
+      <div class="svc-row">
+        <span class="svc-name">Napari viewer</span>
+        <span class="svc-pill" :class="stateInfo(napariSt).tone"><span class="dot" /> {{ stateInfo(napariSt).label }}</span>
+        <span class="svc-port" v-tooltip.top="'Napari bridge WebSocket'">:{{ diag?.napariPort ?? '7655' }}</span>
+        <span class="svc-actions">
+          <button class="save-btn" :disabled="svcBusy === 'napari'" @click="napariAction('restart')"
+                  v-tooltip.top="'Close and relaunch the napari bridge (picks up bridge code changes)'">
+            <i :class="['pi', svcBusy === 'napari' ? 'pi-spin pi-cog' : 'pi-refresh']" />
+            {{ napariSt === 'stopped' ? 'Start' : 'Restart' }}
+          </button>
+          <button v-if="napariSt !== 'stopped'" class="save-btn ghost" :disabled="svcBusy === 'napari'"
+                  @click="napariAction('stop')"><i class="pi pi-stop" /> Stop</button>
+        </span>
+      </div>
+
+      <div class="svc-row">
+        <span class="svc-name">Notebooks</span>
+        <span class="svc-pill" :class="stateInfo(notebooksSt).tone"><span class="dot" /> {{ stateInfo(notebooksSt).label }}</span>
+        <span class="svc-port" v-tooltip.top="'Pluto notebook server'">:{{ diag?.notebooksPort ?? '7660' }}</span>
+        <span class="svc-actions">
+          <button v-if="notebooksSt === 'stopped'" class="save-btn" :disabled="svcBusy === 'notebooks' || !projectUid"
+                  @click="notebooksAction('start')"
+                  v-tooltip.top="projectUid ? 'Launch the Pluto notebook server' : 'Open a project first'">
+            <i :class="['pi', svcBusy === 'notebooks' ? 'pi-spin pi-cog' : 'pi-play']" /> Start
+          </button>
+          <template v-else>
+            <button class="save-btn" :disabled="svcBusy === 'notebooks' || !projectUid" @click="notebooksAction('restart')">
+              <i :class="['pi', svcBusy === 'notebooks' ? 'pi-spin pi-cog' : 'pi-refresh']" /> Restart
+            </button>
+            <button class="save-btn ghost" :disabled="svcBusy === 'notebooks'" @click="notebooksAction('stop')">
+              <i class="pi pi-stop" /> Stop
+            </button>
+          </template>
+        </span>
+      </div>
+
+      <div class="svc-row">
+        <span class="svc-name">Console</span>
+        <span class="svc-pill idle"><span class="dot" /> Log stream</span>
+        <span class="svc-port" />
+        <span class="svc-actions">
+          <button class="save-btn ghost" @click="openConsole"
+                  v-tooltip.top="'Open the live backend/task console in a separate window'">
+            <i class="pi pi-external-link" /> Open console
+          </button>
+        </span>
+      </div>
+
+      <!-- read-only: not a service you control, shown so the full port picture is visible -->
+      <div class="svc-row">
+        <span class="svc-name">Frontend (GUI)</span>
+        <span class="svc-pill ok"><span class="dot" /> This window</span>
+        <span class="svc-port" v-tooltip.top="diag?.dev ? 'Vite dev server (proxies to the backend)' : 'served by the backend'">:{{ guiPort }}</span>
+      </div>
+
+      <span class="field-hint">Cecelia occupies these ports — don't bind other services (e.g. a Jupyter kernel) to them.</span>
+      <span v-if="svcMsg" class="field-hint">{{ svcMsg }}</span>
+
+      <div v-if="showQuitConfirm" class="svc-confirm">
+        <span>Quit Cecelia — stop napari, notebooks and the backend?</span>
+        <button class="save-btn danger" @click="quitApp"><i class="pi pi-power-off" /> Quit everything</button>
+        <button class="save-btn ghost" @click="showQuitConfirm = false">Cancel</button>
+      </div>
+    </section>
 
     <!-- ── Diagnostics ─────────────────────────────────────────────────── -->
     <section class="settings-section">
@@ -441,6 +597,27 @@ onMounted(loadDiag)
   font-size: 0.8rem;
   color: var(--cc-text-dim);
 }
+
+/* system control panel: aligned grid — name · status pill · port · actions */
+.svc-row { display: grid; grid-template-columns: 8rem 7rem 3.5rem 1fr; align-items: center;
+  column-gap: 0.6rem; margin-bottom: 0.55rem; }
+.svc-name { font-size: 0.8rem; color: var(--cc-text); }
+.svc-pill { justify-self: start; display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.72rem;
+  color: var(--cc-text-dim); padding: 0.1rem 0.55rem; border: 1px solid var(--cc-border); border-radius: 999px;
+  white-space: nowrap; }
+.svc-pill .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--cc-text-dim); }
+.svc-pill.ok .dot   { background: #22c55e; }
+.svc-pill.warn .dot { background: #f59e0b; }
+.svc-pill.idle .dot { background: var(--cc-text-dim); }
+.svc-tag { font-size: 0.62rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--cc-accent); border: 1px solid var(--cc-accent); border-radius: 3px; padding: 0 0.3rem; }
+.svc-port { justify-self: start; font-family: var(--cc-mono); font-size: 0.68rem; color: var(--cc-text-dim); }
+.svc-actions { display: flex; gap: 0.4rem; justify-content: flex-end; }
+.save-btn.ghost { background: transparent; color: var(--cc-text-dim); border-color: var(--cc-border); }
+.save-btn.ghost:not(:disabled):hover { color: var(--cc-text); }
+.save-btn.danger { background: var(--cc-danger, #ef4444); border-color: var(--cc-danger, #ef4444); }
+.svc-confirm { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.6rem; font-size: 0.78rem; color: var(--cc-text);
+  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 0.35rem; padding: 0.5rem 0.6rem; }
 
 /* diagnostics key/value grid */
 .diag-grid {

--- a/frontend/src/stores/appControl.ts
+++ b/frontend/src/stores/appControl.ts
@@ -1,0 +1,58 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+// App-level lifecycle actions (global Quit + dev backend Restart), shared by BOTH the Settings → System
+// panel and the sidebar footer so the shutdown/restart logic lives in ONE place (no divergent
+// re-implementation). Per-service (napari/notebooks) controls stay local to the Settings panel.
+export const useAppControlStore = defineStore('appControl', () => {
+  const dev = ref(false)        // dev server → the backend Restart control is offered (prod hides it)
+  const busy = ref(false)       // a quit/restart is in flight (drives spinners in both places)
+  const message = ref('')
+
+  const _post = (url: string) =>
+    fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+
+  // read the dev flag from diagnostics (prod never sets CECELIA_DEV → false)
+  async function refreshDev() {
+    try { dev.value = !!(await (await fetch('/api/diagnostics')).json()).dev } catch { /* leave as-is */ }
+  }
+
+  // global Quit: stop everything + exit the backend. The connection drops as the server exits (expected);
+  // stays busy because the app is gone.
+  async function quit() {
+    busy.value = true; message.value = 'Shutting down…'
+    try { await _post('/api/app/shutdown') } catch { /* connection dropped on exit */ }
+    message.value = 'Cecelia is shutting down — you can close this window.'
+  }
+
+  // dev-only backend restart: the supervisor relaunches; poll /api/health until it's back, then clear.
+  // Returns an error string if the server refused (e.g. not supervised), else null.
+  async function restartBackend(): Promise<string | null> {
+    busy.value = true; message.value = 'Backend restarting…'
+    try {
+      const res = await _post('/api/app/restart')
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({} as { error?: string }))
+        busy.value = false; message.value = d.error ?? 'Restart failed.'
+        return message.value
+      }
+    } catch { /* connection dropped as it exits — expected */ }
+    message.value = 'Backend restarting — reconnecting…'
+    await _waitForBackend()
+    busy.value = false; message.value = 'Backend restarted.'
+    return null
+  }
+
+  // wait for the restarted server to answer /api/health again. The initial delay lets the old process
+  // actually exit first (it exits ~0.4s after responding) so we don't catch it still up.
+  async function _waitForBackend(timeoutMs = 60000) {
+    await new Promise(r => setTimeout(r, 1500))
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      try { if ((await fetch('/api/health', { cache: 'no-store' })).ok) return } catch { /* not up yet */ }
+      await new Promise(r => setTimeout(r, 800))
+    }
+  }
+
+  return { dev, busy, message, refreshDev, quit, restartBackend }
+})

--- a/frontend/src/stores/log.ts
+++ b/frontend/src/stores/log.ts
@@ -28,6 +28,8 @@ export const useLogStore = defineStore('log', () => {
       source: opts?.source,
       timestamp: new Date(),
     })
+    // cap history so the teed server-log stream can't grow the store unbounded over a long session
+    if (entries.value.length > 3000) entries.value.splice(0, entries.value.length - 3000)
     if (level === 'error' && !consoleOpen.value) unreadErrors.value++
   }
 

--- a/frontend/src/stores/ws.ts
+++ b/frontend/src/stores/ws.ts
@@ -71,6 +71,13 @@ export const useWsStore = defineStore('ws', () => {
         )
       }
 
+      // backend's own @info/@warn/@error (startup, napari warnings, …), teed by the server so the
+      // console window is a real "pixi console" — not just task logs. See server.jl BroadcastLogger.
+      if (type === 'server:log') {
+        const level = (data.level === 'error' || data.level === 'warn') ? data.level : 'info'
+        useLogStore().push(level as any, String(data.message ?? ''), { source: 'server' })
+      }
+
       if (type === 'task:progress') {
         const taskId   = String(data.taskId ?? '')
         const progress = Number(data.progress ?? 0)

--- a/frontend/src/utils/serviceStatus.test.ts
+++ b/frontend/src/utils/serviceStatus.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { napariState, notebooksState, stateInfo } from './serviceStatus'
+
+describe('napariState', () => {
+  it('maps the /api/napari/status payload', () => {
+    expect(napariState({ alive: true, starting: false })).toBe('running')
+    expect(napariState({ alive: false, starting: true })).toBe('starting')
+    expect(napariState({ alive: false, starting: false })).toBe('stopped')
+    // starting wins even if a stale alive flag lingers
+    expect(napariState({ alive: true, starting: true })).toBe('starting')
+  })
+  it('treats a missing/failed payload as stopped', () => {
+    expect(napariState(null)).toBe('stopped')
+    expect(napariState(undefined)).toBe('stopped')
+    expect(napariState({})).toBe('stopped')
+  })
+})
+
+describe('notebooksState', () => {
+  it('maps the /api/notebooks/status payload', () => {
+    expect(notebooksState({ running: true })).toBe('running')
+    expect(notebooksState({ running: false, starting: true })).toBe('starting')
+    expect(notebooksState({ running: false, starting: false })).toBe('stopped')
+    expect(notebooksState(null)).toBe('stopped')
+  })
+})
+
+describe('stateInfo', () => {
+  it('gives a label + tone per state', () => {
+    expect(stateInfo('running')).toEqual({ label: 'Running', tone: 'ok' })
+    expect(stateInfo('starting')).toEqual({ label: 'Starting…', tone: 'warn' })
+    expect(stateInfo('stopped')).toEqual({ label: 'Stopped', tone: 'idle' })
+  })
+})

--- a/frontend/src/utils/serviceStatus.ts
+++ b/frontend/src/utils/serviceStatus.ts
@@ -1,0 +1,29 @@
+// Pure helpers for the Settings "System" control panel: normalise each service's raw status payload
+// into a single {running|starting|stopped} state + a display label/tone. Kept out of the SFC so it's
+// unit-testable (see serviceStatus.test.ts) — the component only maps state → which buttons to show.
+
+export type ServiceState = 'running' | 'starting' | 'stopped'
+export type Tone = 'ok' | 'warn' | 'idle'
+
+/** GET /api/napari/status → { alive, starting } */
+export function napariState(s: { alive?: boolean; starting?: boolean } | null | undefined): ServiceState {
+  if (!s) return 'stopped'
+  if (s.starting) return 'starting'
+  return s.alive ? 'running' : 'stopped'
+}
+
+/** GET /api/notebooks/status → { running, starting, … } */
+export function notebooksState(s: { running?: boolean; starting?: boolean } | null | undefined): ServiceState {
+  if (!s) return 'stopped'
+  if (s.starting) return 'starting'
+  return s.running ? 'running' : 'stopped'
+}
+
+/** Display label + colour tone for a state pill. */
+export function stateInfo(state: ServiceState): { label: string; tone: Tone } {
+  switch (state) {
+    case 'running':  return { label: 'Running',   tone: 'ok' }
+    case 'starting': return { label: 'Starting…', tone: 'warn' }
+    default:         return { label: 'Stopped',   tone: 'idle' }
+  }
+}

--- a/pixi.toml
+++ b/pixi.toml
@@ -79,7 +79,7 @@ torchvision = ">=0.21"
 # longer stalls the accept loop / a napari open, and the scheduler's per-image task functions
 # (Threads.@spawn) actually parallelise. Julia HDF5 is serialised via `_with_h5`; shared API state is
 # lock-guarded. Override with JULIA_NUM_THREADS if you want a fixed count.
-dev  = { cmd = "julia --project -t auto -e 'using Revise; includet(\"src/server.jl\")'", cwd = "api" }  # hot-reload (development)
+dev  = { cmd = "julia --project dev.jl", cwd = "api", env = { CECELIA_DEV = "1", CECELIA_SUPERVISED = "1" } }  # dev.jl supervises the Revise hot-reload server + relaunches it on Settings→System Restart. CECELIA_DEV marks a dev server (prod/app.py never sets it → auto-detected); CECELIA_SUPERVISED enables the backend Restart button
 prod = { cmd = "julia --project -t auto src/server.jl", cwd = "api" }                                    # plain include (production)
 
 # Tests — one whole suite per layer. Package (headless Cecelia) + API adapters (loaded with


### PR DESCRIPTION
## Settings → System: service control panel + sidebar Quit/Restart + console window

Makes Cecelia's runtime legible and controllable from the UI. Previously there was no way to see or
manage the moving parts — and a stale napari bridge (survives restarts, not Revise-tracked) needed a
terminal to reload.

### What you get
- **System panel** (Settings) — aligned grid `name · status · port · actions`:
  - Live status pills (Running / Starting… / Stopped, polled ~4s) for **Application · Napari · Notebooks**, each with its **port**; a read-only **Frontend (GUI)** row so the full picture of occupied ports (8080/5173/7655/7660) is visible — with a hint not to bind e.g. a Jupyter kernel to them.
  - **napari** & **notebooks** start/stop/restart (reuse existing `/api/{napari,notebooks}/*`).
  - Global **Quit** (`POST /api/app/shutdown`) — the old shutdown button.
  - Dev-only **Restart backend** (`POST /api/app/restart`).
  - **Open console** — the *same* `ErrorConsole` (`fill` prop) mounted full-window in a separate browser window (`bare` `/console` route + `window.open('#/console')`), fed by a `server:log` WS logger tee + 500-line ring buffer (`GET /api/logs/recent`) → a real "pixi console" (backend `@info/@warn/@error`, not just task logs).
- **Sidebar footer** (bottom-left) — quick **Quit** (all) + **Restart backend** (dev only), via a shared `appControl` store used by both the panel and the sidebar (one implementation).

### Backend restart (dev-only) & zero zombies
- `/api/app/restart` stops children then `exit(42)`; a **supervisor** relaunches in place — `api/dev.jl` in dev, `app.py`'s loop in prod (no detach, no `pixi`-on-PATH dependency).
- Quit/Restart also free child ports by force (`_kill_listeners_on_port`, next to `_kill_tree`) so no napari/pluto zombie survives an adopted/crashed bridge.
- Dev vs prod auto-detected via `CECELIA_DEV` (dev task only; prod/`app.py` never set it) → `diag.dev`. No installer change.

### Tests / docs
- Vitest `serviceStatus`; api `app lifecycle` (9) + diagnostics ports (6). `vue-tsc` clean.
- `docs/API.md`, `docs/UI.md`, `docs/TODO.md` (#00076), `docs/todo/SERVICE_PANEL_PLAN.md`.

### Not yet exercised live (reservations)
- **Prod path** (`app.py` restart loop + prod Quit) — only the dev supervisor was run live.
- **Console window** live streaming/backfill, and **Quit's** kill-by-port zombie-freeness.
- **Windows** branches (`dev.jl`, PowerShell port-kill, `app.py`).
Smoke-test these before a release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)