### PR TITLE
feat(dev): switch backend worktree from Settings → System

### DIFF
--- a/api/dev.jl
+++ b/api/dev.jl
@@ -12,16 +12,36 @@
 
 const RESTART_EXIT_CODE = 42
 
+# Worktree switch (dev only, Settings → System): the server writes a target `api/` dir here, then exits
+# with the restart sentinel; we relaunch the child FROM THAT DIR so it loads the other worktree's project
+# + code. The path is fixed in THIS (the launching) worktree's api dir and exported to the child via env,
+# so wherever the child currently runs it always writes the request to the one place this loop reads.
+const SWITCH_FILE = abspath(joinpath(@__DIR__, ".switch-worktree"))
+ENV["CECELIA_SWITCH_FILE"] = SWITCH_FILE
+isfile(SWITCH_FILE) && rm(SWITCH_FILE; force = true)     # clear a stale request left by a crash
+
 julia = Base.julia_cmd().exec[1]   # this julia's executable; child gets its own flags (-t auto, Revise)
-child = `$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`
+workdir = @__DIR__                  # api/ of the worktree the server currently runs from
 
 while true
+    # `--project` (no path) + relative `includet` resolve against the child's cwd → running it in
+    # `workdir` loads that worktree's environment and server.
+    child = Cmd(`$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`; dir = workdir)
     proc = try
-        run(ignorestatus(child); wait = true)      # inherits stdio + env (CECELIA_DEV/SUPERVISED)
+        run(ignorestatus(child); wait = true)      # inherits stdio + env (CECELIA_DEV/SUPERVISED/SWITCH_FILE)
     catch e
         e isa InterruptException && break           # Ctrl-C → stop supervising
         rethrow()
     end
     proc.exitcode == RESTART_EXIT_CODE || break     # 0 / crash / signal → done
-    @info "[dev] restart requested — relaunching server…"
+    if isfile(SWITCH_FILE)                          # worktree switch requested → relaunch from the target
+        target = strip(read(SWITCH_FILE, String)); rm(SWITCH_FILE; force = true)
+        if !isempty(target) && isdir(target)
+            workdir = target
+            @info "[dev] switching worktree" workdir
+        else
+            @warn "[dev] ignoring invalid worktree-switch target" target
+        end
+    end
+    @info "[dev] relaunching server…" workdir
 end

--- a/api/src/app_api.jl
+++ b/api/src/app_api.jl
@@ -59,3 +59,64 @@ function api_app_restart(body_bytes::Vector{UInt8})
     end
     200, JSON3.write((; ok = true, message = "Restarting Cecelia"))
 end
