### PR TITLE
feat(napari): opt-in discrete-GPU rendering + move gate hint

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -7,6 +7,22 @@ const _viewer_lock     = ReentrantLock()
 const _pending_open    = Ref{Any}(nothing)
 const _viewer_starting = Ref(false)
 
+# Runtime toggle for launching the bridge on the discrete GPU (see app/src/napari.jl → launch!).
+# Authoritative at launch time. `nothing` = not yet resolved → seed lazily from the
+# CECELIA_NAPARI_DISCRETE_GPU env var, then the `[napari].discreteGpu` config default. The Settings
+# switch flips it via POST /api/napari/gpu; the frontend re-asserts its saved choice each session.
+const _napari_discrete_gpu = Ref{Union{Bool,Nothing}}(nothing)
+
+function _napari_gpu()::Bool
+    isnothing(_napari_discrete_gpu[]) || return _napari_discrete_gpu[]
+    envv = lowercase(strip(get(ENV, "CECELIA_NAPARI_DISCRETE_GPU", "")))
+    seed = envv in ("1", "true", "yes", "on") ? true :
+           envv in ("0", "false", "no", "off") ? false :
+           napari_discrete_gpu()
+    _napari_discrete_gpu[] = seed
+    seed
+end
+
 # Track what's currently open so we can auto-save before switching images
 const _current_zarr_path = Ref{Union{String,Nothing}}(nothing)
 const _current_task_dir  = Ref{Union{String,Nothing}}(nothing)
@@ -101,9 +117,10 @@ function _ensure_viewer!()::Bool
         v = NapariViewer()
         _viewer_ref[] = v
         _viewer_starting[] = true
+        gpu = _napari_gpu()
         @async begin
             try
-                launch!(v)   # blocks until bridge is up
+                launch!(v; discrete_gpu = gpu)   # blocks until bridge is up
                 _execute_pending_open()
             catch e
                 @warn "Napari launch failed" exception = e
@@ -349,7 +366,7 @@ function api_napari_restart(body_bytes::Vector{UInt8})
     isnothing(v) && return api_napari_open(body_bytes)
     _with_viewer() do
         try
-            restart!(v)
+            restart!(v; discrete_gpu = _napari_gpu())
             200, JSON3.write((; ok = true))
         catch e
             500, JSON3.write((; error = sprint(showerror, e)))
@@ -675,4 +692,21 @@ end
 
 function api_napari_status(req::HTTP.Request)
     200, JSON3.write((; alive = _viewer_alive(), starting = _viewer_starting[]))
+end
+
+# ── REST: discrete-GPU toggle ─────────────────────────────────────────────────
+# GET  /api/napari/gpu             → { discreteGpu, supported }
+# POST /api/napari/gpu { enabled } → set the runtime flag; effective at the NEXT bridge launch, so
+#   the caller restarts napari (needsRestart) to apply it now. `supported` is false off Linux, where
+#   the flag is a no-op (GPU choice is an OS/driver setting there).
+function api_napari_gpu_get(req::HTTP.Request)
+    200, JSON3.write((; discreteGpu = _napari_gpu(), supported = Sys.islinux()))
+end
+
+function api_napari_gpu_set(body_bytes::Vector{UInt8})
+    data = try; JSON3.read(String(body_bytes), Dict{String,Any}); catch
+        return 400, JSON3.write((; error = "invalid JSON body")); end
+    _napari_discrete_gpu[] = Bool(get(data, "enabled", false))
+    200, JSON3.write((; discreteGpu = _napari_discrete_gpu[], supported = Sys.islinux(),
+                        needsRestart = _viewer_alive()))
 end

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -210,6 +210,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_logs_recent()
         elseif path == "/api/napari/status"
             api_napari_status(req)
+        elseif path == "/api/napari/gpu"
+            api_napari_gpu_get(req)
         elseif path == "/api/notebooks"
             api_notebooks_list(req)
         elseif path == "/api/notebooks/status"
@@ -322,6 +324,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_napari_screenshot(body_bytes)
         elseif path == "/api/napari/restart"
             api_napari_restart(body_bytes)
