### PR TITLE
fix(dev): kill only the LISTENING process when freeing a port

### DIFF
--- a/api/dev.jl
+++ b/api/dev.jl
@@ -37,7 +37,11 @@ function _free_port(port::Integer)
                 run(pipeline(`taskkill /PID $(last(split(strip(ln)))) /F /T`; stdout = devnull, stderr = devnull); wait = false)
             end
         else
-            pids = try readchomp(`lsof -ti tcp:$port`) catch; "" end
+            # -sTCP:LISTEN restricts to the process LISTENING on the port. Without it, `lsof -ti tcp:$port`
+            # also returns PIDs holding an ESTABLISHED connection to it — i.e. the browser (the open tab's
+            # page load + Vite HMR websocket) — so `kill` would reap Firefox/Chrome too (it crashes on a
+            # worktree switch). Mirrors the Windows branch's LISTENING filter above.
+            pids = try readchomp(`lsof -ti tcp:$port -sTCP:LISTEN`) catch; "" end
             isempty(pids) || run(pipeline(`kill $(split(pids))`; stdout = devnull, stderr = devnull))
         end
     catch e

--- a/app/src/tasks/scheduler.jl
+++ b/app/src/tasks/scheduler.jl
@@ -198,7 +198,10 @@ function _kill_listeners_on_port(port::Integer)
     try
         out = Sys.iswindows() ?
             readchomp(`powershell -NoProfile -Command "(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).OwningProcess"`) :
-            readchomp(`lsof -ti tcp:$port`)   # exits non-zero (throws) when nothing is listening → caught
+            # -sTCP:LISTEN keeps this to the LISTENING process (as the docstring promises + the Windows
+            # `-State Listen` above): plain `lsof -ti tcp:$port` also returns clients CONNECTED to the
+            # port, so we'd kill them too. Exits non-zero (throws) when nothing is listening → caught.
+            readchomp(`lsof -ti tcp:$port -sTCP:LISTEN`)
         for line in split(out, '\n'; keepempty=false)
             p = tryparse(Int, strip(line))
             isnothing(p) || push!(pids, p)

--- a/pixi.toml
+++ b/pixi.toml
@@ -132,10 +132,13 @@ julia-instantiate = "julia --project=app -e 'using Pkg; Pkg.instantiate()'"
 # Stop by PORT, not by process name — killing by name self-matches the task's own shell and was
 # orphaning the napari bridge (see docs/SHIPPING.md). `stop-napari` alone forces a fresh bridge
 # after editing napari_bridge.py (the backend otherwise adopts the running bridge on restart).
-stop           = "kill $(lsof -ti tcp:8080) 2>/dev/null ; kill $(lsof -ti tcp:5173) 2>/dev/null ; kill $(lsof -ti tcp:7655) 2>/dev/null ; kill $(lsof -ti tcp:7660) 2>/dev/null ; echo 'stopped backend(8080)/frontend(5173)/napari(7655)/notebooks(7660)'"
-stop-backend   = "kill $(lsof -ti tcp:8080) 2>/dev/null ; echo 'stopped backend(8080)'"
-stop-napari    = "kill $(lsof -ti tcp:7655) 2>/dev/null ; echo 'stopped napari bridge(7655)'"
-stop-notebooks = "kill $(lsof -ti tcp:7660) 2>/dev/null ; echo 'stopped notebooks(7660)'"
+# -sTCP:LISTEN restricts to the LISTENING server; without it lsof also returns clients CONNECTED to the
+# port — the browser on :5173 (page + Vite HMR socket) — so `kill` would crash Firefox/Chrome. Mirrors
+# the win-64 branch's `-State Listen`.
+stop           = "kill $(lsof -ti tcp:8080 -sTCP:LISTEN) 2>/dev/null ; kill $(lsof -ti tcp:5173 -sTCP:LISTEN) 2>/dev/null ; kill $(lsof -ti tcp:7655 -sTCP:LISTEN) 2>/dev/null ; kill $(lsof -ti tcp:7660 -sTCP:LISTEN) 2>/dev/null ; echo 'stopped backend(8080)/frontend(5173)/napari(7655)/notebooks(7660)'"
+stop-backend   = "kill $(lsof -ti tcp:8080 -sTCP:LISTEN) 2>/dev/null ; echo 'stopped backend(8080)'"
+stop-napari    = "kill $(lsof -ti tcp:7655 -sTCP:LISTEN) 2>/dev/null ; echo 'stopped napari bridge(7655)'"
+stop-notebooks = "kill $(lsof -ti tcp:7660 -sTCP:LISTEN) 2>/dev/null ; echo 'stopped notebooks(7660)'"
 
 # Windows: kill by listening port via PowerShell (lsof is unix-only). Untested on Windows hardware.
 [target.win-64.tasks]


### PR DESCRIPTION
## What

Kill **only the LISTENING process** when freeing a TCP port on Unix.

Freeing a port ran `lsof -ti tcp:$port` with no state filter, which returns every PID with a socket on that port — the listening server **and** any client with an ESTABLISHED connection to it. So on a **worktree switch**, `_free_port(5173)` SIGTERM'd the **browser** (the open tab holds the page + Vite HMR websocket to :5173) alongside Vite → **Firefox/Chrome crashed**.

## Fix

Restrict all three Unix kill-by-port sites to `-sTCP:LISTEN`, matching what the Windows branches already do (`-State Listen` / netstat `LISTENING`):

- **`api/dev.jl`** `_free_port` — the reported crash (worktree switch via the GUI).
- **`pixi.toml`** `stop` / `stop-backend` / `stop-napari` / `stop-notebooks` — identical unfiltered kill; `pixi run stop` would also crash the browser.
- **`app/src/tasks/scheduler.jl`** `_kill_listeners_on_port` — the canonical helper (napari :7655 / notebooks :7660 shutdown). No browser attached there, so latent rather than live, but it now matches its own docstring ("kill whatever process is LISTENING") and the Windows branch.

## Testing

- `lsof … -sTCP:LISTEN` validated against a live :5173 — returns only the Vite listener, never the connected browser.
- `dev.jl` + `scheduler.jl` parse-checked.
- Not exercised live through an actual GUI switch / `pixi run stop`; Windows paths already filtered on LISTENING and are unverified on Windows hardware.
- `scheduler.jl` is in `app/` → takes effect after a server restart.