### PR TITLE
Fix/gate outline refresh

### DIFF
--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -230,6 +230,16 @@ watch(() => props.highlight, loadPopLayers, { deep: true })
 // another plot changed the gate of the population we display (or an ancestor) → refresh smoothly
 const parentVersion = computed(() => g.popVersion[parent.value] ?? 0)
 watch(parentVersion, refreshMembership)
+// the outlines we draw are the DIRECT CHILDREN of `parent`. Their set/geometry changes when a child
+// is added, deleted, or edited — here, on another plot, from napari, or via a WS broadcast — but that
+// bumps the CHILD's popVersion, never the displayed parent's, so neither parentVersion nor fetchPlot
+// (axis/parent watch) fires and a deleted child's outline would linger. Watch a signature of the
+// parent's children and re-fetch the outlines when it moves. (Mirrors the montage's `sig`, which
+// already hashes `d.children`; fetchGates is outlines-only, no axis/point reset.)
+const childGateSig = computed(() => g.flat
+  .filter(p => p.parent === parent.value)
+  .map(p => `${p.path}:${JSON.stringify(p.gate ?? null)}`).join('|'))
+watch(childGateSig, fetchGates)
 // a highlighted pop's membership changed elsewhere → refresh just its colour layer
 const hlVersion = computed(() => (props.highlight ?? []).reduce((s, p) => s + (g.popVersion[p] ?? 0), 0))
 watch(hlVersion, loadPopLayers)

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -21,6 +21,8 @@ import GateScatterCell from '../../components/plots/GateScatterCell.vue'
 import RenderModeToggle, { type RenderMode } from '../../components/plots/RenderModeToggle.vue'
 import type { PopLayer } from '../../components/plots/PlotLayers.vue'
 import { downloadDataUrl } from '../../plots/export'
