### PR TITLE
feat(gating): contour-only + contour-with-outliers render modes

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,16 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00080** — **Gate scatter render modes: contour-only + contour-with-outliers** (2026-07-09)
+Old `contour` mode always drew the full point cloud faintly under the contours — slow, especially in
+the pairs matrix. Split into three modes via the shared `RenderModeToggle` (Gate panel + pairs matrix +
+gating-strategy montage): `points` (WebGL pseudocolour), `contour` (density contours ONLY — the WebGL
+cloud is skipped, `null` points to `ScatterGL`, the fast path the user asked for), and `outliers`
+(contours + individual dots for the sparse tail the contours don't enclose — FlowJo / old-R "contour ±
+outliers"). Density grid + outlier subset extracted to the pure, unit-tested `plots/density.ts` (shared
+by `PlotLayers`); outlier threshold = the outermost contour level. 3 hand-rolled seg controls replaced
+by the one `RenderModeToggle`. See `docs/UI.md` → *Gate scatters*.
+
 **#00079** — **Pairs-matrix scatter tiles clipped** (2026-07-09)
 The ggpairs matrix (#00077) packs small tiles, but `GateScatterCell`'s inner `.panel-plot` kept a
 `min-height: 150px` floor in compact mode, so in tiles smaller than that the plot overflowed the square

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -500,7 +500,12 @@ these two primitives.
 **Gate scatters — one renderer, three hosts.** `components/plots/GateScatterCell.vue` is the ONE
 scatter+gate body (WebGL points + contour/pop-colour layer + canvas2D gate overlay). The interactive
 Gate page (`GatePlotPanel`, `mode` = rectangle/polygon) and every read-only montage tile (`mode="off"`)
-share it. Montages of tiles go through `components/plots/GateMontage.vue` — a grid of `GateScatterCell`
+share it. **Render modes** (`points` | `contour` | `outliers`, chosen via the shared
+`components/plots/RenderModeToggle.vue`): `points` = WebGL pseudocolour cloud; `contour` = density
+contours only, with the WebGL cloud SKIPPED (`GateScatterCell` passes `null` points to `ScatterGL`) so
+it's the fast path; `outliers` = contours + individual dots for the sparse tail (FlowJo / old-R
+"contour ± outliers"). The contour/outlier maths (density grid + low-density subset) is the pure,
+unit-tested `plots/density.ts`, shared by `PlotLayers`. Montages of tiles go through `components/plots/GateMontage.vue` — a grid of `GateScatterCell`
 tiles that owns the per-tile fetch (`plotmeta`/`plotdata`/`stats`), transpose reuse, optional coloured
 population overlays (`highlight`), and PNG/PDF export. It has two tile producers: `GatingStrategyView`
 (tree-derived, responsive wrap) and `GatePairsPanel` (a `ggpairs` matrix, `cols` set). A tile carries a