+        elseif path == "/api/napari/gpu"
+            api_napari_gpu_set(body_bytes)
         elseif path == "/api/napari/configure-autosave"
             api_napari_configure_autosave(body_bytes)
         elseif path == "/api/napari/show-labels"

--- a/app/config.toml
+++ b/app/config.toml
@@ -31,6 +31,15 @@ lenUID = 6
   [images.normalise]
   percentile = 99.98
 
+# Napari viewer bridge.
+[napari]
+# Render napari on the discrete GPU when the machine has hybrid graphics. On Linux this launches the
+# bridge with DRI_PRIME (AMD/Intel) and, when an NVIDIA GPU is present, NVIDIA PRIME render-offload
+# env vars so the viewer uses the dGPU instead of the integrated one. Ignored on Windows/macOS (GPU
+# choice is an OS/driver setting there). Can be flipped at runtime from Settings; this value is the
+# default the server starts with. The env var CECELIA_NAPARI_DISCRETE_GPU overrides it.
+discreteGpu = false
+
 [tasks]
 concurrentLimit = 20
 

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -2,7 +2,7 @@ module Cecelia
 
 # ── Config ────────────────────────────────────────────────────────────────────
 export init_cecelia!, cecelia_conf
-export projects_dir, bioformats2raw_bin, python_bin_path, tasks_concurrent_limit
+export projects_dir, bioformats2raw_bin, python_bin_path, tasks_concurrent_limit, napari_discrete_gpu
 
 # ── Utils ─────────────────────────────────────────────────────────────────────
 export gen_uid, UID_LENGTH

--- a/app/src/config.jl
+++ b/app/src/config.jl
@@ -102,5 +102,10 @@ end
 
 python_bin_path()::String = _cfg_dir("python", "python3")
 
+# Default for launching the napari bridge on the discrete GPU (hybrid-graphics machines). Reads
+# `[napari].discreteGpu`; the api layer holds the runtime toggle (Settings) and seeds it from this.
+napari_discrete_gpu()::Bool =
+    Bool(get(get(cecelia_conf(), "napari", Dict{String,Any}()), "discreteGpu", false))
+
 tasks_concurrent_limit()::Int =
     Int(get(get(cecelia_conf(), "tasks", Dict{String,Any}()), "concurrentLimit", 4))

--- a/app/src/napari.jl
+++ b/app/src/napari.jl
@@ -29,17 +29,55 @@ end
 
 # ── Lifecycle ──────────────────────────────────────────────────────────────────
 
+# Environment that steers a process onto the discrete GPU on a Linux hybrid-graphics machine.
+# Two groups, because they differ in safety on non-NVIDIA hardware:
+#   • _MESA_GPU_ENV  — `DRI_PRIME=1` selects the non-default DRI device (AMD/Intel hybrid). Safe
+#     everywhere: a no-op on a single-GPU box, ignored by the NVIDIA driver. Always applied.
+#   • _NVIDIA_GPU_ENV — NVIDIA PRIME render offload. `__GLX_VENDOR_LIBRARY_NAME=nvidia` routes GLX to
+#     libGLX_nvidia; if that vendor lib is ABSENT (Intel/AMD-only machine) glvnd fails to load it and
+#     GL breaks. So these are applied ONLY when an NVIDIA GPU is present. (Offload also *needs* the
+#     GLX vendor var — `__NV_PRIME_RENDER_OFFLOAD` alone does nothing without it.) `__VK*` covers Vulkan.
+# Refs: https://download.nvidia.com/XFree86/Linux-x86_64/latest/README/primerenderoffload.html
+const _MESA_GPU_ENV = ("DRI_PRIME" => "1",)
+const _NVIDIA_GPU_ENV = (
+    "__NV_PRIME_RENDER_OFFLOAD"          => "1",
+    "__NV_PRIME_RENDER_OFFLOAD_PROVIDER" => "NVIDIA-0",
+    "__GLX_VENDOR_LIBRARY_NAME"          => "nvidia",
+    "__VK_LAYER_NV_optimus"              => "NVIDIA_only",
+)
+
+# Is an NVIDIA GPU + userspace present? If `nvidia-smi` is on PATH or the kernel module is loaded,
+# the NVIDIA GLX vendor lib is installed too, so forcing it won't break GL.
+_nvidia_present()::Bool = Sys.which("nvidia-smi") !== nothing || isdir("/proc/driver/nvidia")
+
+# Build the bridge launch command, adding the discrete-GPU env on Linux when requested. Split out
+# from launch! so the env selection is unit-testable without spawning a process. DRI_PRIME is always
+# safe; the NVIDIA offload vars are added only when an NVIDIA GPU is present (see _NVIDIA_GPU_ENV).
+function _bridge_cmd(discrete_gpu::Bool)::Base.AbstractCmd
+    cmd = `$(python_bin_path()) $NAPARI_BRIDGE`
+    (discrete_gpu && Sys.islinux()) || return cmd
+    env = collect(_MESA_GPU_ENV)
+    _nvidia_present() && append!(env, collect(_NVIDIA_GPU_ENV))
+    addenv(cmd, env...)
+end
+
 """
 Start the napari bridge process and wait until it accepts connections.
 Returns the viewer so calls can be chained.
+
+`discrete_gpu = true` launches the bridge on the discrete GPU (Linux hybrid graphics only; see
+`_bridge_cmd`). Ignored on other platforms.
 """
