### PR TITLE
fix(dev): restore backend stdio under the supervisor

### DIFF
--- a/api/dev.jl
+++ b/api/dev.jl
@@ -94,9 +94,13 @@ function supervise()
     try
         while true
             # `--project` (no path) + relative `includet` resolve against the child's cwd → running it in
-            # `workdir` loads that worktree's environment and server.
-            backend[] = run(ignorestatus(Cmd(`$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`;
-                                              dir = workdir)); wait = false)  # inherits stdio + env
+            # `workdir` loads that worktree's environment and server. `wait=false` (so we capture the
+            # handle for teardown before blocking) does NOT inherit stdio by default — unlike the old
+            # blocking `run` — so connect the parent's streams explicitly via `pipeline`, else the
+            # backend's server logs vanish. env is inherited regardless.
+            bcmd = ignorestatus(Cmd(`$julia --project -t auto -e "using Revise; includet(\"src/server.jl\")"`;
+                                    dir = workdir))
+            backend[] = run(pipeline(bcmd; stdin = stdin, stdout = stdout, stderr = stderr); wait = false)
             try
                 wait(backend[])                           # block until it exits; Ctrl-C interrupts HERE
             catch e


### PR DESCRIPTION
## Fix blank Gate page + prevent the class of bug + dev Ctrl-C

### The blank GUI (root cause)
Two type errors merged in #106 (CI flagged both; the PR was merged red):
- `GatingPlots.vue` used `ref(false)` without importing `ref`
- it called `g.napariSetUid()`, which wasn't in the gating store's `return`

At runtime the missing `ref` throws a `ReferenceError` in `<script setup>`, which Vue cascades into **`Maximum recursive updates exceeded in <ModuleLayout>`** — blanking *every* module page. Looks like a reactivity loop; the root is a setup exception. Fixes: import `ref`; export `napariSetUid`.

### Why it slipped through — and the guard
I'd been verifying with `vue-tsc --noEmit`, which **silently skips `.vue` files** (TS project references) and exits 0 on real errors. `vue-tsc -b` (what `npm run build`/CI runs) catches them.
- Added `npm run typecheck` = `vue-tsc -b`.
- `docs/DEV.md`: use `npm run typecheck`/`build` (never `--noEmit`); don't merge a red CI; the ModuleLayout-loop → check the child's setup for undefined identifiers.

### dev.jl Ctrl-C
Ctrl-C on `pixi run dev` orphaned the backend (:8080) + Vite (:5173). Now the supervisor spawns the backend non-blocking, `wait()`s, and on any exit kills both children by handle + frees the ports (SIGKILL backstop).

### Verification
- `npm run build` (`vue-tsc -b && vite build`) green.
- Headless (Playwright) repro: reproduced the loop, applied fixes, loop gone 3/3, Gate page renders.
- `dev.jl` parses; Ctrl-C teardown not runtime-tested (exercise once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)