### PR TITLE
fix(gating): make contour+outliers dots subtler

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,11 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00082** — **Contour + outliers dots too strong** (2026-07-09)
+The outlier dots in the contour+outliers mode (#00080) rendered too heavily. Made them subtler in
+`PlotLayers.drawOutliers` — opacity 0.55 → 0.3, dot radius 1 → 0.6px — so the contours stay the main
+read. Render-only tweak.
+
 **#00081** — **No native browser dialogs — shared `ConfirmButton`** (2026-07-09)
 The Quit control used `window.confirm` (and board-close in `TabbedCanvas` too) — native dialogs look
 out of place and can't be styled. Extracted `components/ConfirmButton.vue` (arm → Confirm/Cancel in

--- a/frontend/src/components/plots/PlotLayers.vue
+++ b/frontend/src/components/plots/PlotLayers.vue
@@ -104,11 +104,11 @@ function drawDots(points: Float32Array, colour: string, r = 1.5) {
   }
 }
 // "contour + outliers": individual dots for the sparse-tail points the contours don't enclose (R:
-// contour ± outliers). Small + semi-transparent so the contours stay the main read.
+// contour ± outliers). Kept subtle — small, faint sub-pixel dots — so the contours stay the main read.
 function drawOutliers(points: Float32Array, colour: string) {
   const pts = outlierPoints(points, props.viewExtents, G)
-  ctx!.globalAlpha = 0.55
-  drawDots(pts, colour, 1)
+  ctx!.globalAlpha = 0.3
+  drawDots(pts, colour, 0.6)
   ctx!.globalAlpha = 1
 }
 


### PR DESCRIPTION
## Make contour + outliers dots subtler

The outlier dots in the contour+outliers render mode (#00080) rendered too strong. Lowered their
opacity (0.55 → 0.3) and shrank them (radius 1 → 0.6px) in `PlotLayers.drawOutliers`, so the contours
stay the main read. Render-only change; `outlierPoints` selection logic unchanged. TODO #00082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)