--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -28,7 +28,7 @@ const props = withDefaults(defineProps<{
   projectUid: string; imageUid: string; valueName: string; popType: string
   defs: PanelDef[]
   colLabel: (col: string) => string
-  renderMode?: 'points' | 'contour'
+  renderMode?: 'points' | 'contour' | 'outliers'
   gateLabels?: boolean
   gateLineWidth?: number
   // coloured population overlays drawn on every tile (the manager's "eye" pops + transient napari

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -34,7 +34,7 @@ const props = withDefaults(defineProps<{
   xLabel: string
   yLabel: string
   popLayers?: PopLayer[]                         // coloured child-pop overlays
-  renderMode?: 'points' | 'contour'
+  renderMode?: 'points' | 'contour' | 'outliers'   // contour = contours only; outliers = + tail dots
   showPops?: boolean
   mode?: 'off' | 'rectangle' | 'polygon'         // 'off' = read-only (no draw/edit)
   gateLineWidth?: number
@@ -99,19 +99,16 @@ async function exportImage(bg = '#0d0b1a', light = false): Promise<string | null
 // montage would composite every subplot at screen resolution.
 defineExpose({ exportImage, hiRes })
 
-// base render look: density for plain points; dim/flat backdrop for contour or pop-colour modes
-function baseColorMode(renderMode: string, showPops: boolean): 'density' | 'flat' {
-  return renderMode === 'points' && !showPops ? 'density' : 'flat'
-}
 </script>
 
 <template>
   <div ref="hostEl" class="plot-capture" :class="{ compact, 'no-axis': hideAxisLabels }">
     <div class="panel-plot">
-      <ScatterGL ref="scatterRef" :points="points" :extents="extents"
-                 :color-mode="baseColorMode(renderMode, showPops)"
-                 :opacity="renderMode === 'contour' ? 0.22 : showPops ? 0.35 : 1"
-                 :point-size="renderMode === 'contour' ? 2 : 3" />
+      <!-- WebGL base cloud only in 'points' mode; contour/outliers draw from PlotLayers instead, so we
+           skip the point upload entirely (contour-only is the fast path the user asked for). -->
+      <ScatterGL ref="scatterRef" :points="renderMode === 'points' ? points : null" :extents="extents"
+                 :color-mode="showPops ? 'flat' : 'density'"
+                 :opacity="showPops ? 0.35 : 1" :point-size="3" />
       <PlotLayers ref="layersRef" :view-extents="viewExtents" :render-mode="renderMode" :base-points="points"
                   :pop-layers="popLayers" :show-pops="showPops" :view-tick="viewTick" />
       <GateOverlay ref="overlayRef" :extents="viewExtents" :mode="mode" :gates="gates" :view-tick="viewTick"

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -18,12 +18,13 @@ import { orientGate } from '../../plots/gateGeometry'
 import type { PanelDef } from '../../plots/montage'
 import type { VisProps } from '../../plots/plot'
 import GateMontage from './GateMontage.vue'
+import RenderModeToggle, { type RenderMode } from './RenderModeToggle.vue'
 
 const props = defineProps<{
   projectUid: string; imageUids: string[]; setUid: string | null
   vis?: VisProps
   state: { imageUid?: string; valueName?: string; popType?: string; rootPop?: string
-    renderMode?: 'points' | 'contour'; showHierarchy?: boolean }
+    renderMode?: RenderMode; showHierarchy?: boolean }
 }>()
 
 // ── selectors (persisted in the panel state) ─────────────────────────────────────────────────────
@@ -196,10 +197,7 @@ defineExpose({ exportImage })
         <option value="root">root</option>
         <option v-for="p in flatPaths" :key="p" :value="p">{{ p }}</option>
       </select>
-      <div class="seg" v-tooltip.bottom="'Render: points / density contour'">
-        <button :class="{ on: renderMode === 'points' }" @click="renderMode = 'points'"><i class="pi pi-circle-fill" /></button>
-        <button :class="{ on: renderMode === 'contour' }" @click="renderMode = 'contour'"><i class="pi pi-chart-line" /></button>
-      </div>
+      <RenderModeToggle v-model="renderMode" />
       <div ref="optsRef" class="gs-opts">
         <button class="gs-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
                 v-tooltip.bottom="'Plot size & hierarchy'"><i class="pi pi-cog" /></button>

--- a/frontend/src/components/plots/PlotLayers.vue
+++ b/frontend/src/components/plots/PlotLayers.vue
@@ -11,25 +11,27 @@
 -->
 <script setup lang="ts">
 import { watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
+import { densityGrid as computeDensityGrid, outlierPoints, DENSITY_GRID, CONTOUR_LEVELS, type Ext } from '../../plots/density'
 
-type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
 export interface PopLayer { path: string; colour: string; points: Float32Array }
 
 const props = defineProps<{
   viewExtents: Ext                          // live (zoom-synced) data extents
-  renderMode: 'points' | 'contour'
+  renderMode: 'points' | 'contour' | 'outliers'   // contour = contours only; outliers = contours + tail dots
   basePoints: Float32Array | null           // base population points (for base contour)
   popLayers: PopLayer[]                      // visible child pops to colour
   showPops: boolean
   viewTick: number                           // bump → redraw (camera moved)
 }>()
+// contour-family modes (contours drawn, no full WebGL point cloud); `outliers` adds the sparse-tail dots
+const isContour = () => props.renderMode === 'contour' || props.renderMode === 'outliers'
 
 const canvasEl = useTemplateRef<HTMLCanvasElement>('canvasEl')
 let ctx: CanvasRenderingContext2D | null = null
 let ro: ResizeObserver | null = null
 
-const G = 64                                 // contour grid resolution (R kde2d n≈25; finer here)
-const LEVELS = [0.05, 0.10, 0.25, 0.50]      // 1 − confidence levels
+const G = DENSITY_GRID                       // contour grid resolution (shared with density.ts)
+const LEVELS = CONTOUR_LEVELS                // 1 − confidence levels (outer→inner)
 
 function size() { const c = canvasEl.value!; return { w: c.clientWidth, h: c.clientHeight } }
 function toPx(vx: number, vy: number): [number, number] {
@@ -38,32 +40,8 @@ function toPx(vx: number, vy: number): [number, number] {
   return [((vx - xMin) / xs) * w, (1 - (vy - yMin) / ys) * h]
 }
 
-// density grid (normalised 0..1) over the current view, lightly blurred to mimic a KDE
-function densityGrid(points: Float32Array): Float32Array {
-  const { xMin, xMax, yMin, yMax } = props.viewExtents
-  const xs = xMax > xMin ? xMax - xMin : 1, ys = yMax > yMin ? yMax - yMin : 1
-  const g = new Float32Array(G * G)
-  const n = points.length / 2
-  for (let i = 0; i < n; i++) {
-    const px = points[2 * i], py = points[2 * i + 1]
-    if (!Number.isFinite(px) || !Number.isFinite(py)) continue   // NaN/Inf object measure → skip
-    let gx = Math.floor(((px - xMin) / xs) * G), gy = Math.floor(((py - yMin) / ys) * G)
-    if (gx < 0 || gx > G - 1 || gy < 0 || gy > G - 1) continue
-    g[gy * G + gx] += 1
-  }
-  const blurred = new Float32Array(G * G)
-  let max = 0
-  for (let y = 0; y < G; y++) for (let x = 0; x < G; x++) {
-    let s = 0, c = 0
-    for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) {
-      const nx = x + dx, ny = y + dy
-      if (nx >= 0 && nx < G && ny >= 0 && ny < G) { s += g[ny * G + nx]; c++ }
-    }
-    const v = s / c; blurred[y * G + x] = v; if (v > max) max = v
-  }
-  if (max > 0) for (let i = 0; i < blurred.length; i++) blurred[i] /= max
-  return blurred
-}
+// density grid (normalised 0..1) over the current view — shared pure helper (plots/density.ts)
+const densityGrid = (points: Float32Array) => computeDensityGrid(points, props.viewExtents, G)
 
 // grid cell coords → data coords. Samples sit at bin CENTRES ((i+0.5)/G), matching the
 // binning above (floor((v-min)/range*G)); using /(G-1) here mis-scaled contours vs the points.
@@ -116,24 +94,41 @@ function drawContours(points: Float32Array, colour: string) {
   ctx!.globalAlpha = 1
 }
 
-function drawDots(points: Float32Array, colour: string) {
+function drawDots(points: Float32Array, colour: string, r = 1.5) {
   const c = ctx!; c.fillStyle = colour
   const n = points.length / 2
+  const s = r * 2
   for (let i = 0; i < n; i++) {
     const [px, py] = toPx(points[2 * i], points[2 * i + 1])
-    c.fillRect(px - 1.5, py - 1.5, 3, 3)
+    c.fillRect(px - r, py - r, s, s)
   }
+}
+// "contour + outliers": individual dots for the sparse-tail points the contours don't enclose (R:
+// contour ± outliers). Small + semi-transparent so the contours stay the main read.
+function drawOutliers(points: Float32Array, colour: string) {
+  const pts = outlierPoints(points, props.viewExtents, G)
+  ctx!.globalAlpha = 0.55
+  drawDots(pts, colour, 1)
+  ctx!.globalAlpha = 1
 }
 
 // paint the layer content (contours + pop overlay) with the current `ctx`; toPx uses size() (CSS px)
 // so it's resolution-independent — the transform on the target ctx sets the actual pixel density.
 function paintContent() {
   ctx!.lineJoin = 'round'
-  if (props.renderMode === 'contour' && props.basePoints?.length) drawContours(props.basePoints, '#cbd5e1')
+  if (isContour() && props.basePoints?.length) {
+    drawContours(props.basePoints, '#cbd5e1')
+    if (props.renderMode === 'outliers') drawOutliers(props.basePoints, '#cbd5e1')
+  }
   if (props.showPops) {
     for (const pop of props.popLayers) {
       if (!pop.points?.length) continue
-      props.renderMode === 'contour' ? drawContours(pop.points, pop.colour) : drawDots(pop.points, pop.colour)
+      if (isContour()) {
+        drawContours(pop.points, pop.colour)
+        if (props.renderMode === 'outliers') drawOutliers(pop.points, pop.colour)
+      } else {
+        drawDots(pop.points, pop.colour)
+      }
     }
   }
 }

--- a/frontend/src/components/plots/RenderModeToggle.vue
+++ b/frontend/src/components/plots/RenderModeToggle.vue
@@ -1,0 +1,31 @@
+<!--
+  Shared render-mode segmented control for gate scatters. ONE definition so the mode set stays in sync
+  across the Gate panel (GatePlotPanel), the channel-pairs matrix (GatePairsPanel) and the read-only
+  gating-strategy montage (GatingStrategyView) — instead of three hand-rolled copies. Ports the old R
+  fcs.gating.plotTypes (pseudocolour / contour / contour ± outliers).
+-->
+<script setup lang="ts">
+export type RenderMode = 'points' | 'contour' | 'outliers'
+defineProps<{ modelValue: RenderMode }>()
+const emit = defineEmits<{ 'update:modelValue': [RenderMode] }>()
+const MODES: { v: RenderMode; icon: string; tip: string }[] = [
+  { v: 'points',   icon: 'pi pi-circle-fill', tip: 'Pseudocolour points (density-coloured)' },
+  { v: 'contour',  icon: 'pi pi-chart-line',  tip: 'Density contours only — fast (no point cloud)' },
+  { v: 'outliers', icon: 'pi pi-asterisk',    tip: 'Contours + outliers (individual sparse-tail points)' },
+]
+</script>
+
+<template>
+  <div class="seg" v-tooltip.bottom="'Render: points / contour / contour + outliers'">
+    <button v-for="m in MODES" :key="m.v" type="button" :class="{ on: modelValue === m.v }"
+            v-tooltip.bottom="m.tip" @click="emit('update:modelValue', m.v)"><i :class="m.icon" /></button>
+  </div>
+</template>
+
+<style scoped>
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 4px 8px; cursor: pointer; font-size: 12px; }
+.seg button + button { border-left: 1px solid var(--cc-border); }
+.seg button:hover { color: var(--cc-text); }
+.seg button.on { background: var(--cc-accent); color: #fff; }
+</style>

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -14,6 +14,7 @@ import { useGatingStore } from '../../stores/gating'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import GateMontage from '../../components/plots/GateMontage.vue'
+import RenderModeToggle, { type RenderMode } from '../../components/plots/RenderModeToggle.vue'
 import { buildPairDefs, reconcileChannels, estimateMatrixLoad } from '../../plots/pairsMatrix'
 import { downloadDataUrl } from '../../plots/export'
 
@@ -26,7 +27,7 @@ const props = defineProps<{
   gateLineWidth: number; gateLabels: boolean; axisFromZero: boolean
   // persisted per-plot config (owned by GatingPlots' PlotState): the channel list, the one shared
   // transform, and the render mode. Read/written directly so they survive navigation.
-  ui: { channels?: string[]; xt?: Kind; renderMode?: 'points' | 'contour' }
+  ui: { channels?: string[]; xt?: Kind; renderMode?: RenderMode }
   arrange?: ArrangeCmd | null
   persistKey?: string
 }>()
@@ -37,7 +38,7 @@ const g = useGatingStore()
 const defaultTransform: Kind = g.popType === 'track' ? 'linear' : 'logicle'
 const channels = computed<string[]>({ get: () => props.ui.channels ?? [], set: v => { props.ui.channels = v } })
 const transform = computed<Kind>({ get: () => props.ui.xt ?? defaultTransform, set: v => { props.ui.xt = v } })
-const renderMode = computed<'points' | 'contour'>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })
+const renderMode = computed<RenderMode>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })
 const parent = computed({ get: () => props.parent, set: v => emit('update:parent', v) })
 const parentOptions = computed(() => ['root', ...g.flat.map(p => p.path)])
 
@@ -108,10 +109,7 @@ function exportPng() {
     <template #actions>
       <span class="ro-tag" v-tooltip.bottom="'Read-only — compare channels; draw gates on a single plot'">read-only</span>
       <span class="ctrl-sep" />
-      <div class="seg" v-tooltip.bottom="'Render: pseudocolour points / density contour'">
-        <button :class="{ on: renderMode === 'points' }" @click="renderMode = 'points'"><i class="pi pi-circle-fill" /></button>
-        <button :class="{ on: renderMode === 'contour' }" @click="renderMode = 'contour'"><i class="pi pi-chart-line" /></button>
-      </div>
+      <RenderModeToggle v-model="renderMode" />
     </template>
     <template #footer>
       <select class="gp-export" v-tooltip.top="'Export the matrix'" :disabled="!channels.length"

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -18,6 +18,7 @@ import { useLogStore } from '../../stores/log'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import GateScatterCell from '../../components/plots/GateScatterCell.vue'
+import RenderModeToggle, { type RenderMode } from '../../components/plots/RenderModeToggle.vue'
 import type { PopLayer } from '../../components/plots/PlotLayers.vue'
 import { orientGate } from '../../plots/gateGeometry'
 import { downloadDataUrl } from '../../plots/export'
@@ -28,7 +29,7 @@ const props = defineProps<{
   // persisted per-plot axis config (owned by GatingPlots' PlotState) — channels, transforms, render
   // mode. Read/written directly like the summary panels' `ui` bag so these survive navigation.
   ui: { x?: string; y?: string; xt?: 'linear' | 'log' | 'asinh' | 'logicle'
-        yt?: 'linear' | 'log' | 'asinh' | 'logicle'; renderMode?: 'points' | 'contour' }
+        yt?: 'linear' | 'log' | 'asinh' | 'logicle'; renderMode?: RenderMode }
   // window-arrangement command (Tile/Cascade); seq bumps to force re-apply
   arrange?: ArrangeCmd | null
   persistKey?: string        // CanvasPanel geometry persistence key
@@ -49,7 +50,7 @@ const xChan = computed({ get: () => props.ui.x ?? '', set: v => { props.ui.x = v
 const yChan = computed({ get: () => props.ui.y ?? '', set: v => { props.ui.y = v } })
 const xt = computed<Kind>({ get: () => props.ui.xt ?? defaultTransform, set: v => { props.ui.xt = v } })
 const yt = computed<Kind>({ get: () => props.ui.yt ?? defaultTransform, set: v => { props.ui.yt = v } })
-const renderMode = computed<'points' | 'contour'>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })
+const renderMode = computed<RenderMode>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })
 // displayed population is owned by GatingPlots (per-panel) so the manager can highlight it
 const parent = computed({ get: () => props.parent, set: v => emit('update:parent', v) })
 // draw tool is transient interaction state (not persisted): reopening a plot shouldn't leave a tool armed
@@ -204,10 +205,7 @@ watch(hlVersion, loadPopLayers)
                @activate="emit('activate', $event)" @remove="emit('remove')">
     <!-- header tools (render mode + gate-draw tools) sit in the panel title bar -->
     <template #actions>
-      <div class="seg" v-tooltip.bottom="'Render: pseudocolour points / density contour'">
-        <button :class="{ on: renderMode === 'points' }" @click="renderMode = 'points'"><i class="pi pi-circle-fill" /></button>
-        <button :class="{ on: renderMode === 'contour' }" @click="renderMode = 'contour'"><i class="pi pi-chart-line" /></button>
-      </div>
+      <RenderModeToggle v-model="renderMode" />
       <span class="ctrl-sep" />
       <button class="cc-btn cc-btn-ghost" :class="{ on: mode === 'rectangle' }" v-tooltip.bottom="'Rectangle gate'"
               @click="mode = mode === 'rectangle' ? 'off' : 'rectangle'"><i class="pi pi-stop" /></button>

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -39,7 +39,7 @@ type GateKind = 'linear' | 'log' | 'asinh' | 'logicle'
 // A panel is either a single gate scatter (default, drawable) or a read-only channel-pairs matrix.
 // `channels` is the pairs plot's selected list; the single plot ignores it (and vice-versa for x/y).
 interface PlotState { kind: 'single' | 'pairs'; parent: string; hl: string[]; lineWidth: number; labels: boolean; fromZero: boolean
-  x: string; y: string; xt: GateKind; yt: GateKind; renderMode: 'points' | 'contour'; channels: string[] }
+  x: string; y: string; xt: GateKind; yt: GateKind; renderMode: 'points' | 'contour' | 'outliers'; channels: string[] }
 const canvasRef = useTemplateRef<HTMLElement>('canvasRef')
 // Per-image + segmentation: gating populations are per-value_name, so each (image, segmentation) keeps
 // its own plots/parents/highlights and the canvas rebinds when either the image or the segmentation

