### PR TITLE
feat(plots): full-box panel controls, A4 board + zoom, 2D raster gati…

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -32,6 +32,22 @@ Each tab renders through `components/canvas/LayoutCanvas.vue`: a **comic-plate**
 content is `{ kind, ref, state }`; the `⚙` popover tunes cols/rows/row-height. `TabbedCanvas.vue` wraps
 it with the tab bar + the PDF/CSV export buttons.
 
+### A4 sheet lock + plates
+
+The board box is **locked to an A4 sheet** by default so it is WYSIWYG with the exported page — no more
+"the board fills the width, so the plates are too wide". Per-tab `sheet` (`analysisLayout` entry):
+`a4-portrait` (default; **undefined reads as portrait** so old boards get the fix) · `a4-landscape` · `free`.
+In an A4 mode the grid's on-screen **width is derived from its height × the page aspect**
+(`A4_PORTRAIT_ASPECT`/`A4_LANDSCAPE_ASPECT` in `layoutTemplates.ts`) and it centres in the free space
+(`.lc-canvas-wrap`); `free` keeps the old flex-fill. Because the on-screen aspect is now exact,
+`capturePage`'s measured aspect drives the correct PDF orientation.
+
+Plates carry an `orient` tag (`portrait`/`landscape`/`any`); the **Plates** picker shows only those
+matching the current sheet. A **custom plate builder** (`components/canvas/PlateBuilder.vue`, "Custom…"
+button) lets you set N×M then **drag cells to merge** into varied-size panels (click a merge to split);
+its span math is the pure, unit-tested `utils/plateBuilder.ts` and it emits a `LayoutTemplate` that
+`applyTemplate` adopts (preserving slot contents by index).
+
 ## Plot families — one registry-driven mechanism
 
 Slots are filled from the **same registries the module pages use** — there is one way to host a plot,
@@ -93,6 +109,12 @@ reproduces the layout exactly (spans, plates, gaps), and `plots/pdf.ts` lays out
   ~2200px long side (scale 4–14×) and re-render the point cloud at that scale via each view's `hiRes`
   resolver (`ScatterGL.exportCanvas`). One path for both the gating scatter and the cluster UMAP — do
   not reinvent the scale math per plot.
+  - **GPU-limit clamp (dots-clipped bug)**: `exportCanvas` clamps the export scale to the GPU's
+    `MAX_TEXTURE_SIZE`/`MAX_VIEWPORT_DIMS`, **accounting for `devicePixelRatio`** — regl-scatterplot
+    multiplies the backing store by DPR, so the real buffer is `size·s·dpr`. Without the DPR factor a
+    hi-DPI screen at a high scale (small board plots hit ~14×) overflows the cap and the render is
+    silently clipped to a sub-rectangle → dots cut off (was visible in the board PDF *and* the
+    module-page PNG export, since both share `exportCanvas`).
 - **CSV**: each summary/cluster panel exposes `getCsv()` (the shown aggregated data); the standalone CSV
   button collects them all (→ Prism).
 

--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -34,8 +34,20 @@ to be reverse-engineered config by config. Observable Plot wins on all three: it
 match ggplot `theme_classic` (the old R look — `plotHelpers.R`), jitter/beeswarm is a real transform,
 and resize is just "re-call `Plot.plot()` with a new width/height" (no signal graph). It also renders
 native SVG (so SVG export is "serialize the node") and does **heatmaps/tiled maps natively** (`Plot.cell`
-/ `Plot.raster`) — both on the roadmap (§9). regl-scatterplot still owns the big WebGL point clouds
-(gating/UMAP); Plot is summaries only, where data is server-aggregated and small.
+/ `Plot.raster`) — both on the roadmap (§9). Plot is summaries only, where data is server-aggregated
+and small. regl-scatterplot now owns **UMAP only**; the **gating** scatter is a **2D density raster**
+(no WebGL) — see below.
+
+**Gating scatter = 2D density raster (no WebGL).** The gating point cloud is non-interactive (fixed
+camera; gate *drawing* is the only interaction, on the canvas2D overlay), so it renders as a
+FlowJo/OMIQ-style density raster instead of a GPU point cloud: `plots/density.ts` bins → Gaussian-blurs
+→ `densityImageData` colours each cell via the shared blue-heat ramp (`plots/flowColors.ts`), upscaled
+smoothly to the plot; contours are clean connected rings from **d3-contour** (`plots/contour.ts`) on the
+blurred grid (replacing jagged marching-squares segments). `components/plots/PlotLayers.vue` draws base
+(raster or contours) + child-pop overlays on one 2D canvas; `GateScatterCell.vue` composites it with the
+gate overlay. **Export re-renders the same 2D content at target scale** (crisp, cannot clip) — this
+replaced the fragile WebGL hi-res screengrab that clipped dots. Re-renders on data/extent change
+(autoscale, zero-extent, image switch); tune the look via `DENSITY_GRID`/`BLUR_*`/`CONTOUR_LEVELS`.
 
 Code: `frontend/src/plots/plot.ts` (`buildPlotOptions(Plot, r, o)` — one builder per chart type,
 returns a `Plot.plot()` options object; takes the Plot module as a param so it carries no eager import)

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -621,6 +621,47 @@ gate-drawing surface into the registry.
 See **`docs/ANALYSIS.md`** for the Analysis board itself (tabs, comic-plate layout, persistence keys,
 the read-only cluster manager, and PDF/CSV export incl. the shared hi-res raster path).
 
+### Auto-hide panel controls (plot fills the whole box)
+
+`CanvasPanel` gives its **plot the whole box** and overlays the control surfaces, revealing them only on
+hover (or when pinned). This is why a board plot — and its PDF export — fills its slot instead of being
+squashed by a stack of dropdowns (the squashed plot exported as a clipped sliver; see `docs/ANALYSIS.md`).
+
+- **Default ON** (`autoHide` prop, default `true`). The `#actions` (top) and `#footer` (bottom) slots
+  render as absolute overlay strips over the body; a **pin** toggle (`pi-thumbtack`, next to the drag
+  icon) keeps them visible. Pin/collapse are transient local refs (chrome preferences), not persisted.
+- **Interactive views whose toolbar lives INSIDE the body** (`GatingStrategyView` `.gs-bar`, `UmapView`
+  `.uv-ctrl`, `ImageStripView` `.is-bar`) opt in by tagging that bar `.cc-panel-controls` **and** giving
+  their root `position: relative` — the global rule in `style.css` (`.panel:hover`/`.panel.controls-pinned`)
+  then auto-hides it by the same trigger. One mechanism for every control surface; don't add a second.
+- **Opt OUT with `:auto-hide="false"`** where you interact with the plot constantly and controls popping
+  over it would fight the tools — the gate-**drawing** panels (`GatePlotPanel`/`GatePairsPanel`) do this,
+  so their render-mode / gate tools stay in flow.
+- **Capture safety**: a `.capturing` ancestor (set on the board grid during export) force-hides every
+  `.cc-panel-controls`, so a pinned/hovered strip never leaks into a snapshot.
+
+### Canvas zoom (fit-to-view)
+
+Every plot canvas — the Analysis board's fixed grid AND the free-floating module canvases
+(`SummaryCanvas`, `GatingPlots`) — shares one visual zoom, so a big workspace fits the screen without
+hiding the sidebar. `composables/useCanvasZoom.ts` owns the `zoom` ref + `fitWidth`/`fitHeight`;
+`components/canvas/CanvasZoomControl.vue` is the shared slider/fit/% control. It's a **CSS
+`transform: scale`** — purely visual: it never resizes a plot's own canvas or changes what's exported
+(the export re-renders at full logical resolution; the board neutralises the zoom during PDF capture).
+
+- **Fixed-grid board**: the grid scales inside a `.lc-zoom` footprint (sized to the scaled dims so the
+  viewport scrolls); auto-fits width on first render if the board would overflow.
+- **Free-floating canvases**: the panels scale inside a `.sc-zoom`/`.gp-zoom` layer; the population
+  manager sits OUTSIDE it so the control panel stays full-size. Because panels are dragged in screen px,
+  the host `provide()`s the zoom under `CANVAS_ZOOM_KEY` and `CanvasPanel` injects it into
+  `useFloatingPanel`, which divides drag deltas by the zoom (else a panel moves `zoom`× too fast).
+
+### Show/hide the population manager
+
+The floating population manager (`PopulationManager` on the gate/tracking pages, `SeriesPicker` on
+summary pages) has a **toggle** (`pi-sitemap`) next to the arrange-windows icons, persisted per canvas in
+the `shared` bag (`shared.showManager`, default shown). Wrap the manager `v-if="showManager"`.
+
 ---
 
 ## WS events — frontend side

--- a/frontend/src/components/canvas/CanvasPanel.vue
+++ b/frontend/src/components/canvas/CanvasPanel.vue
@@ -7,9 +7,10 @@
   Drag/clamp/arrange come from useFloatingPanel so every floating panel behaves identically.
 -->
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, useTemplateRef, watch, useSlots } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, useTemplateRef, watch, useSlots } from 'vue'
 import { useFloatingPanel, type ArrangeCmd } from '../../composables/useFloatingPanel'
 import { useCanvasPanelsStore } from '../../stores/canvasPanels'
+import { useInjectedZoom } from '../../composables/useCanvasZoom'
 
 const props = withDefaults(defineProps<{
   index: number
@@ -23,19 +24,33 @@ const props = withDefaults(defineProps<{
   // DOCKED: fill the parent slot (Analysis-canvas grid layout) instead of free-floating — no drag,
   // no resize, no geometry persistence. Keeps the header/actions/body/footer chrome.
   docked?: boolean
-}>(), { active: false, removable: true, arrange: null, docked: false })
+  // AUTO-HIDE: give the plot the whole box and overlay the control surfaces (actions + footer),
+  // revealing them only on hover (or when pinned). Default ON — every summary/interactive plot wants
+  // its plot un-squashed (and the PDF captures the full-box plot, not a control-squashed strip). The
+  // gate-DRAWING panels opt OUT (`:auto-hide="false"`) because you interact with the plot constantly
+  // there and popping controls over the canvas would fight the gate tools. Interactive views whose
+  // toolbar lives INSIDE the body opt in by tagging it `.cc-panel-controls` (see style.css / docs/UI.md).
+  autoHide?: boolean
+}>(), { active: false, removable: true, arrange: null, docked: false, autoHide: true })
 const emit = defineEmits<{ activate: [number]; remove: [] }>()
 
 const collapsed = ref(false)
+// pin the auto-hide controls open (local like `collapsed` — a transient chrome preference, not a
+// persisted plot option). Only meaningful when autoHide is on and there are controls to reveal.
+const pinned = ref(false)
 const slots = useSlots()
+const hasControls = computed(() => !!slots.actions || !!slots.footer)
 const root = useTemplateRef<HTMLElement>('root')
 const store = useCanvasPanelsStore()
 const saved = props.persistKey ? store.getGeom(props.persistKey) : undefined
+// the host canvas may apply a visual zoom (transform:scale); inject it so drag deltas are zoom-correct
+const injectedZoom = useInjectedZoom()
 const { pos, startDrag } = useFloatingPanel(root, {
   // restore the saved position, else stagger by index
   initial: saved ? { x: saved.x, y: saved.y } : { x: 16 + props.index * 30, y: 16 + props.index * 30 },
   onActivate: () => emit('activate', props.index),
   arrange: () => props.arrange,
+  zoom: injectedZoom,
 })
 
 // persist geometry (position + the CSS-resized size) so the layout survives navigation.
@@ -57,30 +72,46 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
 </script>
 
 <template>
-  <div ref="root" class="panel" :class="{ active, collapsed, docked }"
+  <div ref="root" class="panel" :class="{ active, collapsed, docked, 'controls-pinned': pinned }"
        :style="docked ? undefined : { left: pos.x + 'px', top: pos.y + 'px' }" @mousedown="emit('activate', index)">
     <!-- title row: the WHOLE row drags (like PopulationManager); buttons stop the drag -->
     <div class="panel-head" @mousedown.prevent="docked || startDrag($event)"
          v-tooltip.bottom="docked ? undefined : 'Drag to move'">
-      <span class="panel-title"><i v-if="!docked" class="pi pi-arrows-alt drag-icon" />{{ title }}</span>
+      <span class="panel-title"><i v-if="!docked" class="pi pi-arrows-alt drag-icon" /><!--
+        --><i v-else class="pi pi-arrows-alt drag-icon grip" draggable="true"
+             v-tooltip.bottom="'Drag to move / swap'" @mousedown.stop @click.stop /><!--
+        --><span class="panel-title-txt">{{ title }}</span></span>
       <span class="panel-spacer" />
-      <button v-if="!docked" class="panel-collapse" v-tooltip.bottom="collapsed ? 'Expand' : 'Collapse'"
+      <!-- pin the auto-hiding controls open (next to the drag icon). Only when there ARE controls
+           to reveal and auto-hide is active. -->
+      <button v-if="autoHide && hasControls && !collapsed" class="panel-btn" :class="{ on: pinned }"
+              v-tooltip.bottom="pinned ? 'Auto-hide controls (show on hover)' : 'Keep controls visible'"
+              @mousedown.stop @click.stop="pinned = !pinned">
+        <i class="pi pi-thumbtack" />
+      </button>
+      <button v-if="!docked" class="panel-btn panel-collapse" v-tooltip.bottom="collapsed ? 'Expand' : 'Collapse'"
               @mousedown.stop @click.stop="collapsed = !collapsed">
         <i :class="collapsed ? 'pi pi-chevron-down' : 'pi pi-chevron-up'" />
       </button>
       <template v-if="removable">
         <span class="ctrl-sep" />
-        <button class="panel-remove" v-tooltip.bottom="'Remove this plot'"
+        <button class="panel-btn panel-remove" v-tooltip.bottom="'Remove this plot'"
                 @mousedown.stop @click.stop="emit('remove')">
           <i class="pi pi-minus" />
         </button>
       </template>
     </div>
-    <!-- controls row (plot options) — its own row so it never clips at min width -->
-    <div v-if="slots.actions && !collapsed" class="panel-controls"><slot name="actions" /></div>
-    <div v-show="!collapsed" class="panel-body"><slot /></div>
-    <!-- footer row (utility actions: duplicate / export) -->
-    <div v-if="slots.footer && !collapsed" class="panel-foot"><slot name="footer" /></div>
+    <!-- IN-FLOW controls (auto-hide OFF, e.g. the gate-drawing page): own rows so they never clip -->
+    <div v-if="!autoHide && slots.actions && !collapsed" class="panel-controls inflow"><slot name="actions" /></div>
+    <!-- body always gets the whole box; in auto-hide mode the controls overlay it (see .cc-panel-controls) -->
+    <div v-show="!collapsed" class="panel-main">
+      <div class="panel-body"><slot /></div>
+      <template v-if="autoHide">
+        <div v-if="slots.actions" class="panel-controls cc-panel-controls"><slot name="actions" /></div>
+        <div v-if="slots.footer" class="panel-foot cc-panel-controls bottom"><slot name="footer" /></div>
+      </template>
+    </div>
+    <div v-if="!autoHide && slots.footer && !collapsed" class="panel-foot inflow"><slot name="footer" /></div>
   </div>
 </template>
 
