### PR TITLE
Fix/gating morphology transform

### DIFF
--- a/api/src/gating_api.jl
+++ b/api/src/gating_api.jl
@@ -383,18 +383,29 @@ function api_gating_plotmeta(req::HTTP.Request)
     vn = _resolve_vn(img, get(q, "valueName", ""))
     x = get(q, "x", ""); y = get(q, "y", "")
     (isempty(x) || isempty(y)) && return _gerr(400, "x and y required")
-    xt = _axis_transform(q, "x"); yt = _axis_transform(q, "y")
-    xv, yv = _plot_xy(img, vn, get(q, "popType", "flow"), x, y, get(q, "pop", ROOT), xt, yt)
+    pop_type = get(q, "popType", "flow"); pop = get(q, "pop", ROOT)
+    xt0 = _axis_transform(q, "x"); yt0 = _axis_transform(q, "y")
+    # raw extents over the WHOLE dataset (root): used both for ticks (labels read in data units, and
+    # selecting a population doesn't rescale the axis) AND to decide auto-linearisation — so the
+    # transform choice is stable across populations, not re-decided per subset. Track-aware via _raw.
+    rxv, ryv = _plot_xy_raw(img, vn, pop_type, x, y, ROOT)
+    rxext = _finite_extrema(rxv); ryext = _finite_extrema(ryv)
+    # A non-linear transform that would collapse a bounded/small-range measure (morphology like
+    # solidity ∈ [0,1]) into a sliver is auto-swapped to linear; usedX/usedY tell the client so it can
+    # flag the axis. Both plotmeta and plotdata transform with these EFFECTIVE transforms, so the
+    # extent and the point cloud always agree. (The client sends its PREFERRED transform; the server
+    # decides what's usable — see docs/POPULATION.md.)
+    # Opt-in via autoLinear=1 (sent by the single flow plot AND the channel-pairs / gating-strategy
+    # montage; other callers keep the requested transform verbatim). usedX/usedY report what was used.
+    auto = get(q, "autoLinear", "") == "1"
+    xt = auto ? effective_transform(xt0, rxext[1], rxext[2]) : xt0
+    yt = auto ? effective_transform(yt0, ryext[1], ryext[2]) : yt0
+    xv, yv = _plot_xy(img, vn, pop_type, x, y, pop, xt, yt)
     n = length(xv)
     density_threshold = parse(Int, get(q, "densityThreshold", "200000"))
     mode = n > density_threshold ? "density" : "scatter"
     xext = _finite_extrema(xv)
     yext = _finite_extrema(yv)
-    # ticks use the raw extent (over the WHOLE dataset, not the pop subset) so labels read in data
-    # units and selecting a population doesn't rescale the axis — track-aware via _plot_xy_raw.
-    rxv, ryv = _plot_xy_raw(img, vn, get(q, "popType", "flow"), x, y, ROOT)
-    rxext = _finite_extrema(rxv)
-    ryext = _finite_extrema(ryv)
     # x0/y0=1 → "whole dataset" axis: origin at raw 0, upper bound = the FULL dataset max (rxext
     # is computed from all cells, not the pop subset), so selecting a population doesn't rescale
     # the axis (FlowJo behaviour). Autoscale (x0=0) fits the displayed population's extent.
@@ -404,12 +415,27 @@ function api_gating_plotmeta(req::HTTP.Request)
     if get(q, "y0", "") == "1"
         yext = (apply_transform(yt, 0.0), apply_transform(yt, float(ryext[2]))); ryext = (0.0, ryext[2])
     end
+    # Child gates of the displayed population, re-projected into the EFFECTIVE display transform so
+    # their outlines land on the dots even when a gate was drawn under a different transform (the client
+    # has no transform math). Colour/path travel so the client renders directly. Membership is untouched.
+    m = load_pop_map(img; value_name = vn, pop_type = pop_type)
+    gates = Dict{String,Any}[]
+    for cpath in direct_children(m, pop)
+        p = m.pops[cpath]
+        p.gate === nothing && continue
+        pj = project_gate(p.gate, x, y, xt, yt)
+        pj === nothing && continue
+        pj["path"] = cpath; pj["colour"] = p.colour
+        push!(gates, pj)
+    end
     200, JSON3.write((;
         n = n, mode = mode,
         xExtent = [xext[1], xext[2]], yExtent = [yext[1], yext[2]],
         xLabel = x, yLabel = y,
         xTicks = _axis_ticks(xt, rxext[1], rxext[2]),
         yTicks = _axis_ticks(yt, ryext[1], ryext[2]),
+        usedX = transform_kind(xt), usedY = transform_kind(yt),
+        gates = gates,
     ))
 end
 

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -38,8 +38,9 @@ export obsm, obsm_keys
 # ── Gating engine: transforms, gates, density ─────────────────────────────────
 export AxisTransform, LinearTransform, LogTransform, AsinhTransform, LogicleTransform
 export apply_transform, invert_transform, transform_spec, transform_from_spec
+export transform_kind, transform_collapses, effective_transform
 export Gate, RectangleGate, PolygonGate
-export inside, point_in_polygon, gate_channels, gate_spec, gate_from_spec
+export inside, point_in_polygon, gate_channels, gate_spec, gate_from_spec, project_gate
 export Density2D, density_2d
 
 # ── Population manager ─────────────────────────────────────────────────────────

--- a/app/src/gating/gates.jl
+++ b/app/src/gating/gates.jl
@@ -156,7 +156,30 @@ function project_gate(g::Gate, xcol::AbstractString, ycol::AbstractString,
             "x_min" => min(ax, bx), "x_max" => max(ax, bx),
             "y_min" => min(ay, by), "y_max" => max(ay, by))
     else
