### PR TITLE
Fix/clusttracks tracked pops

### DIFF
--- a/api/src/app_api.jl
+++ b/api/src/app_api.jl
@@ -68,7 +68,7 @@ end
 _git_toplevel(dir::AbstractString) =
     try; strip(readchomp(`git -C $dir rev-parse --show-toplevel`)); catch; ""; end
 
-# GET /api/app/worktrees → { worktrees: [{path, branch, current}], current, canSwitch }
+# GET /api/app/worktrees → { worktrees: [{path, branch, current, primary}], current, canSwitch }
 function api_app_worktrees(::HTTP.Request)
     here = _git_toplevel(pwd())
     out = Any[]
@@ -82,7 +82,10 @@ function api_app_worktrees(::HTTP.Request)
                 startswith(l, "branch ")   && (branch = replace(String(l[8:end]), "refs/heads/" => ""))
             end
             isempty(path) && continue
-            push!(out, (; path, branch, current = path == here))
+            # git lists the primary (main) worktree FIRST — flag it so the UI can identify the main
+            # checkout even when it's on a feature branch (the branch label alone can't, since no
+            # worktree need be on `main`). `primary = isempty(out)` → true only for the first entry.
+            push!(out, (; path, branch, current = path == here, primary = isempty(out)))
         end
     catch e
         return 200, JSON3.write((; worktrees = Any[], current = here, canSwitch = false,

--- a/app/src/gating/population_manager.jl
+++ b/app/src/gating/population_manager.jl
@@ -382,13 +382,24 @@ end
 # track belongs to a pop if any of its cells are in that pop. Mirrors the `_pop_df` dedup, but
 # the row key is the track (value_name, track_id), not the cell label.
 function _pop_df_tracks(img::CciaImage, load_map::Function, pops, default_vn::AbstractString;
-                        pop_cols=nothing, unique_labels::Bool=true, drop_na::Bool=false)::DataFrame
+                        pop_cols=nothing, unique_labels::Bool=true, drop_na::Bool=false,
+                        cell_measures=String[], categorical=String[])::DataFrame
     frames = DataFrame[]
     for (vn, vpops) in _group_pops_by_value_name(pops, default_vn)
-        tpath = img_track_props_path(img, vn)
-        isfile(tpath) || begin
-            @warn "pop_df(:track): no track table for value_name=$vn — run tracking.track_measures" tpath
+        # per-track feature table (label == track_id): motility (from `{vn}__tracks.h5ad`) ⊕ on-read
+        # aggregates of `cell_measures` (HMM-state / transition frequencies, intensity/morphology
+        # means). SAME source (`track_props`) as the `track`/`trackclust` gating path — so a `live`
+        # `_tracked` population clusters on the identical per-track features as a hand-drawn track
+        # gate. This is why clustTracks works off `_tracked` pops. Empty → untracked seg, skip.
+        ttab = track_props(img; value_name=vn, cell_measures=cell_measures, categorical=categorical)
+        nrow(ttab) == 0 && begin
+            @warn "pop_df(:track): no tracks for value_name=$vn — run tracking.track_measures first" vn
             continue
+        end
+        # narrow to requested measures (keeping the track-key bookkeeping); empty pop_cols = all cols
+        if !(pop_cols === nothing || isempty(pop_cols))
+            keep = intersect(unique(vcat("label", "track_id", "num_cells", String.(pop_cols))), names(ttab))
+            select!(ttab, keep)
         end
 
         # cell-level gate membership (Julia is the evaluator), then cell label → track_id
@@ -402,10 +413,6 @@ function _pop_df_tracks(img::CciaImage, load_map::Function, pops, default_vn::Ab
             cell_tid[Int(r.label)] = Int(r.track_id)
         end
 
-        # per-track table (label == track_id); select requested measures when given
-        tview = label_props(tpath)
-        pop_cols === nothing || select_cols(tview, String.(pop_cols))
-        ttab = as_df(tview)
         trow = Dict(Int(t) => i for (i, t) in enumerate(ttab.label))
 
         for pop in vpops
@@ -970,10 +977,12 @@ function pop_df(img::CciaImage, pop_type::AbstractString, pops;
         end
     end
 
-    # :track → one row per track from the companion track table (membership still cell-level).
+    # :track → one row per track (features from `track_props`: motility ⊕ `cell_measures` aggregates),
+    # membership still evaluated at cell level then mapped to tracks.
     if granularity === :track
         df = _pop_df_tracks(img, load_map, pops, resolved_vn;
-                            pop_cols=pop_cols, unique_labels=unique_labels, drop_na=drop_na)
+                            pop_cols=pop_cols, unique_labels=unique_labels, drop_na=drop_na,
+                            cell_measures=cell_measures, categorical=categorical)
         img._pop_df_cache[ckey] = df
         return copy(df)
     end

--- a/app/src/tasks/clustTracks/cluster.jl
+++ b/app/src/tasks/clustTracks/cluster.jl
@@ -36,7 +36,11 @@ function _run_task(::ClustTracks, imgs::Vector{CciaImage}, params::Dict{String,A
 
     pops = _str_list(params, "popsToCluster")           # shared with clustPops (cluster.jl)
     isempty(pops) && (on_log("[ERROR] clustTracks: select at least one track population"); return nothing)
-    pop_type = string(get(params, "popType", "track"))
+    # popScope="tracks" (cluster.json) surfaces `_tracked` populations, which are `live`-derived
+    # (track_id>0 within a cell gate) — resolved under "live" with :track granularity (membership at
+    # cell level → tracks, features from `track_props`). NOT the per-track gate map ("track"), which
+    # is why the old "track" default returned no tracks for `_tracked` pops.
+    pop_type = string(get(params, "popType", "live"))
     suffix   = string(get(params, "valueNameSuffix", "default"))
     feature_cols = _str_list(params, "clusterMeasures") # per-track property column names
     isempty(feature_cols) &&
@@ -61,7 +65,9 @@ function _run_task(::ClustTracks, imgs::Vector{CciaImage}, params::Dict{String,A
     cell_measures = String[f for f in feature_cols if !(f in mot_set)]
 
     # ── pooled per-track features: one row per track tagged with uID + value_name + track_id ──
-    # pop_type="track" → `track_props` (motility ⊕ on-read aggregates), one point per track.
+    # pop_type "live" + :track → membership from the `_tracked` cell gate, features from `track_props`
+    # (motility ⊕ on-read aggregates), one point per track. (pop_type "track"/"trackclust" would gate
+    # the per-track table directly — same `track_props` features, different membership source.)
     df = pop_df(imgs, uids, pop_type, pops;
                 granularity = :track, cell_measures = cell_measures, pop_cols = String[])
     nrow(df) == 0 && (on_log("[ERROR] clustTracks: no tracks for pops=$(pops)"); return nothing)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2566,6 +2566,19 @@ end
             sp = pop_df(img, "live", ["B/_tracked"]; granularity=:track,
                         pop_cols=["live.track.speed"])
             @test "live.track.speed" in names(sp) && !("live.track.duration" in names(sp))
+
+            # cell_measures aggregation (the clustTracks path): a per-cell measure is aggregated to
+            # per-track feature column(s) via track_props, alongside motility — this is what lets
+            # clustTracks cluster `_tracked` pops on HMM/intensity features, not just motility.
+            cvars = col_names(label_props(img; value_name="B"); data_type=:vars)
+            if !isempty(cvars)
+                base = String(first(cvars))                        # a real per-cell measure
+                ag = pop_df(img, "live", ["B/_tracked"]; granularity=:track, cell_measures=[base])
+                @test any(startswith(c, base * ".") for c in names(ag))   # aggregated → {base}.…
+                @test nrow(ag) == nrow(tr)                          # same tracks, extra feature cols
+                @test "live.track.speed" in names(ag)               # motility still present
+                @test "num_cells" in names(ag)                      # per-track cell count (minTracklength)
+            end
         end
     end
 

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -231,6 +231,9 @@ async function quitApp() {
 }
 // dev worktree switch: relaunch the backend from another checkout (backend/:8080 only)
 onMounted(() => appCtl.refreshWorktrees())
+// folder name of a worktree path — labels the option so the PRIMARY ("main") checkout is
+// recognisable even when it's on a feature branch (the branch label alone can't identify it).
+function wtFolder(path: string): string { return path.split('/').filter(Boolean).pop() ?? path }
 async function switchWt(path: string) {
   if (!path) return
   svcMsg.value = 'Switching worktree…'
@@ -386,7 +389,7 @@ async function switchWt(path: string) {
                 @change="switchWt(($event.target as HTMLSelectElement).value)"
                 v-tooltip.top="'Relaunch the backend from another git worktree (dev). The page reconnects when it is back.'">
           <option v-for="w in appCtl.worktrees" :key="w.path" :value="w.path">
-            {{ w.branch }}{{ w.current ? ' (current)' : '' }}
+            {{ wtFolder(w.path) }} — {{ w.branch }}{{ w.primary ? ' (main)' : '' }}{{ w.current ? ' (current)' : '' }}
           </option>
         </select>
       </div>

--- a/frontend/src/stores/appControl.ts
+++ b/frontend/src/stores/appControl.ts
@@ -14,7 +14,7 @@ export const useAppControlStore = defineStore('appControl', () => {
 
   // dev-only: the repo's git worktrees, so the System panel can relaunch the backend from another
   // checkout without the console (backend/:8080 only — a frontend branch still needs its own Vite).
-  const worktrees = ref<{ path: string; branch: string; current: boolean }[]>([])
+  const worktrees = ref<{ path: string; branch: string; current: boolean; primary?: boolean }[]>([])
   const canSwitch = ref(false)   // server supervised → a switch can actually relaunch
 
   // read the dev flag from diagnostics (prod never sets CECELIA_DEV → false)
@@ -24,7 +24,7 @@ export const useAppControlStore = defineStore('appControl', () => {
   async function refreshWorktrees() {
     try {
       const d = await (await fetch('/api/app/worktrees')).json() as {
-        worktrees?: { path: string; branch: string; current: boolean }[]; canSwitch?: boolean }
+        worktrees?: { path: string; branch: string; current: boolean; primary?: boolean }[]; canSwitch?: boolean }
       worktrees.value = d.worktrees ?? []
       canSwitch.value = !!d.canSwitch
     } catch { /* leave as-is */ }


### PR DESCRIPTION
## clustTracks `_tracked` fix + worktree switcher labeling

Two independent changes (separate commits).

### 1. clustTracks: resolve `_tracked` pops via `live`+`:track`
`clustTracks` errored `no tracks for pops=[B/qc/_tracked, T/qc/_tracked]`. After the `popScope="tracks"` picker change, the population picker offers `_tracked` populations — which are **`live`-derived** (`track_id>0` within a cell gate) — but the handler resolved them under `pop_type="track"` (the per-track gate map, which doesn't contain them).

- `_pop_df_tracks` (the `live`+`:track` path) now sources per-track features from `track_props` (motility ⊕ `cell_measures` aggregates) — the **same** source the `track`/`trackclust` gating path uses — so a `_tracked` pop clusters on the identical per-track features (HMM state/transition frequencies, intensity/morphology means), not just motility.
- `pop_df` threads `cell_measures`/`categorical` into the `:track` branch.
- `clustTracks` resolves `popsToCluster` under `live`.

**Test** (real KDIeEm track fixture): `pop_df(:track)` with `cell_measures` produces `{base}.…` per-track columns, same track count, motility + `num_cells` present. Package suite: 845 pass / 0 fail.

### 2. Settings: flag primary worktree + show folder in the switcher
The worktree switcher labeled entries by branch only, so the primary ("main") checkout was unrecognisable when it sat on a feature branch — "main" appeared to vanish from the list.

- Backend flags the first (primary) worktree git lists: `{…, primary}`.
- Dropdown now reads `folder — branch (main) (current)`.

### Notes / limitations
- clustTracks: the Julia stage (membership + feature matrix — the failure point) is verified; the Python/Leiden tail wasn't run end-to-end (needs the pixi env), but the error fired before Python was reached.
- A single clustTracks run assumes one pop-type — genuine per-track-gate/`trackclust` pops mixed with `_tracked` in one run resolve only the `_tracked` ones. Edge case; the tracks-scope picker surfaces `_tracked` as the dominant case.
- Worktree backend field is a one-line tuple addition (shells out to git; no unit test), verified against real porcelain output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)