-function launch!(v::NapariViewer)::NapariViewer
-    v.proc = run(`$(python_bin_path()) $NAPARI_BRIDGE`, wait=false)
+function launch!(v::NapariViewer; discrete_gpu::Bool = false)::NapariViewer
+    discrete_gpu && Sys.islinux() &&
+        @info "Launching Napari on the discrete GPU (PRIME/DRI offload)"
+    v.proc = run(_bridge_cmd(discrete_gpu), wait=false)
     deadline = time() + 30
     while time() < deadline
         try
             send(v, Dict("type" => "ping"))
             @info "Napari bridge connected"
+            _log_gl_info(v)
             return v
         catch
             sleep(0.5)
@@ -48,14 +86,26 @@ function launch!(v::NapariViewer)::NapariViewer
     error("Napari bridge did not start within 30 seconds")
 end
 
+# Query the bridge's OpenGL renderer and log it as @info — this surfaces in the app's server-log
+# console (which tees Julia @info/@warn), unlike the bridge's own stdout print. Confirms which GPU
+# napari is on (see discrete_gpu / _DISCRETE_GPU_ENV). Best-effort: never breaks launch.
+function _log_gl_info(v::NapariViewer)
+    try
+        info = send(v, Dict("type" => "gl_info"))
+        @info "Napari GL renderer" renderer = get(info, "renderer", "?") vendor = get(info, "vendor", "?") gl = get(info, "version", "?")
+    catch e
+        @warn "Could not query Napari GL renderer" exception = e
+    end
+end
+
 function close!(v::NapariViewer)
     v.proc !== nothing && kill(v.proc)
     v.proc = nothing
 end
 
-function restart!(v::NapariViewer)::NapariViewer
+function restart!(v::NapariViewer; discrete_gpu::Bool = false)::NapariViewer
     close!(v)
-    launch!(v)
+    launch!(v; discrete_gpu = discrete_gpu)
 end
 
 # ── Image ──────────────────────────────────────────────────────────────────────

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -50,6 +50,25 @@ end
         @test !isempty(projects_dir())
         @test !isempty(python_bin_path())
         @test tasks_concurrent_limit() >= 1
