### PR TITLE
feat(gating): ggpairs-style pairs matrix — lower scatter, diagonal na…

### DIFF
--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -297,17 +297,21 @@ now includes `membership_sig`, so resizing the selection shape refreshes the hig
   simultaneous panels; hierarchical population tree (generic for all 3 types). **No
   Plotly** for gating.
 - **Channel-pairs matrix (read-only)**: the gating page's `+ Pairs` button (`GatingPlots`) adds a
-  `GatePairsPanel` — the single plot's X/Y generalised to a *list* of channels, rendered as the full
-  N×N matrix of every channel-vs-channel scatter (R `pairs()`), for choosing the best two channels to
-  gate a population on. It draws NO gates, but shows the displayed population's child gate outlines on
-  the matching tiles and honours the SAME highlight pipeline as a normal plot (manager "eye" pops +
-  transient napari cell-selection light up every tile). Shared with both flow and track gating (one
-  `GatingPlots` host, keyed by `popType`). It reuses the shared `GateMontage` renderer (see
-  [`docs/UI.md`](UI.md) → *Gate scatters*); the pure tile builders are `plots/pairsMatrix.ts`
-  (`buildPairDefs` / `reconcileChannels` / `estimateMatrixLoad`, unit-tested). It honours the manager's
+  `GatePairsPanel` — the single plot's X/Y generalised to a *list* of channels, rendered as a
+  scatter-plot matrix (GGally `ggpairs` layout) for choosing the best two channels to gate a population
+  on: **lower triangle** = the scatters, **diagonal** = each channel's name (labels its row + column, so
+  per-tile axis labels are dropped), **upper triangle** = each pair's Pearson correlation (reused from
+  the mirror scatter's points — no extra fetch, text scaled by |r|). Only the lower triangle fetches, so
+  it's N(N-1)/2 point clouds, not N². It draws NO gates, but shows the displayed population's child gate
+  outlines on the matching scatter tiles and honours the SAME highlight pipeline as a normal plot
+  (manager "eye" pops + transient napari cell-selection light up every tile). Shared with both flow and
+  track gating (one `GatingPlots` host, keyed by `popType`). It reuses the shared `GateMontage` renderer
+  (see [`docs/UI.md`](UI.md) → *Gate scatters*); the pure helpers are `plots/pairsMatrix.ts`
+  (`buildPairDefs` / `reconcileChannels` / `estimateMatrixLoad`) + `plots/montage.ts` (`pearson`), all
+  unit-tested. It honours the manager's
   **Axis** toggle (whole-dataset origin-0 vs autoscale-to-population) — alignment holds because a tile's
   x-range depends only on (x-channel, pop) and its y-range only on (y-channel, pop). Channel count is
