### PR TITLE
feat(dev): worktree switch relaunches the frontend too (combined supe…

### DIFF
--- a/api/dev.jl
+++ b/api/dev.jl
@@ -1,52 +1,106 @@
 # Dev supervisor for `pixi run dev`.
 #
-# Runs the API server as a child process and relaunches it whenever it exits with RESTART_EXIT_CODE
-# (42) — the sentinel POST /api/app/restart uses (Settings → System → Restart). Any other exit
-# (0 = Quit, Ctrl-C, crash) stops the loop. Staying the terminal-foreground parent is what lets the
-# fresh server reattach to THIS terminal — a detached relaunch can't. Prod's equivalent loop is in
-# app.py. See docs/todo/SERVICE_PANEL_PLAN.md.
+# Owns BOTH dev processes so a Settings→System worktree switch can relaunch them together:
+#   • the API server (foreground child; Revise hot-reload, multithreaded) — its exit code drives the loop;
+#   • the frontend Vite dev server (background child).
+# The server is relaunched whenever it exits with RESTART_EXIT_CODE (42) — the sentinel POST
+# /api/app/restart and /api/app/switch-worktree use. Any other exit (0 = Quit, Ctrl-C, crash) stops the
+# loop. Staying the terminal-foreground parent is what lets the fresh server reattach to THIS terminal.
+# Prod's equivalent (backend-only) loop is in app.py. See docs/todo/SERVICE_PANEL_PLAN.md.
 #
-# The child is the SAME command the dev task used before this supervisor existed: Revise-tracked
-# hot-reload, multithreaded. CECELIA_SUPERVISED (set by the pixi task) tells the server restart is
-# available; we keep it set for the child too.
+# CECELIA_SUPERVISED (set by the pixi task) tells the server restart/switch are available; kept for the
+# child. `pixi run dev` now starts the frontend too — do NOT also run `pixi run frontend` alongside it
+# (two Vites would fight over the port). `pixi run frontend` stays for running the frontend standalone.
 
 const RESTART_EXIT_CODE = 42
+const FRONTEND_PORT = 5173
 
 # Worktree switch (dev only, Settings → System): the server writes a target `api/` dir here, then exits
-# with the restart sentinel; we relaunch the child FROM THAT DIR so it loads the other worktree's project
-# + code. The path is fixed in THIS (the launching) worktree's api dir and exported to the child via env,
-# so wherever the child currently runs it always writes the request to the one place this loop reads.
+# with the restart sentinel; we relaunch the backend FROM THAT DIR (and the frontend from the sibling
+# `frontend/`) so both load the other worktree's code. The path is fixed in THIS (the launching)
+# worktree's api dir and exported to the child via env, so wherever the child currently runs it always
+# writes the request to the one place this loop reads.
 const SWITCH_FILE = abspath(joinpath(@__DIR__, ".switch-worktree"))
 ENV["CECELIA_SWITCH_FILE"] = SWITCH_FILE
 isfile(SWITCH_FILE) && rm(SWITCH_FILE; force = true)     # clear a stale request left by a crash
 
-# Wrapped in a function so `workdir` is a plain local we can reassign across loop iterations — a bare
+# Free a TCP port by killing whatever listens on it — mirrors `pixi run stop`. dev.jl is a standalone
+# supervisor with no Cecelia loaded, so it can't use api's `_kill_listeners_on_port`; inline it here,
+# OS-guarded (a sanctioned exception to the "no inline kill-by-port" rule — no package to reach into).
+# Best-effort: nothing listening is not an error. Guarantees Vite's port is free before a relaunch binds
+# it (killing the `npm` wrapper alone can orphan the underlying vite process holding the port).
+function _free_port(port::Integer)
+    try
+        if Sys.iswindows()
+            for ln in eachline(`cmd /c netstat -ano -p tcp`)
+                (occursin("LISTENING", ln) && occursin(":$port ", ln)) || continue
+                run(pipeline(`taskkill /PID $(last(split(strip(ln)))) /F /T`; stdout = devnull, stderr = devnull); wait = false)
+            end
+        else
+            pids = try readchomp(`lsof -ti tcp:$port`) catch; "" end
+            isempty(pids) || run(pipeline(`kill $(split(pids))`; stdout = devnull, stderr = devnull))
+        end
+    catch e
+        @warn "[dev] could not free port $port" exception = e
+    end
+end
+
+# Start the frontend (Vite) for a worktree in the background. `npm` needs a shell wrapper on Windows.
+function _start_frontend(root::AbstractString)
+    fe = joinpath(root, "frontend")
+    isdir(joinpath(fe, "node_modules")) || @warn "[dev] $fe/node_modules missing — run `npm install` there"
+    cmd = Sys.iswindows() ? `cmd /c npm run dev` : `npm run dev`
+    try
+        return run(Cmd(cmd; dir = fe); wait = false)   # inherits stdio → Vite logs into this terminal
+    catch e
+        @warn "[dev] frontend (Vite) failed to start" exception = e
+        return nothing
+    end
+end
+
+function _stop_frontend(vite)
+    vite === nothing || (try; kill(vite); catch; end)
+    _free_port(FRONTEND_PORT)     # ensure the port is actually free before a relaunch binds it
+end
+
+# Wrapped in a function so `workdir`/`vite` are plain locals we can reassign across iterations — a bare
 # `while` at script top level is SOFT scope, where reassigning a global needs `global` (and getting it
-# wrong crashes the supervisor on start). Function (hard) scope sidesteps that whole class of bug.
+# wrong crashes the supervisor). Function (hard) scope sidesteps that whole class of bug.
 function supervise()
     julia = Base.julia_cmd().exec[1]   # this julia's executable; child gets its own flags (-t auto, Revise)
     workdir = @__DIR__                 # api/ of the worktree the server currently runs from
-    while true
-        # `--project` (no path) + relative `includet` resolve against the child's cwd → running it in
-        # `workdir` loads that worktree's environment and server.
-        child = Cmd(`$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`; dir = workdir)
-        proc = try
-            run(ignorestatus(child); wait = true)  # inherits stdio + env (CECELIA_DEV/SUPERVISED/SWITCH_FILE)
-        catch e
-            e isa InterruptException && break       # Ctrl-C → stop supervising
-            rethrow()
-        end
-        proc.exitcode == RESTART_EXIT_CODE || break # 0 / crash / signal → done
-        if isfile(SWITCH_FILE)                      # worktree switch requested → relaunch from the target
-            target = strip(read(SWITCH_FILE, String)); rm(SWITCH_FILE; force = true)
-            if !isempty(target) && isdir(target)
-                workdir = target                    # plain local reassignment — no `global`, no soft scope
-                @info "[dev] switching worktree" workdir
+    vite = _start_frontend(dirname(workdir))
+    try
+        while true
+            # `--project` (no path) + relative `includet` resolve against the child's cwd → running it in
+            # `workdir` loads that worktree's environment and server.
+            backend = Cmd(`$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`; dir = workdir)
+            proc = try
+                run(ignorestatus(backend); wait = true)  # inherits stdio + env (CECELIA_DEV/SUPERVISED/SWITCH_FILE)
+            catch e
+                e isa InterruptException && break         # Ctrl-C → stop supervising (finally stops Vite)
+                rethrow()
+            end
+            proc.exitcode == RESTART_EXIT_CODE || break   # 0 / crash / signal → done
+
+            # relaunch target: the switch file names another worktree's api dir, else stay put.
+            newdir = workdir
+            if isfile(SWITCH_FILE)
+                target = strip(read(SWITCH_FILE, String)); rm(SWITCH_FILE; force = true)
+                (!isempty(target) && isdir(target)) ? (newdir = target) :
+                    @warn "[dev] ignoring invalid worktree-switch target" target
+            end
+            if newdir != workdir
+                @info "[dev] switching worktree — relaunching backend + frontend" newdir
+                _stop_frontend(vite)                       # bounce Vite only on an actual switch…
+                workdir = newdir
+                vite = _start_frontend(dirname(workdir))
             else
-                @warn "[dev] ignoring invalid worktree-switch target" target
+                @info "[dev] relaunching server…" workdir   # …a plain restart leaves the frontend running
             end
         end
-        @info "[dev] relaunching server…" workdir
+    finally
+        _stop_frontend(vite)
     end
 end
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -159,15 +159,18 @@ OS in the matrix, and each has a `pixi run` task that runs the whole suite:
 ## Dev worktree switch (Settings → System)
 
 When several git worktrees exist (the branch-preview workflow), **Settings → System → Worktree** lists
-them and lets you relaunch the backend from another checkout **without the console**. Dev + supervised
-only (`pixi run dev`, which sets `CECELIA_SUPERVISED`). Mechanism: `POST /api/app/switch-worktree`
-records the target's `api/` dir in a sentinel file and exits with the restart code; the `api/dev.jl`
-supervisor relaunches the child *from that dir* (so it loads the other worktree's project + code), and
-the page reconnects when `/api/health` is back — same lifecycle as Restart.
+them and lets you relaunch dev from another checkout **without the console**. Dev + supervised only
+(`pixi run dev`, which sets `CECELIA_SUPERVISED`). Mechanism: `POST /api/app/switch-worktree` records the
+target's `api/` dir in a sentinel file and exits with the restart code; the `api/dev.jl` supervisor
+relaunches *from that dir* and the page reconnects when `/api/health` is back — same lifecycle as Restart.
 
-**Scope:** this switches the **backend on :8080 only**. A frontend-only branch still needs its own Vite
-(`cd <worktree>/frontend && npx vite --port 5174`) — the served frontend doesn't change when the backend
-worktree does. Prod (`app.py`) doesn't offer it (the control is hidden when not dev/supervised).
+**`pixi run dev` supervises BOTH the backend and the frontend (Vite),** so a switch relaunches **both**
+from the target worktree — the served frontend follows the branch too, not just the backend. Because of
+that, **don't also run `pixi run frontend`** alongside `pixi run dev` (two Vites would clash on :5173);
+`pixi run frontend` stays for running Vite standalone (e.g. previewing yet another worktree on a spare
+port). A plain Restart bounces only the backend (the frontend keeps its HMR state); only a *switch*
+relaunches Vite. Prod (`app.py`) is backend-only and doesn't offer the switch (control hidden when not
+dev/supervised).
 
 ## Diagnostics & debug console
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -79,7 +79,7 @@ torchvision = ">=0.21"
 # longer stalls the accept loop / a napari open, and the scheduler's per-image task functions
 # (Threads.@spawn) actually parallelise. Julia HDF5 is serialised via `_with_h5`; shared API state is
 # lock-guarded. Override with JULIA_NUM_THREADS if you want a fixed count.
-dev  = { cmd = "julia --project dev.jl", cwd = "api", env = { CECELIA_DEV = "1", CECELIA_SUPERVISED = "1" } }  # dev.jl supervises the Revise hot-reload server + relaunches it on Settings→System Restart. CECELIA_DEV marks a dev server (prod/app.py never sets it → auto-detected); CECELIA_SUPERVISED enables the backend Restart button
+dev  = { cmd = "julia --project dev.jl", cwd = "api", env = { CECELIA_DEV = "1", CECELIA_SUPERVISED = "1" } }  # dev.jl supervises BOTH the Revise hot-reload backend AND the frontend (Vite) — relaunches them on Settings→System Restart/worktree-switch. So `pixi run dev` now starts the frontend too; don't also run `pixi run frontend` alongside it. CECELIA_DEV marks a dev server (prod/app.py never sets it → auto-detected); CECELIA_SUPERVISED enables the backend Restart button
 prod = { cmd = "julia --project -t auto src/server.jl", cwd = "api" }                                    # plain include (production)
 
 # Tests — one whole suite per layer. Package (headless Cecelia) + API adapters (loaded with
@@ -90,7 +90,8 @@ test-api      = { cmd = "julia --project test/runtests.jl", cwd = "api" }
 test-frontend = { cmd = "npm test", cwd = "frontend" }
 test-py       = { cmd = "python -m unittest discover -s python/cecelia/tests -p 'test_*.py' -v" }
 
-# Frontend — Vite (port 5173).
+# Frontend — Vite (port 5173). NOTE: `pixi run dev` already starts this; run it standalone ONLY when
+# not using `pixi run dev` (e.g. previewing another worktree on a spare port), else two Vites clash.
 frontend = { cmd = "npm run dev", cwd = "frontend" }    # dev server, hot reload
 build    = { cmd = "npm run build", cwd = "frontend" }  # static production build
 


### PR DESCRIPTION
## Worktree switch relaunches the frontend too (combined dev supervisor)

The dev worktree switch (#96) relaunched only the **backend**; the served frontend (Vite) stayed on the
launching worktree, so switching to a branch didn't show that branch's UI.

**Change:** `pixi run dev` (`api/dev.jl`) now supervises **both** the backend and Vite. A worktree
switch relaunches both from the target checkout — the frontend follows the branch.

- Vite (`npm run dev` in `<worktree>/frontend`) runs as a **background** child alongside the foreground
  backend. On a switch, `dev.jl` stops Vite (kill the handle **and** free :5173 — killing `npm` can
  orphan the underlying vite) and respawns it from the target's `frontend/`.
- A plain **Restart** bounces only the backend (frontend keeps its HMR); only a **switch** relaunches
  Vite. `try/finally` always stops Vite on exit.
- The switch endpoint + Settings UI are **unchanged** — the frontend follows purely because the
  supervisor now owns Vite.

**Workflow change:** `pixi run dev` starts Vite too, so **don't also run `pixi run frontend`** alongside
it (two Vites clash on :5173). `pixi run frontend` stays for standalone use (e.g. previewing another
worktree on a spare port).

**Verification / caveats — please test before merging:** I can't run `pixi run dev` here, so this is
parse-checked + reasoned only. On Linux, run **this branch's** dev and confirm: (1) frontend comes up on
:5173, (2) a Settings→System worktree switch reloads the other branch's UI, (3) no orphaned Vite lingers
on :5173 after a switch/Quit. Windows paths (npm via `cmd /c`, `netstat`/`taskkill`) are best-effort.

To test: `cd ../cecelia-fedev && pixi run dev` (it starts both now), then Settings → System → Worktree.

Docs: `docs/DEV.md`, `pixi.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)