-        Dict{String,Any}("kind" => "polygon",
-            "vertices" => [collect(to_disp(vx, vy)) for (vx, vy) in g.vertices])
+        verts = g.vertices
+        # display transforms applied to the gate's OWN x/y channels (swap maps gate-x → plot-Y)
+        gxt = swap ? yt : xt
+        gyt = swap ? xt : yt
+        straight = transform_spec(g.x_transform) == transform_spec(gxt) &&
+                   transform_spec(g.y_transform) == transform_spec(gyt)
+        pts = if straight
+            # same transform → edges stay straight, keep the raw corners (a later edit round-trips cleanly)
+            [collect(to_disp(vx, vy)) for (vx, vy) in verts]
+        else
+            # a straight edge in the gate's transform is a CURVE in a different display transform — sample
+            # K points along each edge (in the gate's space) and map each, so the outline follows the curve.
+            K = 12
+            n = length(verts)
+            out = Vector{Vector{Float64}}()
+            for i in 1:n
+                (ax, ay) = verts[i]; (bx, by) = verts[mod1(i + 1, n)]
+                for s in 0:(K - 1)
+                    t = s / K
+                    push!(out, collect(to_disp(ax + t * (bx - ax), ay + t * (by - ay))))
+                end
+            end
+            out
+        end
+        Dict{String,Any}("kind" => "polygon", "vertices" => pts)
     end
 end

--- a/app/src/gating/gates.jl
+++ b/app/src/gating/gates.jl
@@ -124,3 +124,39 @@ function gate_from_spec(spec::AbstractDict)::Gate
         error("Unknown gate kind: $kind")
     end
 end
+
+# ── Projection for display ──────────────────────────────────────────────────────
+# Re-express a gate's stored geometry (in its OWN transform space) into a target DISPLAY transform,
+# oriented to the plot's (xcol, ycol). The plot's points arrive already in the display transform (see
+# api plotdata), so a gate drawn under a DIFFERENT transform — e.g. drawn on logicle, now shown on a
+# coerced/switched linear axis — must be re-projected or its outline lands nowhere near the dots. The
+# client has no transform math (points/ticks are all server-computed), so this must happen here.
+# Per-axis and monotone: stored → raw (invert the gate's transform) → display (apply the target). Axes
+# transform independently, so a rectangle stays a rectangle; polygon vertices map pointwise (edges
+# approximated by straight segments — fine for a gating outline). Returns a JSON-ready Dict in DISPLAY
+# coords, or `nothing` if the gate isn't on this channel pair (either order). Membership is untouched —
+# this is purely for rendering the outline aligned with the displayed points.
+function project_gate(g::Gate, xcol::AbstractString, ycol::AbstractString,
+                      xt::AxisTransform, yt::AxisTransform)
+    gx, gy = g.x_channel, g.y_channel
+    direct = (gx == xcol && gy == ycol)
+    swap   = (gx == ycol && gy == xcol)
+    (direct || swap) || return nothing
+    # a stored point (on the gate's own x/y axes) → the plot's (x,y) display coordinates
+    to_disp(vgx, vgy) = begin
+        rgx = invert_transform(g.x_transform, vgx)          # raw value on the gate's x-channel
+        rgy = invert_transform(g.y_transform, vgy)          # raw value on the gate's y-channel
+        swap ? (apply_transform(xt, rgy), apply_transform(yt, rgx)) :   # gate x ↦ plot Y, gate y ↦ plot X
+               (apply_transform(xt, rgx), apply_transform(yt, rgy))
+    end
+    if g isa RectangleGate
+        (ax, ay) = to_disp(g.x_min, g.y_min)
+        (bx, by) = to_disp(g.x_max, g.y_max)
+        Dict{String,Any}("kind" => "rectangle",
+            "x_min" => min(ax, bx), "x_max" => max(ax, bx),
+            "y_min" => min(ay, by), "y_max" => max(ay, by))
+    else
+        Dict{String,Any}("kind" => "polygon",
+            "vertices" => [collect(to_disp(vx, vy)) for (vx, vy) in g.vertices])
+    end
+end

--- a/app/src/gating/transforms.jl
+++ b/app/src/gating/transforms.jl
@@ -183,3 +183,30 @@ transform_spec(::LinearTransform) = Dict("kind" => "linear")
 transform_spec(t::LogTransform)   = Dict("kind" => "log", "floor" => t.floor)
 transform_spec(t::AsinhTransform) = Dict("kind" => "asinh", "cofactor" => t.cofactor)
 transform_spec(t::LogicleTransform) = Dict("kind" => "logicle", "T" => t.T, "W" => t.W, "M" => t.M, "A" => t.A)
+
+transform_kind(t::AxisTransform)::String = transform_spec(t)["kind"]
+
+# ── Range-based auto-linearisation ──────────────────────────────────────────────
+# A non-linear axis transform (logicle/log/asinh) exists to SPREAD a wide dynamic range across the
+# display. On a bounded / small-range measure — e.g. morphology `solidity` ∈ [0,1] — it does the
+# opposite: it compresses every value into a sliver, so the axis and the point cloud collapse to a
+# line/blank (logicle is calibrated to T≈262144, so a value of 1 lands a hair above logicle(0)). So when
+# the chosen transform would map the data's whole raw extent into only a tiny fraction of the span it can
+# occupy, `effective_transform` substitutes `LinearTransform`. Decided on the WHOLE-dataset extent so the
+# choice is stable across populations. Membership is unaffected — gates keep their own stored transform.
+const COERCE_MIN_FRAC = 0.05          # data must occupy ≥ this fraction of the transform's display span
+
+transform_collapses(::LinearTransform, lo::Real, hi::Real) = false
+function transform_collapses(t::LogicleTransform, lo::Real, hi::Real)
+    full = 1.0 - apply_transform(t, 0.0)                                  # logicle display span [logicle(0), 1]
+    span = apply_transform(t, float(hi)) - apply_transform(t, max(float(lo), 0.0))
+    full > 0 && span < COERCE_MIN_FRAC * full
+end
+transform_collapses(t::LogTransform, lo::Real, hi::Real)   = float(hi) < 10 * t.floor    # < 1 decade above floor
+transform_collapses(t::AsinhTransform, lo::Real, hi::Real) = float(hi) < t.cofactor       # all within the ~linear core
+
+# The transform actually usable for the data extent [lo, hi]: the requested one, or linear if it collapses.
+function effective_transform(t::AxisTransform, lo::Real, hi::Real)::AxisTransform
+    (isfinite(float(lo)) && isfinite(float(hi)) && float(hi) > float(lo) &&
+        transform_collapses(t, lo, hi)) ? LinearTransform() : t
+end

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -1826,6 +1826,25 @@ end
         end
         # vectorised
         @test apply_transform(lc, [0.0, 262144.0]) ≈ [0.1111111111, 1.0] atol=1e-6
