### PR TITLE
fix(dev): dev.jl supervisor crashed on start (soft-scope workdir)

### DIFF
--- a/api/dev.jl
+++ b/api/dev.jl
@@ -20,28 +20,34 @@ const SWITCH_FILE = abspath(joinpath(@__DIR__, ".switch-worktree"))
 ENV["CECELIA_SWITCH_FILE"] = SWITCH_FILE
 isfile(SWITCH_FILE) && rm(SWITCH_FILE; force = true)     # clear a stale request left by a crash
 
-julia = Base.julia_cmd().exec[1]   # this julia's executable; child gets its own flags (-t auto, Revise)
-workdir = @__DIR__                  # api/ of the worktree the server currently runs from
-
-while true
-    # `--project` (no path) + relative `includet` resolve against the child's cwd → running it in
-    # `workdir` loads that worktree's environment and server.
-    child = Cmd(`$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`; dir = workdir)
-    proc = try
-        run(ignorestatus(child); wait = true)      # inherits stdio + env (CECELIA_DEV/SUPERVISED/SWITCH_FILE)
-    catch e
-        e isa InterruptException && break           # Ctrl-C → stop supervising
-        rethrow()
-    end
-    proc.exitcode == RESTART_EXIT_CODE || break     # 0 / crash / signal → done
-    if isfile(SWITCH_FILE)                          # worktree switch requested → relaunch from the target
-        target = strip(read(SWITCH_FILE, String)); rm(SWITCH_FILE; force = true)
-        if !isempty(target) && isdir(target)
-            workdir = target
-            @info "[dev] switching worktree" workdir
-        else
-            @warn "[dev] ignoring invalid worktree-switch target" target
+# Wrapped in a function so `workdir` is a plain local we can reassign across loop iterations — a bare
+# `while` at script top level is SOFT scope, where reassigning a global needs `global` (and getting it
+# wrong crashes the supervisor on start). Function (hard) scope sidesteps that whole class of bug.
+function supervise()
+    julia = Base.julia_cmd().exec[1]   # this julia's executable; child gets its own flags (-t auto, Revise)
+    workdir = @__DIR__                 # api/ of the worktree the server currently runs from
+    while true
+        # `--project` (no path) + relative `includet` resolve against the child's cwd → running it in
+        # `workdir` loads that worktree's environment and server.
+        child = Cmd(`$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`; dir = workdir)
+        proc = try
+            run(ignorestatus(child); wait = true)  # inherits stdio + env (CECELIA_DEV/SUPERVISED/SWITCH_FILE)
+        catch e
+            e isa InterruptException && break       # Ctrl-C → stop supervising
+            rethrow()
         end
+        proc.exitcode == RESTART_EXIT_CODE || break # 0 / crash / signal → done
+        if isfile(SWITCH_FILE)                      # worktree switch requested → relaunch from the target
+            target = strip(read(SWITCH_FILE, String)); rm(SWITCH_FILE; force = true)
+            if !isempty(target) && isdir(target)
+                workdir = target                    # plain local reassignment — no `global`, no soft scope
+                @info "[dev] switching worktree" workdir
+            else
+                @warn "[dev] ignoring invalid worktree-switch target" target
+            end
+        end
+        @info "[dev] relaunching server…" workdir
     end
-    @info "[dev] relaunching server…" workdir
 end
+
+supervise()


### PR DESCRIPTION
## Fix dev.jl supervisor crash on start (soft-scope workdir)

#96's worktree-switch loop reassigns `workdir` inside a **top-level `while`**, which is *soft scope* in
a Julia script — so Julia treated `workdir` as a new local and it was undefined on first read.
`pixi run dev` died immediately with `UndefVarError` before the server could start.

**Fix:** wrap the supervise loop in a `supervise()` function, so `workdir` is a plain local — **no
`global`**, and no soft-scope ambiguity to get wrong again (that ambiguity is the whole class of bug
that caused this). Verified the scope pattern in isolation.

Regression from #96 — the supervisor was the one piece I'd flagged I couldn't run, and this slipped
through. Priority merge: `pixi run dev` is broken on `main` until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)