### PR TITLE
Move console pop-out to the docked console bar; drop it from Settings

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -41,8 +41,8 @@ The **console** is one component — `components/ErrorConsole.vue` over the `log
 places: the docked bar at the bottom of the app shell, and (with the `fill` prop) full-window in the
 standalone **console window**. Do not build a second console. The window is a `bare` route
 (`/console`, `meta.bare` → `App.vue` renders it without the shell) opened via
-`window.open(origin + pathname + '#/console', …)` from Settings → System → **Open console**; being a
-separate browser window it's a fresh app instance with its own WS, and it backfills recent lines from
+`window.open(origin + pathname + '#/console', …)` from the docked console bar's pop-out (↗) button;
+being a separate browser window it's a fresh app instance with its own WS, and it backfills recent lines from
 `GET /api/logs/recent` on open. The stream includes the backend's own logs (WS `server:log`, see
 `docs/API.md`), so it's a real "pixi console", not just task logs.
 
@@ -51,8 +51,9 @@ separate browser window it's a fresh app instance with its own WS, and it backfi
 `SettingsModule.vue` has a **System** section: one row per runtime component (Application / Napari /
 Notebooks) with a status pill (Running / Starting… / Stopped, polled every ~4 s from the existing
 `/api/{napari,notebooks}/status` endpoints — ephemeral UI state, a plain `ref`, NOT persisted) and
-start/stop/restart buttons that reuse the existing control endpoints, plus **Open console** and a
-global **Quit** (`POST /api/app/shutdown`, behind a confirm). Status→verb/label mapping is the pure,
+start/stop/restart buttons that reuse the existing control endpoints, plus a
+global **Quit** (`POST /api/app/shutdown`, behind a confirm). (The pop-out **console window** is
+launched from the docked console bar, not this panel.) Status→verb/label mapping is the pure,
 unit-tested `utils/serviceStatus.ts`. Backend self-restart is planned (see
 `docs/todo/SERVICE_PANEL_PLAN.md`, Phase 3).
 

--- a/frontend/src/components/ErrorConsole.vue
+++ b/frontend/src/components/ErrorConsole.vue
@@ -32,6 +32,13 @@ function toggleExpand(id: number) {
   expandedId.value = expandedId.value === id ? null : id
 }
 
+// Pop the console out into its own browser window: a hash-history route → the popup boots the same
+// SPA, sees #/console, and renders this component full-window (App.vue bare mode) with its own WS.
+function openConsoleWindow() {
+  const url = location.origin + location.pathname + '#/console'
+  window.open(url, 'cecelia-console', 'width=980,height=600')
+}
+
 const filterCounts = computed(() => ({
   all:   log.entries.length,
   info:  log.entries.filter(e => e.level === 'info').length,
@@ -57,6 +64,14 @@ const filterCounts = computed(() => ({
       v-tooltip.top="`${log.unreadErrors} unread error(s)`">
       {{ log.unreadErrors }}
     </span>
+
+    <button
+      class="icon-btn bar-window-btn"
+      @click.stop="openConsoleWindow"
+      v-tooltip.top="'Open the console in a separate window'"
+    >
+      <i class="pi pi-external-link" />
+    </button>
   </div>
 
   <!-- open panel (always shown in fill/window mode) -->
@@ -92,6 +107,15 @@ const filterCounts = computed(() => ({
         :disabled="log.entries.length === 0"
       >
         <i class="pi pi-trash" />
+      </button>
+
+      <button
+        v-if="!fill"
+        class="icon-btn"
+        @click="openConsoleWindow"
+        v-tooltip.top="'Open the console in a separate window'"
+      >
+        <i class="pi pi-external-link" />
       </button>
     </div>
 
@@ -176,6 +200,9 @@ const filterCounts = computed(() => ({
 .bar-last.error .lvl-dot { background: #ef4444; }
 .bar-last.warn  .lvl-dot { background: #f59e0b; }
 .bar-last.info  .lvl-dot { background: #3b82f6; }
+
+/* pop-out button on the collapsed bar — pin to the right edge, don't shrink */
+.bar-window-btn { margin-left: auto; flex-shrink: 0; }
 
 .unread-badge {
   background: #7f1d1d;

--- a/frontend/src/modules/ConsoleView.vue
+++ b/frontend/src/modules/ConsoleView.vue
@@ -1,5 +1,5 @@
 <!--
-  Standalone console window (opened from Settings → System → Open console via window.open('#/console')).
+  Standalone console window (opened from the docked console bar's pop-out button via window.open('#/console')).
   It's a bare, full-window mount of the SAME ErrorConsole component the docked bar uses (one console
   implementation, no second task-tracking path) — this popup is just a second mount point. Being a
   separate browser window it's a fresh app instance with its own WS connection, so it streams

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -192,12 +192,6 @@ async function appRestart() {
   svcMsg.value = appCtl.message
   pollServices()
 }
-function openConsole() {
-  // hash-history route → the popup boots the same SPA, sees #/console, and renders the console
-  // full-window (App.vue bare mode) with its own WS connection.
-  const url = location.origin + location.pathname + '#/console'
-  window.open(url, 'cecelia-console', 'width=980,height=600')
-}
 async function quitApp() {
   showQuitConfirm.value = false
   await appCtl.quit()
@@ -368,18 +362,6 @@ async function quitApp() {
               <i class="pi pi-stop" /> Stop
             </button>
           </template>
-        </span>
-      </div>
-
-      <div class="svc-row">
-        <span class="svc-name">Console</span>
-        <span class="svc-pill idle"><span class="dot" /> Log stream</span>
-        <span class="svc-port" />
-        <span class="svc-actions">
-          <button class="save-btn ghost" @click="openConsole"
-                  v-tooltip.top="'Open the live backend/task console in a separate window'">
-            <i class="pi pi-external-link" /> Open console
-          </button>
         </span>
       </div>
 


### PR DESCRIPTION
## Move console pop-out to the docked console bar; drop it from Settings

The **Open console** action lived in **Settings → System** as its own row, but that row carried no useful status or info of its own. This moves the window pop-out to the docked console bar at the bottom of the page and removes the now-empty row from the System panel.

### Changes
- **`ErrorConsole.vue`** — added `openConsoleWindow()` (the `window.open('#/console')` logic that used to live in Settings) and a pop-out **↗** (`pi-external-link`) icon button:
  - on the collapsed bar, pinned to the right edge (`@click.stop` so it pops out without also expanding the console)
  - in the open-panel toolbar, next to the clear/trash icon
  - both hidden via `v-if="!fill"` so the button doesn't appear inside the standalone console window itself (where it'd be redundant)
- **`SettingsModule.vue`** — removed the **Console** `svc-row` from the System panel and the now-unused `openConsole()` function
- **`ConsoleView.vue`** / **`docs/UI.md`** — updated stale "opened from Settings → System" references to point at the console bar's pop-out button

### Verification
- `vue-tsc -b` typecheck passes clean
- Not run in a browser — icon placement / collapsed-bar right-alignment reasoned from the CSS, not seen rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)