--- a/frontend/src/plots/density.test.ts
+++ b/frontend/src/plots/density.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { densityGrid, outlierPoints, DENSITY_GRID } from './density'
+
+const ext = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 }
+
+// a tight cluster of many points near one corner + a couple of lone points far away
+function cluster(n: number, cx: number, cy: number, spread = 0.01): number[] {
+  const out: number[] = []
+  for (let i = 0; i < n; i++) out.push(cx + (i % 3) * spread, cy + ((i * 7) % 3) * spread)
+  return out
+}
+
+describe('densityGrid', () => {
+  it('is normalised to a max of 1 and peaks where points concentrate', () => {
+    const g = densityGrid(new Float32Array(cluster(300, 0.2, 0.2)), ext)
+    expect(g.length).toBe(DENSITY_GRID * DENSITY_GRID)
+    expect(Math.max(...g)).toBeCloseTo(1, 6)
+    // the peak cell should be near (0.2,0.2): gx=gy≈floor(0.2*64)=12
+    let peak = 0, pi = 0
+    g.forEach((v, i) => { if (v > peak) { peak = v; pi = i } })
+    const gy = Math.floor(pi / DENSITY_GRID), gx = pi % DENSITY_GRID
+    expect(Math.abs(gx - 12)).toBeLessThanOrEqual(2)
+    expect(Math.abs(gy - 12)).toBeLessThanOrEqual(2)
+  })
+  it('skips non-finite and out-of-range points without throwing', () => {
+    const g = densityGrid(new Float32Array([NaN, 0.5, 5, 5, 0.3, 0.3]), ext)
+    expect(Math.max(...g)).toBeGreaterThan(0)   // only the (0.3,0.3) point counted
+  })
+})
+
+describe('outlierPoints', () => {
+  it('returns the sparse-tail points, not the dense core', () => {
+    const pts = new Float32Array([...cluster(400, 0.5, 0.5), 0.02, 0.02, 0.97, 0.95])  // core + 2 far outliers
+    const out = outlierPoints(pts, ext)
+    const has = (x: number, y: number) => {  // Float32 → compare with tolerance
+      for (let i = 0; i < out.length; i += 2) if (Math.abs(out[i] - x) < 1e-3 && Math.abs(out[i + 1] - y) < 1e-3) return true
+      return false
+    }
+    expect(has(0.02, 0.02)).toBe(true)      // the two lone corner points are below the outermost contour → kept
+    expect(has(0.97, 0.95)).toBe(true)
+    expect(has(0.5, 0.5)).toBe(false)       // the dense core is NOT an outlier
+    expect(out.length / 2).toBeLessThan(50) // far fewer than the 402 input points
+  })
+  it('is empty for a single uniform blob with no tail', () => {
+    // all points in one cell → that cell is the max (density 1), nothing below the level
+    const out = outlierPoints(new Float32Array(cluster(200, 0.5, 0.5, 0)), ext)
+    expect(out.length).toBe(0)
+  })
+})