+
+        # Range-based auto-linearisation: logicle collapses a bounded 0–1 measure (morphology) but
+        # spreads a real intensity range → effective_transform swaps to linear only for the former.
+        @test transform_kind(lc) == "logicle"
+        @test transform_collapses(lc, 0.02, 1.0)              # solidity ∈ [0,1] → collapses
+        @test !transform_collapses(lc, 0.0, 262144.0)         # full intensity range → fine
+        @test !transform_collapses(lc, 0.0, 5000.0)           # large-range morphology (area) → keep logicle
+        @test effective_transform(lc, 0.02, 1.0) isa LinearTransform
+        @test effective_transform(lc, 0.0, 262144.0) === lc   # untouched
+        @test effective_transform(LinearTransform(), 0.02, 1.0) isa LinearTransform  # linear never coerces
+        @test !transform_collapses(LinearTransform(), 0.02, 1.0)
+        # log needs ≥1 decade above the floor; asinh coerces when all data is inside its ~linear core
+        @test transform_collapses(LogTransform(floor=1.0), 0.5, 5.0)
+        @test !transform_collapses(LogTransform(floor=1.0), 1.0, 1e5)
+        @test transform_collapses(AsinhTransform(cofactor=150.0), 0.0, 1.0)
+        @test !transform_collapses(AsinhTransform(cofactor=150.0), 0.0, 5000.0)
+        # degenerate extent (single value / non-finite) → no coercion, keep requested
+        @test effective_transform(lc, 1.0, 1.0) === lc
+        @test effective_transform(lc, NaN, 1.0) === lc
     end
 
     # ── Gating engine: gates ──────────────────────────────────────────────────
@@ -1856,6 +1875,33 @@ end
             g2 = gate_from_spec(gate_spec(g))
             @test inside(g2, [5.0, 1000.0], [5.0, 1000.0]) == inside(g, [5.0, 1000.0], [5.0, 1000.0])
         end
+
+        # project_gate: re-express a gate's stored geometry into a DISPLAY transform so its outline
+        # aligns with points drawn in that transform (the client has no transform math).
+        lcp = LogicleTransform(T=262144, W=0.5, M=4.5, A=0)
+        # a rectangle stored in logicle coords, projected onto a LINEAR display → raw bounds
+        rgp = RectangleGate("cd4", "cd8", 0.4543375762, 0.9069275915, 0.4543375762, 0.9069275915;
+                            x_transform=lcp, y_transform=lcp)
+        lin = LinearTransform()
+        pj = project_gate(rgp, "cd4", "cd8", lin, lin)
+        @test pj["kind"] == "rectangle"
+        @test pj["x_min"] ≈ 1000.0 atol=1e-2      # invert(logicle, 0.4543) ≈ 1000
+        @test pj["x_max"] ≈ 100000.0 atol=1e-1    # invert(logicle, 0.9069) ≈ 100000
+        # projecting onto the SAME transform is (near) identity
+        same = project_gate(rgp, "cd4", "cd8", lcp, lcp)
+        @test same["x_min"] ≈ 0.4543375762 atol=1e-4
+        # swapped channel order → x/y transposed
+        sw = project_gate(rgp, "cd8", "cd4", lin, lin)
+        @test sw !== nothing
+        @test sw["y_min"] ≈ 1000.0 atol=1e-2
+        # not on this channel pair → nothing
+        @test project_gate(rgp, "cd4", "cd19", lin, lin) === nothing
+        # polygon vertices map pointwise
+        pgp = PolygonGate("cd4", "cd8", [(0.4543375762, 0.4543375762), (0.9069275915, 0.4543375762),
+                                         (0.9069275915, 0.9069275915)]; x_transform=lcp, y_transform=lcp)
+        pjp = project_gate(pgp, "cd4", "cd8", lin, lin)
+        @test pjp["kind"] == "polygon" && length(pjp["vertices"]) == 3
+        @test pjp["vertices"][1][1] ≈ 1000.0 atol=1e-2
     end
 
     # ── Gating engine: density ────────────────────────────────────────────────

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -1899,9 +1899,17 @@ end
         # polygon vertices map pointwise
         pgp = PolygonGate("cd4", "cd8", [(0.4543375762, 0.4543375762), (0.9069275915, 0.4543375762),
                                          (0.9069275915, 0.9069275915)]; x_transform=lcp, y_transform=lcp)
+        # onto a DIFFERENT display transform (logicle→linear) the edges curve → sampled 12 pts/edge
         pjp = project_gate(pgp, "cd4", "cd8", lin, lin)
-        @test pjp["kind"] == "polygon" && length(pjp["vertices"]) == 3
-        @test pjp["vertices"][1][1] ≈ 1000.0 atol=1e-2
+        @test pjp["kind"] == "polygon"
+        @test length(pjp["vertices"]) == 36                 # 3 edges × 12 samples
+        @test pjp["vertices"][1][1] ≈ 1000.0 atol=1e-2       # first sample = corner 1
+        # edge 1 is horizontal (y const ≈1000); its midpoint (idx 7 = t=0.5) bows far below the straight
+        # chord's linear midpoint (~50500) — that bow is the curve the sampling captures.
+        @test pjp["vertices"][7][2] ≈ 1000.0 atol=1e-2
+        @test pjp["vertices"][7][1] < 50000
+        # onto the SAME transform edges are already straight → corners kept (clean edit round-trip)
+        @test length(project_gate(pgp, "cd4", "cd8", lcp, lcp)["vertices"]) == 3
     end
 
     # ── Gating engine: density ────────────────────────────────────────────────

--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -53,6 +53,32 @@ Transforms (`linear`, `log`, `asinh`, **`logicle`** — Parks 2006) are implemen
 **once, in Julia**. The API serves *already-transformed* `Float32` coordinates + axis
 tick positions to the browser, so the frontend stays transform-free.
 
