### PR TITLE
fix(ci): install rolldown native binding reliably on Windows/macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,20 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: |
-          npm ci
+          # npm intermittently fails to install a platform-specific OPTIONAL native dep on Windows/macOS
+          # (npm/cli#4828): here @rolldown/binding-<os> (vite 8 bundles with rolldown). Because the
+          # binding is optional, a bad download/cache is non-fatal — npm exits 0 with it missing, then
+          # `vite build` dies "Cannot find native binding". On Linux (the lockfile's authoring platform)
+          # `npm ci` is reliable AND trips on lockfile drift, so keep it there as the reproducibility
+          # guard; elsewhere `npm install` re-resolves optional deps for the host, which is far less
+          # prone to the skip. (Not a hard guarantee — a flaky optional download can still be skipped;
+          # re-run on the rare miss.)
+          if [ "$RUNNER_OS" = "Linux" ]; then npm ci; else npm install; fi
           npm run build
 
       # Frontend unit tests (Vitest): pure logic extracted from .vue SFCs into src/utils/*
       # (e.g. the chain start-dot save/reload round-trip). node_modules is already installed by the
-      # build step's `npm ci`. Fast + fixture-free, so it runs on every OS in the matrix.
+      # build step's install. Fast + fixture-free, so it runs on every OS in the matrix.
       - name: Frontend tests
         working-directory: frontend
         run: npm test

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -136,7 +136,13 @@ launcher.
 | `CECELIA_CHANNEL` | Source | Frontend | To update |
 |---|---|---|---|
 | `stable` (default) | newest tagged Release's `cecelia.tar.gz` | prebuilt (shipped in the bundle) | re-run installer / `pixi run update` / in-app Update |
-| `dev` | `main` branch tarball (`archive/refs/heads/<branch>.tar.gz`) | **built locally** (`npm ci && npm run build`) | re-run installer (re-downloads current `main`) |
+| `dev` | `main` branch tarball (`archive/refs/heads/<branch>.tar.gz`) | **built locally** (`npm install && npm run build`) | re-run installer (re-downloads current `main`) |
+
+> The dev-channel local build uses `npm install`, **not** `npm ci`: the rolldown native binding vite 8
+> bundles with is an *optional* dep, and npm can silently skip it on Windows/macOS (a non-fatal optional
+> download/cache miss, npm/cli#4828), leaving the build with "Cannot find native binding". `npm install`
+> re-resolves optional deps for the host and is far less prone to it. `release.yml` keeps `npm ci`
+> because it only ever runs on `ubuntu-latest`, where the current-platform binding installs reliably.
 
 **Why a dev channel.** So testers can track HEAD without a tag being cut every couple of days. GitHub
 serves any branch as a tarball at `archive/refs/heads/<branch>.tar.gz` — no release, no asset upload —

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,18 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00084** — **Windows CI frontend build: "Cannot find native binding" (rolldown)** (2026-07-09)
+The `windows-latest` CI leg intermittently failed at `npm run build` with `Cannot find module
+'@rolldown/binding-win32-x64-msvc'`. vite 8 bundles with rolldown, whose per-platform native binding is
+an *optional* dep; npm treats a bad optional download/cache as non-fatal (npm/cli#4828) and exits 0 with
+it missing, so the build dies later. Made the CI build install platform-conditional:
+`if [ "$RUNNER_OS" = "Linux" ]; then npm ci; else npm install; fi` — `npm ci` stays on Linux (the
+lockfile's authoring platform: reliable there AND keeps the lockfile-drift guard), `npm install`
+re-resolves optional deps for the host on Windows/macOS. Both dev-channel installers (`install.sh`,
+`install.ps1`) use `npm install`; `release.yml` stays on `npm ci` (ubuntu-latest only). Not a hard
+guarantee — a flaky optional download can still be skipped; re-run on the rare miss. Docs:
+`docs/SHIPPING.md`.
+
 **#00083** — **ConfirmButton lost host styling (Quit button unstyled)** (2026-07-09)
 `ConfirmButton` (#00081) rendered the buttons itself and took host classes (`footer-btn`, `save-btn`,
 …) as props — but a child component's rendered DOM doesn't receive the parent's *scoped* CSS, so those

--- a/install.ps1
+++ b/install.ps1
@@ -99,7 +99,10 @@ Say 'Precompiling Julia (a few minutes on first run)...'
 if ($Channel -eq 'dev') {
   Say 'Building the frontend (dev channel)...'
   Push-Location (Join-Path $InstallDir 'frontend')
-  npm ci
+  # `npm install`, not `npm ci`: npm silently skips a platform-specific optional native dep
+  # (@rolldown/binding-win32-x64-msvc, vite 8's bundler) when the lockfile was made on another OS
+  # (npm/cli#4828) — `npm ci` would leave the Windows build without its native binding. See ci.yml.
+  npm install
   npm run build
   Pop-Location
 }

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,10 @@ say "Precompiling Julia (a few minutes on first run)…"
 # The dev channel ships source only — build the frontend the server serves (stable already has it).
 if [ "$CHANNEL" = "dev" ]; then
   say "Building the frontend (dev channel)…"
-  ( cd "$INSTALL_DIR/frontend" && npm ci && npm run build )
+  # `npm install`, not `npm ci`: npm silently skips a platform-specific optional native dep (the
+  # rolldown binding vite 8 bundles with) when the lockfile was made on another OS (npm/cli#4828) —
+  # `npm ci` can leave the build without its native binding. See .github/workflows/ci.yml.
+  ( cd "$INSTALL_DIR/frontend" && npm install && npm run build )
 fi
 
 # Record what was installed (channel + tag/commit) for provenance and bug reports.


### PR DESCRIPTION
## Install rolldown native binding reliably on Windows/macOS CI

The `windows-latest` CI leg intermittently failed at `npm run build`:

```
Error: Cannot find native binding … Cannot find module '@rolldown/binding-win32-x64-msvc'
```

**Cause.** vite 8 bundles with **rolldown**, whose per-platform native binary ships as an *optional*
dependency (`@rolldown/binding-<os>-<arch>`). Because it's optional, npm treats a bad download / cache
miss as non-fatal (npm/cli#4828) — it **exits 0 with the binding missing**, and the failure only
surfaces later when `vite build` does `require()` on it. Hence the *intermittent* red (a re-run often
goes green).

**Fix.** Make the frontend install platform-conditional in `ci.yml`:

```bash
if [ "$RUNNER_OS" = "Linux" ]; then npm ci; else npm install; fi
```

- **ubuntu-latest → `npm ci`** — the lockfile's authoring platform: reliable there, and keeps the
  strict lockfile-drift guard (a PR that edits `package.json` without updating the lockfile still fails
  loudly on this leg).
- **windows / macos → `npm install`** — re-resolves the host's optional deps, far less prone to the skip.

Dev-channel installers (`install.sh`, `install.ps1`) switch to `npm install` (end-user builds, no drift
guard to keep). `release.yml` stays on `npm ci` — it only runs on `ubuntu-latest`, where the
current-platform binding installs reliably.

**Honest caveat.** This is not a hard guarantee: since the underlying miss is a flaky *optional*
download, `npm install` lowers the failure rate but a bad run could still skip the binding — re-run on
the rare miss. It also can't be verified from a Linux dev box; the proof is the CI matrix on this PR.

Docs: `docs/SHIPPING.md`, `docs/TODO.md` #00084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)