+        @test napari_discrete_gpu() isa Bool   # [napari].discreteGpu, default false
+    end
+
+    # ── Napari discrete-GPU launch env ──────────────────────────────────────────
+    # The bridge command gains the offload env only when discrete_gpu is on (Linux). DRI_PRIME is
+    # always applied (safe on single-GPU); the NVIDIA GLX vendor var only when NVIDIA is present.
+    @testset "Napari discrete-GPU command" begin
+        plain = Cecelia._bridge_cmd(false)
+        @test plain.env === nothing                          # no env override → inherits parent
+        gpu = Cecelia._bridge_cmd(true)
+        if Sys.islinux()
+            @test gpu.env !== nothing
+            @test any(==("DRI_PRIME=1"), gpu.env)             # always safe → always applied
+            # nvidia GLX vendor var is gated on detection (forcing it without NVIDIA breaks GL)
+            has_nvidia = any(startswith("__GLX_VENDOR_LIBRARY_NAME=nvidia"), gpu.env)
+            @test has_nvidia == Cecelia._nvidia_present()
+        else
+            @test gpu.env === nothing                         # no-op off Linux
+        end
     end
 
     # ── Model: create project and image ───────────────────────────────────────

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -25,6 +25,50 @@ Browser ──HTTP──▶ Julia server (8080)
 
 **Consequence:** every napari API call must happen on the Qt main thread. The QTimer drain is the only safe path. Never call napari APIs from the asyncio thread.
 
