### PR TITLE
fix(measure): drop redundant compactness (identical to sphericity)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -252,6 +252,15 @@ batch it rather than churn standalone.
 
 ## Fixed
 
+**#00087** — **Drop redundant `compactness` morphology measure** (2026-07-10)
+`compactness` and `sphericity` were computing the identical value (bit-for-bit equal on real data): the
+port had re-derived compactness as `(36π·V²)^(1/3)/A`, which equals the Wadell sphericity exactly. Even
+the old R formula (`surface_area^1.5/volume`) is a monotone transform of sphericity — both are pure
+functions of the isoperimetric ratio `A³/V²` — so it carries no independent information (and R had it
+commented out of its own feature lists). Removed the `compactness` column from `measure_utils.py`; keep
+`sphericity` plus the orthogonal `solidity`/`extent`. Deliberate deviation from R, noted at the code
+site. Affects newly measured images only (existing `.h5ad` keep the column until re-measured).
+
 **#00086** — **Dev worktree switch in Settings → System** (2026-07-10)
 Added a dev-only dropdown to relaunch the backend from another git worktree without the console.
 `GET /api/app/worktrees` lists `git worktree list`; `POST /api/app/switch-worktree {path}` records the

--- a/python/cecelia/utils/measure_utils.py
+++ b/python/cecelia/utils/measure_utils.py
@@ -276,11 +276,15 @@ class MeasureUtils:
             if mesh.volume > 0:
                 row['surface_to_volume'] = float(mesh.area) / float(mesh.volume)
 
-            # sphericity: ratio of sphere area with same volume to actual area
+            # sphericity (Wadell): area of the equal-volume sphere / actual area. Range (0,1], 1 = sphere.
+            # NOTE: `compactness` was intentionally DROPPED. The old R version defined it as
+            # surface_area**1.5 / volume, but that is a monotone transform of sphericity (both are pure
+            # functions of the isoperimetric ratio A**3/V**2), so it carries no independent information —
+            # and the earlier port had re-derived it to a formula that equalled sphericity exactly. Use
+            # `solidity` / `extent` for genuinely orthogonal shape descriptors.
             if mesh.area > 0 and mesh.volume > 0:
                 r_eq = (3 * mesh.volume / (4 * np.pi)) ** (1 / 3)
-                row['sphericity']   = (4 * np.pi * r_eq ** 2) / float(mesh.area)
-                row['compactness']  = (36 * np.pi * mesh.volume ** 2) ** (1 / 3) / float(mesh.area)
+                row['sphericity'] = (4 * np.pi * r_eq ** 2) / float(mesh.area)
 
             # ellipsoid fit from convex hull vertices
             try:


### PR DESCRIPTION
## Drop redundant `compactness` morphology measure

`compactness` and `sphericity` were computing the **identical value** — bit-for-bit equal across all
cells on real data. The port had re-derived `compactness` as `(36π·V²)^(1/3)/A`, which equals the
Wadell `sphericity` exactly.

Checked against the old R version (the port reference): R defined `compactness = surface_area^1.5 /
volume` — a *different* formula, but still a **monotone transform of sphericity** (both are pure
functions of the isoperimetric ratio `A³/V²`), so it carries no independent information. Tellingly, R
had `compactness` **commented out** of its own heatmap/UMAP feature lists.

**Change:** remove the `compactness` column from `measure_utils.py`; keep `sphericity` (standard,
bounded 0–1) plus the genuinely orthogonal `solidity` (convexity) and `extent` (bounding-box fill).
Deliberate deviation from R, documented at the code site so it's not a future "why is this missing"
mystery.

**Scope:** affects **newly measured** images only — existing `.h5ad` keep the column until re-measured
(harmless). Syntax-checked (`py_compile`); equivalence to sphericity was verified on live data before
removal. No mesh-fixture unit test added.

Docs: `docs/TODO.md` #00087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)