+### Auto-linearisation (range-based)
+
+A non-linear transform exists to spread a wide dynamic range; on a **bounded / small-range**
+measure — morphology like `solidity` ∈ [0,1] — it does the opposite and collapses every value into a
+sliver (logicle is calibrated to `T≈262144`, so `1.0` maps a hair above `logicle(0)` → an empty/clipped
+axis). So `plotmeta` (when the client sends `autoLinear=1`) computes `effective_transform` from the
+**whole-dataset** raw extent (stable across populations) and **substitutes `linear`** when the requested
+transform would map the data into < `COERCE_MIN_FRAC` (5%) of its display span (`transforms.jl`). It
+returns the transform it actually used as `usedX`/`usedY`; the client keeps the user's *preferred*
+transform, displays the effective one, marks the axis **amber**, and reverts automatically on a
+compatible measure. `plotmeta` and `plotdata` therefore agree by construction (the client fetches points
+with the effective transform). Membership is untouched — gates keep their own stored transform. Both
+the single flow plot and the channel-pairs / gating-strategy montage opt in (`autoLinear=1`); the montage
+decides per canonical pair and amber-flags its shared transform control when any tile is coerced.
+
+### Gate outlines projected for display
+
+A gate's geometry is stored in the transform it was **drawn** in. If the axis is later shown in a
+different transform (a switched/auto-linearised scale), drawing the stored coordinates as-is puts the
+outline nowhere near the dots — and the client has **no** transform math to fix it. So `plotmeta`
+returns each displayed population's child-gate outlines **re-projected into the effective display
+transform** (`project_gate`: stored → raw via `invert_transform` → display via `apply_transform`, per
+axis; a rectangle stays a rectangle, polygon vertices map pointwise). The client renders them as-is.
+Drawing/editing stamps the **effective** transform on the gate (the space it was drawn in), so
+membership stays correct.
+
 ## Storage
 
 Gating is a **per-segmentation sidecar**, keyed by `value_name`, colocated with the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -269,6 +269,22 @@ child from that dir (loads the other worktree's project + code). Dev + supervise
 via the shared `appControl` lifecycle (same as Restart). Backend :8080 only — a frontend branch still
 needs its own Vite. Docs: `docs/DEV.md`.
 
+**#00085** — **Gating flow plot: morphology measures empty/clipped + gates miss dots after scale change** (2026-07-09)
+On a flow plot every axis defaulted to logicle, which collapses a bounded 0–1 morphology measure
+(`solidity`, `sphericity`, …) into a sliver → empty/clipped plot (worst on the whole-dataset axis where
+the upper bound is `logicle(1)≈logicle(0)`). Fixed range-based: `plotmeta` auto-substitutes `linear`
+when the requested transform would map the data into <5% of its display span (`effective_transform`,
+`app/src/gating/transforms.jl`), reporting `usedX`/`usedY`; the single flow plot (`autoLinear=1`) keeps
+the user's *preferred* transform, shows the effective one, marks the axis **amber** with a tip, and
+reverts automatically on a compatible measure. Separately, gates drawn under one transform missed the
+dots when the scale changed (gates store transformed coords; client has no transform math): `plotmeta`
+now returns child-gate outlines re-projected into the effective display transform (`project_gate`,
+`app/src/gating/gates.jl`), and draw/edit stamps the effective transform. Membership untouched.
+Applied to BOTH the single flow plot and the channel-pairs / gating-strategy montage (`GateMontage`
+adopts `usedX`/`usedY` + server-projected gates per canonical pair, and amber-flags its shared
+transform control when any tile is coerced). Docs: `docs/POPULATION.md`. Tests: `app/test/runtests.jl`
+(Transforms + Gates).
+
 **#00084** — **Windows CI frontend build: "Cannot find native binding" (rolldown)** (2026-07-09)
 The `windows-latest` CI leg intermittently failed at `npm run build` with `Cannot find module
 '@rolldown/binding-win32-x64-msvc'`. vite 8 bundles with rolldown, whose per-platform native binding is

--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -13,13 +13,13 @@
 -->
 <script setup lang="ts">
 import { ref, computed, watch, useTemplateRef } from 'vue'
-import type { GateSpec } from '../../stores/gating'
+import type { GateSpec, TransformSpec } from '../../stores/gating'
 import { plotHostToImageURL } from '../../plots/export'
 import GateScatterCell from './GateScatterCell.vue'
 import type { PopLayer } from './PlotLayers.vue'
 import {
-  type PanelDef, type PanelChild, type MontageId, type Ext, type Tick,
-  idQ, plotQ, canonicalOrient, transposePoints, transposeExt, pearson,
+  type PanelDef, type PanelChild, type MontageId, type Ext, type Tick, type SrvGate,
+  idQ, plotQ, canonicalOrient, transposePoints, transposeExt, pearson, effSpec, transposeGate,
 } from '../../plots/montage'
 
 const isScatter = (d: PanelDef) => (d.role ?? 'scatter') === 'scatter'
@@ -47,6 +47,8 @@ const props = withDefaults(defineProps<{
   renderMode: 'points', gateLabels: true, gateLineWidth: 1.5,
   highlight: () => [], cols: null, axisFromZero: true, reloadKey: 0,
 })
+// true when ≥1 tile's preferred transform was auto-linearised (host shows an amber hint on its control)
+const emit = defineEmits<{ coerced: [boolean] }>()
 
 const montageId = computed<MontageId>(() => ({
   projectUid: props.projectUid, imageUid: props.imageUid, valueName: props.valueName, popType: props.popType }))
@@ -74,24 +76,33 @@ async function loadPanels() {
   const tok = ++loadTok
   loading.value = true; err.value = ''
   const id = montageId.value
-  const metaCache = new Map<string, Promise<{ extents: Ext; xTicks: Tick[]; yTicks: Tick[] }>>()
+  interface MetaData { extents: Ext; xTicks: Tick[]; yTicks: Tick[]
+    effA: TransformSpec; effB: TransformSpec; coerced: boolean; gates: SrvGate[] }
+  const metaCache = new Map<string, Promise<MetaData>>()
   const ptsCache = new Map<string, Promise<Float32Array>>()
   const statCache = new Map<string, Promise<number | undefined>>()
 
-  // meta uses the whole-dataset axis (x0=1 in plotQ) → pop-independent range; cache by canonical pair.
+  // meta uses the whole-dataset axis (x0=1) + autoLinear (server may swap a collapsing transform → linear
+  // and report usedX/usedY) → pop-independent; cache by canonical pair. Carries the EFFECTIVE transforms
+  // (for the point fetch) and the server-projected child-gate outlines (canonical orientation).
   const metaFor = (o: ReturnType<typeof canonicalOrient>, pop: string) => {
     if (!metaCache.has(o.groupKey)) metaCache.set(o.groupKey, (async () => {
-      const m = await (await fetch(`/api/gating/plotmeta?${plotQ(id, pop, o.a, o.b, o.ta, o.tb, props.axisFromZero)}`)).json() as {
-        xExtent: [number, number]; yExtent: [number, number]; xTicks: Tick[]; yTicks: Tick[] }
+      const m = await (await fetch(`/api/gating/plotmeta?${plotQ(id, pop, o.a, o.b, o.ta, o.tb, props.axisFromZero, true)}`)).json() as {
+        xExtent: [number, number]; yExtent: [number, number]; xTicks: Tick[]; yTicks: Tick[]
+        usedX?: string; usedY?: string; gates?: SrvGate[] }
       return { extents: { xMin: m.xExtent[0], xMax: m.xExtent[1], yMin: m.yExtent[0], yMax: m.yExtent[1] },
-               xTicks: m.xTicks, yTicks: m.yTicks }
+               xTicks: m.xTicks, yTicks: m.yTicks,
+               effA: effSpec(m.usedX, o.ta), effB: effSpec(m.usedY, o.tb),
+               coerced: (!!m.usedX && m.usedX !== o.ta.kind) || (!!m.usedY && m.usedY !== o.tb.kind),
+               gates: m.gates ?? [] } as MetaData
     })())
     return metaCache.get(o.groupKey)!
   }
-  const ptsFor = (o: ReturnType<typeof canonicalOrient>, pop: string) => {
+  // points fetched with the EFFECTIVE transforms so the cloud matches the extent + projected gates.
+  const ptsFor = (o: ReturnType<typeof canonicalOrient>, pop: string, effA: TransformSpec, effB: TransformSpec) => {
     const key = `${pop}|${o.groupKey}`
     if (!ptsCache.has(key)) ptsCache.set(key, (async () =>
-      new Float32Array(await (await fetch(`/api/gating/plotdata?${plotQ(id, pop, o.a, o.b, o.ta, o.tb, props.axisFromZero)}`)).arrayBuffer()))())
+      new Float32Array(await (await fetch(`/api/gating/plotdata?${plotQ(id, pop, o.a, o.b, effA, effB, props.axisFromZero)}`)).arrayBuffer()))())
     return ptsCache.get(key)!
   }
   const labelFor = async (c: PanelChild): Promise<string> => {
@@ -106,15 +117,27 @@ async function loadPanels() {
   }
 
   const corrMap: Record<string, number | null> = {}
+  let anyCoerced = false
   try {
     const entries = await Promise.all(defs.map(async d => {
       const o = canonicalOrient(d)
-      const [m, ptsRaw] = await Promise.all([metaFor(o, d.parentPath), ptsFor(o, d.parentPath)])
+      const m = await metaFor(o, d.parentPath)          // effective transforms decided here…
+      const ptsRaw = await ptsFor(o, d.parentPath, m.effA, m.effB)   // …then points fetched with them
+      if (m.coerced) anyCoerced = true
       corrMap[o.groupKey] = pearson(ptsRaw)   // r is orientation-invariant → compute on the canonical cloud
-      const gates = await Promise.all(d.children.map(async c =>
-        ({ path: c.path, colour: c.colour, gate: c.gate, label: await labelFor(c) })))
+      // outlines come from the server (projected into the effective transform), keyed by path; merge the
+      // child's name/colour/label. Transpose for the mirror tile like the points/extents.
+      const gmap = new Map(m.gates.map(sg => [sg.path, o.swap ? transposeGate(sg) : sg]))
+      const gates = (await Promise.all(d.children.map(async c => {
+        const sg = gmap.get(c.path)
+        if (!sg) return null
+        const gate = { kind: sg.kind, x_channel: d.xChan, y_channel: d.yChan,
+          x_transform: o.swap ? m.effB : m.effA, y_transform: o.swap ? m.effA : m.effB,
+          x_min: sg.x_min, x_max: sg.x_max, y_min: sg.y_min, y_max: sg.y_max, vertices: sg.vertices } as GateSpec
+        return { path: c.path, colour: c.colour, gate, label: await labelFor(c) }
+      }))).filter((g): g is { path: string; colour: string; gate: GateSpec; label: string } => g !== null)
       const popLayers = await Promise.all((props.highlight ?? []).map(async h => {
-        const raw = await ptsFor(o, h.path)
+        const raw = await ptsFor(o, h.path, m.effA, m.effB)
         return { path: h.path, colour: h.colour, points: o.swap ? transposePoints(raw) : raw }
       }))
       const data: PanelData = {
@@ -126,7 +149,7 @@ async function loadPanels() {
       }
       return [d.key, data] as const
     }))
-    if (tok === loadTok) { panelData.value = Object.fromEntries(entries); corrByGroup.value = corrMap }
+    if (tok === loadTok) { panelData.value = Object.fromEntries(entries); corrByGroup.value = corrMap; emit('coerced', anyCoerced) }
   } catch (e) {
     if (tok === loadTok) { err.value = e instanceof Error ? e.message : String(e); panelData.value = {}; corrByGroup.value = {} }
   } finally { if (tok === loadTok) loading.value = false }

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -38,6 +38,8 @@ const g = useGatingStore()
 const defaultTransform: Kind = g.popType === 'track' ? 'linear' : 'logicle'
 const channels = computed<string[]>({ get: () => props.ui.channels ?? [], set: v => { props.ui.channels = v } })
 const transform = computed<Kind>({ get: () => props.ui.xt ?? defaultTransform, set: v => { props.ui.xt = v } })
+// ≥1 tile's transform was auto-linearised (measure range too small) → amber the control + explain
+const coerced = ref(false)
 const renderMode = computed<RenderMode>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })
 const parent = computed({ get: () => props.parent, set: v => emit('update:parent', v) })
 const parentOptions = computed(() => ['root', ...g.flat.map(p => p.path)])