+import { childGateSignature } from '../../utils/childGateSig'
+import { coalesceByKey } from '../../utils/coalesce'
 
 const props = defineProps<{
   index: number; active: boolean; parent: string; highlight: string[]
@@ -130,10 +132,20 @@ async function fetchMeta() {
 // refresh ONLY the server-projected child-gate outlines — gates come from plotmeta now, so a gate
 // added/edited/deleted (here or on another plot) needs a re-fetch to appear. Keeps the current axes
 // (no extent/tick reset), so it's cheap enough to run on every membership change.
-async function fetchGates() {
-  if (!g.imageUid || !xChan.value || !yChan.value) return
-  const meta = await (await fetch(`/api/gating/plotmeta?${metaQ.value}`)).json() as { gates?: SrvGate[] }
-  serverGates.value = meta.gates ?? []
+// Coalesced (see utils/coalesce): adding a gate triggers this both from confirmGate (awaited, so the
+// outline is painted before the call returns) and from the childGateSig watcher. metaQ is child-set-
+// independent and the watcher flush always beats the network round-trip, so both share one in-flight
+// request — one plotmeta call, not two. Keyed on metaQ so an axis change (different key) never reuses
+// a stale in-flight promise.
+const fetchGatesFor = coalesceByKey(async (key: string) => {
+  const meta = await (await fetch(`/api/gating/plotmeta?${key}`)).json() as { gates?: SrvGate[] }
+  // drop a late response whose axes/parent (its metaQ key) no longer match the current view — else a
+  // fetchGates in flight for the old axes could overwrite a fresh fetchMeta's outlines (last-writer race).
+  if (key === metaQ.value) serverGates.value = meta.gates ?? []
+})
+function fetchGates(): Promise<void> {
+  if (!g.imageUid || !xChan.value || !yChan.value) return Promise.resolve()
+  return fetchGatesFor(metaQ.value)
 }
 // just the base population points (cheap; regl redraw is instant → smooth membership updates). Uses the
 // EFFECTIVE transforms so the cloud matches the extent + projected gates fetchMeta set.
@@ -196,7 +208,14 @@ async function confirmGate() {
   const palette = ['#ef4444','#f59e0b','#10b981','#3b82f6','#a78bfa','#ec4899','#14b8a6','#eab308']
   const ok = await g.addPop(newName.value.trim(), pending.value as GateSpec, parent.value, palette[g.flat.length % palette.length])
   pending.value = null
-  if (ok) { await fetchGates(); loadPopLayers() }   // pull the new server-projected outline + its colour layer
+  // await the outline so it's painted before we return; the childGateSig watcher fires too but
+  // coalesces into this same request (see fetchGates). loadPopLayers pulls the new pop's colour layer.
+  if (ok) {
+    try { await fetchGates() } catch (e) {
+      log.error(`Gating add: ${e instanceof Error ? e.message : String(e)}`, { source: 'gating' })
+    }
+    loadPopLayers()
+  }
 
 }
 
@@ -235,10 +254,9 @@ watch(parentVersion, refreshMembership)
 // bumps the CHILD's popVersion, never the displayed parent's, so neither parentVersion nor fetchPlot
 // (axis/parent watch) fires and a deleted child's outline would linger. Watch a signature of the
 // parent's children and re-fetch the outlines when it moves. (Mirrors the montage's `sig`, which
-// already hashes `d.children`; fetchGates is outlines-only, no axis/point reset.)
-const childGateSig = computed(() => g.flat
-  .filter(p => p.parent === parent.value)
-  .map(p => `${p.path}:${JSON.stringify(p.gate ?? null)}`).join('|'))
+// already hashes `d.children`; fetchGates is outlines-only, no axis/point reset.) Signature logic is
+// extracted to utils/childGateSig.ts so it's unit-tested.
+const childGateSig = computed(() => childGateSignature(g.flat, parent.value))
 watch(childGateSig, fetchGates)
 // a highlighted pop's membership changed elsewhere → refresh just its colour layer
 const hlVersion = computed(() => (props.highlight ?? []).reduce((s, p) => s + (g.popVersion[p] ?? 0), 0))

--- a/frontend/src/utils/childGateSig.test.ts
+++ b/frontend/src/utils/childGateSig.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { childGateSignature, type FlatPopLite } from './childGateSig'
+
+// The signature drives when GatePlotPanel re-fetches its (server-projected) gate outlines: it must
+// move exactly when the DIRECT children of the displayed parent, or their gates, change — and stay
+// put for anything else (siblings, grandchildren, the parent's own gate). Deleting a child pop that
+// left its outline lingering was the bug this guards.
+describe('childGateSignature', () => {
+  const g = (x: number) => ({ kind: 'rectangle', x_min: 0, x_max: x })
+  const pops: FlatPopLite[] = [
+    { path: '/A', parent: 'root' },
+    { path: '/A/x', parent: '/A', gate: g(1) },
+    { path: '/A/y', parent: '/A', gate: g(2) },
+    { path: '/A/x/deep', parent: '/A/x', gate: g(9) },   // grandchild of /A
+    { path: '/B', parent: 'root', gate: g(5) },           // sibling subtree
+  ]
+
+  it('includes only the direct children of the parent', () => {
+    const sig = childGateSignature(pops, '/A')
+    expect(sig).toContain('/A/x')
+    expect(sig).toContain('/A/y')
+    expect(sig).not.toContain('/A/x/deep')   // grandchild excluded
+    expect(sig).not.toContain('"path":"/B"')
+    expect(sig).not.toContain('/A:')         // the parent itself excluded
+  })
+
+  it('is empty when the parent has no children', () => {
+    expect(childGateSignature(pops, '/A/y')).toBe('')
+    expect(childGateSignature([], 'root')).toBe('')
+  })
+
+  it('changes when a child is deleted (the reported bug)', () => {
+    const before = childGateSignature(pops, '/A')
+    const after = childGateSignature(pops.filter(p => p.path !== '/A/y'), '/A')
+    expect(after).not.toBe(before)
+  })
+
+  it('changes when a child is added', () => {
+    const before = childGateSignature(pops, '/A')
+    const after = childGateSignature([...pops, { path: '/A/z', parent: '/A', gate: g(3) }], '/A')
+    expect(after).not.toBe(before)
+  })
+
+  it("changes when a child's gate geometry changes", () => {
+    const before = childGateSignature(pops, '/A')
+    const edited = pops.map(p => p.path === '/A/x' ? { ...p, gate: g(42) } : p)
+    expect(childGateSignature(edited, '/A')).not.toBe(before)
+  })
+
+  it("does NOT change when a grandchild's or the parent's own gate changes", () => {
+    const before = childGateSignature(pops, '/A')
+    const grandEdit = pops.map(p => p.path === '/A/x/deep' ? { ...p, gate: g(99) } : p)
+    const parentEdit = pops.map(p => p.path === '/A' ? { ...p, gate: g(7) } : p)
+    expect(childGateSignature(grandEdit, '/A')).toBe(before)
+    expect(childGateSignature(parentEdit, '/A')).toBe(before)
+  })
+
+  it('serialises a gate-less (filter/cluster) pop stably as null', () => {
+    const filterPops: FlatPopLite[] = [{ path: '/A/c', parent: '/A' }]
+    expect(childGateSignature(filterPops, '/A')).toBe('/A/c:null')
+  })
+})

--- a/frontend/src/utils/childGateSig.ts
+++ b/frontend/src/utils/childGateSig.ts
@@ -1,0 +1,20 @@
+// Pure signature of the gate outlines a gating plot draws for a given parent population — extracted
+// from GatePlotPanel.vue so it's unit-testable (utils/childGateSig.test.ts). A plot draws the DIRECT
+// CHILDREN of its displayed parent as gate outlines; this hashes their path + gate spec so the panel
+// can watch it and re-fetch outlines when a child is added, removed, or its gate geometry changes.
+// (The parent's own popVersion doesn't move when a CHILD changes, so watching the parent isn't enough.)
+
+// Structural, store-independent (mirrors startDot.ts's EdgeLite): just the fields the signature reads.
+export interface FlatPopLite { path: string; parent: string; gate?: unknown }
+
+/**
+ * Signature of `parent`'s direct-child gate outlines. Changes iff the set of children under `parent`
+ * changes OR one of their gate specs changes; unaffected by siblings, grandchildren, or the parent's
+ * own gate. Pops with no gate (e.g. cluster/filter pops) serialise stably as `null`.
+ */
+export function childGateSignature(flat: readonly FlatPopLite[], parent: string): string {
+  return flat
+    .filter(p => p.parent === parent)
+    .map(p => `${p.path}:${JSON.stringify(p.gate ?? null)}`)
+    .join('|')
+}

--- a/frontend/src/utils/coalesce.test.ts
+++ b/frontend/src/utils/coalesce.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { coalesceByKey } from './coalesce'
+
+// A deferred promise + a counting worker, so we can assert exactly how many times the underlying work
+// ran for a given interleaving of calls.
+function deferred<T>() {
+  let resolve!: (v: T) => void, reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+describe('coalesceByKey', () => {
+  it('runs work once for concurrent calls with the same key and returns the same promise', async () => {
+    const d = deferred<string>()
+    const work = vi.fn((_key: string) => d.promise)
+    const run = coalesceByKey(work)
+
+    const a = run('k')
+    const b = run('k')
+    expect(work).toHaveBeenCalledTimes(1)
+    expect(a).toBe(b)                     // both callers share the in-flight promise
+
+    d.resolve('done')
+    expect(await a).toBe('done')
+    expect(await b).toBe('done')
+  })
+
+  it('runs work separately for concurrent calls with different keys', () => {
+    const work = vi.fn((_key: string) => deferred<string>().promise)
+    const run = coalesceByKey(work)
+    run('k1'); run('k2')
+    expect(work).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-runs work for the same key once the previous call has settled', async () => {
+    const d1 = deferred<string>()
+    const work = vi.fn()
+      .mockImplementationOnce(() => d1.promise)
+      .mockImplementationOnce(() => Promise.resolve('second'))
+    const run = coalesceByKey(work as (k: string) => Promise<string>)
+
+    const first = run('k')
+    d1.resolve('first')
+    expect(await first).toBe('first')
+    await Promise.resolve()               // let the .finally clear the slot
+
+    const second = run('k')               // same key, but the first already settled → fresh work
+    expect(work).toHaveBeenCalledTimes(2)
+    expect(await second).toBe('second')
+  })
+
+  it('clears the slot on rejection so the key can be retried', async () => {
+    const d1 = deferred<string>()
+    const work = vi.fn()
+      .mockImplementationOnce(() => d1.promise)
+      .mockImplementationOnce(() => Promise.resolve('ok'))
+    const run = coalesceByKey(work as (k: string) => Promise<string>)
+
+    const first = run('k')
+    d1.reject(new Error('boom'))
+    await expect(first).rejects.toThrow('boom')
+    await Promise.resolve()
+
+    const retry = run('k')
+    expect(work).toHaveBeenCalledTimes(2)
+    expect(await retry).toBe('ok')
+  })
+})

--- a/frontend/src/utils/coalesce.ts
+++ b/frontend/src/utils/coalesce.ts
@@ -1,0 +1,23 @@
+// Coalesce concurrent async calls that share a key into a single in-flight operation. Extracted from
+// GatePlotPanel.vue (gate-outline fetching) so the dedup logic is unit-testable without a mounted
+// component or a mocked fetch — the .vue side is then just "build the key, assign the result".
+//
+// While a call for `key` is running, later calls with the SAME key return that same promise instead
+// of starting new work; once it settles (resolve OR reject) the next call starts fresh. A call with a
+// DIFFERENT key always starts its own work. Used so an outline re-fetch triggered from two places in
+// the same tick (confirmGate + the childGateSig watcher) issues one request, not two.
+
+export function coalesceByKey<T>(work: (key: string) => Promise<T>): (key: string) => Promise<T> {
+  let inflight: { key: string; p: Promise<T> } | null = null
+  return (key: string) => {
+    if (inflight?.key === key) return inflight.p
+    const p = work(key)
+    inflight = { key, p }
+    // clear once settled so a later call with the same key re-runs (only clear if still the latest).
+    // then(clear, clear) — not finally — so this monitoring chain settles cleanly on rejection too and
+    // doesn't surface as an unhandled rejection; the caller still gets the original `p` to handle.
+    const clear = () => { if (inflight?.p === p) inflight = null }
+    void p.then(clear, clear)
+    return p
+  }
+}


### PR DESCRIPTION
## What

Refresh a plot's **gate outlines** when a *child* population changes — deleting a pop in the manager left its gate outline lingering on the plot.

## Why

A `GatePlotPanel` draws the **direct children** of its displayed parent as gate outlines (server-projected via `plotmeta`). It re-fetched them only when the displayed **parent's own** `popVersion` bumped, or the **axes/parent** changed. But add/delete/edit of a **child** bumps the *child's* `popVersion`, never the parent's — so a pop deleted in the manager (or changed on another plot / napari / a WS broadcast) left its outline until an axis was nudged. (The montage didn't have this bug — its `sig` already hashes `d.children`.)

## Fix

- Watch a signature of the parent's direct children (`path` + gate spec) and re-fetch outlines when it moves.
- Extract the two stateful bits into pure, unit-tested helpers: `utils/childGateSig.ts` (the signature) and `utils/coalesce.ts` (request coalescing). The `.vue` keeps only reactive wiring.
- `confirmGate` awaits `fetchGates()` (outline painted before return); the watcher's concurrent call coalesces into the same in-flight `plotmeta` request → one fetch, not two.
- Guard against a late `fetchGates` (old axes) overwriting a fresh `fetchMeta` (last-writer race): drop a response whose `metaQ` key no longer matches the current view.
- Wrap `fetchGates()` in `confirmGate` so a network error on add can't reject unhandled.

## Testing

- `vue-tsc --noEmit` clean; `vitest` 71/71 (+11 new: `childGateSig` 7, `coalesce` 4).
- **Not exercised live in a browser** — logic mirrors the montage's proven pattern and the extracted helpers are unit-tested. Manual check: delete a child pop → its outline vanishes; add a gate → outline appears with a single request; edit a gate on another plot → this plot updates.