### PR TITLE
fix(ui): ConfirmButton renders host buttons via scoped slot (fixes lo…

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,15 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00083** — **ConfirmButton lost host styling (Quit button unstyled)** (2026-07-09)
+`ConfirmButton` (#00081) rendered the buttons itself and took host classes (`footer-btn`, `save-btn`,
+…) as props — but a child component's rendered DOM doesn't receive the parent's *scoped* CSS, so those
+buttons came out unstyled (the sidebar + Settings Quit looked wrong; all four sites were affected).
+Redesigned it as a logic-only wrapper with a scoped slot (`{ armed, arm, confirm, cancel }`): the HOST
+renders the buttons, so host scoped styles apply. Wrapper is `display:contents` (layout-transparent).
+Rewired all four call sites (sidebar/Settings Quit, `TabbedCanvas` close, metadata delete). See
+`docs/UI.md` → *No native browser dialogs*.
+
 **#00082** — **Contour + outliers dots too strong** (2026-07-09)
 The outlier dots in the contour+outliers mode (#00080) rendered too heavily. Made them subtler in
 `PlotLayers.drawOutliers` — opacity 0.55 → 0.3, dot radius 1 → 0.6px — so the contours stay the main

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -135,23 +135,31 @@ different thing — that's `position:absolute` inside a plot, not a modal.)*
 
 **Never use `window.confirm` / `alert` / `prompt`.** Native dialogs look out of place (OS-styled, not
 our theme), block the JS thread, and can't be positioned or styled. For a destructive-action confirm,
-use **`frontend/src/components/ConfirmButton.vue`** — the shared arm-then-confirm button: the first
-click morphs the button in place into **Confirm + Cancel**, and the `@confirm` event only fires on the
-second click (auto-disarms on an outside click / timeout). This is the two-click pattern the app
-already used inline (segmentation-attribute delete); `ConfirmButton` is the one canonical version.
+use **`frontend/src/components/ConfirmButton.vue`** — a logic-only wrapper with a **scoped slot**: the
+first click arms it, showing **Confirm + Cancel** in place; `@confirm` fires only on the second click
+(auto-disarms on an outside click / timeout).
+
+**The host renders the buttons** (via the slot props `{ armed, arm, confirm, cancel }`), NOT the
+component — this is deliberate: a child component's rendered DOM does **not** receive a parent's
+*scoped* CSS, so if `ConfirmButton` rendered the button, host `.footer-btn` / `.btn-danger` styling
+wouldn't reach it (this bit us once — the Quit button rendered unstyled). Rendering the buttons in the
+host keeps them in the host's style scope. The wrapper is `display:contents`, so the buttons lay out as
+if direct children of the host.
 
 ```vue
-<ConfirmButton trigger-class="btn-danger btn-sm" confirm-class="btn-danger btn-sm" cancel-class="btn-ghost btn-sm"
-               :disabled="!selected" @confirm="doDelete"
-               trigger-tooltip="Delete…" confirm-tooltip="Permanently delete — this can't be undone">
-  <i class="pi pi-trash" />          <!-- trigger content; #confirm / #cancel slots for icon-only buttons -->
+<ConfirmButton @confirm="doDelete" v-slot="{ armed, arm, confirm, cancel }">
+  <button v-if="!armed" class="btn-danger btn-sm" :disabled="!selected" @click="arm"
+          v-tooltip.bottom="'Delete…'"><i class="pi pi-trash" /></button>
+  <template v-else>
+    <button class="btn-danger btn-sm" @click="confirm">Confirm</button>
+    <button class="btn-ghost btn-sm" @click="cancel">Cancel</button>
+  </template>
 </ConfirmButton>
 ```
 
-Style is passed through (`triggerClass`/`confirmClass`/`cancelClass`) so each host keeps its look;
-`needsConfirm=false` fires immediately with no arm step (e.g. closing an already-empty board). Used by
-the sidebar/Settings **Quit**, the board close in `TabbedCanvas`, and the metadata-attribute delete.
-For a bigger modal decision (not a single button), use `BaseModal`.
+`needsConfirm=false` makes `arm` fire immediately with no arm step (e.g. closing an already-empty
+board). Used by the sidebar/Settings **Quit**, the board close in `TabbedCanvas`, and the
+metadata-attribute delete. For a bigger modal decision (not a single button), use `BaseModal`.
 
 ---
 

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -148,13 +148,16 @@ function isNavDisabled(item: NavItem): boolean {
 
     <!-- ── Footer: quick app controls (bottom-left) ────────────────────────── -->
     <div class="sidebar-footer">
-      <ConfirmButton trigger-class="footer-btn danger" confirm-class="footer-btn danger" cancel-class="footer-btn"
-                     :disabled="appCtl.busy" @confirm="appCtl.quit()"
-                     trigger-tooltip="Quit Cecelia — stop napari, notebooks and the backend"
-                     confirm-tooltip="Confirm quit — stops napari, notebooks and the backend">
-        <i class="pi pi-power-off" />
-        <template #confirm><i class="pi pi-check" /></template>
-        <template #cancel><i class="pi pi-times" /></template>
+      <ConfirmButton @confirm="appCtl.quit()" v-slot="{ armed, arm, confirm, cancel }">
+        <button v-if="!armed" class="footer-btn danger" :disabled="appCtl.busy" @click="arm"
+                v-tooltip.right="'Quit Cecelia — stop napari, notebooks and the backend'">
+          <i class="pi pi-power-off" />
+        </button>
+        <template v-else>
+          <button class="footer-btn danger" @click="confirm"
+                  v-tooltip.right="'Confirm quit — stops napari, notebooks and the backend'"><i class="pi pi-check" /></button>
+          <button class="footer-btn" @click="cancel" v-tooltip.right="'Cancel'"><i class="pi pi-times" /></button>
+        </template>
       </ConfirmButton>
       <button v-if="appCtl.dev" class="footer-btn" :disabled="appCtl.busy" @click="appCtl.restartBackend()"
               v-tooltip.right="'Restart the backend server (dev) — reconnects when it is back'">

--- a/frontend/src/components/ConfirmButton.vue
+++ b/frontend/src/components/ConfirmButton.vue
@@ -1,65 +1,58 @@
 <!--
-  Inline "arm → confirm" button — the ONE destructive-action confirm for the app. Replaces native
-  browser dialogs (`window.confirm`), which are discouraged: they look out of place, block the thread,
-  and can't be styled (see docs/UI.md → "No native browser dialogs"). First click arms (the button
-  morphs to Confirm + Cancel in place); the `confirm` event only fires on the second click. Auto-disarms
-  on an outside click or after a timeout, so a stray arm doesn't linger.
+  Logic-only "arm → confirm" wrapper for destructive actions — the one replacement for native browser
+  dialogs (`window.confirm`), which are discouraged (out of place, unstyleable; see docs/UI.md → "No
+  native browser dialogs"). It renders NONE of its own chrome: the HOST provides the buttons via the
+  default scoped slot, so the host's own (scoped) CSS styles them. This matters — a child component's
+  rendered DOM can't receive a parent's scoped styles, so passing host classes into a child that renders
+  the button leaves it unstyled. Here the buttons live in the host template, styled by the host.
 
-  Styling is passed through (`triggerClass`/`confirmClass`/`cancelClass`) so each host keeps its own
-  look; trigger/confirm inner content can be a slot (icon-only buttons) or the icon/label props. Set
-  `needsConfirm=false` to fire immediately with no arm step (e.g. closing an already-empty board).
+  Slot props: `{ armed, arm, confirm, cancel }`. Show the trigger button when `!armed` (calls `arm`);
+  when `armed`, show Confirm (calls `confirm`) + Cancel (calls `cancel`). `arm` fires `@confirm`
+  immediately when `needsConfirm=false` (e.g. an already-empty board). Auto-disarms on an outside click
+  or after `autoDismissMs`. The wrapper span is `display:contents` so it doesn't disturb the host's
+  layout (the buttons lay out as if direct children); it stays in the DOM for outside-click detection.
+
+  <ConfirmButton @confirm="doQuit" v-slot="{ armed, arm, confirm, cancel }">
+    <button v-if="!armed" class="footer-btn danger" @click="arm"><i class="pi pi-power-off" /></button>
+    <template v-else>
+      <button class="footer-btn danger" @click="confirm"><i class="pi pi-check" /></button>
+      <button class="footer-btn" @click="cancel"><i class="pi pi-times" /></button>
+    </template>
+  </ConfirmButton>
 -->
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
 
 const props = withDefaults(defineProps<{
-  triggerClass?: string; triggerIcon?: string; triggerLabel?: string; triggerTooltip?: string
-  confirmClass?: string; confirmLabel?: string; confirmTooltip?: string
-  cancelClass?: string; cancelLabel?: string
-  disabled?: boolean
-  needsConfirm?: boolean          // false → click fires `confirm` immediately (no arm step)
+  needsConfirm?: boolean          // false → arm() fires `confirm` immediately (no arm step)
   autoDismissMs?: number          // armed state auto-cancels after this (0 = never)
-}>(), { confirmLabel: 'Confirm', cancelLabel: 'Cancel', needsConfirm: true, autoDismissMs: 4000 })
+}>(), { needsConfirm: true, autoDismissMs: 4000 })
 const emit = defineEmits<{ confirm: [] }>()
 
 const armed = ref(false)
 const rootEl = useTemplateRef<HTMLElement>('rootEl')
 let timer: ReturnType<typeof setTimeout> | null = null
 const clearTimer = () => { if (timer) { clearTimeout(timer); timer = null } }
-function disarm() { armed.value = false; clearTimer() }
-function onTrigger() {
-  if (props.disabled) return
+function cancel() { armed.value = false; clearTimer() }
+function arm() {
   if (!props.needsConfirm) { emit('confirm'); return }
   armed.value = true
   clearTimer()
-  if (props.autoDismissMs > 0) timer = setTimeout(disarm, props.autoDismissMs)
+  if (props.autoDismissMs > 0) timer = setTimeout(cancel, props.autoDismissMs)
 }
-function doConfirm() { emit('confirm'); disarm() }
-// clicking anywhere outside disarms (so an armed button doesn't stay hot across the UI)
-function onDocClick(e: MouseEvent) { if (armed.value && rootEl.value && !rootEl.value.contains(e.target as Node)) disarm() }
+function confirm() { emit('confirm'); cancel() }
+// clicking anywhere outside disarms (so an armed control doesn't stay hot across the UI)
+function onDocClick(e: MouseEvent) { if (armed.value && rootEl.value && !rootEl.value.contains(e.target as Node)) cancel() }
 onMounted(() => document.addEventListener('mousedown', onDocClick))
 onBeforeUnmount(() => { document.removeEventListener('mousedown', onDocClick); clearTimer() })
 </script>
 
 <template>
-  <span ref="rootEl" class="confirm-btn">
-    <button v-if="!armed" :class="triggerClass" :disabled="disabled" type="button"
-            v-tooltip.bottom="triggerTooltip" @click="onTrigger">
-      <slot><i v-if="triggerIcon" :class="triggerIcon" /><span v-if="triggerLabel">{{ triggerLabel }}</span></slot>
-    </button>
-    <template v-else>
-      <button :class="confirmClass ?? triggerClass" type="button" v-tooltip.bottom="confirmTooltip" @click="doConfirm">
-        <slot name="confirm">{{ confirmLabel }}</slot>
-      </button>
-      <button :class="cancelClass ?? 'cb-cancel'" type="button" @click="disarm"><slot name="cancel">{{ cancelLabel }}</slot></button>
-    </template>
-  </span>
+  <span ref="rootEl" class="confirm-btn"><slot :armed="armed" :arm="arm" :confirm="confirm" :cancel="cancel" /></span>
 </template>
 
 <style scoped>
-.confirm-btn { display: inline-flex; align-items: center; gap: 6px; }
-/* fallback cancel look when the host doesn't pass a cancelClass */
-.cb-cancel { background: var(--cc-surface-2); color: var(--cc-text-dim); border: 1px solid var(--cc-border);
-  border-radius: 5px; padding: 4px 10px; cursor: pointer; font-size: 12px; }
-.cb-cancel:hover { color: var(--cc-text); }
+/* layout-transparent: the host's buttons lay out as if direct children (so a footer/toolbar flex treats
+   them exactly like sibling buttons). Still a real DOM node for outside-click detection. */
+.confirm-btn { display: contents; }
 </style>

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -146,16 +146,18 @@ async function exportCsv() {
         />
         <template v-else>
           <span class="tab-name">{{ t.name }}</span>
-          <span v-if="tabs.length > 1" @click.stop>
-            <ConfirmButton trigger-class="tab-close" confirm-class="tab-close" cancel-class="tab-close"
-                           :needs-confirm="plotCount(t.id) > 0" @confirm="closeTab(t.id)"
-                           trigger-tooltip="Close board"
-                           :confirm-tooltip="`Confirm — close board and its ${plotCount(t.id)} plot${plotCount(t.id) === 1 ? '' : 's'}`">
-              <i class="pi pi-times" />
-              <template #confirm><i class="pi pi-check" /></template>
-              <template #cancel><i class="pi pi-replay" /></template>
-            </ConfirmButton>
-          </span>
+          <ConfirmButton v-if="tabs.length > 1" :needs-confirm="plotCount(t.id) > 0" @confirm="closeTab(t.id)"
+                         v-slot="{ armed, arm, confirm, cancel }">
+            <span @click.stop>
+              <button v-if="!armed" class="tab-close" type="button" @click="arm"
+                      v-tooltip.bottom="'Close board'" aria-label="Close board"><i class="pi pi-times" /></button>
+              <template v-else>
+                <button class="tab-close" type="button" @click="confirm"
+                        v-tooltip.bottom="`Confirm — close board and its ${plotCount(t.id)} plot${plotCount(t.id) === 1 ? '' : 's'}`"><i class="pi pi-check" /></button>
+                <button class="tab-close" type="button" @click="cancel" v-tooltip.bottom="'Keep board'"><i class="pi pi-replay" /></button>
+              </template>
+            </span>
+          </ConfirmButton>
         </template>
       </div>
       <button class="tab-add" type="button" @click="addTab" v-tooltip.bottom="'New board'" aria-label="New board">

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -321,11 +321,16 @@ async function quitApp() {
                   v-tooltip.top="'Restart the backend server (dev): the supervisor relaunches it, page reconnects when it is back'">
             <i :class="['pi', appCtl.busy ? 'pi-spin pi-cog' : 'pi-refresh']" /> Restart
           </button>
-          <ConfirmButton trigger-class="save-btn danger" confirm-class="save-btn danger" cancel-class="save-btn ghost"
-                         :disabled="appCtl.busy" @confirm="quitApp" confirm-label="Quit everything"
-                         trigger-tooltip="Stop napari, notebooks and the backend, then exit Cecelia"
-                         confirm-tooltip="Confirm — stop napari, notebooks and the backend">
-            <i class="pi pi-power-off" /> Quit
+          <ConfirmButton @confirm="quitApp" v-slot="{ armed, arm, confirm, cancel }">
+            <button v-if="!armed" class="save-btn danger" :disabled="appCtl.busy" @click="arm"
+                    v-tooltip.top="'Stop napari, notebooks and the backend, then exit Cecelia'">
+              <i class="pi pi-power-off" /> Quit
+            </button>
+            <template v-else>
+              <button class="save-btn danger" @click="confirm"
+                      v-tooltip.top="'Confirm — stop napari, notebooks and the backend'"><i class="pi pi-power-off" /> Quit everything</button>
+              <button class="save-btn ghost" @click="cancel">Cancel</button>
+            </template>
           </ConfirmButton>
         </span>
       </div>

--- a/frontend/src/modules/metadata/MetadataPanel.vue
+++ b/frontend/src/modules/metadata/MetadataPanel.vue
@@ -314,11 +314,14 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
           <option value="">— select attribute —</option>
           <option v-for="n in attrNames" :key="n" :value="n">{{ n }}</option>
         </select>
-        <ConfirmButton trigger-class="btn-danger btn-sm" confirm-class="btn-danger btn-sm" cancel-class="btn-ghost btn-sm"
-          :disabled="!selectedAttr" @confirm="deleteAttr"
-          trigger-tooltip="Delete this attribute from all images."
-          :confirm-tooltip="`Permanently delete '${selectedAttr}' from every image.`">
-          <i class="pi pi-trash" />
+        <ConfirmButton @confirm="deleteAttr" v-slot="{ armed, arm, confirm, cancel }">
+          <button v-if="!armed" class="btn-danger btn-sm" :disabled="!selectedAttr" @click="arm"
+            v-tooltip.bottom="'Delete this attribute from all images.'"><i class="pi pi-trash" /></button>
+          <template v-else>
+            <button class="btn-danger btn-sm" @click="confirm"
+              v-tooltip.bottom="`Permanently delete '${selectedAttr}' from every image.`">Confirm</button>
+            <button class="btn-ghost btn-sm" @click="cancel">Cancel</button>
+          </template>
         </ConfirmButton>
       </div>
     </section>


### PR DESCRIPTION
## ConfirmButton renders host buttons via scoped slot (fixes lost styling)

`ConfirmButton` rendered the buttons itself and took host classes (`footer-btn`, `save-btn`, …) as
props — but a child component's rendered DOM doesn't receive the parent's **scoped** CSS, so those
buttons came out unstyled (the sidebar and Settings **Quit** looked wrong; all four sites were
affected).

Redesigned it as a **logic-only wrapper with a scoped slot** (`{ armed, arm, confirm, cancel }`): the
**host** renders the buttons, so its scoped styles apply. The wrapper is `display:contents`, so the
buttons lay out as if direct children. Rewired all four sites — sidebar/Settings Quit, `TabbedCanvas`
close, metadata-attribute delete.

Verified in the browser (buttons match their neighbours now). TSC + build green. Docs: `docs/UI.md` →
*No native browser dialogs*, `docs/TODO.md` #00083.

Preview: `cd ../cecelia-btncss/frontend && npx vite --port 5174`

🤖 Generated with [Claude Code](https://claude.com/claude-code)