### PR TITLE
feat(gating): copy strategy to images, defining-plot panel, track-gat…

### DIFF
--- a/api/src/gating_api.jl
+++ b/api/src/gating_api.jl
@@ -384,6 +384,15 @@ function api_gating_plotmeta(req::HTTP.Request)
     x = get(q, "x", ""); y = get(q, "y", "")
     (isempty(x) || isempty(y)) && return _gerr(400, "x and y required")
     pop_type = get(q, "popType", "flow"); pop = get(q, "pop", ROOT)
+    # A track-grained plot (popType track/trackclust) of an untracked segmentation has no data — tell
+    # the client to track first (it shows a message) and skip the empty data reads. `tracked` rides on
+    # every plotmeta response so the client can distinguish "not tracked" from "genuinely no points".
+    if _track_grained(pop_type) && !is_tracked(img; value_name = vn)
+        return 200, JSON3.write((; n = 0, mode = "scatter", tracked = false,
+            xExtent = [0.0, 1.0], yExtent = [0.0, 1.0], xLabel = x, yLabel = y,
+            xTicks = Dict{String,Any}[], yTicks = Dict{String,Any}[],
+            usedX = "linear", usedY = "linear", gates = Dict{String,Any}[]))
+    end
     xt0 = _axis_transform(q, "x"); yt0 = _axis_transform(q, "y")
     # raw extents over the WHOLE dataset (root): used both for ticks (labels read in data units, and
     # selecting a population doesn't rescale the axis) AND to decide auto-linearisation — so the
