### PR TITLE
fix(gating): clear stale napari cell-selection after a server restart

### DIFF
--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -283,6 +283,15 @@ update the manager's cell count (stats always refetch) but **not** the plots —
 per-pop version (`gateSignatures` → `popVersion`) only bumps on a signature change. The signature
 now includes `membership_sig`, so resizing the selection shape refreshes the highlighted overlay.
 
+**Reconnect resync (server restart).** Because the selection lives only in the server's in-memory
+registry, a backend restart wipes it — but the browser keeps the old tree AND the persisted highlight
+that referenced it (`shared.hl` in `moduleCanvases.json`), so on the same image the plot stayed greyed
+(highlight → `showPops` on, but the membership fetch returns 0 points). `GatingPlots` now resyncs on WS
+**reconnect** (`ws.status` → `connected` after a drop, guarded so it skips the first connect): it
+refetches the popmap, the fresh tree drops the transient pop, and the existing stale-highlight prune
+watch clears the dangling reference (which then autosaves the cleaned `hl` back). The fix is
+client-side; the server persistence was already correct.
+
 ## API & frontend
 
 - **Routes** (synchronous, in-process): `GET /api/gating/popmap`; `POST/PUT/DELETE

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -256,7 +256,19 @@ batch it rather than churn standalone.
 The ggpairs matrix (#00077) packs small tiles, but `GateScatterCell`'s inner `.panel-plot` kept a
 `min-height: 150px` floor in compact mode, so in tiles smaller than that the plot overflowed the square
 and was clipped by the cell (`overflow:hidden`). Lifted the floor in compact mode
-(`.plot-capture.compact .panel-plot { min-height: 0 }`) so the plot shrinks to the tile. CSS-only.
+(`.plot-capture.compact .panel-plot { min-height: 0 }`) so the plot shrinks to the tile — general to
+every `GateMontage` tile (pairs matrix + gating-strategy montage). CSS-only.
+
+**#00078** — **Napari cell-selection lingered (grey plot) after a server restart** (2026-07-09)
+Draw a napari cell selection → transient pop highlighted; restart the Julia server; reopen the same
+image → the selection still showed as active but had no members, so the plot rendered grey. The
+transient pop is never persisted server-side (correct), but the browser kept the stale tree + the
+persisted highlight referencing it, and there was **no WS-reconnect resync** — so the same-image case
+never refetched. Fix (client-side): `GatingPlots` now refetches the popmap on WS reconnect (guarded to
+skip the first connect); the fresh tree drops the transient pop and the existing stale-highlight prune
+clears the dangling reference. See `docs/POPULATION.md` → *Transient populations → Reconnect resync*.
+Reservation: verified by typecheck/reasoning, not yet driven in a browser (a WS-lifecycle watch — no
+unit-test surface under the frontend test scope).
 
 **#00077** — **Pairs matrix → `ggpairs` layout (lower scatter / diagonal names / upper correlation)** (2026-07-09)
 Reworked the channel-pairs matrix to GGally `ggpairs` style, halving the load and de-cluttering:

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -116,6 +116,19 @@ watch(() => g.flat.map(p => p.path).join('\n'), () => {
     if (p.state.parent !== 'root' && !exist.has(p.state.parent)) p.state.parent = 'root'
   }
 })
+// WS (re)connect resync: the transient napari-selection pop lives ONLY in the server's in-memory
+// registry (never persisted — see docs/POPULATION.md), so a backend restart wipes it. But the client's
+// tree (and the persisted highlight referencing it) survive, so without a resync the stale selection
+// keeps a plot greyed on the same image. On a RECONNECT (not the first connect — onMounted already
+// loaded) refetch the popmap; the fresh tree drops the transient pop and the prune watch above clears
+// the dangling highlight. `everConnected` seeded from the current status so a reconnect is detected even
+// when the page mounts already-connected.
+let everConnected = ws.status === 'connected'
+watch(() => ws.status, (s) => {
+  if (s !== 'connected') return
+  if (everConnected && props.imageUid) load()
+  everConnected = true
+})
 onMounted(() => { ws.on('gating:popmap', onBroadcast); load() })
 // Seed two starter plots for any (image, segmentation) that has none yet — on first bind AND after an
 // image/segmentation switch (the reactive key rebinds to a fresh entry; the component doesn't remount).


### PR DESCRIPTION
## Clear stale napari cell-selection after a server restart

Draw a napari cell selection → the transient population is highlighted; restart the Julia server;
reopen the same image → the selection still showed as "active" but had no members, so the plot rendered
grey.

The transient pop lives only in the server's in-memory registry (never persisted — correct), so a
restart wipes it. But the browser kept the stale population tree **and** the persisted highlight
referencing it (`shared.hl` in `moduleCanvases.json`), and there was **no WS-reconnect resync** — so
reopening the same image never refetched. `GatingPlots` now refetches the popmap on WS **reconnect**
(guarded to skip the first connect); the fresh tree drops the transient pop and the existing
stale-highlight prune clears the dangling reference (then autosaves the cleaned highlight).

Client-side fix — server persistence was already correct. Verified by typecheck + reasoning; it's a
WS-lifecycle watch with no unit-test surface under the frontend test scope. Docs: `POPULATION.md`
(*Transient populations → Reconnect resync*), `TODO.md` #00078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)