--- a/frontend/src/plots/density.ts
+++ b/frontend/src/plots/density.ts
@@ -1,0 +1,57 @@
+// Density grid + outlier classification for the gate scatter's contour render modes. Extracted from
+// PlotLayers so the pure math (binning → blur → normalise, and the low-density outlier subset) is
+// shared by the renderer AND unit-tested (docs/DEV.md). Mirrors R's kde2d-style density used by the
+// FlowJo-style contour + "contour ± outliers" plots (flowHelpers.R).
+
+export type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
+
+export const DENSITY_GRID = 64             // grid resolution (R kde2d n≈25; finer here)
+export const CONTOUR_LEVELS = [0.05, 0.10, 0.25, 0.50]  // normalised 1 − confidence levels (outer→inner)
+// "outliers" = points below the OUTERMOST contour, i.e. in the sparse tail the contours don't enclose.
+export const OUTLIER_LEVEL = CONTOUR_LEVELS[0]
+
+// normalised (0..1), lightly box-blurred density grid over `ext`, row-major (gy*G + gx).
+export function densityGrid(points: Float32Array, ext: Ext, G = DENSITY_GRID): Float32Array {
+  const xs = ext.xMax > ext.xMin ? ext.xMax - ext.xMin : 1
+  const ys = ext.yMax > ext.yMin ? ext.yMax - ext.yMin : 1
+  const g = new Float32Array(G * G)
+  const n = points.length / 2
+  for (let i = 0; i < n; i++) {
+    const px = points[2 * i], py = points[2 * i + 1]
+    if (!Number.isFinite(px) || !Number.isFinite(py)) continue   // NaN/Inf measure → skip
+    const gx = Math.floor(((px - ext.xMin) / xs) * G), gy = Math.floor(((py - ext.yMin) / ys) * G)
+    if (gx < 0 || gx > G - 1 || gy < 0 || gy > G - 1) continue
+    g[gy * G + gx] += 1
+  }
+  const blurred = new Float32Array(G * G)
+  let max = 0
+  for (let y = 0; y < G; y++) for (let x = 0; x < G; x++) {
+    let s = 0, c = 0
+    for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) {
+      const nx = x + dx, ny = y + dy
+      if (nx >= 0 && nx < G && ny >= 0 && ny < G) { s += g[ny * G + nx]; c++ }
+    }
+    const v = s / c; blurred[y * G + x] = v; if (v > max) max = v
+  }
+  if (max > 0) for (let i = 0; i < blurred.length; i++) blurred[i] /= max
+  return blurred
+}
+
+// The interleaved subset of `points` whose smoothed density is below `level` — the outliers to draw
+// individually in "contour + outliers" mode (the dense core is left to the contours). Out-of-range /
+// non-finite points are dropped (they're not meaningful outliers).
+export function outlierPoints(points: Float32Array, ext: Ext, G = DENSITY_GRID, level = OUTLIER_LEVEL): Float32Array {
+  const grid = densityGrid(points, ext, G)
+  const xs = ext.xMax > ext.xMin ? ext.xMax - ext.xMin : 1
+  const ys = ext.yMax > ext.yMin ? ext.yMax - ext.yMin : 1
+  const n = points.length / 2
+  const out: number[] = []
+  for (let i = 0; i < n; i++) {
+    const px = points[2 * i], py = points[2 * i + 1]
+    if (!Number.isFinite(px) || !Number.isFinite(py)) continue
+    const gx = Math.floor(((px - ext.xMin) / xs) * G), gy = Math.floor(((py - ext.yMin) / ys) * G)
+    if (gx < 0 || gx > G - 1 || gy < 0 || gy > G - 1) continue
+    if (grid[gy * G + gx] < level) { out.push(px, py) }
+  }
+  return new Float32Array(out)
+}