+### Discrete-GPU rendering (hybrid graphics)
+
+On a Linux machine with hybrid graphics (NVIDIA "on-demand" / PRIME, or AMD/Intel), apps render on
+the **integrated** GPU unless launched with offload env vars. `launch!(v; discrete_gpu=true)`
+(`app/src/napari.jl`) adds them, in two safety tiers (`_bridge_cmd`):
+- **`DRI_PRIME=1`** (Mesa, AMD/Intel) — always applied when the flag is on. Safe everywhere: a no-op
+  on a single-GPU box, ignored by the NVIDIA driver.
+- **NVIDIA PRIME** (`__NV_PRIME_RENDER_OFFLOAD`, `__GLX_VENDOR_LIBRARY_NAME=nvidia`, the `__VK_*`
+  pair) — applied **only when an NVIDIA GPU is present** (`_nvidia_present()`: `nvidia-smi` on PATH or
+  `/proc/driver/nvidia`). `__GLX_VENDOR_LIBRARY_NAME=nvidia` forces glvnd to load libGLX_nvidia; on a
+  machine without that vendor lib it would *break* GL, so it must be gated. (Offload also *needs* this
+  var — `__NV_PRIME_RENDER_OFFLOAD` alone does nothing.)
+
+**Default: OFF** (`[napari].discreteGpu = false`) — opt in via the Settings toggle or `custom.toml`.
+The two-tier gating above means it's *safe* to turn on anywhere (non-hybrid/non-NVIDIA included), but
+it's off by default so nothing changes GPU behaviour unless the user asks. **No-op on Windows/macOS**
+(GPU choice is an OS/driver setting there) — gated on `Sys.islinux()`. GPU is fixed at process
+launch, so **switching requires a bridge restart**.
+
+> **Wayland note:** the `__GLX_*`/`__NV_PRIME_*` vars are the **GLX** (X11) offload path. That's the
+> right path here because **PyQt5 defaults to the `xcb` platform (XWayland) even in a Wayland session**
+> — napari's GL runs through XWayland/GLX, not native Wayland/EGL (Qt even logs *"Ignoring
+> XDG_SESSION_TYPE=wayland … Use QT_QPA_PLATFORM=wayland to run on Wayland anyway"*). The GL readback
+> below uses an `xcb` offscreen context too, so it goes through the same GLX stack as the canvas and
+> reports the same GPU. The **only** case this misses is forcing `QT_QPA_PLATFORM=wayland` (native
+> Wayland/EGL), where GLX vendor selection no longer applies and an EGL offload path would be needed.
+
+- **Backend flag** (authoritative at launch): a runtime `Ref` in `napari_api.jl`, seeded from
+  `CECELIA_NAPARI_DISCRETE_GPU` → `[napari].discreteGpu` (config.toml/custom.toml). `_ensure_viewer!`
+  and `restart!` read it.
+- **Endpoints:** `GET /api/napari/gpu` → `{discreteGpu, supported}`; `POST /api/napari/gpu {enabled}`
+  sets the Ref and returns `needsRestart` (true if a bridge is alive → caller then hits
+  `/api/napari/restart`, which relaunches with the new flag).
+- **Frontend:** persisted in the settings store (localStorage), surfaced as the *Use discrete GPU for
+  napari* toggle in Settings, and re-asserted to the backend on app mount (App.vue) so the bridge
+  launches on the right GPU before the first lazy open.
+- **Verify it worked:** the Julia side queries the bridge (`gl_info` command → `_gl_info` in
+  `napari_bridge.py`, a throwaway offscreen GL context — process-wide GPU selection, so it matches
+  napari's canvas) right after connecting and logs `┌ Info: Napari GL renderer / renderer=… vendor=…
+  gl=…`. This is an `@info`, so it appears in the **app's server-log console** (which tees Julia
+  `@info/@warn`) next to "Launching Napari on the discrete GPU". The bridge *also* prints
+  `[napari] GL renderer: …` to its stdout (raw `pixi run dev` terminal) as a fallback. The line names
+  the iGPU with the toggle off and the NVIDIA/AMD dGPU with it on.
+
 ---
 
 ## What needs restarting

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,12 +2,33 @@
 import { onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useWsStore } from './stores/ws'
+import { useSettingsStore } from './stores/settings'
 import AppHeader from './components/AppHeader.vue'
 import AppSidebar from './components/AppSidebar.vue'
 import ErrorConsole from './components/ErrorConsole.vue'
 
 const ws = useWsStore()
-onMounted(() => ws.connect())
+const settings = useSettingsStore()
+onMounted(async () => {
+  ws.connect()
+  // Reconcile the discrete-GPU flag with the backend once at startup. The flag is a launch-time
+  // decision (the bridge starts lazily on first open), so it must be right before then.
+  //  - explicit user choice saved → push it, so the backend uses it even after a backend restart
+  //    reset its Ref to the config default;
+  //  - no saved choice → adopt the backend/config default (don't clobber a custom.toml setting).
+  try {
+    const stored = localStorage.getItem('cc.napariDiscreteGpu')
+    if (stored !== null) {
+      await fetch('/api/napari/gpu', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: stored === 'true' }),
+      })
+    } else {
+      const d = await (await fetch('/api/napari/gpu')).json()
+      settings.napariDiscreteGpu = !!d.discreteGpu
+    }
+  } catch { /* backend keeps its default until Settings sets it */ }
+})
 
 // `bare` routes (e.g. the standalone console window) render full-window without the app shell
 // (header / sidebar / docked console). See the /console route in main.ts.

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -156,6 +156,39 @@ const guiPort = computed(() => location.port || (location.protocol === 'https:' 
 const svcBusy = ref('')     // which row's action is in flight ('napari' | 'notebooks' | 'app')
 const svcMsg = ref('')
 
+// ── Napari discrete-GPU toggle ──────────────────────────────────────────────
+// Persisted in the settings store (localStorage); the backend holds the authoritative launch-time
+// flag. `gpuSupported` is false off Linux (there GPU choice is an OS/driver setting → toggle is a
+// no-op). Flipping it POSTs the flag and restarts napari (if running) so it takes effect now.
+const gpuSupported = ref(true)
+const gpuBusy = ref(false)
+async function loadGpu() {
+  try {
+    const d = await (await fetch('/api/napari/gpu')).json()
+    gpuSupported.value = d.supported !== false
+  } catch { /* leave optimistic default; toggle still works */ }
+}
+async function toggleGpu() {
+  gpuBusy.value = true; svcMsg.value = ''
+  const which = settings.napariDiscreteGpu ? 'discrete' : 'default'
+  try {
+    const res = await fetch('/api/napari/gpu', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: settings.napariDiscreteGpu }),
+    })
+    const d = await res.json()
+    if (d.needsRestart) {
+      await svcPost('/api/napari/restart')
+      svcMsg.value = `Napari restarting on the ${which} GPU — reopen the image to reload its layers.`
+    } else {
+      svcMsg.value = `Napari will use the ${which} GPU next time it starts.`
+    }
+  } catch {
+    svcMsg.value = 'Could not update the GPU setting.'
+  } finally { gpuBusy.value = false; setTimeout(pollServices, 500) }
+}
+onMounted(loadGpu)
+
 async function pollServices() {
   try { napariRaw.value = await (await fetch('/api/napari/status')).json() } catch { napariRaw.value = null }
   try { notebooksRaw.value = await (await fetch('/api/notebooks/status')).json() } catch { notebooksRaw.value = null }
@@ -370,6 +403,22 @@ async function switchWt(path: string) {
           </button>
           <button v-if="napariSt !== 'stopped'" class="save-btn ghost" :disabled="svcBusy === 'napari'"
                   @click="napariAction('stop')"><i class="pi pi-stop" /> Stop</button>
+        </span>
+      </div>
+
+      <!-- discrete-GPU toggle: launches the napari bridge on the dGPU (hybrid-graphics machines).
+           Linux only; disabled with a hint elsewhere. Flipping it restarts napari to apply. -->
+      <div class="field" style="margin: 0.2rem 0 0.6rem;">
+        <label class="toggle-row"
+               :class="{ disabled: !gpuSupported || gpuBusy }"
+               v-tooltip.right="'Render napari on the discrete GPU (hybrid graphics). Restarts napari to apply. Linux only.'">
+          <input type="checkbox" v-model="settings.napariDiscreteGpu"
+                 :disabled="!gpuSupported || gpuBusy" @change="toggleGpu" />
+          <span class="toggle-label">Use discrete GPU for napari</span>
+          <i v-if="gpuBusy" class="pi pi-spin pi-cog" style="font-size:0.7rem;" />
+        </label>
+        <span v-if="!gpuSupported" class="field-hint">
+          Only configurable on Linux — on this system the GPU is selected by the OS/driver.
         </span>
       </div>
 
@@ -597,6 +646,8 @@ async function switchWt(path: string) {
   user-select: none;
 }
 .toggle-row input { accent-color: var(--cc-accent); cursor: pointer; }
+.toggle-row.disabled { opacity: 0.5; cursor: not-allowed; }
+.toggle-row.disabled input { cursor: not-allowed; }
 
 .no-project {
   font-size: 0.8rem;

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -302,7 +302,9 @@ watch(hlVersion, loadPopLayers)
            v-tooltip.bottom="`${g.colLabel(yChan)}’s range is too small for ${yt} — shown linear`" /></label>
       <label class="ax-row"><span class="ax-lbl">pop</span>
         <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to display; new gates are its children'">
-        <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select></label>
+        <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select>
+        <!-- affordance beside the pop selector (out of the plot): the draw tool stays armed, hold Shift to grab/move/resize -->
+        <span v-if="mode !== 'off' && !pending" class="gate-hint">hold <kbd>Shift</kbd> to adjust gates</span></label>
     </div>
     <GateScatterCell ref="cell" :points="points" :extents="extents" :view-extents="viewExtents"
                      :x-ticks="xTicks" :y-ticks="yTicks" :gates="currentGates"
@@ -311,8 +313,6 @@ watch(hlVersion, loadPopLayers)
                      :mode="mode" :gate-line-width="gateLineWidth" :gate-labels="gateLabels"
                      :view-tick="viewTick" :loading="loading"
                      @draw="onDraw" @edit="onEdit" @cancel="mode = 'off'">
-      <!-- brief affordance: the draw tool stays armed, hold Shift to grab/move/resize a gate -->
-      <div v-if="mode !== 'off' && !pending" class="gate-hint">hold <kbd>Shift</kbd> to adjust gates</div>
       <div v-if="pending" class="panel-name">
         <span>new {{ pending.kind }}</span>
         <input v-model="newName" placeholder="name…" autofocus
@@ -362,9 +362,9 @@ watch(hlVersion, loadPopLayers)
 .panel-name input.name-invalid { border-color: var(--cc-danger, #ef4444); }
 .name-hint { color: var(--cc-danger, #ef4444); font-size: 10px; max-width: 150px; line-height: 1.2; }
 /* subtle draw-mode affordance (top-right of the plot); mirrors .panel-name but muted and non-interactive */
-.gate-hint { position: absolute; top: 4px; right: 4px; pointer-events: none; display: flex; align-items: center; gap: 4px;
-  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 4px; padding: 2px 6px;
-  font-size: 10px; color: var(--cc-text-dim); }
+/* inline affordance beside the pop selector (was overlaid on the plot, which obscured gating) */
+.gate-hint { margin-left: 2px; pointer-events: none; display: inline-flex; align-items: center; gap: 4px;
+  font-size: 10px; color: var(--cc-text-dim); white-space: nowrap; }
 .gate-hint kbd { font: inherit; background: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: 3px;
   padding: 0 3px; color: var(--cc-text); }
 </style>

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -32,6 +32,13 @@ export const useSettingsStore = defineStore('settings', () => {
     localStorage.getItem('cc.napariAsDask') !== 'false'  // default true
   )
 
+  // Render napari on the discrete GPU (hybrid-graphics machines, Linux only). Persisted here and
+  // re-asserted to the backend each session (App.vue) so the bridge launches on the right GPU; the
+  // backend holds the authoritative launch-time flag. Effective on the next bridge (re)start.
+  const napariDiscreteGpu = ref(
+    localStorage.getItem('cc.napariDiscreteGpu') === 'true'  // default false
+  )
+
   // ── Layout: collapse the main nav sidebar (left) and the module function/tasks panel (right)
   // to free up working space. Both default expanded, both persist across sessions.
   const sidebarCollapsed = ref(localStorage.getItem('cc.sidebarCollapsed') === 'true')
@@ -111,8 +118,9 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(napariResetOnReload,      v => localStorage.setItem('cc.napariResetOnReload',      String(v)))
   watch(napariAutoSaveLayerProps, v => localStorage.setItem('cc.napariAutoSaveLayerProps', String(v)))
   watch(napariAsDask,             v => localStorage.setItem('cc.napariAsDask',             String(v)))
+  watch(napariDiscreteGpu,        v => localStorage.setItem('cc.napariDiscreteGpu',        String(v)))
   watch(sidebarCollapsed,         v => localStorage.setItem('cc.sidebarCollapsed',         String(v)))
   watch(rightPanelCollapsed,      v => localStorage.setItem('cc.rightPanelCollapsed',      String(v)))
 
-  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, sidebarCollapsed, rightPanelCollapsed, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible }
+  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, napariDiscreteGpu, sidebarCollapsed, rightPanelCollapsed, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible }
 })

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -1113,6 +1113,9 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
         if t == "ping":
             return {"type": "pong"}
 
+        elif t == "gl_info":
+            return {"type": "gl_info", **_gl_info()}
+
         elif t == "open_image":
             state.open_image(
                 path=cmd["path"],
@@ -1262,6 +1265,45 @@ def _port_available(host: str, port: int) -> bool:
         s.close()
 
 
+def _gl_info() -> dict:
+    """Query the OpenGL renderer/vendor/version the process is using, so discrete-GPU offload is
+    self-evident. GPU selection (the __NV_PRIME_*/__GLX_*/DRI_PRIME env the Julia side sets when 'Use
+    discrete GPU' is on) is process-wide, so a throwaway offscreen context reports the same GPU
+    napari's canvas renders on — and this avoids reaching into napari's private canvas internals.
+    Returns a dict; on failure it carries an 'error' key rather than raising (never fatal). Must run
+    on the Qt main thread (GL context creation) — the WS command dispatcher already does."""
+    try:
+        from qtpy.QtGui import QOffscreenSurface, QOpenGLContext
+        surface = QOffscreenSurface()
+        surface.create()
+        ctx = QOpenGLContext()
+        if not ctx.create() or not ctx.makeCurrent(surface):
+            return {"renderer": "unavailable", "vendor": "", "version": "",
+                    "error": "could not create a GL context"}
+        try:
+            from OpenGL.GL import (GL_RENDERER, GL_VENDOR, GL_VERSION, glGetString)
+            info = {"renderer": glGetString(GL_RENDERER).decode(errors="replace"),
+                    "vendor":   glGetString(GL_VENDOR).decode(errors="replace"),
+                    "version":  glGetString(GL_VERSION).decode(errors="replace")}
+        finally:
+            ctx.doneCurrent()
+        return info
+    except Exception as e:
+        return {"renderer": "unavailable", "vendor": "", "version": "", "error": str(e)}
+
+
+def _log_gl_renderer():
+    """Also print the renderer to stdout (belt-and-braces for anyone watching the raw terminal; the
+    Julia side additionally logs it as @info via the gl_info command, which is where the app console
+    surfaces it)."""
+    info = _gl_info()
+    if info.get("error"):
+        print(f"[napari] GL renderer: {info['renderer']} ({info['error']})", flush=True)
+    else:
+        print(f"[napari] GL renderer: {info['renderer']}  |  vendor: {info['vendor']}"
+              f"  |  {info['version']}", flush=True)
+
+
 def main():
     global _state
 
@@ -1279,6 +1321,7 @@ def main():
     timer.timeout.connect(drain_queue)
     timer.start(100)
 
+    _log_gl_renderer()
     print("napari viewer started", flush=True)
     napari.run()
 


### PR DESCRIPTION
## Opt-in discrete-GPU rendering for napari (+ gate hint move)

Adds a **Use discrete GPU for napari** toggle (Settings → System) that launches the napari bridge on the discrete GPU. **Linux only** — no-op on Windows/macOS, where GPU choice is an OS/driver setting. Default **off**.

### How it works
- **`launch!(v; discrete_gpu)`** sets offload env in two safety tiers (`_bridge_cmd`):
  - `DRI_PRIME=1` — always applied when on (AMD/Intel; a no-op on single-GPU, so safe everywhere).
  - **NVIDIA PRIME** (`__NV_PRIME_RENDER_OFFLOAD`, `__GLX_VENDOR_LIBRARY_NAME=nvidia`, `__VK_*`) — only when an NVIDIA GPU is present (`_nvidia_present()`). Forcing the GLX vendor var without the vendor lib would *break* GL, so it's gated.
- **Backend flag** (authoritative at launch): runtime `Ref` in `napari_api.jl`, seeded from `CECELIA_NAPARI_DISCRETE_GPU` → `[napari].discreteGpu`. `GET/POST /api/napari/gpu`; `_ensure_viewer!`/`restart!` read it. GPU is fixed at launch → switching restarts the bridge.
- **Frontend:** persisted in the settings store (localStorage), toggle in Settings, re-asserted to the backend on app mount (adopts the config default when unset).
- **GL readback:** bridge `gl_info` command; Julia logs `Napari GL renderer` as `@info`, so the active GPU shows in the app console (verified live: `NVIDIA RTX 2000 Ada Generation`).
- **Gate hint:** moved *hold Shift to adjust gates* off the plot to beside the pop selector (it was obscuring gating).

### Wayland note
PyQt5 defaults to `xcb`/XWayland even in a Wayland session, so GL runs through GLX — which is what these vars target. Only breaks if forced to native Wayland (`QT_QPA_PLATFORM=wayland`). Documented in `docs/NAPARI.md`.

### Tests
- `_bridge_cmd` env gating (`DRI_PRIME` always; NVIDIA vars match `_nvidia_present()`) + config default.
- Package **798 pass / 0 fail**, API suite pass, frontend `vue-tsc` clean.

### Reservations
- Frontend flows (toggle→restart, mount reconcile, gate-hint move) typecheck clean but not click-tested in a browser; backend launch + GL readback are verified via live logs.
- `_nvidia_present()` is a heuristic — if NVIDIA is present but undetected, it falls back to `DRI_PRIME` only (no breakage, just no offload).
- Native Wayland not handled (documented).

### Files
`app/config.toml`, `app/src/config.jl`, `app/src/Cecelia.jl`, `app/src/napari.jl`, `api/src/napari_api.jl`, `api/src/server.jl`, `napari/napari_bridge.py`, `frontend/src/stores/settings.ts`, `frontend/src/App.vue`, `frontend/src/modules/SettingsModule.vue`, `frontend/src/modules/gate/GatePlotPanel.vue`, `docs/NAPARI.md`, `app/test/runtests.jl`.