@@ -99,22 +130,33 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
 .panel.collapsed { height: auto !important; min-height: 0 !important; resize: none; }
 .panel-head { display: flex; align-items: center; gap: 8px; padding: 5px 8px; cursor: move;
   border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2); }
+/* min-width:0 lets the title shrink; the text span truncates so it never shoves the head buttons */
 .panel-title { display: inline-flex; align-items: center; gap: 5px; font-weight: 700; font-size: 12px;
-  letter-spacing: 0.02em; user-select: none; }
-.drag-icon { font-size: 10px; opacity: 0.55; }
+  letter-spacing: 0.02em; user-select: none; min-width: 0; }
+.panel-title-txt { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.drag-icon { font-size: 10px; opacity: 0.55; flex: none; }
+/* docked panels: the drag icon IS the reorder handle (in-flow in the header → aligned with the other
+   buttons, no absolute overlay to collide with the pin). Its native dragstart bubbles to the board slot. */
+.drag-icon.grip { cursor: grab; font-size: 12px; opacity: 0.7; padding: 2px; margin: -2px 0; }
+.drag-icon.grip:active { cursor: grabbing; }
 .panel-spacer { flex: 1; }
-/* controls row: wraps instead of clipping when the panel is narrow */
-.panel-controls { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 5px 8px;
-  border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-1); }
-/* footer row: utility actions, right-aligned */
-.panel-foot { display: flex; align-items: center; justify-content: flex-end; gap: 6px; padding: 5px 8px;
-  border-top: 1px solid var(--cc-border); background: var(--cc-surface-2); flex-shrink: 0; }
+/* main region below the head: the anchor for the auto-hide control overlays (position: relative) and
+   the box the body fills. */
+.panel-main { position: relative; flex: 1; min-height: 0; display: flex; flex-direction: column; }
+/* controls / footer: shared layout only. The overlay look + hover-reveal live in the global
+   .cc-panel-controls utility (style.css); the in-flow look (auto-hide off) is the .inflow variant. */
+.panel-controls { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 5px 8px; }
+.panel-foot { display: flex; align-items: center; justify-content: flex-end; gap: 6px; padding: 5px 8px; }
+/* in-flow (auto-hide OFF): solid rows that reserve height, as before */
+.panel-controls.inflow { border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-1); }
+.panel-foot.inflow { border-top: 1px solid var(--cc-border); background: var(--cc-surface-2); flex-shrink: 0; }
 .ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
-.panel-remove, .panel-collapse { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
+.panel-btn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
   border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-1); color: var(--cc-text-dim);
   cursor: pointer; font-size: 0.7rem; }