+
+# ── Dev worktree switch (Settings → System) ─────────────────────────────────────
+# A dev convenience: relaunch the BACKEND from another git worktree without dropping to the console.
+# The supervisor (`dev.jl`) does the actual relaunch — this endpoint just records the target and exits
+# with the restart sentinel (same mechanism as restart). DEV + supervised only. NOTE: this switches the
+# server on :8080 only; a frontend-only branch still needs its own Vite (see docs/DEV.md branch preview).
+_git_toplevel(dir::AbstractString) =
+    try; strip(readchomp(`git -C $dir rev-parse --show-toplevel`)); catch; ""; end
+
+# GET /api/app/worktrees → { worktrees: [{path, branch, current}], current, canSwitch }
+function api_app_worktrees(::HTTP.Request)
+    here = _git_toplevel(pwd())
+    out = Any[]
+    try
+        text = readchomp(`git -C $(pwd()) worktree list --porcelain`)
+        for block in split(text, "\n\n")
+            isempty(strip(block)) && continue
+            path = ""; branch = "(detached)"
+            for l in split(block, "\n")
+                startswith(l, "worktree ") && (path = String(l[10:end]))
+                startswith(l, "branch ")   && (branch = replace(String(l[8:end]), "refs/heads/" => ""))
+            end
+            isempty(path) && continue
+            push!(out, (; path, branch, current = path == here))
+        end
+    catch e
+        return 200, JSON3.write((; worktrees = Any[], current = here, canSwitch = false,
+                                   error = "git worktree list failed: $(sprint(showerror, e))"))
+    end
+    200, JSON3.write((; worktrees = out, current = here, canSwitch = _can_restart()))
+end
+
+# POST /api/app/switch-worktree { path } → { ok } | 4xx  — relaunch the backend from `path`'s api/ dir.
+function api_app_switch_worktree(body_bytes::Vector{UInt8})
+    _can_restart() || return 409, JSON3.write((;
+        error = "Worktree switch unavailable — the server isn't running under a supervisor."))
+    sf = get(ENV, "CECELIA_SWITCH_FILE", "")
+    isempty(sf) && return 409, JSON3.write((; error = "Supervisor didn't provide a switch channel."))
+    body = JSON3.read(body_bytes, Dict{String,Any})
+    target = String(get(body, "path", ""))
+    isempty(target) && return 400, JSON3.write((; error = "path required"))
+    here = _git_toplevel(pwd())
+    known = Set{String}()
+    try
+        for l in eachline(`git -C $(pwd()) worktree list --porcelain`)
+            startswith(l, "worktree ") && push!(known, String(l[10:end]))
+        end
+    catch; end
+    (target in known) || return 400, JSON3.write((; error = "Not a known worktree: $target"))
+    target == here && return 200, JSON3.write((; ok = true, message = "Already on this worktree"))
+    apidir = joinpath(target, "api")
+    isdir(apidir) || return 400, JSON3.write((; error = "No api/ directory in $target"))
+    write(sf, apidir)                    # the supervisor relaunches the child here on the next loop
+    @info "Worktree switch requested via /api/app/switch-worktree" target apidir
+    _stop_children_for_exit()
+    @async begin
+        sleep(0.4)
+        exit(RESTART_EXIT_CODE)
+    end
+    200, JSON3.write((; ok = true, message = "Switching to $(basename(target))"))
+end

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -176,6 +176,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             200, JSON3.write((; ok=true, version="CeceliaAPI"))
         elseif path == "/api/diagnostics"
             api_diagnostics(req)
+        elseif path == "/api/app/worktrees"
+            api_app_worktrees(req)
         elseif path == "/api/diagnostics/packages"
             api_packages(req)
         elseif path == "/api/version"
@@ -310,6 +312,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_app_shutdown(body_bytes)
         elseif path == "/api/app/restart"
             api_app_restart(body_bytes)
+        elseif path == "/api/app/switch-worktree"
+            api_app_switch_worktree(body_bytes)
         elseif path == "/api/napari/open"
             api_napari_open(body_bytes)
         elseif path == "/api/napari/close"

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -156,6 +156,19 @@ OS in the matrix, and each has a `pixi run` task that runs the whole suite:
   `python` + `numpy`/`dask`/`zarr` resolve. First member: `test_zarr_store.py` (the `create_multiscales`
   chunk-aligned store round-trip).
 
