### PR TITLE
Fix/gating blank page

### DIFF
--- a/api/dev.jl
+++ b/api/dev.jl
@@ -14,6 +14,7 @@
 
 const RESTART_EXIT_CODE = 42
 const FRONTEND_PORT = 5173
+const BACKEND_PORT  = 8080   # dev default; the by-handle kill covers a custom port, this is the backstop
 
 # Worktree switch (dev only, Settings → System): the server writes a target `api/` dir here, then exits
 # with the restart sentinel; we relaunch the backend FROM THAT DIR (and the frontend from the sibling
@@ -42,7 +43,12 @@ function _free_port(port::Integer)
             # page load + Vite HMR websocket) — so `kill` would reap Firefox/Chrome too (it crashes on a
             # worktree switch). Mirrors the Windows branch's LISTENING filter above.
             pids = try readchomp(`lsof -ti tcp:$port -sTCP:LISTEN`) catch; "" end
-            isempty(pids) || run(pipeline(`kill $(split(pids))`; stdout = devnull, stderr = devnull))
+            if !isempty(pids)
+                run(pipeline(`kill $(split(pids))`; stdout = devnull, stderr = devnull))
+                sleep(0.4)                                    # give SIGTERM a moment, then force survivors
+                left = try readchomp(`lsof -ti tcp:$port -sTCP:LISTEN`) catch; "" end
+                isempty(left) || run(pipeline(`kill -9 $(split(left))`; stdout = devnull, stderr = devnull))
+            end
         end
     catch e
         @warn "[dev] could not free port $port" exception = e
@@ -79,18 +85,25 @@ function supervise()
     julia = Base.julia_cmd().exec[1]   # this julia's executable; child gets its own flags (-t auto, Revise)
     workdir = @__DIR__                 # api/ of the worktree the server currently runs from
     vite = _start_frontend(dirname(workdir))
+    # Track the running backend so teardown can kill it. CRITICAL: the backend is spawned NON-blocking
+    # (`wait=false`) and we block on `wait(proc)` — with the old blocking `run(...; wait=true)` the handle
+    # wasn't captured until the call returned, so a Ctrl-C mid-run left the supervisor with nothing to
+    # kill, and the backend julia (which SURVIVES a bare terminal SIGINT) + Vite were orphaned on their
+    # ports. Now Ctrl-C interrupts `wait`, and `finally` kills BOTH children by handle + frees the ports.
+    backend = Ref{Union{Base.Process,Nothing}}(nothing)
     try
         while true
             # `--project` (no path) + relative `includet` resolve against the child's cwd → running it in
             # `workdir` loads that worktree's environment and server.
-            backend = Cmd(`$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`; dir = workdir)
-            proc = try
-                run(ignorestatus(backend); wait = true)  # inherits stdio + env (CECELIA_DEV/SUPERVISED/SWITCH_FILE)
+            backend[] = run(ignorestatus(Cmd(`$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`;
+                                              dir = workdir)); wait = false)  # inherits stdio + env
+            try
+                wait(backend[])                           # block until it exits; Ctrl-C interrupts HERE
             catch e
-                e isa InterruptException && break         # Ctrl-C → stop supervising (finally stops Vite)
-                rethrow()
+                e isa InterruptException || rethrow()
+                break                                     # Ctrl-C → stop supervising (finally tears down)
             end
-            proc.exitcode == RESTART_EXIT_CODE || break   # 0 / crash / signal → done
+            backend[].exitcode == RESTART_EXIT_CODE || break   # 0 / crash / signal → done
 
             # relaunch target: the switch file names another worktree's api dir, else stay put.
             newdir = workdir
@@ -109,6 +122,10 @@ function supervise()
             end
         end
     finally
+        # Kill BOTH children on any exit (Ctrl-C, Quit, crash). The backend survives SIGINT, so kill it
+        # by handle and free :8080 as a backstop; _stop_frontend does the same for Vite (:5173).
+        try; backend[] === nothing || kill(backend[]); catch; end
+        _free_port(BACKEND_PORT)
         _stop_frontend(vite)
     end
 end

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -113,6 +113,16 @@ GitHub-hosted runners are free on all OSes (no minute metering — the multiplie
 repos). All steps run under `bash` (Git Bash on the Windows runner). Keep it green before requesting
 a merge. See `docs/SHIPPING.md` for the release pipeline.
 
