### PR TITLE
fix(dev): log a flushed line when the frontend (Vite) starts

### DIFF
--- a/api/dev.jl
+++ b/api/dev.jl
@@ -51,7 +51,12 @@ function _start_frontend(root::AbstractString)
     isdir(joinpath(fe, "node_modules")) || @warn "[dev] $fe/node_modules missing — run `npm install` there"
     cmd = Sys.iswindows() ? `cmd /c npm run dev` : `npm run dev`
     try
-        return run(Cmd(cmd; dir = fe); wait = false)   # inherits stdio → Vite logs into this terminal
+        p = run(Cmd(cmd; dir = fe); wait = false)   # inherits stdio → Vite logs into this terminal
+        # Julia-flushed confirmation: Vite's own "ready" banner is block-buffered when its stdout is a
+        # pipe (under this supervisor, not a TTY), so it can appear late or not at all — this line always
+        # shows that the frontend was launched, and where.
+        @info "[dev] frontend (Vite) starting → http://localhost:$FRONTEND_PORT" dir = fe
+        return p
     catch e
         @warn "[dev] frontend (Vite) failed to start" exception = e
         return nothing


### PR DESCRIPTION
## Log a flushed line when the frontend (Vite) starts

Running under the combined dev supervisor, Vite's stdout is a pipe (not a TTY), so its "ready" banner
is **block-buffered** — it can appear late or not at all, making it look like the frontend never
launched even though it did (`:5173` is bound).

Add a **Julia-flushed** confirmation on spawn (and on worktree switch — both go through
`_start_frontend`):

[dev] frontend (Vite) starting → http://localhost:5173

So you always get an immediate, visible signal that the frontend came up, independent of Vite's own
buffering. `dev.jl`-only; parse-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)