-  capped (8 → 64 tiles); above an estimated point-load threshold (pairs × population cell-count) a
+  capped (8 → 28 scatter plots); above an estimated point-load threshold (pairs × population cell-count) a
   brief amber warning shows, with the numbers + the fix in its tooltip. The selection is pruned to the
   current segmentation's columns on a value_name switch (reseeding defaults if it empties).
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,18 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00077** — **Pairs matrix → `ggpairs` layout (lower scatter / diagonal names / upper correlation)** (2026-07-09)
+Reworked the channel-pairs matrix to GGally `ggpairs` style, halving the load and de-cluttering:
+- **Only the lower triangle** renders scatters (N(N-1)/2), not the full N² — drops the mirror
+  duplicates. `buildPairDefs` tags each tile with a `role` (`scatter`/`diagonal`/`corr`).
+- **Diagonal** = the channel name (labels its row + column); **upper triangle** = each pair's Pearson
+  correlation, reused from the mirror scatter's already-fetched points (pure `pearson`, no extra fetch,
+  text scaled by |r|).
+- **Per-tile axis labels dropped** in matrix mode (`GateScatterCell` `hideAxisLabels`) — they were
+  clipping and are redundant with the diagonal; reclaims their padding for the plot.
+Contour-only + contour-with-outliers render modes are the NEXT change; the napari transient-pop-persists
+bug is a separate branch. Tests: `pearson` + role assignment (56 frontend tests pass).
+
 **#00076** — **Settings → System: service control panel + sidebar Quit/Restart + console window** (2026-07-09)
 Made the runtime legible/controllable from the UI (was: no way to see or manage the moving parts; a
 stale napari bridge needed a terminal). New **System** section in `SettingsModule.vue` (aligned grid

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -502,8 +502,12 @@ Gate page (`GatePlotPanel`, `mode` = rectangle/polygon) and every read-only mont
 share it. Montages of tiles go through `components/plots/GateMontage.vue` — a grid of `GateScatterCell`
 tiles that owns the per-tile fetch (`plotmeta`/`plotdata`/`stats`), transpose reuse, optional coloured
 population overlays (`highlight`), and PNG/PDF export. It has two tile producers: `GatingStrategyView`
-(tree-derived, responsive wrap) and `GatePairsPanel` (channel-product N×N matrix, `cols` set). Add a new
-gate-montage view by building `PanelDef[]` and rendering `<GateMontage>` — never a second gate renderer.
+(tree-derived, responsive wrap) and `GatePairsPanel` (a `ggpairs` matrix, `cols` set). A tile carries a
+`role`: `scatter` (fetches + renders — the default, so tree-derived defs need no role), `diagonal` (a
+labelled name cell, no fetch), or `corr` (an upper-triangle Pearson-r cell reusing its mirror scatter's
+points, no fetch). In matrix mode `GateScatterCell` gets `hideAxisLabels` (the diagonal names each
+channel, so per-tile axis labels only clutter/clip). Add a new gate-montage view by building `PanelDef[]`
+and rendering `<GateMontage>` — never a second gate renderer.
 
 ### Generic plot-integration interface (reuse across surfaces)
 

--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -19,8 +19,10 @@ import GateScatterCell from './GateScatterCell.vue'
 import type { PopLayer } from './PlotLayers.vue'
 import {
   type PanelDef, type PanelChild, type MontageId, type Ext, type Tick,
-  idQ, plotQ, canonicalOrient, transposePoints, transposeExt,
+  idQ, plotQ, canonicalOrient, transposePoints, transposeExt, pearson,
 } from '../../plots/montage'
+
+const isScatter = (d: PanelDef) => (d.role ?? 'scatter') === 'scatter'
 
 const props = withDefaults(defineProps<{
   projectUid: string; imageUid: string; valueName: string; popType: string
@@ -57,14 +59,18 @@ interface PanelData {
   popLayers: PopLayer[]
 }
 const panelData = ref<Record<string, PanelData>>({})
+// Pearson r per canonical pair (groupKey) — computed once from each scatter tile's points and reused by
+// its upper-triangle mirror (the corr cell), so the whole matrix costs nothing extra.
+const corrByGroup = ref<Record<string, number | null>>({})
+const corrFor = (d: PanelDef) => corrByGroup.value[canonicalOrient(d).groupKey]
 const loading = ref(false)
 const err = ref('')
 let loadTok = 0
 
 // per-run fetch memo → mirror tiles (a,b)/(b,a) and repeated highlight/stat lookups hit the network once.
 async function loadPanels() {
-  const defs = props.defs.filter(d => !d.diagonal)
-  if (!props.imageUid || !defs.length) { panelData.value = {}; err.value = ''; return }
+  const defs = props.defs.filter(isScatter)
+  if (!props.imageUid || !defs.length) { panelData.value = {}; corrByGroup.value = {}; err.value = ''; return }
   const tok = ++loadTok
   loading.value = true; err.value = ''
   const id = montageId.value
@@ -99,10 +105,12 @@ async function loadPanels() {
     return pct == null ? c.name : `${c.name}  ${pct.toFixed(1)}%`
   }
 
+  const corrMap: Record<string, number | null> = {}
   try {
     const entries = await Promise.all(defs.map(async d => {
       const o = canonicalOrient(d)
       const [m, ptsRaw] = await Promise.all([metaFor(o, d.parentPath), ptsFor(o, d.parentPath)])
+      corrMap[o.groupKey] = pearson(ptsRaw)   // r is orientation-invariant → compute on the canonical cloud
       const gates = await Promise.all(d.children.map(async c =>
         ({ path: c.path, colour: c.colour, gate: c.gate, label: await labelFor(c) })))
       const popLayers = await Promise.all((props.highlight ?? []).map(async h => {
@@ -118,9 +126,9 @@ async function loadPanels() {
       }
       return [d.key, data] as const
     }))
-    if (tok === loadTok) panelData.value = Object.fromEntries(entries)
+    if (tok === loadTok) { panelData.value = Object.fromEntries(entries); corrByGroup.value = corrMap }
   } catch (e) {
-    if (tok === loadTok) { err.value = e instanceof Error ? e.message : String(e); panelData.value = {} }
+    if (tok === loadTok) { err.value = e instanceof Error ? e.message : String(e); panelData.value = {}; corrByGroup.value = {} }
   } finally { if (tok === loadTok) loading.value = false }
 }
 
@@ -129,7 +137,7 @@ async function loadPanels() {
 // material fields — cheap for the tile counts a montage holds.
 const sig = computed(() => JSON.stringify({
   id: montageId.value,
-  defs: props.defs.filter(d => !d.diagonal).map(d =>
+  defs: props.defs.filter(isScatter).map(d =>
     ({ k: d.key, p: d.parentPath, x: d.xChan, y: d.yChan, xt: d.xt, yt: d.yt, c: d.children.map(c => [c.path, c.gate]) })),
   hl: props.highlight, rk: props.reloadKey, fz: props.axisFromZero,
 }))
@@ -144,7 +152,7 @@ type CellExport = {
 const cellRefs = new Map<string, CellExport>()
 function setCellRef(key: string, el: unknown) { if (el) cellRefs.set(key, el as CellExport); else cellRefs.delete(key) }
 async function exportImage(bg = '#ffffff', light = true): Promise<string | null> {
-  const defs = props.defs.filter(d => !d.diagonal)
+  const defs = props.defs.filter(isScatter)
   if (defs.length === 1) return (await cellRefs.get(defs[0].key)?.exportImage(bg, light)) ?? null
   const el = gridRef.value
   if (!el) return null
@@ -160,6 +168,9 @@ async function exportImage(bg = '#ffffff', light = true): Promise<string | null>
 defineExpose({ exportImage })
 
 const titleFor = (parentPath: string) => (parentPath === 'root' ? 'all events (root)' : parentPath)
+// upper-triangle correlation cell (ggpairs): show r, scaling the text with |r| so strong pairs stand out
+const fmtCorr = (r: number | null | undefined) => (r == null ? '–' : (r >= 0 ? '' : '−') + Math.abs(r).toFixed(2))
+const corrFont = (r: number | null | undefined) => `${Math.round(13 + Math.abs(r ?? 0) * 13)}px`
 </script>
 
 <template>
@@ -167,8 +178,14 @@ const titleFor = (parentPath: string) => (parentPath === 'root' ? 'all events (r
     <div v-if="err" class="gm-msg">{{ err }}</div>
     <div v-else-if="!defs.length" class="gm-msg"><slot name="empty">Nothing to show.</slot></div>
     <template v-for="d in defs" :key="d.key">
-      <!-- diagonal (channel vs itself, pairs matrix): a labelled cell, R pairs()-style -->
-      <div v-if="d.diagonal" class="gm-cell gm-diag"><span>{{ colLabel(d.xChan) }}</span></div>
+      <!-- DIAGONAL (ggpairs): the channel name — labels its whole row and column -->
+      <div v-if="d.role === 'diagonal'" class="gm-cell gm-diag"><span>{{ colLabel(d.xChan) }}</span></div>
+      <!-- UPPER triangle (ggpairs): the pair's correlation, reused from its mirror scatter -->
+      <div v-else-if="d.role === 'corr'" class="gm-cell gm-corr"
+           v-tooltip.top="`corr(${colLabel(d.xChan)}, ${colLabel(d.yChan)})`">
+        <span class="gm-corr-k">Corr</span>
+        <span class="gm-corr-v" :style="{ fontSize: corrFont(corrFor(d)) }">{{ fmtCorr(corrFor(d)) }}</span>
+      </div>
       <div v-else class="gm-cell">
         <div v-if="cols == null" class="gm-title" v-tooltip.top="`derived from ${titleFor(d.parentPath)}`">{{ titleFor(d.parentPath) }}</div>
         <GateScatterCell v-if="panelData[d.key]" class="gm-plot" :ref="el => setCellRef(d.key, el)"
@@ -178,7 +195,8 @@ const titleFor = (parentPath: string) => (parentPath === 'root' ? 'all events (r
                          :gates="panelData[d.key].gates" :x-label="colLabel(d.xChan)" :y-label="colLabel(d.yChan)"
                          :pop-layers="panelData[d.key].popLayers" :show-pops="(highlight?.length ?? 0) > 0"
                          :render-mode="renderMode" mode="off" :gate-labels="gateLabels"
-                         :gate-line-width="gateLineWidth" :compact="!single" :readonly="true" />
+                         :gate-line-width="gateLineWidth" :compact="!single" :readonly="true"
+                         :hide-axis-labels="cols != null" />
         <div v-else class="gm-loading">…</div>
       </div>
     </template>
@@ -206,6 +224,10 @@ const titleFor = (parentPath: string) => (parentPath === 'root' ? 'all events (r
 /* diagonal label cell (matrix): channel name centred, matches the tile square */
 .gm-diag { align-items: center; justify-content: center; aspect-ratio: 1; background: var(--cc-surface-2);
   color: var(--cc-text); font-weight: 700; font-size: 12px; padding: 4px; text-align: center; word-break: break-word; }
+/* upper-triangle correlation cell (ggpairs): "Corr" label + the value, text scaled by |r| */
+.gm-corr { align-items: center; justify-content: center; aspect-ratio: 1; gap: 2px; border-color: var(--cc-border); }
+.gm-corr-k { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--cc-text-dim); }
+.gm-corr-v { font-weight: 700; color: var(--cc-text); font-variant-numeric: tabular-nums; line-height: 1; }
 .gm-title { flex-shrink: 0; font-size: 11px; font-weight: 700; padding: 3px 6px; color: var(--cc-text-dim);
   border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .gm-loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--cc-text-dim); aspect-ratio: 1; }

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -43,9 +43,13 @@ const props = withDefaults(defineProps<{
   loading?: boolean
   compact?: boolean                              // tight chrome for small montage panels (gating strategy)
   readonly?: boolean                             // static gates — no move/resize (read-only Analysis board)
+  hideAxisLabels?: boolean                       // drop the x/y axis-name labels (pairs matrix — the
+                                                 // diagonal names each channel, so per-tile labels only
+                                                 // clutter/clip); also reclaims their padding
 }>(), {
   gates: () => [], popLayers: () => [], renderMode: 'points', showPops: false,
   mode: 'off', gateLineWidth: 1.5, gateLabels: false, viewTick: 0, loading: false, compact: false, readonly: false,
+  hideAxisLabels: false,
 })
 const emit = defineEmits<{ draw: [Partial<GateSpec>]; edit: [{ path: string; gate: GateSpec }]; cancel: [] }>()
 
@@ -102,7 +106,7 @@ function baseColorMode(renderMode: string, showPops: boolean): 'density' | 'flat
 </script>
 
 <template>
-  <div ref="hostEl" class="plot-capture" :class="{ compact }">
+  <div ref="hostEl" class="plot-capture" :class="{ compact, 'no-axis': hideAxisLabels }">
     <div class="panel-plot">
       <ScatterGL ref="scatterRef" :points="points" :extents="extents"
                  :color-mode="baseColorMode(renderMode, showPops)"
@@ -121,8 +125,8 @@ function baseColorMode(renderMode: string, showPops: boolean): 'density' | 'flat
       <span v-for="t in yTicks" :key="'y'+t.pos" class="ytick" :style="{ top: tickY(t.pos, viewExtents) }">
         <span class="ytick-lbl">{{ fmtTick(t.label) }}</span><span class="ytick-mark" />
       </span>
-      <span class="axis-x">{{ xLabel }}</span>
-      <span class="axis-y">{{ yLabel }}</span>
+      <span v-if="!hideAxisLabels" class="axis-x">{{ xLabel }}</span>
+      <span v-if="!hideAxisLabels" class="axis-y">{{ yLabel }}</span>
       <PlotSpinner v-if="showSpinner && !compact" label="Loading…" />
       <div v-else-if="loading && compact" class="panel-loading">…</div>
       <slot />
@@ -144,6 +148,9 @@ function baseColorMode(renderMode: string, showPops: boolean): 'density' | 'flat
 .plot-capture.compact .axis-x { bottom: -15px; font-size: 10px; }
 .plot-capture.compact .axis-y { left: -24px; font-size: 10px; }
 .plot-capture.compact .xtick-lbl, .plot-capture.compact .ytick-lbl { display: none; }
+/* no-axis (pairs matrix): no axis-name labels → drop the padding they lived in so the scatter fills
+   the tile. Small uniform inset just for the axis lines / tick marks. */
+.plot-capture.no-axis { padding: 6px 6px 10px 12px; }
 /* min-width:0 so this flex-row item can shrink below the scatter canvas's intrinsic width. */
 .panel-plot { position: relative; flex: 1; min-height: 150px; min-width: 0; }
 .axisline { position: absolute; background: var(--cc-border); pointer-events: none; }

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -90,9 +90,8 @@ const load = computed(() => estimateMatrixLoad(channels.value.length, parentCoun
 const heavy = computed(() => load.value.heavy)
 const fmtN = (n: number) => n >= 1e6 ? `${(n / 1e6).toFixed(1)}M` : n >= 1e3 ? `${Math.round(n / 1e3)}k` : `${n}`
 const heavyTip = computed(() => {
-  const n = channels.value.length
   const pts = load.value.estPoints != null ? `, ~${fmtN(load.value.estPoints)} points` : ''
-  return `${n}×${n} = ${load.value.tiles} plots (${load.value.fetches} fetches${pts}). Pick fewer channels or a smaller population to speed up.`
+  return `${load.value.fetches} scatter plots${pts}. Pick fewer channels or a smaller population to speed up.`
 })
 
 const montageRef = useTemplateRef<{ exportImage(bg?: string, light?: boolean): Promise<string | null> }>('montageRef')
@@ -147,7 +146,7 @@ function exportPng() {
                 <span>{{ g.colLabel(c) }}</span>
               </label>
             </div>
-            <div v-if="atCap" class="chan-cap">Max {{ MAX_CHANNELS }} channels ({{ MAX_CHANNELS * MAX_CHANNELS }} tiles). Clear one to swap.</div>
+            <div v-if="atCap" class="chan-cap">Max {{ MAX_CHANNELS }} channels ({{ MAX_CHANNELS * (MAX_CHANNELS - 1) / 2 }} scatter plots). Clear one to swap.</div>
           </div>
         </div>
         <select class="tsel" v-model="transform" v-tooltip.bottom="'Axis transform (applied to every channel)'">

--- a/frontend/src/plots/montage.ts
+++ b/frontend/src/plots/montage.ts
@@ -9,6 +9,10 @@ import type { GateSpec, TransformSpec } from '../stores/gating'
 // plain .ts (no Vue) so the pure logic — orientation/transpose reuse — is unit-tested (docs/DEV.md).
 
 export interface PanelChild { path: string; name: string; colour: string; gate: GateSpec }
+// A tile is a scatter (fetches + renders the point cloud), the matrix diagonal (a labelled cell, no
+// fetch), or a correlation cell (upper triangle of the pairs matrix — shows Pearson r reused from its
+// mirror scatter's points, no fetch). Tree-derived montages (gating strategy) leave it unset → scatter.
+export type TileRole = 'scatter' | 'diagonal' | 'corr'
 export interface PanelDef {
   key: string                    // stable tile id (unique within a montage)
   parentPath: string             // population whose cells are the density backdrop ('root' = all events)
@@ -16,7 +20,7 @@ export interface PanelDef {
   xChan: string; yChan: string   // the tile's axes (raw column names)
   xt: TransformSpec; yt: TransformSpec
   children: PanelChild[]         // gate outlines already oriented to (xChan,yChan)
-  diagonal?: boolean             // xChan===yChan (pairs matrix): a labelled cell, no scatter fetch
+  role?: TileRole                // default 'scatter'
 }
 
 export interface MontageId { projectUid: string; imageUid: string; valueName: string; popType: string }
@@ -56,6 +60,25 @@ export function transposePoints(pts: Float32Array): Float32Array {
   return out
 }
 export const transposeExt = (e: Ext): Ext => ({ xMin: e.yMin, xMax: e.yMax, yMin: e.xMin, yMax: e.xMax })
+
+// Pearson correlation of an interleaved [x0,y0,x1,y1,…] point cloud (the pairs matrix shows this in the
+// upper triangle, ggpairs-style). Computed on the PLOTTED coords (post-transform) since that's what the
+// user sees; orientation-invariant so it doesn't matter which tile of a mirror pair supplies the points.
+// null when undefined (fewer than 2 points, or a degenerate axis with zero variance).
+export function pearson(points: Float32Array): number | null {
+  const n = Math.floor(points.length / 2)
+  if (n < 2) return null
+  let sx = 0, sy = 0
+  for (let i = 0; i < n; i++) { sx += points[2 * i]; sy += points[2 * i + 1] }
+  const mx = sx / n, my = sy / n
+  let cxy = 0, cxx = 0, cyy = 0
+  for (let i = 0; i < n; i++) {
+    const dx = points[2 * i] - mx, dy = points[2 * i + 1] - my
+    cxy += dx * dy; cxx += dx * dx; cyy += dy * dy
+  }
+  const d = Math.sqrt(cxx * cyy)
+  return d > 0 ? cxy / d : null
+}
 
 export interface Orient { a: string; b: string; ta: TransformSpec; tb: TransformSpec; swap: boolean; groupKey: string }
 // Canonical (sorted-channel) orientation for a tile + whether the tile is the mirror of it. `groupKey`

--- a/frontend/src/plots/pairsMatrix.test.ts
+++ b/frontend/src/plots/pairsMatrix.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { buildPairDefs, pairTransform, reconcileChannels, estimateMatrixLoad } from './pairsMatrix'
-import { canonicalOrient, transposePoints, transposeExt, plotQ } from './montage'
+import { canonicalOrient, transposePoints, transposeExt, plotQ, pearson } from './montage'
 import type { FlatPop, GateSpec } from '../stores/gating'
 
 const rect = (xc: string, yc: string): GateSpec => ({
@@ -12,33 +12,35 @@ const child = (name: string, gate?: GateSpec): FlatPop => ({
   path: `/${name}`, name, parent: 'root', colour: '#fff', show: true, depth: 0, gate,
 })
 
-describe('buildPairDefs (channel-pairs matrix)', () => {
+describe('buildPairDefs (ggpairs matrix)', () => {
   const chans = ['A', 'B', 'C']
+  const roleAt = (defs: ReturnType<typeof buildPairDefs>, xc: string, yc: string) =>
+    defs.find(d => d.xChan === xc && d.yChan === yc)!.role
 
-  it('produces the full N×N matrix (columns = X, rows = Y)', () => {
+  it('produces an N×N grid (columns = X, rows = Y)', () => {
     const defs = buildPairDefs(chans, 'root', 'linear', [])
     expect(defs).toHaveLength(9)
-    // row-major: first row is y=A across x=A,B,C
     expect(defs.slice(0, 3).map(d => [d.xChan, d.yChan])).toEqual([['A', 'A'], ['B', 'A'], ['C', 'A']])
     expect(defs.every(d => d.parentPath === 'root' && d.parentName === 'all events')).toBe(true)
   })
 
-  it('marks the diagonal (channel vs itself) and gives it no gate outlines', () => {
-    const defs = buildPairDefs(chans, 'root', 'linear', [child('P', rect('A', 'B'))])
-    const diag = defs.filter(d => d.diagonal)
-    expect(diag.map(d => d.xChan)).toEqual(['A', 'B', 'C'])
-    expect(diag.every(d => d.xChan === d.yChan && d.children.length === 0)).toBe(true)
+  it('assigns ggpairs roles: diagonal = name, lower triangle = scatter, upper = corr', () => {
+    const defs = buildPairDefs(chans, 'root', 'linear', [])
+    expect(roleAt(defs, 'A', 'A')).toBe('diagonal')
+    expect(roleAt(defs, 'A', 'B')).toBe('scatter')   // col A (0) < row B (1) → lower
+    expect(roleAt(defs, 'B', 'A')).toBe('corr')       // col B (1) > row A (0) → upper
+    const counts = defs.reduce((m, d) => (m[d.role!] = (m[d.role!] ?? 0) + 1, m), {} as Record<string, number>)
+    expect(counts).toEqual({ diagonal: 3, scatter: 3, corr: 3 })   // N(N-1)/2 = 3 scatters (the fetches)
   })
 
-  it('attaches a child gate to its tile in EITHER channel order (orientGate)', () => {
-    const defs = buildPairDefs(chans, 'root', 'linear', [child('P', rect('A', 'B'))])
-    const ab = defs.find(d => d.xChan === 'A' && d.yChan === 'B')!
-    const ba = defs.find(d => d.xChan === 'B' && d.yChan === 'A')!
-    const ac = defs.find(d => d.xChan === 'A' && d.yChan === 'C')!
-    expect(ab.children.map(c => c.name)).toEqual(['P'])          // same order
-    expect(ba.children.map(c => c.name)).toEqual(['P'])          // swapped order — still matches
-    expect(ba.children[0].gate.x_channel).toBe('B')             // oriented to the tile's axes
-    expect(ac.children).toHaveLength(0)                         // unrelated pair → no gate
+  it('attaches a gate only to its SCATTER tile, oriented to that tile (either channel order)', () => {
+    const defs = buildPairDefs(chans, 'root', 'linear', [child('P', rect('B', 'A'))])  // gate defined B,A
+    const scatter = defs.find(d => d.xChan === 'A' && d.yChan === 'B')!                 // lower-triangle tile
+    const corr = defs.find(d => d.xChan === 'B' && d.yChan === 'A')!                     // upper mirror
+    expect(scatter.role).toBe('scatter')
+    expect(scatter.children.map(c => c.name)).toEqual(['P'])
+    expect(scatter.children[0].gate.x_channel).toBe('A')   // oriented to the tile's axes
+    expect(corr.children).toHaveLength(0)                  // corr tiles carry no outlines
   })
 
   it('skips ungated children entirely', () => {
@@ -50,6 +52,19 @@ describe('buildPairDefs (channel-pairs matrix)', () => {
     expect(pairTransform('logicle')).toMatchObject({ kind: 'logicle', T: 262144, W: 0.5, M: 4.5, A: 0 })
     expect(pairTransform('linear')).toEqual({ kind: 'linear' })
     expect(buildPairDefs(['A'], 'root', 'logicle', [])[0].xt.kind).toBe('logicle')
+  })
+})
+
+describe('pearson (upper-triangle correlation)', () => {
+  it('is +1 for a perfectly increasing line', () => {
+    expect(pearson(new Float32Array([0, 0, 1, 1, 2, 2, 3, 3]))).toBeCloseTo(1, 6)
+  })
+  it('is -1 for a perfectly decreasing line', () => {
+    expect(pearson(new Float32Array([0, 3, 1, 2, 2, 1, 3, 0]))).toBeCloseTo(-1, 6)
+  })
+  it('is null for <2 points or a zero-variance axis', () => {
+    expect(pearson(new Float32Array([1, 2]))).toBeNull()
+    expect(pearson(new Float32Array([1, 5, 1, 9, 1, 3]))).toBeNull()   // constant x
   })
 })
 

--- a/frontend/src/plots/pairsMatrix.ts
+++ b/frontend/src/plots/pairsMatrix.ts
@@ -1,15 +1,15 @@
 import type { FlatPop, GateSpec, TransformSpec } from '../stores/gating'
 import { orientGate } from './gateGeometry'
-import type { PanelDef, PanelChild } from './montage'
+import type { PanelDef, PanelChild, TileRole } from './montage'
 
-// ── Channel-pairs matrix (R pairs()) ────────────────────────────────────────────────────────────
-// Turn a set of channels into the full N×N montage of every channel-vs-channel scatter for ONE
-// displayed population — the single gate plot's X/Y generalised to a list (the user's ask). Columns =
-// X channel, rows = Y channel. The diagonal (channel vs itself) is a labelled cell, not a scatter. On
-// each off-diagonal tile the displayed population's child gates whose channel-pair matches that tile —
-// in EITHER order (orientGate) — are attached as outlines, so the gates that define the populations
-// show, exactly as on the normal gating plot (but read-only). Pure + unit-tested (docs/DEV.md); the
-// tiles it returns feed the shared GateMontage renderer.
+// ── Channel-pairs matrix (R ggpairs()) ───────────────────────────────────────────────────────────
+// Turn a set of channels into a scatter-plot MATRIX for ONE displayed population — the single gate
+// plot's X/Y generalised to a list (the user's ask). Columns = X channel, rows = Y channel. Laid out
+// like GGally::ggpairs: the LOWER triangle holds the scatters, the DIAGONAL names each channel, and the
+// UPPER triangle shows each pair's correlation (reused from its mirror scatter — no extra fetch). Only
+// the lower triangle fetches, so it's N(N-1)/2 point clouds, not N². On each scatter the displayed
+// population's child gates whose channel-pair matches that tile — in EITHER order (orientGate) — are
+// attached as outlines, so the gates that define the populations show (read-only). Pure + unit-tested.
 
 // one transform applied to every axis (default logicle for flow, linear for track). Logicle carries its
 // FlowJo shape (matches GatePlotPanel.tspec) so the axis reads identically to the single plot.
@@ -46,10 +46,13 @@ export function buildPairDefs(
   const parentName = parentPath === 'root' ? 'all events' : parentPath
   const gated = children.filter(c => c.gate)
   const defs: PanelDef[] = []
-  for (const yc of channels) {               // rows
-    for (const xc of channels) {             // columns
-      const diagonal = xc === yc
-      const tileChildren: PanelChild[] = diagonal ? [] : gated
+  // ggpairs layout: LOWER triangle (row > col) = scatter; DIAGONAL = channel name; UPPER triangle
+  // (row < col) = the correlation of its mirror. Only scatter tiles fetch, so we render N(N-1)/2 point
+  // clouds instead of N² — half the load, no duplicate (a,b)/(b,a) plots.
+  channels.forEach((yc, ri) => {             // rows (y channel)
+    channels.forEach((xc, ci) => {           // columns (x channel)
+      const role: TileRole = ri === ci ? 'diagonal' : ri > ci ? 'scatter' : 'corr'
+      const tileChildren: PanelChild[] = role !== 'scatter' ? [] : gated
         .map(c => {
           const g = orientGate(c.gate as GateSpec, xc, yc)
           return g ? { path: c.path, name: c.name, colour: c.colour, gate: g } : null
@@ -58,9 +61,9 @@ export function buildPairDefs(
       defs.push({
         key: `${parentPath}::${xc}~~${yc}`,
         parentPath, parentName, xChan: xc, yChan: yc, xt: ts, yt: ts,
-        children: tileChildren, diagonal,
+        children: tileChildren, role,
       })
-    }
-  }
+    })
+  })
   return defs
 }


### PR DESCRIPTION
## Pairs matrix → `ggpairs` layout (lower scatter / diagonal names / upper correlation)

Reworks the channel-pairs matrix to a GGally `ggpairs`-style scatter-plot matrix — halving the load
and de-cluttering the axis labels the screenshot showed clipping.

- **Lower triangle** = the scatters. Only these fetch → **N(N-1)/2** point clouds instead of N²
  (drops the mirror duplicates).
- **Diagonal** = each channel's name (labels its whole row + column).
- **Upper triangle** = each pair's **Pearson correlation**, reused from the mirror scatter's
  already-fetched points (no extra fetch; text size scales with |r|).
- **Per-tile axis labels dropped** in matrix mode (`GateScatterCell` `hideAxisLabels`) — redundant
  with the diagonal, and they were the thing clipping. Padding reclaimed for the plot.

`buildPairDefs` tags each tile with a `role` (`scatter`/`diagonal`/`corr`); tree-derived montages
(gating strategy) default to `scatter`, unchanged. Pure `pearson` + role assignment unit-tested
(56 frontend tests). Docs: `POPULATION.md`, `UI.md`, `TODO.md` (#00077).

🤖 Generated with [Claude Code](https://claude.com/claude-code)