+.panel-btn:hover { color: var(--cc-text); border-color: #484f58; }
+.panel-btn.on { color: var(--cc-text); border-color: var(--cc-accent); }
 .panel-remove:hover { color: #f87171; border-color: #f87171; }
-.panel-collapse:hover { color: var(--cc-text); border-color: #484f58; }
 /* the panel content fills the rest; body is a column so a plot area can flex:1 inside it */
 .panel-body { display: flex; flex-direction: column; flex: 1; min-height: 0; }
 </style>

--- a/frontend/src/components/canvas/CanvasZoomControl.vue
+++ b/frontend/src/components/canvas/CanvasZoomControl.vue
@@ -1,0 +1,34 @@
+<!--
+  Reusable zoom control (fit-width / fit-height / slider / % reset) for any plot canvas — the Analysis
+  board and the free-floating module canvases share it (docs/UI.md → "Canvas zoom"). Pure UI: it owns no
+  state, just relays to the host's useCanvasZoom. Styled to sit in a canvas toolbar's `.seg` row.
+-->
+<script setup lang="ts">
+import { ZOOM_MIN, ZOOM_MAX } from '../../composables/useCanvasZoom'
+
+const props = defineProps<{ zoom: number }>()
+const emit = defineEmits<{ 'update:zoom': [number]; fitWidth: []; fitHeight: []; reset: [] }>()
+const pct = () => Math.round(props.zoom * 100)
+</script>
+
+<template>
+  <div class="cz" v-tooltip.bottom="'Zoom the view to fit your screen (does not change the exported page)'">
+    <button class="cz-btn" @click="emit('fitWidth')" v-tooltip.bottom="'Fit width'"><i class="pi pi-arrows-h" /></button>
+    <button class="cz-btn" @click="emit('fitHeight')" v-tooltip.bottom="'Fit height'"><i class="pi pi-arrows-v" /></button>
+    <input class="cz-range" type="range" :min="ZOOM_MIN * 100" :max="ZOOM_MAX * 100" step="5"
+           :value="pct()" @input="emit('update:zoom', +($event.target as HTMLInputElement).value / 100)" />
+    <button class="cz-val" @click="emit('reset')" v-tooltip.bottom="'Reset to 100%'">{{ pct() }}%</button>
+  </div>
+</template>
+
+<style scoped>
+.cz { display: inline-flex; align-items: center; gap: 4px; border: 1px solid var(--cc-border);
+  border-radius: 5px; padding: 1px 4px; background: var(--cc-surface-2); }
+.cz-btn { display: inline-flex; align-items: center; justify-content: center; width: 1.4rem; height: 1.4rem;
+  background: transparent; color: var(--cc-text-dim); border: none; cursor: pointer; font-size: 0.72rem; }
+.cz-btn:hover { color: var(--cc-text); }
+.cz-range { width: 6rem; }
+.cz-val { min-width: 2.6rem; text-align: center; background: transparent; border: none; cursor: pointer;
+  color: var(--cc-text-dim); font-size: 11px; font-variant-numeric: tabular-nums; }
+.cz-val:hover { color: var(--cc-text); }
+</style>

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -12,7 +12,9 @@
   under this tab's `canvasKey`; the parent (TabbedCanvas) :keys us by it so a tab switch rebinds.
 -->
 <script setup lang="ts">
-import { computed, watch, ref, useTemplateRef, onMounted, onUnmounted } from 'vue'
+import { computed, watch, ref, provide, nextTick, useTemplateRef, onMounted, onUnmounted } from 'vue'
+import { useCanvasZoom, CANVAS_ZOOM_KEY } from '../../composables/useCanvasZoom'
+import CanvasZoomControl from './CanvasZoomControl.vue'
 import { plotHostToImageURL } from '../../plots/export'
 import { useProjectStore } from '../../stores/project'
 import { useProjectMetaStore } from '../../stores/projectMeta'
@@ -21,10 +23,12 @@ import { useSummaryData } from '../../composables/useSummaryData'
 import { useClusterContext } from '../../composables/useClusterContext'
 import { tkey, parseTkey } from '../../plots/series'
 import { defaultVis, type VisProps } from '../../plots/plot'
-import { UNIFORM_PRESETS, COMIC_PRESETS, uniform } from '../../plots/layoutTemplates'
+import { UNIFORM_PRESETS, COMIC_PRESETS, uniform, A4_PORTRAIT_ASPECT, A4_LANDSCAPE_ASPECT } from '../../plots/layoutTemplates'
 import type { SeriesTarget } from '../../plots/types'
 import SummaryPanel from './SummaryPanel.vue'
 import InteractivePanel from './InteractivePanel.vue'
+import PlateBuilder from './PlateBuilder.vue'
+import type { LayoutTemplate } from '../../plots/layoutTemplates'
 import { INTERACTIVE_VIEWS } from './interactiveViews'
 import SeriesPicker from './SeriesPicker.vue'
 import PopulationManager from './PopulationManager.vue'
@@ -49,17 +53,67 @@ const entry = computed(() => layout.entries[props.canvasKey])
 // page if it's taller than the viewport. Default 320px/row.
 const rowHeight = computed({ get: () => entry.value.rowHeight ?? 320, set: v => (entry.value.rowHeight = v) })
 
+// A4 sheet lock — undefined (older boards) reads as portrait so the "board is too wide" fix applies
+// retroactively. In an A4 mode the board's WIDTH is derived from its height × the page aspect, so the
+// on-screen layout matches the exported PDF page exactly (capturePage's measured aspect becomes exact).
+const sheet = computed<'free' | 'a4-portrait' | 'a4-landscape'>({
+  get: () => entry.value.sheet ?? 'a4-portrait', set: v => (entry.value.sheet = v) })
+// only the plates that suit the current sheet orientation (all when Free); uniform grids are neutral
+const platePresets = computed(() => {
+  if (sheet.value === 'free') return COMIC_PRESETS
+  const want = sheet.value === 'a4-portrait' ? 'portrait' : 'landscape'
+  return COMIC_PRESETS.filter(t => (t.orient ?? 'any') === want || t.orient === 'any')
+})
+
 // grid size + height controls live in a ⚙ popover so the board bar doesn't crowd; close on outside click
 const optsOpen = ref(false)
 const optsRef = useTemplateRef<HTMLElement>('optsRef')
-function onDocClick(e: MouseEvent) { if (optsOpen.value && optsRef.value && !optsRef.value.contains(e.target as Node)) optsOpen.value = false }
+// custom plate builder popover (Phase 3)
+const builderOpen = ref(false)
+const builderRef = useTemplateRef<HTMLElement>('builderRef')
+function applyCustomPlate(t: LayoutTemplate) { layout.applyTemplate(props.canvasKey, t); builderOpen.value = false }
+function onDocClick(e: MouseEvent) {
+  const t = e.target as Node
+  if (optsOpen.value && optsRef.value && !optsRef.value.contains(t)) optsOpen.value = false
+  if (builderOpen.value && builderRef.value && !builderRef.value.contains(t)) builderOpen.value = false
+}
 onMounted(() => document.addEventListener('mousedown', onDocClick))
 onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
-const gridStyle = computed(() => ({
-  gridTemplateColumns: entry.value.colTracks ?? `repeat(${entry.value.cols}, minmax(0, 1fr))`,
-  gridTemplateRows: entry.value.rowTracks ?? `repeat(${entry.value.rows}, minmax(0, 1fr))`,
-  height: `${rowHeight.value * entry.value.rows + 8 * (entry.value.rows - 1)}px`,
-}))
+// board natural (unscaled) size — height from rows×rowHeight; width from the A4 page aspect (null in
+// Free mode, where the grid fills the available width).
+const boardH = computed(() => rowHeight.value * entry.value.rows + 8 * (entry.value.rows - 1))
+const boardW = computed<number | null>(() => {
+  if (sheet.value === 'a4-portrait') return boardH.value * A4_PORTRAIT_ASPECT
+  if (sheet.value === 'a4-landscape') return boardH.value * A4_LANDSCAPE_ASPECT
+  return null
+})
+const gridStyle = computed(() => {
+  const base: Record<string, string> = {
+    gridTemplateColumns: entry.value.colTracks ?? `repeat(${entry.value.cols}, minmax(0, 1fr))`,
+    gridTemplateRows: entry.value.rowTracks ?? `repeat(${entry.value.rows}, minmax(0, 1fr))`,
+    height: `${boardH.value}px`,
+  }
+  // A4: lock width to height × page aspect so the box IS the page. Free: leave width to CSS (fills).
+  if (boardW.value != null) { base.width = `${boardW.value}px`; base.flex = 'none' }
+  return base
+})
+
+// ── visual zoom (fit-to-view, Word/Illustrator style) — A4 modes only (Free already fills width) ──
+const canvasWrapRef = useTemplateRef<HTMLElement>('canvasWrapRef')
+const { zoom, fitWidth, fitHeight, fitWidthIfOverflow, setZoom, reset: resetZoom } =
+  useCanvasZoom(canvasWrapRef, () => ({ w: boardW.value, h: boardH.value }))
+provide(CANVAS_ZOOM_KEY, zoom)   // docked panels don't pixel-drag, but keep the contract uniform
+// neutralise zoom during PDF capture so the measured slot rects are at full 1:1 size (the transform
+// would otherwise scale getBoundingClientRect and throw off the hi-res composite)
+const effZoom = computed(() => (capturing.value ? 1 : zoom.value))
+const zoomWrapStyle = computed(() => boardW.value != null
+  ? { width: `${boardW.value * effZoom.value}px`, height: `${boardH.value * effZoom.value}px`, margin: '0 auto' }
+  : { width: '100%' })
+const gridZoomStyle = computed(() => (boardW.value != null && effZoom.value !== 1)
+  ? { transform: `scale(${effZoom.value})`, transformOrigin: 'top left' } : {})
+// first render (and image switch): fit-to-width if the board would overflow, so the whole board is
+// visible without hiding the sidebar; a board that already fits stays at 100%.
+watch(imageUid, () => nextTick(fitWidthIfOverflow), { immediate: true })
 
 // shared summary-plot data + view-state (same composable the free-floating canvas uses)
 const {
@@ -313,6 +367,15 @@ defineExpose({ capturePage, collectCsvs })
                 <span class="lc-val">{{ rowHeight }}</span></label>
             </div>
           </div>
+          <!-- A4 sheet lock: keep the board at page proportions (WYSIWYG with the PDF) or let it fill -->
+          <div class="seg" v-tooltip.bottom="'Sheet — A4 locks the board to page proportions (what you see is the exported page); Free fills the width'">
+            <button :class="{ on: sheet === 'a4-portrait' }" @click="sheet = 'a4-portrait'">A4 ↕</button>
+            <button :class="{ on: sheet === 'a4-landscape' }" @click="sheet = 'a4-landscape'">A4 ↔</button>
+            <button :class="{ on: sheet === 'free' }" @click="sheet = 'free'">Free</button>
+          </div>
+          <!-- fit-to-view zoom (visual only; the exported page is unchanged) -->
+          <CanvasZoomControl v-if="sheet !== 'free'" :zoom="zoom"
+                             @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
           <!-- clustering run: ONE per board (drives all cluster slots + the cluster pop manager) -->
           <div v-if="hasClusterSlot" class="lc-clust" v-tooltip.bottom="'Clustering run shown by this board’s cluster plots'">
             <span class="lc-lbl">cluster</span>
@@ -354,25 +417,37 @@ defineExpose({ capturePage, collectCsvs })
         </div>
         <div class="lc-row">
           <span class="lc-lbl">Plates</span>
-          <div class="seg seg-wrap" v-tooltip.bottom="'Comic plates — varied-size panels'">
-            <button v-for="t in COMIC_PRESETS" :key="t.id" @click="layout.applyTemplate(canvasKey, t)"
+          <div class="seg seg-wrap" v-tooltip.bottom="'Comic plates — varied-size panels, matched to the sheet orientation'">
+            <button v-for="t in platePresets" :key="t.id" @click="layout.applyTemplate(canvasKey, t)"
                     :class="{ on: entry.slotAreas.join('|') === t.slots.join('|') }">{{ t.label }}</button>
+          </div>
+          <!-- custom plate builder: drag cells to merge into varied-size panels -->
+          <div ref="builderRef" class="lc-opts">
+            <button class="cc-btn cc-btn-ghost lc-custom" :class="{ on: builderOpen }" @click="builderOpen = !builderOpen"
+                    v-tooltip.bottom="'Build a custom plate — drag cells to merge, click a merge to split'">
+              <i class="pi pi-th-large" /> Custom…</button>
+            <div v-if="builderOpen" class="lc-pop">
+              <PlateBuilder :cols="entry.cols" :rows="entry.rows" :slot-areas="entry.slotAreas"
+                            @apply="applyCustomPlate" @cancel="builderOpen = false" />
+            </div>
           </div>
         </div>
       </div>
 
       <div class="lc-body">
-        <!-- the grid of slots -->
-        <div ref="gridRef" class="lc-grid" :class="{ capturing }" :style="gridStyle">
+        <!-- scroll viewport → .lc-zoom (scaled footprint, centred) → the grid (visually scaled) -->
+        <div ref="canvasWrapRef" class="lc-canvas-wrap">
+        <div class="lc-zoom" :style="zoomWrapStyle">
+        <div ref="gridRef" class="lc-grid" :class="{ capturing }" :style="[gridStyle, gridZoomStyle]">
+          <!-- reorder drag: the drag SOURCE is the panel header's drag icon (CanvasPanel, docked);
+               its native dragstart bubbles here, so the grip lives IN the header (aligned with the
+               other buttons) instead of a fragile absolute overlay that collided with the pin. -->
           <div v-for="(area, i) in entry.slotAreas" :key="i" class="lc-slot"
                :class="{ active: i === entry.activeIndex, filled: !!entry.contents[i] }"
                :style="{ gridArea: area }"
+               @dragstart="dragFrom.i = i" @dragend="dragFrom.i = -1"
                @dragover.prevent @drop.prevent="onDrop(i)"
                @mousedown="layout.setActive(canvasKey, i)">
-            <!-- grip: the ONLY drag source, so dragging inside the plot never starts a reorder -->
-            <div v-if="entry.contents[i]" class="lc-grip" draggable="true"
-                 @dragstart="dragFrom.i = i" @dragend="dragFrom.i = -1"
-                 v-tooltip.bottom="'Drag to move / swap'"><i class="pi pi-arrows-alt" /></div>
             <!-- summary plot -->
             <SummaryPanel v-if="entry.contents[i]?.kind === 'summary' && specById[entry.contents[i]!.ref]"
                           :ref="el => setSummaryRef(i, el)"
@@ -419,6 +494,8 @@ defineExpose({ capturePage, collectCsvs })
             </div>
           </div>
         </div>
+        </div>
+        </div>
 
         <!-- docked pop manager (control, not content — excluded from PDF). Follows the ACTIVE slot:
              cluster PopulationManager for a cluster slot, else the summary SeriesPicker. -->
@@ -458,6 +535,8 @@ defineExpose({ capturePage, collectCsvs })
   border: 1px solid var(--cc-border); border-radius: 5px; background: var(--cc-surface-2); color: var(--cc-text-dim);
   cursor: pointer; font-size: 0.72rem; }
 .lc-gear:hover, .lc-gear.on { color: var(--cc-text); border-color: #7c3aed; }
+.lc-custom { font-size: 11px; padding: 0.22rem 0.55rem; }
+.lc-custom.on { color: var(--cc-text); border-color: #7c3aed; }
 .lc-pop { position: absolute; top: calc(100% + 4px); left: 0; z-index: 20; min-width: 13rem;
   display: flex; flex-direction: column; gap: 8px; padding: 10px; background: var(--cc-surface-1);
   border: 1px solid var(--cc-border); border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,0.35); }
@@ -479,21 +558,17 @@ defineExpose({ capturePage, collectCsvs })
 .seg button.on { background: #2d1b69; color: #c4b5fd; }
 /* the board sizes to its grid (rowHeight × rows); the page's panel-scroll handles overflow */
 .lc-body { display: flex; align-items: flex-start; gap: 8px; }
+/* scroll viewport for the board. .lc-zoom holds the (visually scaled) footprint: fixed-size + centred
+   via margin auto for an A4 board, full-width for a Free board (styled inline via zoomWrapStyle). */
+.lc-canvas-wrap { flex: 1; min-width: 0; overflow: auto; }
+.lc-zoom { display: block; }
 .lc-grid { flex: 1; display: grid; gap: 8px; padding: 4px; overflow: hidden; }
 .lc-slot { position: relative; border: 1px dashed var(--cc-border); border-radius: 6px; overflow: hidden;
   display: flex; min-width: 0; min-height: 0; background: var(--cc-bg); }
 .lc-slot.filled { border-style: solid; }
 .lc-slot.active { border-color: #7c3aed; }
-/* drag grip: sits in the docked panel header's empty spacer (left of the remove button) */
-.lc-grip { position: absolute; top: 5px; right: 2.3rem; z-index: 7; width: 1.4rem; height: 1.4rem;
-  display: flex; align-items: center; justify-content: center; cursor: grab; font-size: 0.62rem;
-  color: var(--cc-text-dim); background: var(--cc-surface-1); border: 1px solid var(--cc-border);
-  border-radius: 4px; opacity: 0.4; transition: opacity 0.1s, color 0.1s; }
-.lc-slot:hover .lc-grip { opacity: 1; }
-.lc-grip:hover { color: var(--cc-text); border-color: #7c3aed; }
-.lc-grip:active { cursor: grabbing; }
-/* hide the drag grips while capturing so they don't appear in the exported PDF */
-.lc-grid.capturing .lc-grip { display: none; }
+/* reorder drag handle now lives IN the panel header (CanvasPanel docked drag icon); its native
+   dragstart bubbles to .lc-slot (@dragstart above). No absolute overlay grip here anymore. */
 .lc-add { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; }
 .lc-add-hint { color: var(--cc-text-dim); font-size: 11px; opacity: 0.6; }
 .lc-rail { flex-shrink: 0; width: 300px; overflow-y: auto; }

--- a/frontend/src/components/canvas/PlateBuilder.vue
+++ b/frontend/src/components/canvas/PlateBuilder.vue
@@ -1,0 +1,99 @@
+<!--
+  Custom plate builder for the Analysis board (docs/ANALYSIS.md). Set the grid size, then DRAG across
+  cells to MERGE them into one panel (a rectangular span); click a merged block to split it back to 1×1s.
+  Emits the resulting LayoutTemplate on Apply — the board then applyTemplate()s it, preserving slot
+  contents by index. All the span math is the pure, unit-tested utils/plateBuilder.ts; this is just the
+  drag UI. Seeded from the current plate so you can tweak rather than start over.
+-->
+<script setup lang="ts">
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { normSpan, applyDrag, clampSpans, slotsToSpans, buildPlate, type PlateSpan, type Cell } from '../../utils/plateBuilder'
+import type { LayoutTemplate } from '../../plots/layoutTemplates'
+
+const props = defineProps<{ cols: number; rows: number; slotAreas: string[] }>()
+const emit = defineEmits<{ apply: [LayoutTemplate]; cancel: [] }>()
+
+const MIN = 1, MAX = 6
+const clamp = (v: number) => Math.max(MIN, Math.min(MAX, Math.round(v || MIN)))
+const cols = ref(clamp(props.cols))
+const rows = ref(clamp(props.rows))
+const spans = ref<PlateSpan[]>(slotsToSpans(props.slotAreas))
+// resizing the grid must not leave spans hanging outside it
+watch([cols, rows], () => { spans.value = clampSpans(spans.value, cols.value, rows.value) })
+
+const gridCells = computed<Cell[]>(() => {
+  const out: Cell[] = []
+  for (let r = 0; r < rows.value; r++) for (let c = 0; c < cols.value; c++) out.push({ r, c })
+  return out
+})
+const gridTmpl = computed(() => ({
+  gridTemplateColumns: `repeat(${cols.value}, 1fr)`, gridTemplateRows: `repeat(${rows.value}, 1fr)` }))
+const areaStyle = (s: PlateSpan) => ({ gridArea: `${s.r0 + 1} / ${s.c0 + 1} / ${s.r1 + 2} / ${s.c1 + 2}` })
+
+// ── drag to merge / click to split ────────────────────────────────────────────
+const dragging = ref(false)
+const start = ref<Cell | null>(null)
+const hover = ref<Cell | null>(null)
+const dragRect = computed(() => (dragging.value && start.value && hover.value) ? normSpan(start.value, hover.value) : null)
+function onDown(cell: Cell) { start.value = hover.value = cell; dragging.value = true; window.addEventListener('pointerup', onUp) }
+function onEnter(cell: Cell) { if (dragging.value) hover.value = cell }
+function onUp() {
+  window.removeEventListener('pointerup', onUp)
+  if (dragging.value && start.value && hover.value) spans.value = applyDrag(spans.value, normSpan(start.value, hover.value))
+  dragging.value = false; start.value = hover.value = null
+}
+onBeforeUnmount(() => window.removeEventListener('pointerup', onUp))
+
+const slotCount = computed(() => buildPlate(cols.value, rows.value, spans.value).slots.length)
+function apply() { emit('apply', buildPlate(cols.value, rows.value, spans.value)) }
+</script>
+
+<template>
+  <div class="pb">
+    <div class="pb-head">
+      <label class="pb-num"><span>cols</span>
+        <input type="number" :min="MIN" :max="MAX" v-model.number="cols" @change="cols = clamp(cols)" /></label>
+      <label class="pb-num"><span>rows</span>
+        <input type="number" :min="MIN" :max="MAX" v-model.number="rows" @change="rows = clamp(rows)" /></label>
+      <span class="pb-hint">drag to merge · click a merge to split</span>
+    </div>
+
+    <div class="pb-grid" :style="gridTmpl">
+      <div v-for="cell in gridCells" :key="`${cell.r}-${cell.c}`" class="pb-cell"
+           @pointerdown.prevent="onDown(cell)" @pointerenter="onEnter(cell)" />
+      <div v-for="(s, i) in spans" :key="`s${i}`" class="pb-span" :style="areaStyle(s)" />
+      <div v-if="dragRect" class="pb-drag" :style="areaStyle(dragRect)" />
+    </div>
+
+    <div class="pb-foot">
+      <span class="pb-count">{{ slotCount }} panel{{ slotCount === 1 ? '' : 's' }}</span>
+      <span class="pb-spacer" />
+      <button class="cc-btn cc-btn-ghost" type="button" @click="emit('cancel')">Cancel</button>
+      <button class="cc-btn cc-btn-primary" type="button" @click="apply">Apply</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.pb { display: flex; flex-direction: column; gap: 8px; width: 15rem; }
+.pb-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.pb-num { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: var(--cc-text-dim); }
+.pb-num input { width: 3rem; font-size: 12px; padding: 2px 4px; }
+.pb-hint { flex-basis: 100%; font-size: 10px; color: var(--cc-text-dim); opacity: 0.75; }
+/* the plate canvas: an A4-portrait-ish aspect so the preview reads like a page */
+.pb-grid { position: relative; display: grid; gap: 3px; aspect-ratio: 0.78; width: 100%;
+  padding: 3px; background: var(--cc-border); border-radius: 5px; user-select: none; touch-action: none; }
+.pb-cell { background: var(--cc-surface-2); border-radius: 3px; cursor: crosshair; }
+.pb-cell:hover { background: var(--cc-surface-1); }
+/* a merged span: one contiguous block over the cells it covers (spanning a grid-area covers the
+   internal gaps automatically); pointer-events none so a click passes through to the cell to split */
+.pb-span { pointer-events: none; z-index: 2; border-radius: 3px;
+  background: color-mix(in srgb, var(--cc-accent) 30%, var(--cc-surface-2));
+  border: 1px solid var(--cc-accent); }
+/* live drag highlight */
+.pb-drag { pointer-events: none; z-index: 3; border-radius: 3px;
+  background: color-mix(in srgb, var(--cc-accent) 22%, transparent); border: 1px dashed var(--cc-accent); }
+.pb-foot { display: flex; align-items: center; gap: 6px; }
+.pb-count { font-size: 11px; color: var(--cc-text-dim); }
+.pb-spacer { flex: 1; }
+</style>

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -14,13 +14,15 @@
   module filter off.
 -->
 <script setup lang="ts">
-import { computed, watch, useTemplateRef } from 'vue'
+import { computed, watch, provide, useTemplateRef } from 'vue'
 import { useProjectStore } from '../../stores/project'
 import { useProjectMetaStore } from '../../stores/projectMeta'
 import { useCanvasPanels } from '../../composables/useCanvasPanels'
 import { useSummaryData } from '../../composables/useSummaryData'
+import { useCanvasZoom, CANVAS_ZOOM_KEY } from '../../composables/useCanvasZoom'
 import SeriesPicker from './SeriesPicker.vue'
 import SummaryPanel from './SummaryPanel.vue'
+import CanvasZoomControl from './CanvasZoomControl.vue'
 import { tkey, parseTkey } from '../../plots/series'
 import { defaultVis, type VisProps } from '../../plots/plot'
 import type { SeriesTarget, ChartType } from '../../plots/types'
@@ -52,6 +54,18 @@ const canvasRef = useTemplateRef<HTMLElement>('canvasRef')
 const { panels, activeId, activePanel, shared, add, remove, arrangeGrid, arrangeCascade } =
   useCanvasPanels<PanelState>(canvasRef, () => ({ specId: specs.value[0]?.id ?? '', sel: [], vis: defaultVis() }),
     ckey)
+// show/hide the floating population picker — persisted per canvas in the `shared` bag (default shown)
+const showManager = computed<boolean>({ get: () => (shared.value.showManager as boolean) ?? true, set: v => (shared.value.showManager = v) })
+
+// ── visual zoom (shared control) — scale the free-floating workspace to see everything at once.
+// Fit measures the panel bounding box (the zoom layer's scroll size); drag is zoom-corrected via the
+// injected zoom (CanvasPanel → useFloatingPanel). The population picker sits OUTSIDE the zoom layer so
+// the control panel stays full-size.
+const zoomRef = useTemplateRef<HTMLElement>('zoomRef')
+const { zoom, fitWidth, fitHeight, setZoom, reset: resetZoom } = useCanvasZoom(canvasRef,
+  () => { const el = zoomRef.value; return el ? { w: el.scrollWidth, h: el.scrollHeight } : { w: null, h: 0 } })
+provide(CANVAS_ZOOM_KEY, zoom)
+const zoomStyle = computed(() => zoom.value !== 1 ? { transform: `scale(${zoom.value})`, transformOrigin: 'top left' } : {})
 // shared summary-plot data + canvas-level view-state (identical whether plots float or sit in a grid)
 const {
   specs, specById, segPops, seriesColor, reloadToken, validSelKeys,
@@ -144,10 +158,19 @@ watch(segPops, () => { for (const p of panels.value) p.state.sel = p.state.sel.f
           <button v-tooltip.bottom="'Tile in a grid'" @click="arrangeGrid"><i class="pi pi-th-large" /></button>
           <button v-tooltip.bottom="'Cascade windows'" @click="arrangeCascade"><i class="pi pi-clone" /></button>
         </div>
+        <div class="seg">
+          <button :class="{ on: showManager }" @click="showManager = !showManager"
+                  v-tooltip.bottom="showManager ? 'Hide the population picker' : 'Show the population picker'">
+            <i class="pi pi-sitemap" />
+          </button>
+        </div>
+        <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
         <span v-if="!specs.length" class="sc-hint">No plot types available for this module yet.</span>
         <span v-else class="sc-hint">eye-select populations to plot · drag plots by their title</span>
       </div>
       <div ref="canvasRef" class="sc-canvas">
+        <!-- scaled workspace: the panels zoom together; the population picker stays full-size (below) -->
+        <div ref="zoomRef" class="sc-zoom" :style="zoomStyle">
         <template v-for="(p, i) in panels" :key="`${ckey}:${p.id}`">
           <SummaryPanel v-if="specById[p.state.specId]" :index="i" :arrange="p.arrange"
                         :active="p.id === activeId" :spec="specById[p.state.specId]"
@@ -160,7 +183,8 @@ watch(segPops, () => { for (const p of panels.value) p.state.sel = p.state.sel.f
                         @activate="activeId = p.id" @remove="remove(p.id)"
                         @duplicate="duplicatePanel(p)" @explode="explodePanel(p, $event)" />
         </template>
-        <SeriesPicker :groups="segPops" :selected="activeSel" :scope="scope" :vis="activeVis"
+        </div>
+        <SeriesPicker v-if="showManager" :groups="segPops" :selected="activeSel" :scope="scope" :vis="activeVis"
                       @toggle="toggleTarget" @update:scope="scope = $event" @update:vis="setVis" />
       </div>
     </template>
@@ -185,5 +209,8 @@ watch(segPops, () => { for (const p of panels.value) p.state.sel = p.state.sel.f
 .seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 5px 9px; cursor: pointer; font-size: 12px; }
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button:hover { color: var(--cc-text); }
+.seg button.on { color: var(--cc-accent); background: var(--cc-surface-1); }
 .sc-canvas { position: relative; flex: 1; min-height: 70vh; }
+/* the scaled workspace fills the canvas (offsetParent for the floating panels); transform set inline */
+.sc-zoom { position: absolute; inset: 0; }
 </style>

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -15,7 +15,6 @@
 <script setup lang="ts">
 import { useTemplateRef, toRef } from 'vue'
 import type { GateSpec } from '../../stores/gating'
-import ScatterGL from './ScatterGL.vue'
 import PlotSpinner from './PlotSpinner.vue'
 import { useDelayedLoading } from '../../composables/useDelayedLoading'
 import PlotLayers, { type PopLayer } from './PlotLayers.vue'
@@ -75,11 +74,10 @@ function fmtTick(label: string): string {
 // scale so nothing is upscaled from the screen-DPR backing store; route each live canvas to its layer.
 const hostEl = useTemplateRef<HTMLElement>('hostEl')
 type LayerExport = { exportCanvas(scale: number): Promise<HTMLCanvasElement | null>; getCanvas(): HTMLCanvasElement | null }
-const scatterRef = useTemplateRef<LayerExport>('scatterRef')
 const layersRef = useTemplateRef<LayerExport>('layersRef')
 const overlayRef = useTemplateRef<LayerExport>('overlayRef')
 const hiRes = async (cv: HTMLCanvasElement, scale: number) => {
-  for (const r of [scatterRef, layersRef, overlayRef]) {
+  for (const r of [layersRef, overlayRef]) {
     if (cv === r.value?.getCanvas()) return (await r.value?.exportCanvas(scale)) ?? null
   }
   return null
@@ -104,11 +102,7 @@ defineExpose({ exportImage, hiRes })
 <template>
   <div ref="hostEl" class="plot-capture" :class="{ compact, 'no-axis': hideAxisLabels }">
     <div class="panel-plot">
-      <!-- WebGL base cloud only in 'points' mode; contour/outliers draw from PlotLayers instead, so we
-           skip the point upload entirely (contour-only is the fast path the user asked for). -->
-      <ScatterGL ref="scatterRef" :points="renderMode === 'points' ? points : null" :extents="extents"
-                 :color-mode="showPops ? 'flat' : 'density'"
-                 :opacity="showPops ? 0.35 : 1" :point-size="3" />
+      <!-- base cloud (density raster / contours), child-pop overlays, and outliers — all 2D, no WebGL -->
       <PlotLayers ref="layersRef" :view-extents="viewExtents" :render-mode="renderMode" :base-points="points"
                   :pop-layers="popLayers" :show-pops="showPops" :view-tick="viewTick" />
       <GateOverlay ref="overlayRef" :extents="viewExtents" :mode="mode" :gates="gates" :view-tick="viewTick"

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -181,7 +181,7 @@ defineExpose({ exportImage })
 
 <template>
   <div class="gs-view">
-    <div class="gs-bar">
+    <div class="gs-bar cc-panel-controls">
       <select v-if="imageUids.length > 1" :value="imageUid" @change="setImageUid(($event.target as HTMLSelectElement).value)"
               v-tooltip.bottom="'Image'">
         <option v-for="u in imageUids" :key="u" :value="u">{{ u }}</option>
@@ -222,9 +222,10 @@ defineExpose({ exportImage })
 </template>
 
 <style scoped>
-.gs-view { display: flex; flex-direction: column; height: 100%; min-height: 0; }
-.gs-bar { display: flex; align-items: center; gap: 6px; padding: 6px 8px; flex-wrap: wrap; flex-shrink: 0;
-  border-bottom: 1px solid var(--cc-border); font-size: 12px; }
+/* position: relative so the overlaid .gs-bar (.cc-panel-controls) anchors to the plot box, not the panel */
+.gs-view { position: relative; display: flex; flex-direction: column; height: 100%; min-height: 0; }
+.gs-bar { display: flex; align-items: center; gap: 6px; padding: 6px 8px; flex-wrap: wrap;
+  font-size: 12px; }
 .gs-bar select { font-size: 12px; max-width: 9rem; }
 /* ⚙ options popover (hierarchy toggle). margin-left:auto pins the gear to the far right so the popover —
    anchored right:0 — always opens LEFTWARD into the panel and is never clipped at the left edge. */

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -101,7 +101,7 @@ defineExpose({ exportImage })
 
 <template>
   <div class="is-view">
-    <div class="is-bar">
+    <div class="is-bar cc-panel-controls">
       <div class="seg" v-tooltip.bottom="'Strip direction'">
         <button :class="{ on: orientation === 'h' }" @click="orientation = 'h'"><i class="pi pi-arrows-h" /></button>
         <button :class="{ on: orientation === 'v' }" @click="orientation = 'v'"><i class="pi pi-arrows-v" /></button>
@@ -158,10 +158,11 @@ defineExpose({ exportImage })
 </template>
 
 <style scoped>
-.is-view { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+/* position: relative so the overlaid .is-bar (.cc-panel-controls) anchors to the strip box */
+.is-view { position: relative; display: flex; flex-direction: column; height: 100%; min-height: 0; }
 /* angle/width live in a ⚙ popover (below), so the bar stays short and never wraps */
-.is-bar { display: flex; align-items: center; gap: 8px; padding: 6px 8px; flex-wrap: wrap; flex-shrink: 0;
-  border-bottom: 1px solid var(--cc-border); font-size: 12px; }
+.is-bar { display: flex; align-items: center; gap: 8px; padding: 6px 8px; flex-wrap: wrap;
+  font-size: 12px; }
 .is-opts { position: relative; display: inline-flex; }
 .is-gear { display: inline-flex; align-items: center; justify-content: center; width: 1.7rem; height: 1.6rem;
   border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-2); color: var(--cc-text-dim);

--- a/frontend/src/components/plots/PlotLayers.vue
+++ b/frontend/src/components/plots/PlotLayers.vue
@@ -1,37 +1,38 @@
 <!--
-  canvas2D render layer between ScatterGL (base points) and GateOverlay (gate drawing).
-  Two FlowJo-style jobs, both rescaling on zoom (it maps data→px via the LIVE viewExtents):
+  The gating base renderer + overlays, all on ONE 2D canvas (no WebGL — see docs/PLOTS.md). Replaces the
+  old regl point cloud for gating: the base population is a FlowJo/OMIQ-style DENSITY RASTER (points
+  mode) or clean d3-contour rings (contour/outliers mode). Sits between the (now-removed) WebGL layer
+  and GateOverlay (gate drawing). Everything maps data→px via the LIVE viewExtents, so it rescales on
+  zoom / axis-extent change; export re-renders the same 2D content at scale (crisp, cannot clip).
 
-   1. Contour mode  → marching-squares contours of the base population's density, at
-      normalised z = 1 − [0.95, 0.90, 0.75, 0.5]  (R: .flowContourLines, flowHelpers.R:46).
-   2. Population colour overlay (showPops) → for each visible child population on these axes,
-      draw its cells in the population colour: as dots (points mode) or as a contour (contour
-      mode). Works for BOTH base modes. Subsets come from the server (plotdata?pop=…), so Julia
-      still owns membership; we only colour.
+    • points   → density raster of the base population (dimmed when showing pops).
+    • contour  → nested contour rings of the base density.
+    • outliers → contour rings + the sparse-tail dots the rings don't enclose.
+    • showPops → each visible child population drawn in its colour (dots in points mode, rings otherwise).
+  Subsets come from the server (plotdata?pop=…), so Julia still owns membership; we only colour.
 -->
 <script setup lang="ts">
 import { watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
-import { densityGrid as computeDensityGrid, outlierPoints, DENSITY_GRID, CONTOUR_LEVELS, type Ext } from '../../plots/density'
+import { densityGrid, densityImageData, outlierPoints, DENSITY_GRID, CONTOUR_LEVELS, type Ext } from '../../plots/density'
+import { densityContours } from '../../plots/contour'
 
 export interface PopLayer { path: string; colour: string; points: Float32Array }
 
 const props = defineProps<{
   viewExtents: Ext                          // live (zoom-synced) data extents
-  renderMode: 'points' | 'contour' | 'outliers'   // contour = contours only; outliers = contours + tail dots
-  basePoints: Float32Array | null           // base population points (for base contour)
+  renderMode: 'points' | 'contour' | 'outliers'
+  basePoints: Float32Array | null           // base population points
   popLayers: PopLayer[]                      // visible child pops to colour
   showPops: boolean
   viewTick: number                           // bump → redraw (camera moved)
 }>()
-// contour-family modes (contours drawn, no full WebGL point cloud); `outliers` adds the sparse-tail dots
-const isContour = () => props.renderMode === 'contour' || props.renderMode === 'outliers'
 
 const canvasEl = useTemplateRef<HTMLCanvasElement>('canvasEl')
 let ctx: CanvasRenderingContext2D | null = null
 let ro: ResizeObserver | null = null
 
-const G = DENSITY_GRID                       // contour grid resolution (shared with density.ts)
-const LEVELS = CONTOUR_LEVELS                // 1 − confidence levels (outer→inner)
+const G = DENSITY_GRID
+const LEVELS = CONTOUR_LEVELS
 
 function size() { const c = canvasEl.value!; return { w: c.clientWidth, h: c.clientHeight } }
 function toPx(vx: number, vy: number): [number, number] {
@@ -39,99 +40,83 @@ function toPx(vx: number, vy: number): [number, number] {
   const xs = xMax > xMin ? xMax - xMin : 1, ys = yMax > yMin ? yMax - yMin : 1
   return [((vx - xMin) / xs) * w, (1 - (vy - yMin) / ys) * h]
 }
-
-// density grid (normalised 0..1) over the current view — shared pure helper (plots/density.ts)
-const densityGrid = (points: Float32Array) => computeDensityGrid(points, props.viewExtents, G)
-
-// grid cell coords → data coords. Samples sit at bin CENTRES ((i+0.5)/G), matching the
-// binning above (floor((v-min)/range*G)); using /(G-1) here mis-scaled contours vs the points.
-function cellToData(gx: number, gy: number): [number, number] {
+// d3-contour ring coord (grid space [0,G], col=x row=y) → px
+function gridToPx(gx: number, gy: number): [number, number] {
   const { xMin, xMax, yMin, yMax } = props.viewExtents
-  return [xMin + ((gx + 0.5) / G) * (xMax - xMin), yMin + ((gy + 0.5) / G) * (yMax - yMin)]
+  return toPx(xMin + (gx / G) * (xMax - xMin), yMin + (gy / G) * (yMax - yMin))
 }
 
-// marching squares: stroke contour segments for one level
-function strokeContour(z: Float32Array, level: number) {
+// FlowJo pseudocolour density raster: build the G×G RGBA image, then upscale (smoothed) to the plot rect
+function drawRaster(points: Float32Array, alpha = 1) {
   const c = ctx!
-  const interp = (a: number, b: number) => (a === b ? 0.5 : (level - a) / (b - a))
-  c.beginPath()
-  for (let y = 0; y < G - 1; y++) for (let x = 0; x < G - 1; x++) {
-    const tl = z[y * G + x], tr = z[y * G + x + 1], br = z[(y + 1) * G + x + 1], bl = z[(y + 1) * G + x]
-    let idx = 0
-    if (tl > level) idx |= 8; if (tr > level) idx |= 4; if (br > level) idx |= 2; if (bl > level) idx |= 1
-    if (idx === 0 || idx === 15) continue
-    // edge crossing points in cell-space → data → px
-    const top: [number, number]    = [x + interp(tl, tr), y]
-    const right: [number, number]  = [x + 1, y + interp(tr, br)]
-    const bottom: [number, number] = [x + interp(bl, br), y + 1]
-    const left: [number, number]   = [x, y + interp(tl, bl)]
-    const seg = (a: [number, number], b: [number, number]) => {
-      const [ax, ay] = toPx(...cellToData(a[0], a[1])), [bx, by] = toPx(...cellToData(b[0], b[1]))
-      c.moveTo(ax, ay); c.lineTo(bx, by)
-    }
-    switch (idx) {
-      case 1: case 14: seg(left, bottom); break
-      case 2: case 13: seg(bottom, right); break
-      case 3: case 12: seg(left, right); break
-      case 4: case 11: seg(top, right); break
-      case 5: seg(left, top); seg(bottom, right); break
-      case 6: case 9: seg(top, bottom); break
-      case 7: case 8: seg(left, top); break
-      case 10: seg(left, bottom); seg(top, right); break
-    }
-  }
-  c.stroke()
+  const img = densityImageData(points, props.viewExtents, G)
+  const off = document.createElement('canvas'); off.width = G; off.height = G
+  const octx = off.getContext('2d')!
+  const idata = octx.createImageData(G, G); idata.data.set(img.data)   // avoids ImageData-ctor buffer typing
+  octx.putImageData(idata, 0, 0)
+  const { w, h } = size()
+  c.save()
+  c.globalAlpha = alpha; c.imageSmoothingEnabled = true; c.imageSmoothingQuality = 'high'
+  c.drawImage(off, 0, 0, G, G, 0, 0, w, h)
+  c.restore()
 }
 
+// clean nested contour rings (d3-contour on the blurred grid). Outer levels faint → inner solid.
 function drawContours(points: Float32Array, colour: string) {
-  const z = densityGrid(points)
-  for (let i = 0; i < LEVELS.length; i++) {
-    ctx!.strokeStyle = colour
-    ctx!.globalAlpha = 0.45 + 0.55 * (i / (LEVELS.length - 1))   // outer faint → inner solid
-    ctx!.lineWidth = 1.2
-    strokeContour(z, LEVELS[i])
-  }
-  ctx!.globalAlpha = 1
+  const c = ctx!
+  const grid = densityGrid(points, props.viewExtents, G)
+  const levels = densityContours(grid, G, LEVELS)
+  c.strokeStyle = colour; c.lineWidth = 1.2; c.lineJoin = 'round'; c.lineCap = 'round'
+  levels.forEach((lvl, i) => {
+    c.globalAlpha = 0.5 + 0.5 * (i / Math.max(1, LEVELS.length - 1))
+    c.beginPath()
+    for (const ring of lvl.rings) {
+      if (ring.length < 2) continue
+      let [px, py] = gridToPx(ring[0][0], ring[0][1]); c.moveTo(px, py)
+      for (let k = 1; k < ring.length; k++) { [px, py] = gridToPx(ring[k][0], ring[k][1]); c.lineTo(px, py) }
+      c.closePath()
+    }
+    c.stroke()
+  })
+  c.globalAlpha = 1
 }
 
 function drawDots(points: Float32Array, colour: string, r = 1.5) {
   const c = ctx!; c.fillStyle = colour
-  const n = points.length / 2
-  const s = r * 2
+  const n = points.length / 2, s = r * 2
   for (let i = 0; i < n; i++) {
     const [px, py] = toPx(points[2 * i], points[2 * i + 1])
     c.fillRect(px - r, py - r, s, s)
   }
 }
-// "contour + outliers": individual dots for the sparse-tail points the contours don't enclose (R:
-// contour ± outliers). Kept subtle — small, faint sub-pixel dots — so the contours stay the main read.
+// "contour + outliers": the sparse-tail points the contours don't enclose, drawn as subtle dots
 function drawOutliers(points: Float32Array, colour: string) {
-  const pts = outlierPoints(points, props.viewExtents, G)
   ctx!.globalAlpha = 0.3
-  drawDots(pts, colour, 0.6)
+  drawDots(outlierPoints(points, props.viewExtents, G), colour, 0.6)
   ctx!.globalAlpha = 1
 }
 
-// paint the layer content (contours + pop overlay) with the current `ctx`; toPx uses size() (CSS px)
-// so it's resolution-independent — the transform on the target ctx sets the actual pixel density.
 function paintContent() {
   ctx!.lineJoin = 'round'
-  if (isContour() && props.basePoints?.length) {
-    drawContours(props.basePoints, '#cbd5e1')
-    if (props.renderMode === 'outliers') drawOutliers(props.basePoints, '#cbd5e1')
+  const mode = props.renderMode
+  // BASE population
+  if (props.basePoints?.length) {
+    if (mode === 'points') drawRaster(props.basePoints, props.showPops ? 0.4 : 1)   // dim under pop overlays
+    else {
+      drawContours(props.basePoints, '#cbd5e1')
+      if (mode === 'outliers') drawOutliers(props.basePoints, '#cbd5e1')
+    }
   }
+  // child POPULATION overlays
   if (props.showPops) {
     for (const pop of props.popLayers) {
       if (!pop.points?.length) continue
-      if (isContour()) {
-        drawContours(pop.points, pop.colour)
-        if (props.renderMode === 'outliers') drawOutliers(pop.points, pop.colour)
-      } else {
-        drawDots(pop.points, pop.colour)
-      }
+      if (mode === 'points') drawDots(pop.points, pop.colour)
+      else { drawContours(pop.points, pop.colour); if (mode === 'outliers') drawOutliers(pop.points, pop.colour) }
     }
   }
 }
+
 function draw() {
   if (!ctx || !canvasEl.value) return
   const dpr = window.devicePixelRatio || 1
@@ -142,9 +127,8 @@ function draw() {
   paintContent()
 }
 
-// hi-res export (see plots/export.ts): re-paint the same content onto a scale× offscreen canvas so
-// the contours/dots are crisp instead of the compositor upscaling the screen-DPR canvas. We swap the
-// module `ctx` to the offscreen context so the existing draw helpers target it, then restore.
+// hi-res export: re-paint the SAME 2D content onto a scale× offscreen canvas (crisp; a 2D canvas can't
+// clip like the old WebGL re-render). Swap the module ctx so the draw helpers target the offscreen.
 async function exportCanvas(scale: number): Promise<HTMLCanvasElement | null> {
   if (!canvasEl.value) return null
   const { w, h } = size(); if (!w || !h) return null

--- a/frontend/src/components/plots/ScatterGL.vue
+++ b/frontend/src/components/plots/ScatterGL.vue
@@ -17,6 +17,7 @@
 -->
 <script setup lang="ts">
 import { watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
+import { BLUE_HEAT_RAMP as RAMP } from '../../plots/flowColors'
 
 type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
 const props = withDefaults(defineProps<{
@@ -34,26 +35,7 @@ const props = withDefaults(defineProps<{
 }>(), { colorMode: 'density', pointSize: 3, opacity: 1, flatColor: '#8b8b8b',
         categories: null, palette: () => [], backgroundColor: '#0d0b1a' })
 
-// FlowJo "pseudocolour" blue-heat ramp (R: .flowColorRampBlueHeat, flowHelpers.R:775),
-// low end lifted off pure black so sparse points stay visible on the dark background, and
-// interpolated to 256 stops so regl shows a smooth gradient (not 5 hard bands).
-function hexRgb(h: string): [number, number, number] {
-  return [parseInt(h.slice(1, 3), 16), parseInt(h.slice(3, 5), 16), parseInt(h.slice(5, 7), 16)]
-}
-function buildRamp(anchors: string[], n: number): string[] {
-  const rgb = anchors.map(hexRgb)
-  const out: string[] = []
-  const hex = (n: number) => n.toString(16).padStart(2, '0')
-  for (let i = 0; i < n; i++) {
-    const t = (i / (n - 1)) * (rgb.length - 1)
-    const k = Math.min(rgb.length - 2, Math.floor(t)), f = t - k
-    const c = [0, 1, 2].map(j => Math.round(rgb[k][j] + (rgb[k + 1][j] - rgb[k][j]) * f))
-    out.push(`#${hex(c[0])}${hex(c[1])}${hex(c[2])}`)   // hex — regl's colour parser needs it
-  }
-  return out
-}
-const RAMP = buildRamp(['#0b1a4d', '#1793ff', '#04fa00', '#ffa805', '#ff3856'], 256)
-
+// FlowJo "pseudocolour" blue-heat ramp — shared with the 2D raster renderer (plots/flowColors.ts).
 const canvasEl = useTemplateRef<HTMLCanvasElement>('canvasEl')
 // regl-scatterplot has TS types but the instance is dynamic; keep it loosely typed.
 let scatterplot: any = null
@@ -242,16 +224,24 @@ async function exportCanvas(scale: number): Promise<HTMLCanvasElement | null> {
     const vp = gl?.getParameter(gl.MAX_VIEWPORT_DIMS) as (Int32Array | number[] | undefined)
     const tex = gl?.getParameter(gl.MAX_TEXTURE_SIZE) as (number | undefined)
     const cap = Math.max(1, Math.min(vp?.[0] ?? 8192, vp?.[1] ?? 8192, tex ?? 8192))
-    const s = Math.max(1, Math.min(scale, cap / w, cap / h))
-    scatterplot.set({ backgroundColor: [0, 0, 0, 0], width: Math.round(w * s), height: Math.round(h * s), aspectRatio: aspect() })
+    // regl-scatterplot multiplies the backing store by devicePixelRatio, so the REAL buffer is
+    // (w|h)·s·dpr — clamp against THAT, not the CSS px. Without the dpr factor a hi-DPI screen at a
+    // high export scale (small board plots hit ~14×) silently overflows the GPU cap in the taller
+    // dimension and the render is clipped to a sub-rectangle → dots cut off at the bottom of the PDF.
+    const dpr = (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1)
+    const s = Math.max(1, Math.min(scale, cap / (w * dpr), cap / (h * dpr)))
+    // ROOT CAUSE of the export clip: regl-scatterplot resets the data `aspectRatio` to its default
+    // (square) during an internal RESIZE, so passing aspectRatio in the SAME set() as width/height does
+    // not survive — the next draw renders the data square and, on our non-square plot, overscales Y and
+    // clips the cloud (dots cut off top/bottom). Fix: resize first, then RE-ASSERT aspectRatio on a
+    // separate frame so the projection matches the resized canvas before we draw.
+    scatterplot.set({ backgroundColor: [0, 0, 0, 0], width: Math.round(w * s), height: Math.round(h * s) })
     live.style.width = cssW || `${w}px`; live.style.height = cssH || `${h}px`   // keep the on-screen size
-    // regl-scatterplot applies the new viewport/projection on the NEXT frame, not synchronously — so
-    // drawing in the same tick would render the point cloud with the pre-resize projection and clip it
-    // into a corner. Wait one frame for the resize to take, THEN draw the final frame (transition:false
-    // = no animated tween a snapshot could catch mid-way), then wait once more for it to actually paint.
-    await nextFrame()
-    await drawCurrent(s, { transition: false })   // point size scaled to match the big backing
-    await nextFrame()
+    await nextFrame()                              // let the resize take (it resets aspectRatio)
+    scatterplot.set({ aspectRatio: aspect() })     // re-assert the projection AFTER the resize
+    await nextFrame()                              // let aspectRatio take
+    await drawCurrent(s, { transition: false })    // point size scaled to match the big backing
+    await nextFrame()                              // let the (preserveDrawingBuffer) frame actually paint
     const snap = document.createElement('canvas'); snap.width = live.width; snap.height = live.height
     snap.getContext('2d')?.drawImage(live, 0, 0)
     return snap.width > fallback.width ? snap : fallback

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -206,7 +206,7 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
 
 <template>
   <div class="uv">
-    <div class="uv-ctrl">
+    <div class="uv-ctrl cc-panel-controls">
       <button class="cc-btn cc-btn-ghost" :class="{ on: labels }" @click="labels = !labels"
               v-tooltip.bottom="'Toggle cluster-number labels'"><i class="pi pi-tag" /> #</button>
       <span class="uv-spacer" />
@@ -241,7 +241,8 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
 </template>
 
 <style scoped>
-.uv { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+/* position: relative so the overlaid .uv-ctrl (.cc-panel-controls) anchors to the plot box */
+.uv { position: relative; display: flex; flex-direction: column; flex: 1; min-height: 0; }
 .uv-ctrl { display: flex; align-items: center; gap: 8px; padding: 4px 6px; font-size: 12px; color: var(--cc-text-dim); }
 /* active (ticked) label toggle: filled accent so it's clearly on/off */
 .uv-ctrl .cc-btn.on { background: var(--cc-accent); border-color: var(--cc-accent); color: #fff; }

--- a/frontend/src/composables/useCanvasZoom.ts
+++ b/frontend/src/composables/useCanvasZoom.ts
@@ -1,0 +1,45 @@
+import { ref, inject, type Ref, type InjectionKey } from 'vue'
+
+// Generic VISUAL zoom for any plot canvas (the Analysis board's fixed grid AND the free-floating module
+// canvases). A CSS `transform: scale` on the content — purely visual, so it never resizes the plots'
+// own canvases or changes what's exported (the export re-renders at full logical resolution; hosts
+// neutralise the zoom during capture). Fit-to-width/height mirror Word/Illustrator.
+//
+// Free-floating canvases ALSO inject the zoom into `useFloatingPanel` so drag deltas (screen px) are
+// divided by the zoom — otherwise a panel would move `zoom`× too fast under a scaled workspace. The host
+// `provide()`s the zoom ref under CANVAS_ZOOM_KEY; CanvasPanel injects it (default 1 when unhosted).
+export const CANVAS_ZOOM_KEY: InjectionKey<Ref<number>> = Symbol('canvasZoom')
+export function useInjectedZoom(): () => number {
+  const z = inject(CANVAS_ZOOM_KEY, null)
+  return () => z?.value ?? 1
+}
+
+export const ZOOM_MIN = 0.2, ZOOM_MAX = 2
+const clampZoom = (z: number) => Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, z))
+
+// `viewport` = the scroll container the board/canvas lives in; `content()` = the board's natural
+// (unscaled) size in px (`w` may be null when the content has no fixed width, e.g. a free canvas that
+// fills the width — then fitWidth is a no-op).
+export function useCanvasZoom(viewport: Ref<HTMLElement | null>, content: () => { w: number | null; h: number }) {
+  const zoom = ref(1)
+  function fitWidth() {
+    const vp = viewport.value, c = content()
+    if (!vp || c.w == null || c.w <= 0) return
+    zoom.value = clampZoom((vp.clientWidth - 8) / c.w)
+  }
+  function fitHeight() {
+    const vp = viewport.value, c = content()
+    if (!vp || c.h <= 0) return
+    const availH = window.innerHeight - vp.getBoundingClientRect().top - 16
+    zoom.value = clampZoom(availH / c.h)
+  }
+  function setZoom(z: number) { zoom.value = clampZoom(z) }
+  function reset() { zoom.value = 1 }
+  // fit width only if the content actually overflows the viewport (used on first render so a big board
+  // is visible without hiding the sidebar, but a board that already fits is left at 100%).
+  function fitWidthIfOverflow() {
+    const vp = viewport.value, c = content()
+    if (vp && c.w != null && c.w > vp.clientWidth) fitWidth()
+  }
+  return { zoom, fitWidth, fitHeight, fitWidthIfOverflow, setZoom, reset }
+}

--- a/frontend/src/composables/useFloatingPanel.ts
+++ b/frontend/src/composables/useFloatingPanel.ts
@@ -21,11 +21,16 @@ export function useFloatingPanel(
     margin?: number
     onActivate?: () => void
     arrange?: () => ArrangeCmd | null | undefined
+    // current visual zoom of the canvas (CSS transform:scale). Positions (`pos`) are in UNSCALED CSS
+    // px, but the mouse moves in screen px — so a screen delta moves the panel by delta/zoom in CSS
+    // space. Default 1 (no zoom). See useCanvasZoom.
+    zoom?: () => number
   } = {},
 ) {
   const margin = opts.margin ?? 24
   const pos = ref({ x: opts.initial?.x ?? 16, y: opts.initial?.y ?? 16 })
-  let dragging = false, ox = 0, oy = 0
+  // drag tracked from the START mouse+pos so we can divide the screen-space delta by the zoom
+  let dragging = false, sx = 0, sy = 0, spx = 0, spy = 0
 
   function clamp(x: number, y: number) {
     const node = el.value
@@ -36,7 +41,11 @@ export function useFloatingPanel(
       y: Math.min(Math.max(y, 0), par.clientHeight - margin),
     }
   }
-  function onMove(e: MouseEvent) { if (dragging) pos.value = clamp(e.clientX - ox, e.clientY - oy) }
+  function onMove(e: MouseEvent) {
+    if (!dragging) return
+    const z = opts.zoom?.() ?? 1
+    pos.value = clamp(spx + (e.clientX - sx) / z, spy + (e.clientY - sy) / z)
+  }
   function endDrag() {
     dragging = false
     window.removeEventListener('mousemove', onMove)
@@ -45,8 +54,7 @@ export function useFloatingPanel(
   function startDrag(e: MouseEvent) {
     opts.onActivate?.()
     dragging = true
-    ox = e.clientX - pos.value.x
-    oy = e.clientY - pos.value.y
+    sx = e.clientX; sy = e.clientY; spx = pos.value.x; spy = pos.value.y
     window.addEventListener('mousemove', onMove)
     window.addEventListener('mouseup', endDrag)
   }

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -111,8 +111,9 @@ function exportPng() {
 </script>
 
 <template>
+  <!-- auto-hide OFF: sibling of the gate-drawing panel; keep its controls in flow, not on hover -->
   <CanvasPanel :index="index" :active="props.active" :arrange="props.arrange" :title="`Pairs ${channels.length}×${channels.length}`"
-               :persist-key="props.persistKey"
+               :persist-key="props.persistKey" :auto-hide="false"
                @activate="emit('activate', $event)" @remove="emit('remove')">
     <template #actions>
       <span class="ro-tag" v-tooltip.bottom="'Read-only — compare channels; draw gates on a single plot'">read-only</span>

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -286,8 +286,10 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
 </script>
 
 <template>
+  <!-- auto-hide OFF: you draw gates on this canvas constantly, so the render-mode / gate tools stay
+       in flow rather than popping over the plot on hover -->
   <CanvasPanel :index="index" :active="props.active" :arrange="props.arrange" :title="`Plot ${index + 1}`"
-               :persist-key="props.persistKey"
+               :persist-key="props.persistKey" :auto-hide="false"
                @activate="emit('activate', $event)" @remove="emit('remove')">
     <!-- header tools (render mode + gate-draw tools) sit in the panel title bar -->
     <template #actions>

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -14,16 +14,18 @@
   active panel) are shared as-is — no track-specific clone.
 -->
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from 'vue'
+import { ref, computed, watch, provide, onMounted, onUnmounted, useTemplateRef } from 'vue'
 import { useGatingStore } from '../../stores/gating'
 import { useWsStore } from '../../stores/ws'
 import { useProjectStore } from '../../stores/project'
 import { useNapariOpen } from '../../composables/useNapariOpen'
 import { useCanvasPanels } from '../../composables/useCanvasPanels'
 import { useViewState } from '../../composables/useViewState'
+import { useCanvasZoom, CANVAS_ZOOM_KEY } from '../../composables/useCanvasZoom'
 import GatePlotPanel from './GatePlotPanel.vue'
 import GatePairsPanel from './GatePairsPanel.vue'
 import PopulationManager from '../../components/canvas/PopulationManager.vue'
+import CanvasZoomControl from '../../components/canvas/CanvasZoomControl.vue'
 import GatingCopyDialog from './GatingCopyDialog.vue'
 import type { FlatPop } from '../../stores/gating'
 
@@ -62,6 +64,17 @@ const { panels, activeId, activePanel, shared, add, remove, arrangeGrid, arrange
   useCanvasPanels<PlotState>(canvasRef, () =>
     ({ kind: 'single', parent: 'root', hl: [], lineWidth: 1.5, labels: true, fromZero: true,
        x: '', y: '', xt: defT, yt: defT, renderMode: 'points', channels: [] }), ckey)
+// show/hide the floating population manager — persisted per canvas in the `shared` bag (default shown)
+const showManager = computed<boolean>({ get: () => (shared.value.showManager as boolean) ?? true, set: v => (shared.value.showManager = v) })
+
+// visual zoom (shared control): scale the free-floating plot workspace to see everything at once. Fit
+// measures the plot bounding box (zoom layer scroll size); drag is zoom-corrected via the injected zoom.
+// The population manager sits OUTSIDE the zoom layer so it stays full-size.
+const zoomRef = useTemplateRef<HTMLElement>('zoomRef')
+const { zoom, fitWidth, fitHeight, setZoom, reset: resetZoom } = useCanvasZoom(canvasRef,
+  () => { const el = zoomRef.value; return el ? { w: el.scrollWidth, h: el.scrollHeight } : { w: null, h: 0 } })
+provide(CANVAS_ZOOM_KEY, zoom)
+const zoomStyle = computed(() => zoom.value !== 1 ? { transform: `scale(${zoom.value})`, transformOrigin: 'top left' } : {})
 // add a read-only channel-pairs matrix panel (same canvas, same shared options as a single plot)
 function addPairs() { const id = add(); const p = panels.value.find(x => x.id === id); if (p) p.state.kind = 'pairs' }
 
@@ -230,15 +243,24 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
           <button v-tooltip.bottom="'Tile in a grid'" @click="arrangeGrid"><i class="pi pi-th-large" /></button>
           <button v-tooltip.bottom="'Cascade windows'" @click="arrangeCascade"><i class="pi pi-clone" /></button>
         </div>
+        <div class="seg">
+          <button :class="{ on: showManager }" @click="showManager = !showManager"
+                  v-tooltip.bottom="showManager ? 'Hide the population manager' : 'Show the population manager'">
+            <i class="pi pi-sitemap" />
+          </button>
+        </div>
         <div class="seg" v-tooltip.bottom="'Step to the previous / next image in the list'">
           <button :disabled="!hasPrev" @click="navTo(-1)" aria-label="Previous image">&laquo;</button>
           <button :disabled="!hasNext" @click="navTo(1)" aria-label="Next image">&raquo;</button>
         </div>
         <button class="cc-btn" v-tooltip.bottom="'Copy this gating to other images in the set'"
                 @click="showCopy = true"><i class="pi pi-copy" /> Copy</button>
+        <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
         <span class="gp-hint">drag plots by their title · resize from the corner</span>
       </div>
       <div ref="canvasRef" class="gp-canvas">
+        <!-- scaled workspace: the plots zoom together; the population manager stays full-size (below) -->
+        <div ref="zoomRef" class="gp-zoom" :style="zoomStyle">
         <template v-for="(p, i) in panels" :key="`${ckey}:${p.id}`">
           <GatePairsPanel v-if="p.state.kind === 'pairs'" :index="i" :arrange="p.arrange"
                           :active="p.id === activeId" :parent="p.state.parent" :highlight="panelHL(p.state)"
@@ -251,7 +273,8 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
                          :ui="p.state" :persist-key="`${ckey}:${p.id}`"
                          @activate="activeId = p.id" @update:parent="setParent(p.id, $event)" @remove="remove(p.id)" />
         </template>
-        <PopulationManager :selected="selected" :highlighted="activeHL" :scope="scope" :pop-type="props.popType"
+        </div>
+        <PopulationManager v-if="showManager" :selected="selected" :highlighted="activeHL" :scope="scope" :pop-type="props.popType"
                            :line-width="activeLineWidth" :gate-labels="activeLabels" :axis-from-zero="activeFromZero"
                            @update:selected="onPickPop" @update:scope="scope = $event" @toggle-highlight="toggleHighlight"
                            @update:line-width="setLineWidth" @update:gate-labels="setLabels"
@@ -284,4 +307,6 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
 .zwin input { width: 3.2rem; font-size: 12px; padding: 3px 4px; }
 /* free-floating plot workspace: panels + manager are absolutely positioned within */
 .gp-canvas { position: relative; flex: 1; min-height: 70vh; }
+/* the scaled workspace fills the canvas (offsetParent for the floating plot panels); transform inline */
+.gp-zoom { position: absolute; inset: 0; }
 </style>

--- a/frontend/src/plots/contour.ts
+++ b/frontend/src/plots/contour.ts
@@ -1,0 +1,15 @@
+// Clean contour rings for a normalised density grid, via d3-contour. Unlike hand-rolled marching
+// squares (which emitted disconnected per-cell segments → jagged "too detailed" lines), d3-contour
+// LINKS the crossings into closed rings and `.smooth(true)` linearly interpolates them, so a
+// heavily-blurred grid (density.ts) yields clean nested FlowJo-style contours. Rings are in GRID
+// coordinates ([0,G]); the renderer maps grid→data→px.
+import { contours as d3contours } from 'd3-contour'
+
+export interface ContourLevel { level: number; rings: number[][][] }   // rings: ring[]; ring: [x,y][]
+
+export function densityContours(grid: Float32Array, G: number, levels: number[]): ContourLevel[] {
+  const gen = d3contours().size([G, G]).thresholds(levels).smooth(true)
+  const polys = gen(Array.from(grid))
+  // MultiPolygon coordinates = [polygon][ring][point]; flatten to all rings (outer + holes) for outlines
+  return polys.map(p => ({ level: p.value, rings: p.coordinates.flatMap(polygon => polygon) }))
+}

--- a/frontend/src/plots/density.test.ts
+++ b/frontend/src/plots/density.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { densityGrid, outlierPoints, DENSITY_GRID } from './density'
+import { densityGrid, densityImageData, outlierPoints, DENSITY_GRID } from './density'
 
 const ext = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 }
 
@@ -15,16 +15,34 @@ describe('densityGrid', () => {
     const g = densityGrid(new Float32Array(cluster(300, 0.2, 0.2)), ext)
     expect(g.length).toBe(DENSITY_GRID * DENSITY_GRID)
     expect(Math.max(...g)).toBeCloseTo(1, 6)
-    // the peak cell should be near (0.2,0.2): gx=gy≈floor(0.2*64)=12
+    // the peak cell should be near (0.2,0.2): gx=gy≈floor(0.2*G) (± a couple of cells for the blur)
+    const expected = Math.floor(0.2 * DENSITY_GRID)
     let peak = 0, pi = 0
     g.forEach((v, i) => { if (v > peak) { peak = v; pi = i } })
     const gy = Math.floor(pi / DENSITY_GRID), gx = pi % DENSITY_GRID
-    expect(Math.abs(gx - 12)).toBeLessThanOrEqual(2)
-    expect(Math.abs(gy - 12)).toBeLessThanOrEqual(2)
+    expect(Math.abs(gx - expected)).toBeLessThanOrEqual(3)
+    expect(Math.abs(gy - expected)).toBeLessThanOrEqual(3)
   })
   it('skips non-finite and out-of-range points without throwing', () => {
     const g = densityGrid(new Float32Array([NaN, 0.5, 5, 5, 0.3, 0.3]), ext)
     expect(Math.max(...g)).toBeGreaterThan(0)   // only the (0.3,0.3) point counted
+  })
+})
+
+describe('densityImageData', () => {
+  it('returns G×G RGBA with empty cells transparent and dense cells opaque + coloured', () => {
+    const img = densityImageData(new Float32Array(cluster(400, 0.5, 0.5)), ext)
+    expect(img.width).toBe(DENSITY_GRID)
+    expect(img.height).toBe(DENSITY_GRID)
+    expect(img.data.length).toBe(DENSITY_GRID * DENSITY_GRID * 4)
+    // a corner far from the (0.5,0.5) blob → empty → fully transparent
+    const cornerA = (0 * DENSITY_GRID + 0) * 4
+    expect(img.data[cornerA + 3]).toBe(0)
+    // the centre cell (rows flipped: destRow = G-1-gy, gy≈G/2 → still ≈centre) is opaque + non-black
+    const mid = Math.floor(DENSITY_GRID / 2)
+    const o = (mid * DENSITY_GRID + mid) * 4
+    expect(img.data[o + 3]).toBe(255)
+    expect(img.data[o] + img.data[o + 1] + img.data[o + 2]).toBeGreaterThan(0)
   })
 })
 

--- a/frontend/src/plots/density.ts
+++ b/frontend/src/plots/density.ts
@@ -1,45 +1,98 @@
-// Density grid + outlier classification for the gate scatter's contour render modes. Extracted from
-// PlotLayers so the pure math (binning → blur → normalise, and the low-density outlier subset) is
-// shared by the renderer AND unit-tested (docs/DEV.md). Mirrors R's kde2d-style density used by the
-// FlowJo-style contour + "contour ± outliers" plots (flowHelpers.R).
+// Density grid + raster image + outlier classification for the gate scatter. The base gating cloud is
+// rendered as a FlowJo/OMIQ-style 2D DENSITY RASTER (no WebGL): bin → blur → blue-heat ramp. The same
+// blurred grid feeds the contour rings (plots/contour.ts). Pure + unit-tested (docs/DEV.md).
+import { BLUE_HEAT_RGB } from './flowColors'
 
 export type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
 
-export const DENSITY_GRID = 64             // grid resolution (R kde2d n≈25; finer here)
-export const CONTOUR_LEVELS = [0.05, 0.10, 0.25, 0.50]  // normalised 1 − confidence levels (outer→inner)
-// "outliers" = points below the OUTERMOST contour, i.e. in the sparse tail the contours don't enclose.
+export const DENSITY_GRID = 128            // grid resolution (raster + contour); upscaled smoothly to px
+// blur strength — a few box-blur passes ≈ a Gaussian. Heavier than a single 3×3 so contours read as
+// clean nested rings (FlowJo look) instead of jagged per-cell wiggles.
+export const BLUR_RADIUS = 2
+export const BLUR_PASSES = 3
+// contour thresholds (normalised 0..1, outer→inner). Geometric-ish spacing: more lines through the
+// sparse shoulder, fewer at the dense core — reads like FlowJo probability contours.
+export const CONTOUR_LEVELS = [0.05, 0.12, 0.24, 0.42, 0.65, 0.88]
 export const OUTLIER_LEVEL = CONTOUR_LEVELS[0]
 
-// normalised (0..1), lightly box-blurred density grid over `ext`, row-major (gy*G + gx).
-export function densityGrid(points: Float32Array, ext: Ext, G = DENSITY_GRID): Float32Array {
+// separable box blur, `passes` times (≈ Gaussian), in place on a G×G grid
+function boxBlur(g: Float32Array, G: number, radius: number, passes: number) {
+  if (radius < 1) return
+  const tmp = new Float32Array(G * G)
+  const win = radius * 2 + 1
+  for (let p = 0; p < passes; p++) {
+    for (let y = 0; y < G; y++) {                              // horizontal
+      let acc = 0
+      for (let x = -radius; x <= radius; x++) acc += g[y * G + Math.min(G - 1, Math.max(0, x))]
+      for (let x = 0; x < G; x++) {
+        tmp[y * G + x] = acc / win
+        const add = Math.min(G - 1, x + radius + 1), sub = Math.max(0, x - radius)
+        acc += g[y * G + add] - g[y * G + sub]
+      }
+    }
+    for (let x = 0; x < G; x++) {                              // vertical
+      let acc = 0
+      for (let y = -radius; y <= radius; y++) acc += tmp[Math.min(G - 1, Math.max(0, y)) * G + x]
+      for (let y = 0; y < G; y++) {
+        g[y * G + x] = acc / win
+        const add = Math.min(G - 1, y + radius + 1), sub = Math.max(0, y - radius)
+        acc += tmp[add * G + x] - tmp[sub * G + x]
+      }
+    }
+  }
+}
+
+// bin points into a G×G count grid over `ext`, then blur. Returns the raw blurred grid + its max.
+function binAndBlur(points: Float32Array, ext: Ext, G: number): { grid: Float32Array; max: number } {
   const xs = ext.xMax > ext.xMin ? ext.xMax - ext.xMin : 1
   const ys = ext.yMax > ext.yMin ? ext.yMax - ext.yMin : 1
   const g = new Float32Array(G * G)
   const n = points.length / 2
   for (let i = 0; i < n; i++) {
     const px = points[2 * i], py = points[2 * i + 1]
-    if (!Number.isFinite(px) || !Number.isFinite(py)) continue   // NaN/Inf measure → skip
+    if (!Number.isFinite(px) || !Number.isFinite(py)) continue
     const gx = Math.floor(((px - ext.xMin) / xs) * G), gy = Math.floor(((py - ext.yMin) / ys) * G)
     if (gx < 0 || gx > G - 1 || gy < 0 || gy > G - 1) continue
     g[gy * G + gx] += 1
   }
-  const blurred = new Float32Array(G * G)
+  boxBlur(g, G, BLUR_RADIUS, BLUR_PASSES)
   let max = 0
-  for (let y = 0; y < G; y++) for (let x = 0; x < G; x++) {
-    let s = 0, c = 0
-    for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) {
-      const nx = x + dx, ny = y + dy
-      if (nx >= 0 && nx < G && ny >= 0 && ny < G) { s += g[ny * G + nx]; c++ }
-    }
-    const v = s / c; blurred[y * G + x] = v; if (v > max) max = v
-  }
-  if (max > 0) for (let i = 0; i < blurred.length; i++) blurred[i] /= max
-  return blurred
+  for (let i = 0; i < g.length; i++) if (g[i] > max) max = g[i]
+  return { grid: g, max }
 }
 
-// The interleaved subset of `points` whose smoothed density is below `level` — the outliers to draw
-// individually in "contour + outliers" mode (the dense core is left to the contours). Out-of-range /
-// non-finite points are dropped (they're not meaningful outliers).
+// normalised (0..1) blurred density grid, row-major (gy*G + gx) — used by the contour rings + outliers.
+export function densityGrid(points: Float32Array, ext: Ext, G = DENSITY_GRID): Float32Array {
+  const { grid, max } = binAndBlur(points, ext, G)
+  if (max > 0) for (let i = 0; i < grid.length; i++) grid[i] /= max
+  return grid
+}
+
+// FlowJo-style pseudocolour raster: RGBA bytes (G×G), each cell coloured by LOG-scaled density via the
+// blue-heat ramp; empty cells transparent. Rows are FLIPPED (yMax at the top) so it draws directly onto
+// a top-left-origin canvas matching the axes. `putImageData` this at G×G then drawImage-upscale (smooth)
+// to the plot rect.
+export function densityImageData(points: Float32Array, ext: Ext, G = DENSITY_GRID):
+    { data: Uint8ClampedArray; width: number; height: number } {
+  const { grid, max } = binAndBlur(points, ext, G)
+  const lmax = Math.log1p(max) || 1
+  const data = new Uint8ClampedArray(G * G * 4)
+  for (let gy = 0; gy < G; gy++) {
+    const destRow = G - 1 - gy                             // flip: high data-y → top row
+    for (let gx = 0; gx < G; gx++) {
+      const raw = grid[gy * G + gx]
+      const o = (destRow * G + gx) * 4
+      if (raw <= 0) { data[o + 3] = 0; continue }          // empty → transparent
+      const c = Math.min(255, Math.max(0, Math.round((Math.log1p(raw) / lmax) * 255)))
+      data[o] = BLUE_HEAT_RGB[c * 3]; data[o + 1] = BLUE_HEAT_RGB[c * 3 + 1]
+      data[o + 2] = BLUE_HEAT_RGB[c * 3 + 2]; data[o + 3] = 255
+    }
+  }
+  return { data, width: G, height: G }
+}
+
+// interleaved subset of `points` whose smoothed density is below `level` — the sparse tail drawn as
+// individual dots in "contour + outliers" mode (the dense core is left to the contours).
 export function outlierPoints(points: Float32Array, ext: Ext, G = DENSITY_GRID, level = OUTLIER_LEVEL): Float32Array {
   const grid = densityGrid(points, ext, G)
   const xs = ext.xMax > ext.xMin ? ext.xMax - ext.xMin : 1
@@ -51,7 +104,7 @@ export function outlierPoints(points: Float32Array, ext: Ext, G = DENSITY_GRID, 
     if (!Number.isFinite(px) || !Number.isFinite(py)) continue
     const gx = Math.floor(((px - ext.xMin) / xs) * G), gy = Math.floor(((py - ext.yMin) / ys) * G)
     if (gx < 0 || gx > G - 1 || gy < 0 || gy > G - 1) continue
-    if (grid[gy * G + gx] < level) { out.push(px, py) }
+    if (grid[gy * G + gx] < level) out.push(px, py)
   }
   return new Float32Array(out)
 }

--- a/frontend/src/plots/flowColors.ts
+++ b/frontend/src/plots/flowColors.ts
@@ -1,0 +1,37 @@
+// FlowJo-style "pseudocolour" blue-heat ramp, shared by the raster density renderer (2D canvas) AND
+// the WebGL scatter (regl, UMAP). One source of truth for the colours so the gating raster and any
+// remaining WebGL plot read the same. Low end lifted off pure black so sparse density stays visible.
+// (R: .flowColorRampBlueHeat, flowHelpers.R:775.)
+
+export function hexRgb(h: string): [number, number, number] {
+  return [parseInt(h.slice(1, 3), 16), parseInt(h.slice(3, 5), 16), parseInt(h.slice(5, 7), 16)]
+}
+
+// interpolate `anchors` to `n` hex stops (regl's colour parser wants hex strings)
+export function buildRamp(anchors: string[], n: number): string[] {
+  const rgb = anchors.map(hexRgb)
+  const out: string[] = []
+  const hex = (v: number) => v.toString(16).padStart(2, '0')
+  for (let i = 0; i < n; i++) {
+    const t = (i / (n - 1)) * (rgb.length - 1)
+    const k = Math.min(rgb.length - 2, Math.floor(t)), f = t - k
+    const c = [0, 1, 2].map(j => Math.round(rgb[k][j] + (rgb[k + 1][j] - rgb[k][j]) * f))
+    out.push(`#${hex(c[0])}${hex(c[1])}${hex(c[2])}`)
+  }
+  return out
+}
+
+export const BLUE_HEAT_ANCHORS = ['#0b1a4d', '#1793ff', '#04fa00', '#ffa805', '#ff3856']
+export const BLUE_HEAT_RAMP = buildRamp(BLUE_HEAT_ANCHORS, 256)   // hex stops (regl)
+
+// packed RGB lookup (256×3) for the 2D raster renderer — index a 0..255 density bucket → [r,g,b]
+export const BLUE_HEAT_RGB: Uint8ClampedArray = (() => {
+  const rgb = BLUE_HEAT_ANCHORS.map(hexRgb), n = 256
+  const out = new Uint8ClampedArray(n * 3)
+  for (let i = 0; i < n; i++) {
+    const t = (i / (n - 1)) * (rgb.length - 1)
+    const k = Math.min(rgb.length - 2, Math.floor(t)), f = t - k
+    for (let j = 0; j < 3; j++) out[i * 3 + j] = Math.round(rgb[k][j] + (rgb[k + 1][j] - rgb[k][j]) * f)
+  }
+  return out
+})()

--- a/frontend/src/plots/layoutTemplates.ts
+++ b/frontend/src/plots/layoutTemplates.ts
@@ -15,6 +15,10 @@ export interface LayoutTemplate {
   // short header row. When absent, tracks are equal `repeat(n, minmax(0,1fr))`.
   rowTracks?: string
   colTracks?: string
+  // which A4 sheet orientation this plate is designed for — the board's "Plates" picker shows only the
+  // plates matching the current sheet (portrait / landscape), or all when the sheet is Free. 'any' =
+  // shown in both. Uniform grids are orientation-neutral, so they carry no tag (treated as 'any').
+  orient?: 'portrait' | 'landscape' | 'any'
 }
 
 // Uniform N×M — every cell 1×1, row-major.
@@ -33,39 +37,58 @@ export const UNIFORM_PRESETS: LayoutTemplate[] = [
 
 // Rectangular "comic plates": varied-size panels over a base grid (decision 8). Rectangular only —
 // angled panels are deferred; the filmstrip slot covers the angled-image use (decision 10).
-// Ordered into families so the picker reads as two tidy rows:
-//   ROW 1 — a wide FEATURE + small panels: split, big-left, and "top banner + N".
-//   ROW 2 — HEADER banner + a grid, and tall HERO / SIDEBAR layouts.
+// Grouped by the A4 sheet they suit: PORTRAIT plates are taller than wide (stacks, banner-over-grid,
+// tall hero) so they fill a portrait page; LANDSCAPE plates are wide feature/header/sidebar rows. The
+// board's "Plates" picker filters to the current sheet orientation (all when the sheet is Free).
 export const COMIC_PRESETS: LayoutTemplate[] = [
-  // ── Row 1: feature + small panels ─────────────────────────────────────────
+  // ── PORTRAIT (tall) — fill a portrait A4 page ──────────────────────────────
+  // two / three big panels stacked
+  { id: 'p-stack-2', label: '2 stacked', cols: 1, rows: 2, orient: 'portrait',
+    slots: ['1 / 1 / 2 / 2', '2 / 1 / 3 / 2'] },
+  { id: 'p-stack-3', label: '3 stacked', cols: 1, rows: 3, orient: 'portrait',
+    slots: ['1 / 1 / 2 / 2', '2 / 1 / 3 / 2', '3 / 1 / 4 / 2'] },
+  // 2 columns × 3 rows (six panels down the page)
+  { id: 'p-2x3', label: '2 × 3', cols: 2, rows: 3, orient: 'portrait',
+    slots: ['1 / 1 / 2 / 2', '1 / 2 / 2 / 3', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3'] },
+  // big hero on top (2 rows tall) + two small beneath
+  { id: 'p-hero-2', label: 'Hero + 2', cols: 2, rows: 3, orient: 'portrait',
+    slots: ['1 / 1 / 3 / 3', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3'] },
+  // wide header banner on top + a 2×2 grid beneath
+  { id: 'p-header-quad', label: 'Header + 2×2', cols: 2, rows: 3, orient: 'portrait',
+    slots: ['1 / 1 / 2 / 3', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3'] },
+  // top feature banner + a row of two beneath (squarish → good for portrait)
+  { id: 'feature-2', label: 'Top + 2', cols: 2, rows: 2, orient: 'portrait',
+    slots: ['1 / 1 / 2 / 3', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3'] },
+
+  // ── LANDSCAPE (wide) — fill a landscape A4 page ────────────────────────────
   // wide left + narrow right (single row)
-  { id: 'wide-tall', label: '2 + 1', cols: 3, rows: 1,
+  { id: 'wide-tall', label: '2 + 1', cols: 3, rows: 1, orient: 'landscape',
     slots: ['1 / 1 / 2 / 3', '1 / 3 / 2 / 4'] },
   // big square left + two stacked on the right
-  { id: 'big-2', label: 'Big + 2', cols: 3, rows: 2,
+  { id: 'big-2', label: 'Big + 2', cols: 3, rows: 2, orient: 'landscape',
     slots: ['1 / 1 / 3 / 3', '1 / 3 / 2 / 4', '2 / 3 / 3 / 4'] },
-  // wide feature on top + a row of two / three / four beneath (progressive family)
-  { id: 'feature-2', label: 'Top + 2', cols: 2, rows: 2,
-    slots: ['1 / 1 / 2 / 3', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3'] },
-  { id: 'feature-3', label: 'Top + 3', cols: 3, rows: 2,
+  // wide feature on top + a row of three / four beneath (progressive family)
+  { id: 'feature-3', label: 'Top + 3', cols: 3, rows: 2, orient: 'landscape',
     slots: ['1 / 1 / 2 / 4', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4'] },
-  { id: 'feature-4', label: 'Top + 4', cols: 4, rows: 2,
+  { id: 'feature-4', label: 'Top + 4', cols: 4, rows: 2, orient: 'landscape',
     slots: ['1 / 1 / 2 / 5', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '2 / 4 / 3 / 5'] },
-  // ── Row 2: header banner + grid, and hero / sidebar ───────────────────────
   // wide header banner on top + two rows of three / four smaller slots (all rows equal height)
-  { id: 'header-2x3', label: 'Header + 2×3', cols: 3, rows: 3,
+  { id: 'header-2x3', label: 'Header + 2×3', cols: 3, rows: 3, orient: 'landscape',
     slots: ['1 / 1 / 2 / 4', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4'] },
-  { id: 'header-2x4', label: 'Header + 2×4', cols: 4, rows: 3,
+  { id: 'header-2x4', label: 'Header + 2×4', cols: 4, rows: 3, orient: 'landscape',
     slots: ['1 / 1 / 2 / 5', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4', '2 / 4 / 3 / 5', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4', '3 / 4 / 4 / 5'] },
-  // tall hero left + two small right + wide footer
-  { id: 'hero-3', label: 'Hero + 3', cols: 2, rows: 3,
-    slots: ['1 / 1 / 3 / 2', '1 / 2 / 2 / 3', '2 / 2 / 3 / 3', '3 / 1 / 4 / 3'] },
   // large hero (2×2) with an L of five smaller panels
-  { id: 'hero-quad', label: 'Hero + 5', cols: 3, rows: 3,
+  { id: 'hero-quad', label: 'Hero + 5', cols: 3, rows: 3, orient: 'landscape',
     slots: ['1 / 1 / 3 / 3', '1 / 3 / 2 / 4', '2 / 3 / 3 / 4', '3 / 1 / 4 / 2', '3 / 2 / 4 / 3', '3 / 3 / 4 / 4'] },
   // tall sidebar left + three stacked on the right
-  { id: 'side-3', label: 'Side + 3', cols: 3, rows: 3,
+  { id: 'side-3', label: 'Side + 3', cols: 3, rows: 3, orient: 'landscape',
     slots: ['1 / 1 / 4 / 2', '1 / 2 / 2 / 4', '2 / 2 / 3 / 4', '3 / 2 / 4 / 4'] },
 ]
 
 export const ALL_PRESETS = [...UNIFORM_PRESETS, ...COMIC_PRESETS]
+
+// A4 sheet aspect (width / height), from the A4 point dimensions used by the PDF export (pdf.ts).
+// Portrait = tall (<1); landscape = wide (>1). The board locks its on-screen box to this so the layout
+// is WYSIWYG with the exported page.
+export const A4_PORTRAIT_ASPECT = 595.28 / 841.89   // ≈ 0.7071
+export const A4_LANDSCAPE_ASPECT = 841.89 / 595.28  // ≈ 1.4142

--- a/frontend/src/stores/analysisLayout.ts
+++ b/frontend/src/stores/analysisLayout.ts
@@ -17,6 +17,10 @@ interface LayoutEntry {
   rowTracks?: string; colTracks?: string   // non-uniform plates (e.g. a short header row)
   rowHeight?: number                       // px per grid row (board-level slot-height slider); the board
                                            // scrolls in the page if taller than the viewport
+  // A4 sheet lock: 'a4-portrait' | 'a4-landscape' constrain the board's on-screen box to page
+  // proportions (WYSIWYG with the PDF); 'free' lets it fill the page width (the old behaviour).
+  // Undefined (older persisted boards) is read as 'a4-portrait' so the fix applies retroactively.
+  sheet?: 'free' | 'a4-portrait' | 'a4-landscape'
   contents: (SlotContent | null)[]     // aligned 1:1 with slotAreas
   activeIndex: number
   shared: Record<string, unknown>      // canvas-level view-state for useSummaryData (compare/scope/sel/vis)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -147,3 +147,35 @@ select option { background: var(--cc-surface-1); color: var(--cc-text); }
 /* tinted native widgets to the accent */
 input[type="range"] { accent-color: var(--cc-accent); cursor: pointer; }
 input[type="checkbox"], input[type="radio"] { accent-color: var(--cc-accent); cursor: pointer; }
+
+/* ── CanvasPanel auto-hide control overlays ────────────────────────────────── */
+/* A CanvasPanel (auto-hide on, the default) gives its plot the WHOLE box; every control surface is
+   overlaid on the plot and hidden until the panel is hovered — or pinned open (the panel toggles
+   `.controls-pinned` on itself). Two producers wear this class:
+     • CanvasPanel's own #actions / #footer overlays (top / bottom `.bottom`);
+     • an interactive VIEW whose toolbar lives inside the body (GatingStrategyView `.gs-bar`,
+       UmapView `.uv-ctrl`, ImageStripView `.is-bar`) — those tag their bar `.cc-panel-controls` and
+       give their root `position: relative`, so it anchors to the plot box, not the panel.
+   This is why the analysis-board plots (and their PDF export) fill their slot instead of being squashed
+   by a stack of controls. See docs/UI.md → "Auto-hide panel controls". */
+/* NB: do NOT add backdrop-filter/filter/transform here — they make this the containing block for
+   `position: fixed` descendants, which throws the SummaryPanel "Plot options" popover (fixed,
+   viewport-positioned) off to the overlay's corner. Use a near-opaque background instead of a blur. */
+.cc-panel-controls {
+  position: absolute; left: 0; right: 0; top: 0; z-index: 6;
+  opacity: 0; pointer-events: none; transition: opacity 0.12s ease;
+  background: color-mix(in srgb, var(--cc-surface-2) 96%, transparent);
+  border-bottom: 1px solid var(--cc-border);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.28);
+}
+.cc-panel-controls.bottom {
+  top: auto; bottom: 0;
+  border-bottom: none; border-top: 1px solid var(--cc-border);
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.28);
+}
+.panel:hover .cc-panel-controls,
+.panel.controls-pinned .cc-panel-controls { opacity: 1; pointer-events: auto; }
+/* during a PDF / board capture a revealed strip (and the header drag handle) must never land in a
+   snapshot (the `.capturing` ancestor is set on the board grid while exporting) */
+.capturing .cc-panel-controls { opacity: 0 !important; pointer-events: none !important; }
+.capturing .drag-icon { visibility: hidden !important; }

--- a/frontend/src/types/d3-contour.d.ts
+++ b/frontend/src/types/d3-contour.d.ts
@@ -1,0 +1,17 @@
+// Minimal typings for d3-contour (v4 ships no bundled types and @types/d3-contour isn't installed).
+// Only the surface we use: `contours().size().thresholds().smooth()` → ContourMultiPolygon[].
+declare module 'd3-contour' {
+  // GeoJSON MultiPolygon: coordinates = [polygon][ring][point][x|y]
+  export interface ContourMultiPolygon {
+    type: 'MultiPolygon'
+    value: number
+    coordinates: number[][][][]
+  }
+  export interface Contours {
+    (values: number[]): ContourMultiPolygon[]
+    size(size: [number, number]): Contours
+    thresholds(thresholds: number[] | number): Contours
+    smooth(smooth: boolean): Contours
+  }
+  export function contours(): Contours
+}

--- a/frontend/src/utils/plateBuilder.test.ts
+++ b/frontend/src/utils/plateBuilder.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { normSpan, applyDrag, clampSpans, spansToSlots, slotsToSpans, buildPlate, type PlateSpan } from './plateBuilder'
+
+describe('normSpan', () => {
+  it('orders two dragged corners top-left → bottom-right', () => {
+    expect(normSpan({ r: 2, c: 3 }, { r: 0, c: 1 })).toEqual({ r0: 0, c0: 1, r1: 2, c1: 3 })
+  })
+})
+
+describe('spansToSlots', () => {
+  it('a plain grid with no spans is row-major 1×1 cells', () => {
+    expect(spansToSlots(2, 2, [])).toEqual([
+      '1 / 1 / 2 / 2', '1 / 2 / 2 / 3', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3',
+    ])
+  })
+  it('emits a span at its top-left, remaining cells as 1×1s (row-major)', () => {
+    // 3×2 grid, top row merged into one banner
+    const banner: PlateSpan = { r0: 0, c0: 0, r1: 0, c1: 2 }
+    expect(spansToSlots(3, 2, [banner])).toEqual([
+      '1 / 1 / 2 / 4',                       // banner spans all 3 cols of row 1
+      '2 / 1 / 3 / 2', '2 / 2 / 3 / 3', '2 / 3 / 3 / 4',
+    ])
+  })
+})
+
+describe('applyDrag', () => {
+  it('a multi-cell rectangle merges and drops overlapping spans', () => {
+    const rect: PlateSpan = { r0: 0, c0: 0, r1: 1, c1: 1 }
+    expect(applyDrag([], rect)).toEqual([rect])
+    // a new merge overlapping an old one replaces it
+    const old: PlateSpan = { r0: 0, c0: 0, r1: 0, c1: 1 }
+    expect(applyDrag([old], rect)).toEqual([rect])
+  })
+  it('a single cell inside a span un-merges it; elsewhere is a no-op', () => {
+    const span: PlateSpan = { r0: 0, c0: 0, r1: 1, c1: 1 }
+    expect(applyDrag([span], { r0: 0, c0: 0, r1: 0, c1: 0 })).toEqual([])   // split
+    expect(applyDrag([span], { r0: 3, c0: 3, r1: 3, c1: 3 })).toEqual([span]) // no-op
+  })
+})
+
+describe('clampSpans', () => {
+  it('drops spans that fall outside a resized grid', () => {
+    const inside: PlateSpan = { r0: 0, c0: 0, r1: 1, c1: 1 }
+    const outside: PlateSpan = { r0: 2, c0: 0, r1: 3, c1: 1 }
+    expect(clampSpans([inside, outside], 2, 2)).toEqual([inside])
+  })
+})
+
+describe('slotsToSpans (round-trip)', () => {
+  it('recovers multi-cell spans from slot areas and drops 1×1s', () => {
+    const banner: PlateSpan = { r0: 0, c0: 0, r1: 0, c1: 2 }
+    const slots = spansToSlots(3, 2, [banner])
+    expect(slotsToSpans(slots)).toEqual([banner])
+  })
+})
+
+describe('buildPlate', () => {
+  it('produces a template with clamped spans applied', () => {
+    const t = buildPlate(2, 2, [{ r0: 0, c0: 0, r1: 0, c1: 1 }])
+    expect(t).toMatchObject({ cols: 2, rows: 2, orient: 'any' })
+    expect(t.slots).toEqual(['1 / 1 / 2 / 3', '2 / 1 / 3 / 2', '2 / 2 / 3 / 3'])
+  })
+})

--- a/frontend/src/utils/plateBuilder.ts
+++ b/frontend/src/utils/plateBuilder.ts
@@ -1,0 +1,74 @@
+// Pure logic for the Analysis-board custom plate builder (PlateBuilder.vue). A "plate" is a CSS-grid
+// template (cols × rows) with a grid-area per slot; the builder lets the user drag across cells to MERGE
+// them into rectangular spans, the rest staying 1×1. Kept out of the SFC so it's unit-tested
+// (docs/DEV.md → Tests). Spans are 0-indexed, INCLUSIVE of both corners; slot grid-areas are the CSS
+// 1-indexed, end-EXCLUSIVE form ("rowStart / colStart / rowEnd / colEnd").
+import type { LayoutTemplate } from '../plots/layoutTemplates'
+
+export interface PlateSpan { r0: number; c0: number; r1: number; c1: number }
+export interface Cell { r: number; c: number }
+
+// order two dragged corners into a normalised span (top-left → bottom-right)
+export function normSpan(a: Cell, b: Cell): PlateSpan {
+  return { r0: Math.min(a.r, b.r), c0: Math.min(a.c, b.c), r1: Math.max(a.r, b.r), c1: Math.max(a.c, b.c) }
+}
+export function spanArea(s: PlateSpan): number { return (s.r1 - s.r0 + 1) * (s.c1 - s.c0 + 1) }
+export function spansOverlap(a: PlateSpan, b: PlateSpan): boolean {
+  return a.r0 <= b.r1 && b.r0 <= a.r1 && a.c0 <= b.c1 && b.c0 <= a.c1
+}
+export function cellInSpan(s: PlateSpan, r: number, c: number): boolean {
+  return r >= s.r0 && r <= s.r1 && c >= s.c0 && c <= s.c1
+}
+
+// apply a dragged rectangle: a SINGLE cell that lands inside an existing span un-merges it (split back
+// to 1×1s); a MULTI-cell rectangle merges (dropping any spans it overlaps, so merges never overlap).
+export function applyDrag(spans: PlateSpan[], rect: PlateSpan): PlateSpan[] {
+  if (spanArea(rect) <= 1) {
+    const hit = spans.find(s => cellInSpan(s, rect.r0, rect.c0))
+    return hit ? spans.filter(s => s !== hit) : spans
+  }
+  return [...spans.filter(s => !spansOverlap(s, rect)), rect]
+}
+
+// drop spans that fall outside a resized grid (so shrinking cols/rows can't leave dangling spans)
+export function clampSpans(spans: PlateSpan[], cols: number, rows: number): PlateSpan[] {
+  return spans.filter(s => s.r0 >= 0 && s.c0 >= 0 && s.r1 < rows && s.c1 < cols)
+}
+
+// row-major slot list: each span emitted at its top-left, remaining cells as 1×1s. Row-major keeps slot
+// indices stable-ish so applyTemplate can preserve existing slot CONTENTS by index.
+export function spansToSlots(cols: number, rows: number, spans: PlateSpan[]): string[] {
+  const used: boolean[][] = Array.from({ length: rows }, () => Array(cols).fill(false))
+  const slots: string[] = []
+  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) {
+    if (used[r][c]) continue
+    const s = spans.find(sp => sp.r0 === r && sp.c0 === c)
+    if (s) {
+      for (let rr = s.r0; rr <= s.r1; rr++) for (let cc = s.c0; cc <= s.c1; cc++) used[rr][cc] = true
+      slots.push(`${s.r0 + 1} / ${s.c0 + 1} / ${s.r1 + 2} / ${s.c1 + 2}`)
+    } else {
+      used[r][c] = true
+      slots.push(`${r + 1} / ${c + 1} / ${r + 2} / ${c + 2}`)
+    }
+  }
+  return slots
+}
+
+// parse an existing plate's slot areas back into multi-cell spans (so the builder opens seeded from the
+// current layout). 1×1 slots are implicit and dropped.
+export function slotsToSpans(slotAreas: string[]): PlateSpan[] {
+  const spans: PlateSpan[] = []
+  for (const a of slotAreas) {
+    const p = a.split('/').map(x => parseInt(x.trim(), 10))
+    if (p.length !== 4 || p.some(n => Number.isNaN(n))) continue
+    const [rs, cs, re, ce] = p                       // 1-indexed, end-exclusive
+    const s: PlateSpan = { r0: rs - 1, c0: cs - 1, r1: re - 2, c1: ce - 2 }
+    if (s.r1 > s.r0 || s.c1 > s.c0) spans.push(s)     // keep multi-cell spans only
+  }
+  return spans
+}
+
+export function buildPlate(cols: number, rows: number, spans: PlateSpan[]): LayoutTemplate {
+  return { id: 'custom', label: 'Custom', cols, rows, orient: 'any',
+           slots: spansToSlots(cols, rows, clampSpans(spans, cols, rows)) }
+}


### PR DESCRIPTION
## Plot canvas overhaul: full-box controls, A4 board + zoom, and 2D-raster gating

### Board / panel UX
- **Auto-hide panel controls** — `CanvasPanel` gives the plot the whole box and overlays `#actions`/`#footer` as hover-reveal strips with a **pin** toggle. Fixes squashed board plots (and the clipped PDF slivers that came from capturing a squashed plot). Gate-drawing panels opt out (`:auto-hide="false"`). Interactive view toolbars (gating-strategy / UMAP / filmstrip) auto-hide via the shared `.cc-panel-controls` class.
- **A4 board** — per-tab sheet lock (**A4 portrait default / landscape / free**); the board is width-locked to the page aspect and centred, so it's WYSIWYG with the exported PDF (no more over-wide boards). Presets are orientation-tagged and filtered to the sheet.
- **Custom plate builder** — "Custom…" popover: set N×M, **drag cells to merge** into varied-size panels (click a merge to split). Pure logic in `utils/plateBuilder.ts` (unit-tested).
- **Canvas zoom** — shared fit-width / fit-height / slider control on the board **and** the free-floating module canvases (`useCanvasZoom` + `CanvasZoomControl`). Visual only (transform); drag is zoom-corrected in `useFloatingPanel`; neutralised during PDF capture.
- **Population-manager show/hide** toggle next to the arrange icons on module pages.
- Fixes: in-header drag handle (no pin overlap), plot-options popover placement (removed `backdrop-filter` so `position: fixed` resolves to the viewport).

### Gating renderer → 2D density raster (drops WebGL)
- The gating scatter is non-interactive (fixed camera; gate *drawing* is the only interaction), so it now renders as a **FlowJo/OMIQ-style 2D density raster** (bin → Gaussian blur → blue-heat ramp) on screen **and** export — no WebGL.
- **Clean contours** via `d3-contour` connected rings on the blurred grid, replacing the jagged disconnected marching-squares segments.
- **Export re-renders the 2D content at target scale** (crisp, *cannot* clip) — this removes the WebGL screengrab that clipped dots in the board PDF and the module-page PNG.
- `regl-scatterplot` is now **UMAP-only**; the colour ramp was extracted to `plots/flowColors.ts` and shared.

### Docs / tests
- Updated `UI.md`, `ANALYSIS.md`, `PLOTS.md`. `vue-tsc` clean; **84 Vitest tests pass** (added `plateBuilder` + `densityImageData`).

### ⚠️ Needs in-browser verification (not run by me)
- Raster **look** (density/colours) — tunable via `DENSITY_GRID` / `BLUR_RADIUS`/`BLUR_PASSES` / log scaling.
- **Contour** cleanliness / count — tunable via `CONTOUR_LEVELS` (6) / blur.
- Export a **board PDF** and a **module PNG** → confirm dots reach every edge and are crisp.
- Gate **drawing** still works (overlay untouched); show-pops overlay.
- Perf of bin+blur on a very large PhenoCycler image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)