@@ -147,9 +149,12 @@ function exportPng() {
             <div v-if="atCap" class="chan-cap">Max {{ MAX_CHANNELS }} channels ({{ MAX_CHANNELS * (MAX_CHANNELS - 1) / 2 }} scatter plots). Clear one to swap.</div>
           </div>
         </div>
-        <select class="tsel" v-model="transform" v-tooltip.bottom="'Axis transform (applied to every channel)'">
+        <select class="tsel" :class="{ 'tsel-amber': coerced }" v-model="transform"
+                v-tooltip.bottom="'Axis transform (per channel; auto-linear where the range needs it)'">
           <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option>
         </select>
+        <i v-if="coerced" class="pi pi-exclamation-triangle ax-warn"
+           v-tooltip.bottom="`Some channels’ range is too small for ${transform} — those shown linear`" />
       </div>
     </div>
 
@@ -161,7 +166,7 @@ function exportPng() {
                  :value-name="g.valueName" :pop-type="g.popType" :defs="defs" :col-label="g.colLabel"
                  :render-mode="renderMode" :gate-labels="props.gateLabels" :gate-line-width="props.gateLineWidth"
                  :highlight="highlightPops" :cols="channels.length || 1" :axis-from-zero="props.axisFromZero"
-                 :reload-key="reloadKey">
+                 :reload-key="reloadKey" @coerced="coerced = $event">
       <template #empty>Pick channels above to compare them against each other.</template>
     </GateMontage>
   </CanvasPanel>
@@ -181,6 +186,9 @@ function exportPng() {
 .ax-lbl { width: 2.6rem; color: var(--cc-text-dim); flex-shrink: 0; }
 .ax-chan { width: 12rem; flex: none; }
 .tsel { width: 5.5rem; flex-shrink: 0; }
+/* amber: some channels' range can't use the chosen transform → those tiles auto-shown on linear */
+.tsel.tsel-amber { border-color: #f59e0b; color: #f59e0b; }
+.ax-warn { color: #f59e0b; font-size: 0.7rem; flex-shrink: 0; cursor: help; }
 /* channel multiselect popover */
 .chan-pick { position: relative; flex: 1; min-width: 0; }
 .chan-btn { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 6px;

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -127,6 +127,14 @@ async function fetchMeta() {
   effYt.value = meta.usedY ?? yt.value
   serverGates.value = meta.gates ?? []
 }
+// refresh ONLY the server-projected child-gate outlines — gates come from plotmeta now, so a gate
+// added/edited/deleted (here or on another plot) needs a re-fetch to appear. Keeps the current axes
+// (no extent/tick reset), so it's cheap enough to run on every membership change.
+async function fetchGates() {
+  if (!g.imageUid || !xChan.value || !yChan.value) return
+  const meta = await (await fetch(`/api/gating/plotmeta?${metaQ.value}`)).json() as { gates?: SrvGate[] }
+  serverGates.value = meta.gates ?? []
+}
 // just the base population points (cheap; regl redraw is instant → smooth membership updates). Uses the
 // EFFECTIVE transforms so the cloud matches the extent + projected gates fetchMeta set.
 async function fetchPoints() {
@@ -150,6 +158,7 @@ async function fetchPlot() {
 // membership refresh (another plot changed a gate on the pop we're showing) — no axis reload
 async function refreshMembership() {
   try {
+    await fetchGates()                    // outlines are server-projected → refresh them on any gate change
     if (parent.value !== 'root') await fetchPoints()
     await loadPopLayers()
   } catch (e) {
@@ -187,7 +196,8 @@ async function confirmGate() {
   const palette = ['#ef4444','#f59e0b','#10b981','#3b82f6','#a78bfa','#ec4899','#14b8a6','#eab308']
   const ok = await g.addPop(newName.value.trim(), pending.value as GateSpec, parent.value, palette[g.flat.length % palette.length])
   pending.value = null
-  if (ok) loadPopLayers()   // new child → its outline is reactive; refresh its colour layer
+  if (ok) { await fetchGates(); loadPopLayers() }   // pull the new server-projected outline + its colour layer
+
 }
 
 // existing gate moved/resized/vertex-edited on the canvas → persist (server recomputes + broadcasts)

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -20,7 +20,6 @@ import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import GateScatterCell from '../../components/plots/GateScatterCell.vue'
 import RenderModeToggle, { type RenderMode } from '../../components/plots/RenderModeToggle.vue'
 import type { PopLayer } from '../../components/plots/PlotLayers.vue'
-import { orientGate } from '../../plots/gateGeometry'
 import { downloadDataUrl } from '../../plots/export'
 
 const props = defineProps<{
@@ -74,40 +73,65 @@ const tspec = (k: Kind): TransformSpec => k === 'logicle' ? { kind: k, T: 262144
 const axisQ = (p: string, k: Kind) => k === 'logicle'
   ? `&${p}t=logicle&${p}T=262144&${p}W=0.5&${p}M=4.5&${p}A=0` : `&${p}t=${k}`
 
-// query for a given population on the current axes
-function plotQ(pop: string) {
+// query for a given population on given axis transforms
+function plotQ(pop: string, xk: Kind, yk: Kind) {
   const z = props.axisFromZero ? 1 : 0
   return `projectUid=${g.projectUid()}&imageUid=${g.imageUid}&valueName=${g.valueName}&popType=${g.popType}` +
     `&x=${encodeURIComponent(xChan.value)}&y=${encodeURIComponent(yChan.value)}` +
-    `&pop=${encodeURIComponent(pop)}${axisQ('x', xt.value)}${axisQ('y', yt.value)}&x0=${z}&y0=${z}`
+    `&pop=${encodeURIComponent(pop)}${axisQ('x', xk)}${axisQ('y', yk)}&x0=${z}&y0=${z}&autoLinear=1`
 }
-const baseQ = computed(() => plotQ(parent.value))
+// meta is fetched with the PREFERRED transforms (xt/yt); the server decides what's actually usable and
+// reports it as usedX/usedY (a non-linear transform that would collapse a bounded/0–1 measure → linear).
+const metaQ = computed(() => plotQ(parent.value, xt.value, yt.value))
 
-// child gates of this panel's parent that live on the current axis pair → outlines (for edit).
-// orientGate is shared with the read-only gating-strategy plot (plots/gateGeometry.ts).
-const currentGates = computed(() =>
-  g.flat.filter(p => p.parent === parent.value && p.gate)
-        .map(p => ({ path: p.path, colour: p.colour, gate: orientGate(p.gate!, xChan.value, yChan.value) }))
-        .filter((p): p is { path: string; colour: string; gate: GateSpec } => p.gate !== null))
+// The transform the server actually USED for each axis (from plotmeta). It differs from the preferred
+// xt/yt when the measure's range can't use it (auto-linearised): the axis select then shows this and
+// goes amber. It reverts to the preference automatically on a compatible measure (server re-decides).
+const effXt = ref<Kind>(xt.value)
+const effYt = ref<Kind>(yt.value)
+const xCoerced = computed(() => effXt.value !== xt.value)
+const yCoerced = computed(() => effYt.value !== yt.value)
+// the axis dropdown DISPLAYS the effective transform; changing it sets the user's PREFERENCE (persisted)
+const xtSel = computed<Kind>({ get: () => effXt.value, set: v => { xt.value = v } })
+const ytSel = computed<Kind>({ get: () => effYt.value, set: v => { yt.value = v } })
+
+// child-gate outlines for the current axes, already projected into the effective display transform by
+// the server (plotmeta) — the client has no transform math, so it can't re-project a gate drawn under a
+// different transform onto these axes. Colour/path arrive with them; we attach the current channels +
+// effective transforms so a drag-edit round-trips (a moved gate is re-stored in the displayed transform).
+interface SrvGate { path: string; colour: string; kind: 'rectangle' | 'polygon'
+  x_min?: number; x_max?: number; y_min?: number; y_max?: number; vertices?: [number, number][] }
+const serverGates = ref<SrvGate[]>([])
+const currentGates = computed(() => serverGates.value.map(s => ({
+  path: s.path, colour: s.colour,
+  gate: { kind: s.kind, x_channel: xChan.value, y_channel: yChan.value,
+          x_transform: tspec(effXt.value), y_transform: tspec(effYt.value),
+          x_min: s.x_min, x_max: s.x_max, y_min: s.y_min, y_max: s.y_max, vertices: s.vertices } as GateSpec })))
 
 async function fetchBuf(q: string): Promise<Float32Array> {
   const buf = await (await fetch(`/api/gating/plotdata?${q}`)).arrayBuffer()
   return new Float32Array(buf)
 }
 
-// axes/extents/ticks — only when X/Y/transform/parent change (NOT on membership change)
+// axes/extents/ticks + effective transforms + projected gate outlines — only when X/Y/transform/parent
+// change (NOT on membership change). Sends the PREFERRED transform; adopts what the server used.
 async function fetchMeta() {
-  const meta = await (await fetch(`/api/gating/plotmeta?${baseQ.value}`)).json() as {
+  const meta = await (await fetch(`/api/gating/plotmeta?${metaQ.value}`)).json() as {
     xExtent: [number, number]; yExtent: [number, number]
-    xTicks: { pos: number; label: string }[]; yTicks: { pos: number; label: string }[] }
+    xTicks: { pos: number; label: string }[]; yTicks: { pos: number; label: string }[]
+    usedX?: Kind; usedY?: Kind; gates?: SrvGate[] }
   extents.value = { xMin: meta.xExtent[0], xMax: meta.xExtent[1], yMin: meta.yExtent[0], yMax: meta.yExtent[1] }
   viewExtents.value = { ...extents.value }
   xTicks.value = meta.xTicks; yTicks.value = meta.yTicks
+  effXt.value = meta.usedX ?? xt.value
+  effYt.value = meta.usedY ?? yt.value
+  serverGates.value = meta.gates ?? []
 }
-// just the base population points (cheap; regl redraw is instant → smooth membership updates)
+// just the base population points (cheap; regl redraw is instant → smooth membership updates). Uses the
+// EFFECTIVE transforms so the cloud matches the extent + projected gates fetchMeta set.
 async function fetchPoints() {
   if (!g.imageUid || !xChan.value || !yChan.value) return
-  points.value = await fetchBuf(baseQ.value)
+  points.value = await fetchBuf(plotQ(parent.value, effXt.value, effYt.value))
 }
 
 // full reload: axes + points + layers (axes / parent / image / value-name change)
@@ -140,15 +164,18 @@ async function loadPopLayers() {
   if (!hl.length) { popLayers.value = []; return }
   try {
     popLayers.value = await Promise.all(hl.map(async path =>
-      ({ path, colour: g.flat.find(p => p.path === path)?.colour ?? '#22d3ee', points: await fetchBuf(plotQ(path)) })))
+      ({ path, colour: g.flat.find(p => p.path === path)?.colour ?? '#22d3ee',
+         points: await fetchBuf(plotQ(path, effXt.value, effYt.value)) })))
   } catch (e) {
     log.error(`Gating pop layers: ${e instanceof Error ? e.message : String(e)}`, { source: 'gating' })
   }
 }
 
 function onDraw(geom: Partial<GateSpec>) {
+  // stamp the EFFECTIVE transform (what the axis is actually displayed in), not the preference — the
+  // geometry was drawn in that space, so this is what membership must test against.
   pending.value = { ...geom, x_channel: xChan.value, y_channel: yChan.value,
-                    x_transform: tspec(xt.value), y_transform: tspec(yt.value) }
+                    x_transform: tspec(effXt.value), y_transform: tspec(effYt.value) }
   // keep the draw tool armed (rectangle/polygon) so you can gate repeatedly without re-selecting it.
   // To adjust a gate without disarming, hold Shift over the plot — GateOverlay grabs/moves/resizes the
   // gate under the cursor while armed (see its onDown/onMove); release Shift to keep drawing.
@@ -225,10 +252,16 @@ watch(hlVersion, loadPopLayers)
     <div class="panel-ctrl">
       <label class="ax-row"><span class="ax-lbl">X</span>
         <select class="ax-chan" v-model="xChan"><option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option></select>
-        <select class="tsel" v-model="xt"><option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select></label>
+        <select class="tsel" :class="{ 'tsel-amber': xCoerced }" v-model="xtSel" v-tooltip.bottom="'Axis transform'">
+          <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
+        <i v-if="xCoerced" class="pi pi-exclamation-triangle ax-warn"
+           v-tooltip.bottom="`${g.colLabel(xChan)}’s range is too small for ${xt} — shown linear`" /></label>
       <label class="ax-row"><span class="ax-lbl">Y</span>
         <select class="ax-chan" v-model="yChan"><option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option></select>
-        <select class="tsel" v-model="yt"><option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select></label>
+        <select class="tsel" :class="{ 'tsel-amber': yCoerced }" v-model="ytSel" v-tooltip.bottom="'Axis transform'">
+          <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
+        <i v-if="yCoerced" class="pi pi-exclamation-triangle ax-warn"
+           v-tooltip.bottom="`${g.colLabel(yChan)}’s range is too small for ${yt} — shown linear`" /></label>
       <label class="ax-row"><span class="ax-lbl">pop</span>
         <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to display; new gates are its children'">
         <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select></label>
@@ -273,6 +306,9 @@ watch(hlVersion, loadPopLayers)
    (background, border, chevron, focus) comes from the global form base in style.css */
 .panel-ctrl select { width: 8rem; font-size: 12px; padding-top: 2px; padding-bottom: 2px; }
 .panel-ctrl select.tsel { width: 5.5rem; }
+/* amber: this axis' preferred transform was auto-linearised because the measure's range can't use it */
+.panel-ctrl select.tsel.tsel-amber { border-color: #f59e0b; color: #f59e0b; }
+.ax-warn { color: #f59e0b; font-size: 0.7rem; flex-shrink: 0; cursor: help; }
 .panel-ctrl select:focus { outline: none; border-color: var(--cc-accent); }
 .ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
 .seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }

--- a/frontend/src/plots/montage.ts
+++ b/frontend/src/plots/montage.ts
@@ -42,9 +42,28 @@ export function idQ(id: MontageId): string {
 // (y-channel, pop) — never on the OTHER axis — so a matrix column (shared x) and row (shared y) still
 // line up when autoscaled. Mirrors GatePlotPanel's axisFromZero → x0/y0 flag.
 export function plotQ(id: MontageId, pop: string, xc: string, yc: string, xt: TransformSpec, yt: TransformSpec,
-                      fromZero = true): string {
+                      fromZero = true, autoLinear = false): string {
   const z = fromZero ? 1 : 0
-  return `${idQ(id)}&x=${encodeURIComponent(xc)}&y=${encodeURIComponent(yc)}&pop=${encodeURIComponent(pop)}${axisQ('x', xt)}${axisQ('y', yt)}&x0=${z}&y0=${z}`
+  return `${idQ(id)}&x=${encodeURIComponent(xc)}&y=${encodeURIComponent(yc)}&pop=${encodeURIComponent(pop)}${axisQ('x', xt)}${axisQ('y', yt)}&x0=${z}&y0=${z}${autoLinear ? '&autoLinear=1' : ''}`
+}
+
+// ── Auto-linearise + server-projected gates (montage side) ──────────────────────────────────────────
+// plotmeta (with autoLinear=1) may substitute linear for a transform that would collapse a bounded
+// measure, reporting the transform it actually USED. effSpec turns that report back into a spec for the
+// plotdata fetch (keeping logicle's params when uncoerced) so points + extent + gates all agree.
+export function effSpec(used: string | undefined, requested: TransformSpec): TransformSpec {
+  return !used || used === requested.kind ? requested : { kind: used as TransformSpec['kind'] }
+}
+// A gate outline the server projected into the current display transform (display coords), canonical
+// orientation. Transposed for the mirror tile like points/extents.
+export interface SrvGate {
+  path: string; colour: string; kind: 'rectangle' | 'polygon'
+  x_min?: number; x_max?: number; y_min?: number; y_max?: number; vertices?: [number, number][]
+}
+export function transposeGate(g: SrvGate): SrvGate {
+  return g.kind === 'rectangle'
+    ? { ...g, x_min: g.y_min, x_max: g.y_max, y_min: g.x_min, y_max: g.x_max }
+    : { ...g, vertices: (g.vertices ?? []).map(([x, y]) => [y, x] as [number, number]) }
 }
 
 // ── Transpose reuse ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Morphology axes auto-linearise; gates re-project on scale change

Two coupled gating bugs on morphology measures:
- On a flow plot every axis defaulted to **logicle**, which collapses a bounded 0–1 measure (`solidity`,
  `sphericity`, …) into a sliver → **empty/clipped plot** (logicle is calibrated to `T≈262144`, so `1.0`
  lands a hair above `logicle(0)`).
- A gate drawn under one transform **missed the dots** after switching the scale — gates store
  *transformed* coords and the client has no transform math.

### Fix
- **Range-based auto-linearise (server).** `plotmeta` with `autoLinear=1` substitutes `linear` when the
  requested transform would map the data into <5% of its display span (`effective_transform`,
  `transforms.jl`), and reports `usedX`/`usedY`. Per-axis, decided on the whole-dataset extent so it's
  stable across populations. **Membership untouched** (gates keep their own transform).
- **Client** keeps your *preferred* transform, displays the effective one, marks the axis **amber + a ⚠
  icon** (brief tooltip), and reverts automatically on a compatible measure. Draw/edit stamps the
  effective transform.
- **Gates re-projected** into the effective display transform server-side (`project_gate`, `gates.jl`)
  so outlines sit on the dots after a scale change. A rectangle stays a rectangle; polygon vertices map
  pointwise. Per-axis throughout, so `CD4-logicle × solidity-linear` works.
- Applies to the **single flow plot** *and* the **channel-pairs / gating-strategy montage** (`GateMontage`
  adopts `usedX`/`usedY` + server gates per canonical pair, amber-flags its shared control when any tile
  is coerced).

### Verification / caveats
- `app` tests (new Transforms + Gates cases), `test-api` load, `vue-tsc`, vitest — all green.
- Browser-confirmed on the single flow plot; the montage's canonical-orientation transpose is the
  least-exercised path. Editing a gate after a scale switch re-stamps it to the effective transform
  (its raw shape changes). Polygon edges are vertex-wise, not curve-exact.

Docs: `docs/POPULATION.md`, `docs/TODO.md` #00085.

### Update — follow-up commit (7b937ae)

Two fixes on top of the server-projected gate outlines:

- **Freshly-drawn gates now appear immediately.** Outlines come from `plotmeta`, but gate add/edit was
  only refreshing points, not outlines — so a new gate didn't show until a full re-fetch (toggling the
  channel). Rectangles merely *looked* fine (their draw rubber-band lingers); a polygon's preview clears
  on close, so nothing was left. Added a lightweight `fetchGates()` (outlines only, no axis reset),
  called after drawing and on any membership change; the read-only montage already reloads.
- **Curve-exact polygon re-projection.** A straight polygon edge in the gate's transform is a *curve* in
  a different display transform — `project_gate` now samples 12 points/edge (only when the transforms
  differ) so the outline follows the curve after a scale switch; corners kept as-is when transforms
  match (clean edit round-trip). Covered in `app/test/runtests.jl`.

tsc + app tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)