+> **Frontend typecheck — use `vue-tsc -b`, never `vue-tsc --noEmit`.** The frontend uses TS **project
+> references**, and `vue-tsc --noEmit` on the root config **silently skips the `.vue` files** (exits 0
+> with real errors). Verify types with **`npm run typecheck`** (`vue-tsc -b`) or `npm run build` —
+> which is exactly what CI runs. **Don't merge a red CI**: a merged type error here (an unimported
+> `ref`, a store method not in the store's `return`, …) throws a `ReferenceError` in a component's
+> `<script setup>`, which Vue surfaces as **`Maximum recursive updates exceeded in component
+> <ModuleLayout>`** and **blanks every module page** — it reads like a reactivity loop, but the root is
+> a setup exception in the child component. (This cost hours on 2026-07-10; CI *had* caught both errors,
+> the PR was merged red.)
+
 ## Releases
 
 Cut **off `main`** after the relevant PRs have merged, by pushing a tag:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
+    "typecheck": "vue-tsc -b",
     "preview": "vite preview",
     "test": "vitest run"
   },

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -14,7 +14,7 @@
   active panel) are shared as-is — no track-specific clone.
 -->
 <script setup lang="ts">
-import { computed, watch, onMounted, onUnmounted, useTemplateRef } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from 'vue'
 import { useGatingStore } from '../../stores/gating'
 import { useWsStore } from '../../stores/ws'
 import { useCanvasPanels } from '../../composables/useCanvasPanels'

--- a/frontend/src/stores/gating.ts
+++ b/frontend/src/stores/gating.ts
@@ -306,7 +306,7 @@ export const useGatingStore = defineStore('gating', () => {
     imageUid, valueName, popType, mirrorUids, tree, columns, channels, channelNames, valueNames,
     cellMeasures, trackAggregates, stats, popVersion, flat,
     transientPaths, napariZMode, napariZWindow,
-    projectUid, colLabel, selectImage, fetchChannels, fetchPopmap, fetchStats,
+    projectUid, napariSetUid, colLabel, selectImage, fetchChannels, fetchPopmap, fetchStats,
     addPop, addClusterPop, setGate, deletePop, renamePop, updatePop, applyBroadcast,
     refreshNapariPops, refreshNapari, startCellSelection, clearNapariSelection, updateSelectionScope,
   }


### PR DESCRIPTION
## Fix blank Gate page + prevent the class of bug + dev Ctrl-C

### The blank GUI (root cause)
Two type errors merged in #106 (CI flagged both; the PR was merged red):
- `GatingPlots.vue` used `ref(false)` without importing `ref`
- it called `g.napariSetUid()`, which wasn't in the gating store's `return`

At runtime the missing `ref` throws a `ReferenceError` in `<script setup>`, which Vue cascades into **`Maximum recursive updates exceeded in <ModuleLayout>`** — blanking *every* module page. Looks like a reactivity loop; the root is a setup exception. Fixes: import `ref`; export `napariSetUid`.

### Why it slipped through — and the guard
I'd been verifying with `vue-tsc --noEmit`, which **silently skips `.vue` files** (TS project references) and exits 0 on real errors. `vue-tsc -b` (what `npm run build`/CI runs) catches them.
- Added `npm run typecheck` = `vue-tsc -b`.
- `docs/DEV.md`: use `npm run typecheck`/`build` (never `--noEmit`); don't merge a red CI; the ModuleLayout-loop → check the child's setup for undefined identifiers.

### dev.jl Ctrl-C
Ctrl-C on `pixi run dev` orphaned the backend (:8080) + Vite (:5173). Now the supervisor spawns the backend non-blocking, `wait()`s, and on any exit kills both children by handle + frees the ports (SIGKILL backstop).

### Verification
- `npm run build` (`vue-tsc -b && vite build`) green.
- Headless (Playwright) repro: reproduced the loop, applied fixes, loop gone 3/3, Gate page renders.
- `dev.jl` parses; Ctrl-C teardown not runtime-tested (exercise once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)