### PR TITLE
fix(gating): pairs-matrix scatter tiles no longer clipped in small tiles

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,12 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00079** — **Pairs-matrix scatter tiles clipped** (2026-07-09)
+The ggpairs matrix (#00077) packs small tiles, but `GateScatterCell`'s inner `.panel-plot` kept a
+`min-height: 150px` floor in compact mode, so in tiles smaller than that the plot overflowed the square
+and was clipped by the cell (`overflow:hidden`). Lifted the floor in compact mode
+(`.plot-capture.compact .panel-plot { min-height: 0 }`) so the plot shrinks to the tile. CSS-only.
+
 **#00077** — **Pairs matrix → `ggpairs` layout (lower scatter / diagonal names / upper correlation)** (2026-07-09)
 Reworked the channel-pairs matrix to GGally `ggpairs` style, halving the load and de-cluttering:
 - **Only the lower triangle** renders scatters (N(N-1)/2), not the full N² — drops the mirror

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -148,6 +148,9 @@ function baseColorMode(renderMode: string, showPops: boolean): 'density' | 'flat
 .plot-capture.compact .axis-x { bottom: -15px; font-size: 10px; }
 .plot-capture.compact .axis-y { left: -24px; font-size: 10px; }
 .plot-capture.compact .xtick-lbl, .plot-capture.compact .ytick-lbl { display: none; }
+/* compact tiles can be smaller than the full-size 150px plot floor — lift it so the plot shrinks to the
+   (square) tile instead of overflowing and being clipped by the cell (the pairs matrix packs small tiles). */
+.plot-capture.compact .panel-plot { min-height: 0; }
 /* no-axis (pairs matrix): no axis-name labels → drop the padding they lived in so the scatter fills
    the tile. Small uniform inset just for the axis lines / tick marks. */
 .plot-capture.no-axis { padding: 6px 6px 10px 12px; }


### PR DESCRIPTION
## Pairs-matrix scatter tiles no longer clipped

The ggpairs matrix packs small tiles, but `GateScatterCell`'s inner `.panel-plot` kept a
`min-height: 150px` floor in compact mode — so in tiles smaller than that the plot overflowed the
square and was clipped by the cell's `overflow:hidden`. Lifted the floor in compact mode
(`.plot-capture.compact .panel-plot { min-height: 0 }`) so the plot shrinks to fit the tile. CSS-only.
Fixes the clipping in `docs/TODO.md` #00079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)