+## Dev worktree switch (Settings → System)
+
+When several git worktrees exist (the branch-preview workflow), **Settings → System → Worktree** lists
+them and lets you relaunch the backend from another checkout **without the console**. Dev + supervised
+only (`pixi run dev`, which sets `CECELIA_SUPERVISED`). Mechanism: `POST /api/app/switch-worktree`
+records the target's `api/` dir in a sentinel file and exits with the restart code; the `api/dev.jl`
+supervisor relaunches the child *from that dir* (so it loads the other worktree's project + code), and
+the page reconnects when `/api/health` is back — same lifecycle as Restart.
+
+**Scope:** this switches the **backend on :8080 only**. A frontend-only branch still needs its own Vite
+(`cd <worktree>/frontend && npx vite --port 5174`) — the served frontend doesn't change when the backend
+worktree does. Prod (`app.py`) doesn't offer it (the control is hidden when not dev/supervised).
+
 ## Diagnostics & debug console
 
 **Settings → Diagnostics** (always on) shows server threads, Julia version, memory, the bound

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,14 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00086** — **Dev worktree switch in Settings → System** (2026-07-10)
+Added a dev-only dropdown to relaunch the backend from another git worktree without the console.
+`GET /api/app/worktrees` lists `git worktree list`; `POST /api/app/switch-worktree {path}` records the
+target's `api/` dir in a sentinel file and exits with the restart code; `api/dev.jl` relaunches the
+child from that dir (loads the other worktree's project + code). Dev + supervised only; page reconnects
+via the shared `appControl` lifecycle (same as Restart). Backend :8080 only — a frontend branch still
+needs its own Vite. Docs: `docs/DEV.md`.
+
 **#00084** — **Windows CI frontend build: "Cannot find native binding" (rolldown)** (2026-07-09)
 The `windows-latest` CI leg intermittently failed at `npm run build` with `Cannot find module
 '@rolldown/binding-win32-x64-msvc'`. vite 8 bundles with rolldown, whose per-platform native binding is

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -196,6 +196,15 @@ async function quitApp() {
   await appCtl.quit()
   svcMsg.value = appCtl.message
 }
+// dev worktree switch: relaunch the backend from another checkout (backend/:8080 only)
+onMounted(() => appCtl.refreshWorktrees())
+async function switchWt(path: string) {
+  if (!path) return
+  svcMsg.value = 'Switching worktree…'
+  await appCtl.switchWorktree(path)
+  svcMsg.value = appCtl.message
+  pollServices()
+}
 </script>
 
 <template>
@@ -333,6 +342,20 @@ async function quitApp() {
             </template>
           </ConfirmButton>
         </span>
+      </div>
+
+      <!-- dev worktree switch: relaunch the backend from another git worktree (avoids the console).
+           Backend :8080 only — a frontend-only branch still needs its own Vite (see docs/DEV.md). -->
+      <div v-if="diag?.dev && appCtl.canSwitch && appCtl.worktrees.length > 1" class="svc-row">
+        <span class="svc-name">Worktree</span>
+        <select class="wt-select" :disabled="appCtl.busy"
+                :value="appCtl.worktrees.find(w => w.current)?.path ?? ''"
+                @change="switchWt(($event.target as HTMLSelectElement).value)"
+                v-tooltip.top="'Relaunch the backend from another git worktree (dev). The page reconnects when it is back.'">
+          <option v-for="w in appCtl.worktrees" :key="w.path" :value="w.path">
+            {{ w.branch }}{{ w.current ? ' (current)' : '' }}
+          </option>
+        </select>
       </div>
 
       <div class="svc-row">
@@ -584,6 +607,7 @@ async function quitApp() {
 .svc-row { display: grid; grid-template-columns: 8rem 7rem 3.5rem 1fr; align-items: center;
   column-gap: 0.6rem; margin-bottom: 0.55rem; }
 .svc-name { font-size: 0.8rem; color: var(--cc-text); }
+.wt-select { font-size: 0.8rem; padding: 2px 6px; max-width: 18rem; }
 .svc-pill { justify-self: start; display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.72rem;
   color: var(--cc-text-dim); padding: 0.1rem 0.55rem; border: 1px solid var(--cc-border); border-radius: 999px;
   white-space: nowrap; }

--- a/frontend/src/stores/appControl.ts
+++ b/frontend/src/stores/appControl.ts
@@ -9,12 +9,25 @@ export const useAppControlStore = defineStore('appControl', () => {
   const busy = ref(false)       // a quit/restart is in flight (drives spinners in both places)
   const message = ref('')
 
-  const _post = (url: string) =>
-    fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+  const _post = (url: string, body: unknown = {}) =>
+    fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+
+  // dev-only: the repo's git worktrees, so the System panel can relaunch the backend from another
+  // checkout without the console (backend/:8080 only — a frontend branch still needs its own Vite).
+  const worktrees = ref<{ path: string; branch: string; current: boolean }[]>([])
+  const canSwitch = ref(false)   // server supervised → a switch can actually relaunch
 
   // read the dev flag from diagnostics (prod never sets CECELIA_DEV → false)
   async function refreshDev() {
     try { dev.value = !!(await (await fetch('/api/diagnostics')).json()).dev } catch { /* leave as-is */ }
+  }
+  async function refreshWorktrees() {
+    try {
+      const d = await (await fetch('/api/app/worktrees')).json() as {
+        worktrees?: { path: string; branch: string; current: boolean }[]; canSwitch?: boolean }
+      worktrees.value = d.worktrees ?? []
+      canSwitch.value = !!d.canSwitch
+    } catch { /* leave as-is */ }
   }
 
   // global Quit: stop everything + exit the backend. The connection drops as the server exits (expected);
@@ -54,5 +67,24 @@ export const useAppControlStore = defineStore('appControl', () => {
     }
   }
 
-  return { dev, busy, message, refreshDev, quit, restartBackend }
+  // dev-only: relaunch the backend from another worktree. Same lifecycle as restartBackend — the
+  // supervisor exits the current server and relaunches in the target checkout; we poll /api/health.
+  async function switchWorktree(path: string): Promise<string | null> {
+    busy.value = true; message.value = 'Switching worktree…'
+    try {
+      const res = await _post('/api/app/switch-worktree', { path })
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({} as { error?: string }))
+        busy.value = false; message.value = d.error ?? 'Worktree switch failed.'
+        return message.value
+      }
+    } catch { /* connection dropped as it exits — expected */ }
+    message.value = 'Backend switching worktree — reconnecting…'
+    await _waitForBackend()
+    busy.value = false; message.value = 'Switched worktree.'
+    await refreshWorktrees()
+    return null
+  }
+
+  return { dev, busy, message, worktrees, canSwitch, refreshDev, refreshWorktrees, quit, restartBackend, switchWorktree }
 })


### PR DESCRIPTION
## Switch the backend worktree from Settings → System (dev)

A dev-only convenience so the branch-preview workflow doesn't need a manual console `cd` + restart:
**Settings → System → Worktree** lists the repo's git worktrees and relaunches the backend from the one
you pick.

**How it works** (reuses the existing supervised-restart mechanism):
- `GET /api/app/worktrees` → `git worktree list` (path, branch, current).
- `POST /api/app/switch-worktree {path}` → records the target's `api/` dir in a sentinel file and exits
  with the restart sentinel. **Dev + supervised only** (`pixi run dev`).
- `api/dev.jl` relaunches the child **from that dir**, so it loads the other worktree's project + code;
  the page reconnects when `/api/health` is back — identical lifecycle to Restart.
- The dropdown shows only when dev + supervised + more than one worktree exists.

**Scope / caveats**
- **Backend (:8080) only** — the served frontend doesn't change; a frontend-only branch still needs its
  own Vite (`npx vite --port 5174`). Prod (`app.py`) doesn't offer the control.
- The supervisor stays the *launching* worktree's `dev.jl` (it just relaunches the child elsewhere).

**Honestly untested by me:** I can't run `pixi run dev`, so the supervisor relaunch-from-another-dir
path is verified only by reading + a clean Julia load (`test-api` app-lifecycle 9/9) + `vue-tsc`. Needs
your hands-on test. To try it, run **this branch's backend** (it carries the new `dev.jl` + endpoints):
`cd ../cecelia-wtswitch && pixi run dev` + its frontend, then Settings → System → Worktree.

Docs: `docs/DEV.md`, `docs/TODO.md` #00086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)