### PR DESCRIPTION
## Gate scatter render modes: contour-only + contour-with-outliers

Old `contour` mode always drew the full point cloud faintly under the contours — slow, especially in
the pairs matrix. Split into **three** render modes, selected via a shared `RenderModeToggle` (used by
the Gate panel, the pairs matrix, and the gating-strategy montage):

- **points** — WebGL pseudocolour cloud (unchanged).
- **contour** — density contours **only**; the WebGL point cloud is skipped (`GateScatterCell` passes
  `null` points to `ScatterGL`), so it's the fast path.
- **outliers** — contours **plus** individual dots for the sparse tail the contours don't enclose
  (FlowJo / old-R "contour ± outliers"). Outlier threshold = the outermost contour level.

The density grid + outlier subset are extracted to a pure, unit-tested `plots/density.ts`, shared by
`PlotLayers`. Three hand-rolled segmented controls are replaced by the one `RenderModeToggle`.

### Notes / reservations
- Not yet driven in a browser: the contour-only look, the **outlier dot density/size** (threshold
  `0.05` normalised — may want visual tuning), and the `null`-points ScatterGL path.
- `contour` mode now means contours-only **everywhere** (single Gate plot + gating-strategy montage),
  not just the pairs matrix — intentional, but a visible change.
- Outliers button uses `pi-asterisk`; swappable if it doesn't render.

Tests: `plots/density.test.ts` (grid normalisation, outlier selection); 60 frontend tests pass.
Typecheck + build green. Docs: `docs/UI.md` → *Gate scatters*, `docs/TODO.md` #00080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)