@@ -429,7 +438,7 @@ function api_gating_plotmeta(req::HTTP.Request)
         push!(gates, pj)
     end
     200, JSON3.write((;
-        n = n, mode = mode,
+        n = n, mode = mode, tracked = true,
         xExtent = [xext[1], xext[2]], yExtent = [yext[1], yext[2]],
         xLabel = x, yLabel = y,
         xTicks = _axis_ticks(xt, rxext[1], rxext[2]),
@@ -620,5 +629,41 @@ function api_gating_pop_rename(body_bytes::Vector{UInt8})
         end
         tree = _persist_and_broadcast!(m, img, body, vn, pt)
         200, JSON3.write((; tree = tree, path = newpath))
+    end
+end
+
+# POST /api/gating/copy  { projectUid, imageUid (source), valueName, popType, toImageUids: [...] }
+# Copy the gating strategy for ONE gating pop_type (flow = cell gates, or track = track gates) from
+# the source image to each target image, by writing the source's gating sidecar to each target —
+# REPLACING any existing gating there. Membership recomputes per image on read, so gates alone are
+# enough (no per-image recompute step, unlike the old R flowGatingSet copy). Plot layout is copied
+# client-side (the canvas store is in-memory + autosaves), not here.
+function api_gating_copy(body_bytes::Vector{UInt8})
+    img, vn, pt, body, err = _gating_post(body_bytes); err === nothing || return err
+    is_gating_pop_type(pt) || return _gerr(400, "Not a gating pop type: $pt (only flow/track)")
+    tgt_raw = get(body, "toImageUids", nothing)
+    (tgt_raw isa AbstractVector && !isempty(tgt_raw)) || return _gerr(400, "toImageUids required")
+    proj    = String(body["projectUid"])
+    src_uid = String(body["imageUid"])
+    _with_popmap_lock() do
+        m = load_pop_map(img; value_name = vn, pop_type = pt)
+        isempty(m.order) && return _gerr(400, "Source image has no $pt gating to copy")
+        copied = String[]; skipped = Dict{String,String}()
+        for t in tgt_raw
+            tuid = String(t)
+            tuid == src_uid && continue
+            timg, terr = _gating_image(proj, tuid)
+            timg === nothing && (skipped[tuid] = "not found"; continue)
+            img_has_value_name(timg, vn) ||
+                (skipped[tuid] = "no segmentation '$vn'"; continue)   # gates would reference absent channels
+            try
+                save_pop_map!(m, timg)                        # writes target gating sidecar (replace)
+                _broadcast_popmap(proj, tuid, vn, pt, m)      # refresh any client viewing the target
+                push!(copied, tuid)
+            catch e
+                skipped[tuid] = sprint(showerror, e)
+            end
+        end
+        200, JSON3.write((; copied = copied, skipped = skipped))
     end
 end

--- a/api/src/plotting_api.jl
+++ b/api/src/plotting_api.jl
@@ -75,7 +75,13 @@ function api_plot_populations(req::HTTP.Request)
         imgs,
         img -> versioned_keys(img.label_props),
         (img, vn, pt) -> load_pop_map(img; value_name = vn, pop_type = pt),
-        plot_pop_types(pop_type, granularity))
+        plot_pop_types(pop_type, granularity);
+        # Only offer the root-level `/_tracked` when a segmentation has tracks OUTSIDE its gates
+        # (ungated tracking). When tracking was gated (e.g. to /qc) the root pop is a redundant
+        # duplicate of /<gate>/_tracked and misleadingly implies whole-segmentation tracking.
+        root_derived_ok = (vn, _pt, dpath) -> dpath != "/_tracked" ? true :
+            any(im -> (vn in String.(versioned_keys(im.label_props))) &&
+                      has_ungated_tracks(im; value_name = vn), imgs))
     result = [Dict("valueName" => g.value_name,
                    "populations" => [Dict("path" => p.path, "name" => p.name,
                                           "colour" => p.colour, "popType" => p.pop_type)

--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -444,6 +444,31 @@ function api_projects_canvases(body_bytes::Vector{UInt8})
     200, JSON3.write((; ok=true))
 end
 
+# POST /api/images/value-name-check  { projectUid, valueName, imageUids: [...] }
+# Partition images by whether they carry the labelProps value_name (segmentation) — a generic
+# building block for any feature that must skip images lacking a value_name (e.g. copy gating across
+# images). Just a value_name-presence check per image (img_has_value_name); returns {available, missing}.
+function api_images_value_name_check(body_bytes::Vector{UInt8})
+    body = try JSON3.read(String(body_bytes)) catch
+        return 400, JSON3.write((; error="Invalid JSON body"))
+    end
+    proj = String(get(body, :projectUid, ""))
+    vn   = String(get(body, :valueName, ""))
+    uids = get(body, :imageUids, nothing)
+    (uids isa AbstractVector) || return 400, JSON3.write((; error="imageUids required"))
+    isdir(joinpath(projects_dir(), proj)) || return 404, JSON3.write((; error="Project not found: $proj"))
+    available = String[]; missing = String[]
+    for u in uids
+        uid = String(u)
+        ok = try
+            img = init_object(proj, uid)
+            img isa CciaImage && img_has_value_name(img, vn)
+        catch; false end
+        ok ? push!(available, uid) : push!(missing, uid)
+    end
+    200, JSON3.write((; available, missing))
+end
+
 function api_projects_rename(body_bytes::Vector{UInt8})
     body = try JSON3.read(String(body_bytes)) catch
         return 400, JSON3.write((; error="Invalid JSON body"))

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -354,6 +354,10 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_gating_pop_update(body_bytes)
         elseif path == "/api/gating/pop/rename"
             api_gating_pop_rename(body_bytes)
+        elseif path == "/api/gating/copy"
+            api_gating_copy(body_bytes)
+        elseif path == "/api/images/value-name-check"
+            api_images_value_name_check(body_bytes)
         elseif path == "/api/plot_data"
             api_plot_data(body_bytes)
         elseif path == "/api/repl"

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -19,7 +19,7 @@ export load_project, init_object
 export create_project!, add_image!, add_set!, images, sets
 export delete_image!, delete_set!
 export active, set_active!, value_names, img_filepath, img_zero_dir, img_physical_sizes, image_included
-export img_label_props_dir, img_label_props_path, img_track_props_path
+export img_label_props_dir, img_label_props_path, img_track_props_path, img_value_names, img_has_value_name
 export read_module_fun_params, write_module_fun_params!
 export TRACK_PROPS_SUFFIX, is_reserved_value_name
 export write_qc, read_qc, read_all_qc, qc_finding, qc_canvas_expansion, qc_path
@@ -47,13 +47,14 @@ export Density2D, density_2d
 export Population, PopulationMap, ROOT
 export pop_parent, pop_name, pop_path, is_root
 export add_pop!, set_gate!, rename_pop!, del_pop!
-export is_reserved_pop_name, DERIVED_POP_PREFIX, derived_pop_paths
+export is_reserved_pop_name, DERIVED_POP_PREFIX, derived_pop_paths, has_ungated_tracks
+export GATING_POP_TYPES, is_gating_pop_type
 export flatten_pop_tree, plot_pop_types, plot_population_groups
 export pop_at, has_pop, pop_paths, direct_children, descendants, topo_order
 export to_tree, from_tree, save_pop_map!, load_pop_map, gating_dir, gating_path
 export recompute!, cells_in_pop, pop_membership, pop_stats, pop_df
 export plot_summary_data
-export track_props, track_cell_measures
+export track_props, track_cell_measures, is_tracked
 export hmm_fit_states, hmm_transitions, DiagGaussEmission
 
 # ── Task system ───────────────────────────────────────────────────────────────

--- a/app/src/gating/population_manager.jl
+++ b/app/src/gating/population_manager.jl
@@ -246,6 +246,13 @@ const POP_MAP_SUFFIX = Dict{String,String}(
     "clust"      => "__clust",
     "trackclust" => "__trackclust",
 )
+
+# The pop types that are hand-drawn *gating* (a gate geometry per pop), as opposed to the
+# filter/membership pop types (clust/trackclust) and the derived `live`. `flow` gates cells, `track`
+# gates tracks — one abstraction over both so gating features (e.g. copy-to-images, the defining-plot
+# view) treat them uniformly instead of special-casing flow. Single source of truth.
+const GATING_POP_TYPES = ("flow", "track")
+is_gating_pop_type(pop_type) = String(pop_type) in GATING_POP_TYPES
 gating_dir(task_dir::AbstractString) = joinpath(task_dir, "gating")
 gating_path(task_dir::AbstractString, value_name::AbstractString; pop_type::AbstractString="flow") =
     joinpath(gating_dir(task_dir), value_name * get(POP_MAP_SUFFIX, pop_type, "") * ".json")
@@ -543,6 +550,37 @@ surface them. Generic over `_DERIVED_POPS`, so future reserved pops appear autom
 derived_pop_paths(pop_type::AbstractString)::Vector{String} =
     ["/" * name for (name, spec) in _DERIVED_POPS if spec.pop_type == String(pop_type)]
 
+"""
+    has_ungated_tracks(img; value_name) -> Bool
+
+True when the segmentation has tracked cells (`track_id > 0`) that fall OUTSIDE every stored (flow)
+gate — i.e. tracking was run ungated on the whole segmentation, so a root-level `/_tracked` pop is
+real. False when every tracked cell sits within a gate (tracking was gated, e.g. to `/qc`), which
+makes a root `/_tracked` a redundant duplicate of the per-gate `/<gate>/_tracked`; false too when the
+segmentation isn't tracked. The pop picker uses this to decide whether to offer the root `/_tracked`.
+"""
+function has_ungated_tracks(img::CciaImage; value_name::Union{AbstractString,Nothing}=nothing)::Bool
+    is_tracked(img; value_name=value_name) || return false
+    vn = something(value_name, get(img.label_props, "_active", "default"))
+    cell = label_props(img; value_name=vn) |> lp -> select_cols(lp, ["track_id"]) |> as_df
+    "track_id" in names(cell) || return false
+    tracked = Set{Any}()
+    for i in eachindex(cell[!, "label"])
+        t = cell[i, "track_id"]
+        (t isa Real && isfinite(t) && t > 0) && push!(tracked, cell[i, "label"])
+    end
+    isempty(tracked) && return false
+    # cells covered by any stored flow gate (empty/absent map → tracks can't be gated → ungated)
+    fm = try; load_pop_map(img; value_name=vn, pop_type="flow"); catch; nothing; end
+    (fm === nothing || isempty(fm.order)) && return true
+    covered = try
+        Set(pop_df(img, "flow", collect(fm.order); value_name=vn)[!, "label"])
+    catch
+        return true                                    # can't evaluate gates → don't hide the pop
+    end
+    any(t -> !(t in covered), tracked)
+end
+
 # ── Summary-canvas population picker (logic lives here, NOT in the API — api/plotting_api.jl is a
 #    thin wrapper; this is Revise-tracked + headless-testable per docs/ARCHITECTURE.md) ────────────
 
@@ -587,7 +625,8 @@ first-appearance order; `load_map` returning `nothing`/throwing for a missing (v
 skipped.
 """
 function plot_population_groups(imgs, value_names_for::Function, load_map::Function,
-                                pop_types::Vector{String})
+                                pop_types::Vector{String};
+                                root_derived_ok::Function = (_v, _pt, _dpath) -> true)
     # Gateless pop_type (`labels` = ungated all-cells, R parity): there is no gating map to flatten —
     # each segmentation IS its own population, named by its value_name. One selectable entry per vn, so
     # the user overlays whole segmentations (B, T, …) side by side. The path is the fixed "/labels" tag
@@ -629,6 +668,7 @@ function plot_population_groups(imgs, value_names_for::Function, load_map::Funct
     for v in vn_order
         rebuilt = Tuple{String,String}[]
         for pt in pop_types, dpath in derived_pop_paths(pt)              # root-level derived, at the top
+            root_derived_ok(v, pt, dpath) || continue                   # e.g. hide root /_tracked when gated
             key = (pt, dpath)
             haskey(meta[v], key) || (meta[v][key] = (pop_name(dpath), "#7c93b8", pt))
             key in rebuilt || push!(rebuilt, key)

--- a/app/src/model/image.jl
+++ b/app/src/model/image.jl
@@ -86,6 +86,14 @@ function img_label_props_path(img::CciaImage, value_name::AbstractString="defaul
     joinpath(img_label_props_dir(img), filename)
 end
 
+# Generic value_name checks over a versioned property field (default `label_props` = the segmentations).
+# It's just "does this versioned field carry this value_name" — reusable wherever a feature must know
+# whether an image has a given value_name before acting on it (e.g. copying gating across images).
+img_value_names(img::CciaImage; field::Symbol = :label_props)::Vector{String} =
+    versioned_keys(getfield(img, field))
+img_has_value_name(img::CciaImage, value_name::AbstractString; field::Symbol = :label_props)::Bool =
+    String(value_name) in img_value_names(img; field = field)
+
 # Per-track table suffix. A tracked segmentation gets a companion `.h5ad` holding ONE row per
 # track (track measures in X/var, lineage in obs) alongside the per-cell labelProps. The double
 # underscore keeps it distinct from a segmentation literally named "{x}_tracks" and marks the

--- a/app/src/tasks/tracking/track_measures.json
+++ b/app/src/tasks/tracking/track_measures.json
@@ -23,7 +23,7 @@
       "key": "forceRecompute",
       "label": "Force recompute",
       "type": "bool",
-      "default": false
+      "default": true
     }
   ]
 }

--- a/app/src/tracking/track_props.jl
+++ b/app/src/tracking/track_props.jl
@@ -78,6 +78,9 @@ function track_props(img::CciaImage; value_name::Union{AbstractString,Nothing}=n
     # read tracked cells: track_id + requested measures (label-keyed)
     cols = unique(vcat("track_id", cell_measures))
     cell = label_props(img; value_name=vn) |> lp -> select_cols(lp, cols) |> as_df
+    # segmentation isn't tracked (no track_id column) → no tracks. Return an empty, well-formed table
+    # rather than indexing a missing column (was an unhandled 500 on a track-grained gating plot).
+    "track_id" in names(cell) || return DataFrame(track_id = Int[], num_cells = Int[], label = Int[])
     keep = [r isa Number && !isnan(r) && Int(r) > 0 for r in cell[!, "track_id"]]
     cell = cell[keep, :]
     cell[!, :track_id] = Int.(cell[!, "track_id"])
@@ -124,6 +127,21 @@ function track_props(img::CciaImage; value_name::Union{AbstractString,Nothing}=n
 
     out[!, :label] = out[!, :track_id]         # engine membership is by-`label`
     out
+end
+
+"""
+    is_tracked(img; value_name) -> Bool
+
+Whether segmentation `value_name` has tracks — i.e. its label props carry a `track_id` obs column.
+Cheap: reads only the obs column list, not the data. A track-grained view (`pop_type`
+"track"/"trackclust") of an untracked segmentation has no data, so callers use this to say "track
+first" instead of erroring or showing an empty plot.
+"""
+function is_tracked(img::CciaImage; value_name::Union{AbstractString,Nothing}=nothing)::Bool
+    vn = something(value_name, get(img.label_props, "_active", "default"))
+    lp = label_props(img; value_name=vn)
+    isfile(lp.path) || return false
+    "track_id" in col_names(lp; data_type=:obs)
 end
 
 # numeric aggregate suffixes track_props appends to a base cell measure

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -1597,6 +1597,13 @@ end
             @test [df[1, "bbox-$j"] for j in 0:4] == Float32[0, 0, 71, 2, 29]
             @test [df[2, "bbox-$j"] for j in 0:4] == Float32[0, 7, 368, 4, 38]
 
+            # is_tracked's signal: a tracked segmentation carries a track_id obs column (KDIeEm/B is
+            # tracked). track_props / the track-grained gating plots key off this to say "track first"
+            # (empty) instead of erroring when it's absent.
+            obs = col_names(label_props(h5); data_type=:obs)
+            @test "track_id" in obs
+            @test !("not_a_column" in obs)
+
             # lazy column selection — only requested columns (+ label) are returned
             @test names(label_props(h5) |> select_cols(["area"]) |> as_df) == ["label", "area"]
 
@@ -1992,6 +1999,27 @@ end
     # A cluster pop is a filter on the `clusters.{suffix}` column (clustPops/clustTracks output):
     # filter_fun="in", filter_values=[ticked cluster ids]. Stored in its own sidecar so it never
     # collides with flow gates. Headless — membership via a recompute! closure (no fixture).
+    # gating pop types = the hand-drawn ones (flow=cells, track=tracks); clust/trackclust are filters.
+    # Drives copy-to-images + the defining-plot view (one abstraction over both, no flow special-casing).
+    @testset "GATING_POP_TYPES" begin
+        @test GATING_POP_TYPES == ("flow", "track")
+        @test is_gating_pop_type("flow") && is_gating_pop_type("track")
+        @test !is_gating_pop_type("clust") && !is_gating_pop_type("trackclust") && !is_gating_pop_type("live")
+    end
+
+    # generic value_name presence check on an image (drives copy-to-images target filtering).
+    # `_active` is a bookkeeping key, not a value_name → excluded by versioned_keys.
+    @testset "img_has_value_name" begin
+        proj = create_project!(name="vn-test-$(rand(1000:9999))", kind="static")
+        s    = add_set!(proj; name="s")
+        img  = add_image!(s; name="i")
+        img.label_props = Dict("A" => "A.h5ad", "B" => "B.h5ad", "_active" => "A")
+        @test Set(img_value_names(img)) == Set(["A", "B"])
+        @test img_has_value_name(img, "A") && img_has_value_name(img, "B")
+        @test !img_has_value_name(img, "C") && !img_has_value_name(img, "_active")
+        rm(proj.root; recursive=true)
+    end
+
     @testset "clust / trackclust pop types" begin
         td = mktempdir()
         # each clustering pop_type routes to its OWN gating sidecar (no collision with flow's {vn}.json)
@@ -2067,6 +2095,15 @@ end
         @test test_pop.pop_type == "track" && test_pop.colour == "#f59e0b"
         @test only(p for p in tp if p.path == "/qc").pop_type == "live"
         @test !any(p.path == "/TEST/_tracked" for p in tp)          # no track-derived pop registered
+
+        # root_derived_ok predicate: hide the root-level /_tracked (the API passes false when tracking
+        # was gated → root is a redundant duplicate of /qc/_tracked) while KEEPING the per-pop derived
+        # children. Default (no predicate) still offers root /_tracked — asserted by `cell` above.
+        gated = plot_population_groups([:img1], names_for, load, plot_pop_types("live", "cell");
+                                       root_derived_ok = (_v, _pt, dpath) -> dpath != "/_tracked")
+        gpaths = [p.path for p in gated[1].populations]
+        @test !("/_tracked" in gpaths)                              # root hidden
+        @test "/qc/_tracked" in gpaths && "/qc/sub/_tracked" in gpaths   # per-gate derived kept
 
         # cross-image UNION + dedup: two images both expose "C" → each (pop_type, path) appears once
         dedup = plot_population_groups([:img1, :img2], names_for, load, ["live"])

--- a/docs/API.md
+++ b/docs/API.md
@@ -170,6 +170,10 @@ coordinates live in **transformed** space; `xTicks`/`yTicks` give `{pos, label}`
 | `/api/gating/pop/delete` | `path` (cascades to descendants) |
 | `/api/gating/pop/rename` | `path`, `newName` (cascades child paths) → also returns `path` (new) |
 
+**Copy gating across images** (does NOT return `{tree}`): `POST /api/gating/copy` `{projectUid, imageUid (source), valueName, popType, toImageUids:[…]}` → `{copied:[uid], skipped:{uid→why}}`. Replaces each target's gating sidecar for the ONE gating pop_type (`flow`/`track`; validated via `is_gating_pop_type`) with the source's — membership recomputes per image on read, so gates alone suffice (no per-image recompute). Targets lacking the `valueName` segmentation are skipped. Broadcasts `gating:popmap` per target. Plot layout is copied client-side (canvas store), not here. Ports R "Propagate to Selected".
+
+`POST /api/images/value-name-check` `{projectUid, valueName, imageUids:[…]}` → `{available:[uid], missing:[uid]}` — generic value_name-presence check per image (`img_has_value_name`), NOT gating-specific; the copy dialog uses it (`imagesWithValueName`) to flag/exclude targets without the segmentation up front.
+
 **Gate spec** (JSON, readable by Julia + Python):
 ```json
 { "kind": "rectangle", "x_channel": "mean_intensity_0", "y_channel": "mean_intensity_1",

--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -199,6 +199,28 @@ Returns a `DataFrame` with a `pop` column (+ `value_name`, requested cols). Capa
   `_`-leaf (→ 400), and the frontend hints against it while typing. This makes a derived name
   unambiguous and impossible to shadow with a real gate. (Deserialisation via `from_tree` bypasses
   the guard, and the derived injection itself passes `reserved_ok=true`.)
+- **Root `/_tracked` is offered only for *ungated* tracking.** The picker
+  (`plot_population_groups`) injects `/_tracked` under every stored pop (`/qc/_tracked` = qc's tracked
+  subset) but at ROOT only when `has_ungated_tracks(img; value_name)` — i.e. there are tracked cells
+  outside every gate. When tracking was gated (all `track_id>0` cells sit within gates) a root
+  `/_tracked` would just duplicate the per-gate ones and imply whole-segmentation tracking that never
+  happened, so it's suppressed. `is_tracked(img; value_name)` (cheap obs-column check) gates
+  track-grained plots too — an untracked segmentation shows "track first", not an error/empty plot.
+
+## Gating pop types & copy across images
+
+`GATING_POP_TYPES = ("flow", "track")` — the hand-drawn *gating* pop types (`flow` gates cells,
+`track` gates tracks), as opposed to the filter pop types (`clust`/`trackclust`) and derived `live`.
+One abstraction (`is_gating_pop_type`) so gating features treat both uniformly, no flow special-casing.
+
+**Copy gating → other images** (`POST /api/gating/copy`, ports R "Propagate to Selected"): because
+gate geometry lives *in* the `gating/{vn}.json` sidecar (not a binary GatingSet like R) and membership
+recomputes per image on read, copying a strategy is just writing the source sidecar to each target
+(REPLACE) — no per-image gate recompute. Copies ONE pop type at a time (the page's). Targets lacking
+the segmentation are skipped (`img_has_value_name`; the copy dialog prechecks via
+`/api/images/value-name-check` and flags them). The canvas **plot layout** is separate frontend state
+(the canvas store, loaded project-wide + autosaved), so it's copied client-side (`canvasPanels.copyEntry`),
+not by the route.
 - **`value_name=nothing`** resolves to the image's **active** segmentation (same resolution
   as `label_props(img)`); pass a name to set the default value_name for unprefixed pops.
 - **`drop_na`** drops cells that are NA/NaN in any requested `pop_col` (mirrors R popDT

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -47,6 +47,7 @@ const emit = defineEmits<{
   'update:axisFromZero': [boolean]
   'update:vis': [patch: Partial<VisProps>]
   toggleHighlight: [string]
+  showDefiningPlot: [FlatPop]      // open the plot where this pop's gate was drawn
 }>()
 const g = useGatingStore()
 const log = useLogStore()
@@ -156,6 +157,10 @@ async function addClusterPopulation() {
             <small>{{ fmtPct(g.stats[p.path]?.pctParent) }}</small>
           </span>
 
+          <button v-if="p.gate" class="pm-icon" v-tooltip.left="'Show the plot where this gate was drawn'"
+                  @click.stop="emit('showDefiningPlot', p)">
+            <i class="pi pi-search" />
+          </button>
           <button class="pm-icon" :class="{ lit: isLit(p) }"
                   v-tooltip.left="isLit(p) ? 'Hide colour on plots' : 'Highlight colour on plots'"
                   @click.stop="emit('toggleHighlight', p.path)">

--- a/frontend/src/lib/valueNames.ts
+++ b/frontend/src/lib/valueNames.ts
@@ -1,0 +1,21 @@
+// Reusable value_name (segmentation) presence check across images. Thin wrapper over
+// POST /api/images/value-name-check → partitions image uids into those that carry the value_name and
+// those that don't. Use wherever a feature must skip images lacking a value_name (e.g. copy gating
+// across images). Fails open (all available) so the caller's server-side guard stays the source of truth.
+export interface ValueNameCheck { available: string[]; missing: string[] }
+
+export async function imagesWithValueName(
+  projectUid: string, valueName: string, imageUids: string[],
+): Promise<ValueNameCheck> {
+  if (!projectUid || !imageUids.length) return { available: [], missing: [] }
+  try {
+    const res = await fetch('/api/images/value-name-check', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid, valueName, imageUids }),
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    return await res.json() as ValueNameCheck
+  } catch {
+    return { available: imageUids, missing: [] }
+  }
+}

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -17,6 +17,7 @@ import GateMontage from '../../components/plots/GateMontage.vue'
 import RenderModeToggle, { type RenderMode } from '../../components/plots/RenderModeToggle.vue'
 import { buildPairDefs, reconcileChannels, estimateMatrixLoad } from '../../plots/pairsMatrix'
 import { downloadDataUrl } from '../../plots/export'
+import { useDataRefresh } from '../../composables/useDataRefresh'
 
 type Kind = 'linear' | 'log' | 'asinh' | 'logicle'
 const TRANSFORMS: Kind[] = ['linear', 'log', 'asinh', 'logicle']
@@ -53,10 +54,15 @@ const defs = computed(() => buildPairDefs(channels.value, parent.value, transfor
 // resolved from the store (GateMontage is store-agnostic).
 const highlightPops = computed(() => (props.highlight ?? []).map(path =>
   ({ path, colour: g.flat.find(p => p.path === path)?.colour ?? '#22d3ee' })))
+// a task finished on the image we show (e.g. tracking) → refetch the tiles. Same universal mechanism
+// every other plot uses (gated by autoRefreshOnTask); interactive gating was the gap. Bumping this
+// token flows into reloadKey below, which GateMontage watches to refetch.
+const taskReload = ref(0)
+useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { taskReload.value++ })
 // force a point refresh when membership moves without the tiles changing (ancestor gate edit, napari
 // selection re-evaluated) — the parent's / a highlighted pop's version bumps in the store.
 const reloadKey = computed(() =>
-  `${g.popVersion[parent.value] ?? 0}:${(props.highlight ?? []).map(p => g.popVersion[p] ?? 0).join(',')}`)
+  `${taskReload.value}:${g.popVersion[parent.value] ?? 0}:${(props.highlight ?? []).map(p => g.popVersion[p] ?? 0).join(',')}`)
 
 // channel picker (compact popover)
 const pickOpen = ref(false)

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -23,6 +23,7 @@ import type { PopLayer } from '../../components/plots/PlotLayers.vue'
 import { downloadDataUrl } from '../../plots/export'
 import { childGateSignature } from '../../utils/childGateSig'
 import { coalesceByKey } from '../../utils/coalesce'
+import { useDataRefresh } from '../../composables/useDataRefresh'
 
 const props = defineProps<{
   index: number; active: boolean; parent: string; highlight: string[]
@@ -67,6 +68,9 @@ const xTicks = ref<{ pos: number; label: string }[]>([])
 const yTicks = ref<{ pos: number; label: string }[]>([])
 const popLayers = ref<PopLayer[]>([])
 const loading = ref(false)
+// server flag: a track-grained plot (popType track/trackclust) on a segmentation that hasn't been
+// tracked → show a "track first" message instead of an empty plot. Set from plotmeta.
+const notTracked = ref(false)
 const pending = ref<Partial<GateSpec> | null>(null)
 const newName = ref('')
 
@@ -121,7 +125,8 @@ async function fetchMeta() {
   const meta = await (await fetch(`/api/gating/plotmeta?${metaQ.value}`)).json() as {
     xExtent: [number, number]; yExtent: [number, number]
     xTicks: { pos: number; label: string }[]; yTicks: { pos: number; label: string }[]
-    usedX?: Kind; usedY?: Kind; gates?: SrvGate[] }
+    usedX?: Kind; usedY?: Kind; gates?: SrvGate[]; tracked?: boolean }
+  notTracked.value = meta.tracked === false
   extents.value = { xMin: meta.xExtent[0], xMax: meta.xExtent[1], yMin: meta.yExtent[0], yMax: meta.yExtent[1] }
   viewExtents.value = { ...extents.value }
   xTicks.value = meta.xTicks; yTicks.value = meta.yTicks
@@ -261,6 +266,10 @@ watch(childGateSig, fetchGates)
 // a highlighted pop's membership changed elsewhere → refresh just its colour layer
 const hlVersion = computed(() => (props.highlight ?? []).reduce((s, p) => s + (g.popVersion[p] ?? 0), 0))
 watch(hlVersion, loadPopLayers)
+// a task finished on the image we show (e.g. tracking → track_id appears, so a track plot goes from
+// "not tracked" to populated) → full reload. Same universal mechanism every other plot uses; gated by
+// the global autoRefreshOnTask setting. Interactive gating was the one plot family not wired in.
+useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
 // initial load is handled by the { immediate: true } store-readiness watch above.
 </script>
 
@@ -313,6 +322,11 @@ watch(hlVersion, loadPopLayers)
                      :mode="mode" :gate-line-width="gateLineWidth" :gate-labels="gateLabels"
                      :view-tick="viewTick" :loading="loading"
                      @draw="onDraw" @edit="onEdit" @cancel="mode = 'off'">
+      <!-- untracked segmentation on a track plot: nothing to show, point the user at tracking -->
+      <div v-if="notTracked" class="gate-empty">
+        <i class="pi pi-share-alt" />
+        <span>Not tracked yet — run tracking on this segmentation first.</span>
+      </div>
       <div v-if="pending" class="panel-name">
         <span>new {{ pending.kind }}</span>
         <input v-model="newName" placeholder="name…" autofocus
@@ -365,6 +379,12 @@ watch(hlVersion, loadPopLayers)
 /* inline affordance beside the pop selector (was overlaid on the plot, which obscured gating) */
 .gate-hint { margin-left: 2px; pointer-events: none; display: inline-flex; align-items: center; gap: 4px;
   font-size: 10px; color: var(--cc-text-dim); white-space: nowrap; }
+
+/* centred empty-state over the plot: track-grained pop type on an untracked segmentation */
+.gate-empty { position: absolute; inset: 0; margin: auto; width: max-content; height: max-content;
+  display: flex; align-items: center; gap: 6px; padding: 8px 12px; pointer-events: none;
+  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 6px;
+  font-size: 12px; color: var(--cc-text-dim); }
 .gate-hint kbd { font: inherit; background: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: 3px;
   padding: 0 3px; color: var(--cc-text); }
 </style>

--- a/frontend/src/modules/gate/GatingCopyDialog.vue
+++ b/frontend/src/modules/gate/GatingCopyDialog.vue
@@ -1,0 +1,153 @@
+<!--
+  Copy the current gating strategy (ONE gating pop_type — flow=cells or track=tracks) from the open
+  image to other images in the same set. Gates are a JSON copy (server /api/gating/copy REPLACES each
+  target's gating sidecar); membership recomputes per image. Optionally also copy the canvas plot
+  layout (client-side, via the canvas store). A precheck (imagesWithValueName → /api/images/value-name-check)
+  flags images lacking the segmentation — those are shown separately and never copied to. Ports R "Propagate to Selected".
+-->
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import BaseModal from '../../components/BaseModal.vue'
+import { useProjectStore } from '../../stores/project'
+import { useProjectMetaStore } from '../../stores/projectMeta'
+import { useCanvasPanelsStore } from '../../stores/canvasPanels'
+import { useLogStore } from '../../stores/log'
+import { imagesWithValueName } from '../../lib/valueNames'
+
+const props = defineProps<{
+  setUid: string
+  sourceUid: string
+  valueName: string
+  popType: string          // 'flow' | 'track' (a gating pop type)
+}>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const project     = useProjectStore()
+const projectMeta = useProjectMetaStore()
+const canvas      = useCanvasPanelsStore()
+const log         = useLogStore()
+
+// other images in the same set (never the source itself)
+const siblings = computed(() =>
+  (project.sets.find(s => s.uid === props.setUid)?.images ?? []).filter(i => i.uid !== props.sourceUid))
+
+// precheck: which siblings have the segmentation (copyable) vs not (flagged, never copied to)
+const checking = ref(true)
+const availableUids = ref<Set<string>>(new Set())
+const canCopy = (uid: string) => availableUids.value.has(uid)
+const available = computed(() => siblings.value.filter(i => canCopy(i.uid)))
+const missing   = computed(() => siblings.value.filter(i => !canCopy(i.uid)))
+
+onMounted(async () => {
+  const projectUid = projectMeta.current?.uid
+  const uids = siblings.value.map(i => i.uid)
+  if (!projectUid || !uids.length) { checking.value = false; return }
+  const { available } = await imagesWithValueName(projectUid, props.valueName, uids)
+  availableUids.value = new Set(available)
+  checking.value = false
+})
+
+const picked = ref<Set<string>>(new Set())
+const copyLayout = ref(true)
+const busy = ref(false)
+
+function toggle(uid: string) { picked.value.has(uid) ? picked.value.delete(uid) : picked.value.add(uid); picked.value = new Set(picked.value) }
+const allPicked = computed(() => available.value.length > 0 && available.value.every(i => picked.value.has(i.uid)))
+function toggleAll() { picked.value = allPicked.value ? new Set() : new Set(available.value.map(i => i.uid)) }
+
+const label = computed(() => props.popType === 'track' ? 'track gating' : 'cell gating')
+const ckey = (uid: string) => `gate:${props.popType}:${uid}:${props.valueName}`
+
+async function copy() {
+  const toImageUids = [...picked.value].filter(canCopy)
+  if (!toImageUids.length) { log.warn('Select at least one image.', { source: 'gating' }); return }
+  const projectUid = projectMeta.current?.uid
+  if (!projectUid) return
+  busy.value = true
+  try {
+    const res = await fetch('/api/gating/copy', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid, imageUid: props.sourceUid, valueName: props.valueName,
+                             popType: props.popType, toImageUids }),
+    })
+    const d = await res.json().catch(() => ({})) as { copied?: string[]; error?: string }
+    if (!res.ok) throw new Error(d.error ?? `HTTP ${res.status}`)
+    const copied = d.copied ?? []
+    if (copyLayout.value) for (const uid of copied) canvas.copyEntry(ckey(props.sourceUid), ckey(uid))
+    log.info(`Copied ${label.value} to ${copied.length} image(s)` + (copyLayout.value ? ' (incl. plot layout)' : '') + '.', { source: 'gating' })
+    emit('close')
+  } catch (e) {
+    log.error(`Copy gating: ${e instanceof Error ? e.message : String(e)}`, { source: 'gating' })
+  } finally { busy.value = false }
+}
+</script>
+
+<template>
+  <BaseModal width="420px" @close="emit('close')">
+    <template #title><i class="pi pi-copy" /> Copy {{ label }} to images</template>
+
+    <div class="cg-body">
+      <p class="cg-warn"><i class="pi pi-exclamation-triangle" />
+        Overwrites the {{ label }} on each selected image ({{ valueName }}) — no undo.</p>
+
+      <p v-if="checking" class="cg-empty">Checking images…</p>
+      <template v-else>
+        <p v-if="!siblings.length" class="cg-empty">No other images in this set.</p>
+
+        <template v-if="available.length">
+          <label class="cg-all"><input type="checkbox" :checked="allPicked" @change="toggleAll" /> Select all</label>
+          <div class="cg-list">
+            <label v-for="i in available" :key="i.uid" class="cg-item">
+              <input type="checkbox" :checked="picked.has(i.uid)" @change="toggle(i.uid)" />
+              <span class="cg-name">{{ i.name }}</span>
+            </label>
+          </div>
+          <label class="cg-layout" v-tooltip.top="'Also copy the plot layout (plots, channels, parents).'">
+            <input type="checkbox" v-model="copyLayout" /> Also copy plot layout
+          </label>
+        </template>
+        <p v-else-if="siblings.length" class="cg-empty">No images have the “{{ valueName }}” segmentation.</p>
+
+        <!-- flagged: no such segmentation → never copied to -->
+        <div v-if="missing.length" class="cg-missing">
+          <span class="cg-missing-head"><i class="pi pi-ban" /> No “{{ valueName }}” segmentation — skipped:</span>
+          <span class="cg-missing-names">{{ missing.map(i => i.name).join(', ') }}</span>
+        </div>
+      </template>
+    </div>
+
+    <template #footer>
+      <button class="btn-ghost btn-sm" @click="emit('close')">Cancel</button>
+      <button class="btn-primary btn-sm" :disabled="busy || checking || !picked.size" @click="copy">
+        <i v-if="busy" class="pi pi-spin pi-cog" /><i v-else class="pi pi-copy" />
+        Copy to {{ picked.size }} image{{ picked.size === 1 ? '' : 's' }}
+      </button>
+    </template>
+  </BaseModal>
+</template>
+
+<style scoped>
+.cg-body { padding: 1rem 1.25rem; display: flex; flex-direction: column; gap: 0.7rem; }
+.cg-warn { display: flex; align-items: center; gap: 0.4rem; margin: 0; font-size: 0.78rem; color: #fcd34d;
+  background: #7c2d1244; border: 1px solid #92400e55; border-radius: 0.3rem; padding: 0.4rem 0.55rem; line-height: 1.35; }
+.cg-empty { margin: 0; font-size: 0.8rem; color: var(--cc-text-dim); }
+.cg-all { font-size: 0.75rem; color: var(--cc-text-dim); display: flex; align-items: center; gap: 0.4rem; cursor: pointer; }
+.cg-list { display: flex; flex-direction: column; gap: 0.15rem; max-height: 240px; overflow: auto;
+  border: 1px solid var(--cc-border); border-radius: 0.35rem; padding: 0.4rem 0.5rem; }
+.cg-item { display: flex; align-items: center; gap: 0.5rem; font-size: 0.82rem; color: var(--cc-text); cursor: pointer; padding: 0.15rem 0; }
+.cg-item input, .cg-all input, .cg-layout input { accent-color: var(--cc-accent); cursor: pointer; }
+.cg-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cg-layout { display: flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; color: var(--cc-text); cursor: pointer; }
+.cg-missing { display: flex; flex-direction: column; gap: 0.2rem; font-size: 0.72rem; color: var(--cc-text-dim);
+  border-top: 1px solid var(--cc-border); padding-top: 0.5rem; }
+.cg-missing-head { display: flex; align-items: center; gap: 0.35rem; color: #f59e0b; }
+.cg-missing-names { padding-left: 1.1rem; word-break: break-word; }
+
+.btn-sm { display: flex; align-items: center; gap: 0.3rem; font-size: 0.78rem; font-weight: 500;
+  padding: 0.35rem 0.75rem; border-radius: 0.35rem; border: 1px solid transparent; cursor: pointer; white-space: nowrap; }
+.btn-ghost { background: var(--cc-surface-2); border-color: var(--cc-border); color: var(--cc-text-dim); }
+.btn-ghost:hover:not(:disabled) { color: var(--cc-text); }
+.btn-primary { background: var(--cc-accent); color: #fff; }
+.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
+.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+</style>

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -22,6 +22,8 @@ import { useViewState } from '../../composables/useViewState'
 import GatePlotPanel from './GatePlotPanel.vue'
 import GatePairsPanel from './GatePairsPanel.vue'
 import PopulationManager from '../../components/canvas/PopulationManager.vue'
+import GatingCopyDialog from './GatingCopyDialog.vue'
+import type { FlatPop } from '../../stores/gating'
 
 const props = withDefaults(defineProps<{ imageUid: string | null; popType?: string }>(),
   { popType: 'flow' })
@@ -94,6 +96,26 @@ function onPickPop(path: string) {
   if (s) s.parent = s.parent === path ? 'root' : path
 }
 
+// "Copy gating strategy to other images" dialog (per current pop type; see GatingCopyDialog).
+const showCopy = ref(false)
+const setUid = computed(() => g.napariSetUid())   // the set the gated image belongs to
+
+// Defining-plot: open the plot where a pop's gate was drawn — a new single panel showing the pop's
+// PARENT (the cloud the gate was drawn on) on the gate's own channels + transforms. The gate outline
+// appears automatically (it's a child of that parent, server-projected). Works for flow or track.
+function showDefiningPlot(pop: FlatPop) {
+  if (!pop.gate) return
+  const id = add()
+  const p = panels.value.find(x => x.id === id)
+  if (!p) return
+  p.state.kind = 'single'
+  p.state.parent = pop.parent
+  p.state.x = pop.gate.x_channel
+  p.state.y = pop.gate.y_channel
+  p.state.xt = pop.gate.x_transform.kind
+  p.state.yt = pop.gate.y_transform.kind
+}
+
 async function load() {
   if (props.imageUid) await g.selectImage(props.imageUid, g.valueName, props.popType)
 }
@@ -161,7 +183,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
           <i class="pi pi-plus" /> Pairs
         </button>
         <!-- FLOW: spatial cell-selection brush (linked brushing → transient cell pop). -->
-        <div v-if="!isTrack" class="seg" v-tooltip.bottom="'Napari linked brushing'">
+        <div v-if="!isTrack" class="seg">
           <!-- showing populations in napari is the ViewerPanel's palette toggle (remembered);
                here we only offer the spatial cell-selection brush. -->
           <button v-tooltip.bottom="'Draw a region on the napari image to highlight those cells here'"
@@ -180,14 +202,12 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
                v-tooltip.bottom="'z-slice window: include cells within ± this many slices of the current z (0 = current slice only)'">
           ±<input type="number" min="0" max="50" step="1" v-model.number="g.napariZWindow" />
         </label>
-        <!-- TRACK: push the gated tracks to napari as Tracks layers (needs a running napari + timecourse). -->
-        <button v-if="isTrack" class="cc-btn cc-btn-ghost"
-                v-tooltip.bottom="'Show the gated tracks in napari (Tracks layers)'"
-                @click="g.showTracks()"><i class="pi pi-share-alt" /> Tracks</button>
-        <div class="seg" v-tooltip.bottom="'Arrange windows'">
+        <div class="seg">
           <button v-tooltip.bottom="'Tile in a grid'" @click="arrangeGrid"><i class="pi pi-th-large" /></button>
           <button v-tooltip.bottom="'Cascade windows'" @click="arrangeCascade"><i class="pi pi-clone" /></button>
         </div>
+        <button class="cc-btn" v-tooltip.bottom="'Copy this gating to other images in the set'"
+                @click="showCopy = true"><i class="pi pi-copy" /> Copy</button>
         <span class="gp-hint">drag plots by their title · resize from the corner</span>
       </div>
       <div ref="canvasRef" class="gp-canvas">
@@ -207,9 +227,11 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
                            :line-width="activeLineWidth" :gate-labels="activeLabels" :axis-from-zero="activeFromZero"
                            @update:selected="onPickPop" @update:scope="scope = $event" @toggle-highlight="toggleHighlight"
                            @update:line-width="setLineWidth" @update:gate-labels="setLabels"
-                           @update:axis-from-zero="setFromZero" />
+                           @update:axis-from-zero="setFromZero" @show-defining-plot="showDefiningPlot" />
       </div>
     </template>
+    <GatingCopyDialog v-if="showCopy" :set-uid="setUid" :source-uid="props.imageUid!"
+                      :value-name="g.valueName" :pop-type="props.popType" @close="showCopy = false" />
   </div>
 </template>
 

--- a/frontend/src/stores/canvasPanels.ts
+++ b/frontend/src/stores/canvasPanels.ts
@@ -31,6 +31,18 @@ export const useCanvasPanelsStore = defineStore('canvasPanels', () => {
     delete entries.value[key]
     for (const k of Object.keys(geom.value)) if (k.startsWith(`${key}:`)) delete geom.value[k]
   }
+  // Deep-copy one canvas's full layout (entry + all panel geometry) to another key. Used by "copy
+  // gating strategy → other images" with the plot-layout option: clones gate:{pt}:{src}:{vn} onto
+  // gate:{pt}:{tgt}:{vn}. Autosave then persists the new key to the TARGET object's file (the key's
+  // 3rd colon-segment). No-op if the source has no saved layout.
+  function copyEntry(srcKey: string, tgtKey: string) {
+    const src = entries.value[srcKey]
+    if (!src) return
+    entries.value[tgtKey] = JSON.parse(JSON.stringify(src))
+    for (const [k, v] of Object.entries(geom.value)) {
+      if (k.startsWith(`${srcKey}:`)) geom.value[`${tgtKey}${k.slice(srcKey.length)}`] = { ...v }
+    }
+  }
   // last-persisted JSON per object uid — the dirty-tracking baseline so autosave sends ONLY objects
   // whose canvas state actually changed since the last save (not every visited object).
   let _lastSaved: Record<string, string> = {}
@@ -109,5 +121,5 @@ export const useCanvasPanelsStore = defineStore('canvasPanels', () => {
   }
   watch([entries, geom], _scheduleAutosave, { deep: true })
 
-  return { entries, geom, ensure, getGeom, setGeom, delGeom, drop, clear, load }
+  return { entries, geom, ensure, getGeom, setGeom, delGeom, drop, copyEntry, clear, load }
 })

--- a/frontend/src/stores/gating.ts
+++ b/frontend/src/stores/gating.ts
@@ -279,8 +279,6 @@ export const useGatingStore = defineStore('gating', () => {
   }
   // re-push populations to napari after a per-pop visibility change (silent if napari is down)
   const refreshNapariPops = () => _napari('/api/napari/show-populations', true)
-  // track gating: render the gated tracks as napari Tracks layers (one per pop). Loud (user action).
-  const showTracks = () => _napari('/api/napari/show-tracks', false)
   // unified re-push used by the manager's per-pop visibility toggle — routes to the right overlay
   // for the current popType (track → Tracks layers, else → population Points), silent.
   const refreshNapari = () => popType.value === 'track'
@@ -310,6 +308,6 @@ export const useGatingStore = defineStore('gating', () => {
     transientPaths, napariZMode, napariZWindow,
     projectUid, colLabel, selectImage, fetchChannels, fetchPopmap, fetchStats,
     addPop, addClusterPop, setGate, deletePop, renamePop, updatePop, applyBroadcast,
-    refreshNapariPops, showTracks, refreshNapari, startCellSelection, clearNapariSelection, updateSelectionScope,
+    refreshNapariPops, refreshNapari, startCellSelection, clearNapariSelection, updateSelectionScope,
   }
 })


### PR DESCRIPTION
## Gating: copy strategy to images, defining-plot panel, track-gating fixes

  A gating/tracking UX + robustness batch.

  ### Copy gating strategy → other images
  - **`POST /api/gating/copy`** copies one gating pop type's strategy to other images in the set. Because gates live *in* the `gating/{vn}.json` sidecar (not a binary GatingSet like R) and membership recomputes per image on read, this is a **JSON sidecar copy** — no per-image gate rebuild. Ports R's "Propagate to Selected".
  - Toolbar **Copy** button → dialog with an **overwrite warning** (destructive, no undo), the set's other images as checkboxes, and a flagged **"no '{vn}' segmentation — skipped"** section. Prechecks targets so missing-segmentation images are never copied to.
  - **Value_name check abstracted** (reusable, not gating-specific): `img_has_value_name` accessor + `POST /api/images/value-name-check` + `imagesWithValueName()`.
  - **Defining-plot icon** (left of the eye, gated pops only) → adds a plot panel at the pop's parent + gate channels/transforms.
  - **Plot layout** is separate frontend state → copied client-side (`canvasPanels.copyEntry`, in-memory + autosave), with an optional checkbox.

  ### Track-gating correctness
  - No more **500** on a track-grained plot of an untracked segmentation: `track_props` returns empty; `is_tracked` accessor; plotmeta carries `tracked`; the plot shows **"track first"**.
  - Root **`/_tracked`** offered only when `has_ungated_tracks` (tracked cells outside every gate) — no redundant/misleading root pop after gated tracking.
  - `GATING_POP_TYPES` (flow+track) abstraction + `is_gating_pop_type`.
  - **Force-recompute default on** for track measures.

  ### Other
  - **Universal auto-refresh**: `useDataRefresh` wired into `GatePlotPanel`/`GatePairsPanel` (gating 
### Other
- **Universal auto-refresh**: `useDataRefresh` wired into `GatePlotPanel`/`GatePairsPanel` (gating plots were the one family not refreshing on task completion).
- Removed the **obsolete/broken "Tracks" button** on the gating canvas (+ dead `showTracks`).
- Fixed **double tooltips** (Arrange + Napari-brushing wrappers).

### Tests / docs
- `runtests.jl`: `is_tracked` obs check, `GATING_POP_TYPES`, `img_has_value_name`, `root_derived_ok` predicate. Package **808 pass**, API + frontend build/typecheck clean.
- Docs: `API.md` (routes), `POPULATION.md` (copy, gating pop types, root `/_tracked` rule).

### Reservations
- Not browser-verified (backend was down); typecheck + build + unit tests only.
- `api/src` changes need a **backend restart** to take effect.
- Copy replaces target gating (destructive; warned). Same-panel assumption for channels.
- Auto-refresh resets the plot camera/extents on task completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)