### PR TITLE
Fix/gating raster tuning plate builder

### DIFF
--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -38,16 +38,20 @@ native SVG (so SVG export is "serialize the node") and does **heatmaps/tiled map
 and small. regl-scatterplot now owns **UMAP only**; the **gating** scatter is a **2D density raster**
 (no WebGL) — see below.
 
-**Gating scatter = 2D density raster (no WebGL).** The gating point cloud is non-interactive (fixed
-camera; gate *drawing* is the only interaction, on the canvas2D overlay), so it renders as a
-FlowJo/OMIQ-style density raster instead of a GPU point cloud: `plots/density.ts` bins → Gaussian-blurs
-→ `densityImageData` colours each cell via the shared blue-heat ramp (`plots/flowColors.ts`), upscaled
-smoothly to the plot; contours are clean connected rings from **d3-contour** (`plots/contour.ts`) on the
-blurred grid (replacing jagged marching-squares segments). `components/plots/PlotLayers.vue` draws base
-(raster or contours) + child-pop overlays on one 2D canvas; `GateScatterCell.vue` composites it with the
-gate overlay. **Export re-renders the same 2D content at target scale** (crisp, cannot clip) — this
-replaced the fragile WebGL hi-res screengrab that clipped dots. Re-renders on data/extent change
-(autoscale, zero-extent, image switch); tune the look via `DENSITY_GRID`/`BLUR_*`/`CONTOUR_LEVELS`.
+**Gating scatter = 2D pseudocolour DOT plot (no WebGL).** The gating point cloud is non-interactive
+(fixed camera; gate *drawing* is the only interaction, on the canvas2D overlay), so it renders on a 2D
+canvas instead of a GPU point cloud. **FlowJo/OMIQ look = each point drawn coloured by its LOCAL
+density** (`plots/density.ts` `pointDensities` → blue-heat ramp `plots/flowColors.ts`), NOT a binned
+image — a binned raster showed "weird rectangles"; the dot plot reads at point resolution. Points are
+bucketed by colour so `fillStyle` is set ~64×, not per point. Contours are clean connected rings from
+**d3-contour** (`plots/contour.ts`) on a separate, heavily-blurred grid (`DENSITY_GRID`/`CONTOUR_BLUR_*`;
+the dots use `DOT_GRID`/`DOT_BLUR_*`). `components/plots/PlotLayers.vue` draws base (dots or contours) +
+child-pop overlays on one 2D canvas; `GateScatterCell.vue` composites it with the gate overlay.
+**Export re-renders the same 2D content at target scale** (crisp, cannot clip) — replaced the fragile
+WebGL hi-res screengrab that clipped dots. Re-renders on data/extent change (autoscale, zero-extent,
+image switch). Base contour/outlier ink comes from the themed `--cc-text-dim` var (so it flips
+dark-on-white for the light PDF, not an invisible grey). Tune: `DOT_GRID`/`DOT_BLUR_*`/`DOT_R` (dot
+detail/size), `CONTOUR_LEVELS`, the outlier alpha/size.
 
 Code: `frontend/src/plots/plot.ts` (`buildPlotOptions(Plot, r, o)` — one builder per chart type,
 returns a `Plot.plot()` options object; takes the Plot module as a param so it carries no eager import)

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -642,9 +642,9 @@ squashed by a stack of dropdowns (the squashed plot exported as a clipped sliver
 
 ### Canvas zoom (fit-to-view)
 
-Every plot canvas — the Analysis board's fixed grid AND the free-floating module canvases
-(`SummaryCanvas`, `GatingPlots`) — shares one visual zoom, so a big workspace fits the screen without
-hiding the sidebar. `composables/useCanvasZoom.ts` owns the `zoom` ref + `fitWidth`/`fitHeight`;
+Every plot canvas — the Analysis board's fixed grid AND **all** free-floating module canvases
+(`SummaryCanvas`, `GatingPlots`, `ClusterPlots`) — shares one visual zoom, so a big workspace fits the
+screen without hiding the sidebar. `composables/useCanvasZoom.ts` owns the `zoom` ref + `fitWidth`/`fitHeight`;
 `components/canvas/CanvasZoomControl.vue` is the shared slider/fit/% control. It's a **CSS
 `transform: scale`** — purely visual: it never resizes a plot's own canvas or changes what's exported
 (the export re-renders at full logical resolution; the board neutralises the zoom during PDF capture).

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -658,9 +658,10 @@ screen without hiding the sidebar. `composables/useCanvasZoom.ts` owns the `zoom
 
 ### Show/hide the population manager
 
-The floating population manager (`PopulationManager` on the gate/tracking pages, `SeriesPicker` on
-summary pages) has a **toggle** (`pi-sitemap`) next to the arrange-windows icons, persisted per canvas in
-the `shared` bag (`shared.showManager`, default shown). Wrap the manager `v-if="showManager"`.
+The floating population manager (`PopulationManager` on gate/tracking + cluster pages, `SeriesPicker`
+on summary pages) has a **toggle** (`pi-sitemap`) next to the arrange-windows icons on **every** module
+canvas that has one (`SummaryCanvas`, `GatingPlots`, `ClusterPlots`), persisted per canvas in the
+`shared` bag (`shared.showManager`, default shown). Wrap the manager `v-if="showManager"`.
 
 ---
 

--- a/frontend/src/components/canvas/CanvasPanel.vue
+++ b/frontend/src/components/canvas/CanvasPanel.vue
@@ -142,7 +142,9 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
 .panel-spacer { flex: 1; }
 /* main region below the head: the anchor for the auto-hide control overlays (position: relative) and
    the box the body fills. */
-.panel-main { position: relative; flex: 1; min-height: 0; display: flex; flex-direction: column; }
+/* overflow: hidden so a plot with its own min-height can't spill out of the main region and cover the
+   footer (export/duplicate) or header when the panel/slot is small — it clips within the box instead */
+.panel-main { position: relative; flex: 1; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
 /* controls / footer: shared layout only. The overlay look + hover-reveal live in the global
    .cc-panel-controls utility (style.css); the in-flow look (auto-hide off) is the .inflow variant. */
 .panel-controls { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 5px 8px; }

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -566,7 +566,11 @@ defineExpose({ capturePage, collectCsvs })
 .lc-slot { position: relative; border: 1px dashed var(--cc-border); border-radius: 6px; overflow: hidden;
   display: flex; min-width: 0; min-height: 0; background: var(--cc-bg); }
 .lc-slot.filled { border-style: solid; }
-.lc-slot.active { border-color: #7c3aed; }
+/* selection = amber, matching CanvasPanel .panel.active and every module page (was a clashing violet).
+   A FILLED slot's panel already draws the amber border + glow, so don't double it there — only an empty
+   slot needs its own amber selection border. */
+.lc-slot.active { border-color: #ff8c1a; }
+.lc-slot.filled.active { border-color: var(--cc-border); }
 /* reorder drag handle now lives IN the panel header (CanvasPanel docked drag icon); its native
    dragstart bubbles to .lc-slot (@dragstart above). No absolute overlay grip here anymore. */
 .lc-add { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; }

--- a/frontend/src/components/canvas/PlateBuilder.vue
+++ b/frontend/src/components/canvas/PlateBuilder.vue
@@ -6,7 +6,7 @@
   drag UI. Seeded from the current plate so you can tweak rather than start over.
 -->
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onBeforeUnmount, useTemplateRef } from 'vue'
 import { normSpan, applyDrag, clampSpans, slotsToSpans, buildPlate, type PlateSpan, type Cell } from '../../utils/plateBuilder'
 import type { LayoutTemplate } from '../../plots/layoutTemplates'
 
@@ -31,18 +31,34 @@ const gridTmpl = computed(() => ({
 const areaStyle = (s: PlateSpan) => ({ gridArea: `${s.r0 + 1} / ${s.c0 + 1} / ${s.r1 + 2} / ${s.c1 + 2}` })
 
 // ── drag to merge / click to split ────────────────────────────────────────────
+// Hit-test the CELL under the pointer from its position relative to the grid rect — robust to fast
+// drags and to the grid re-rendering after a merge (per-cell pointerenter was jumpy and stopped
+// firing after the first merge). One pointerdown → window move/up so the drag survives leaving a cell.
+const gridRef = useTemplateRef<HTMLElement>('gridRef')
 const dragging = ref(false)
 const start = ref<Cell | null>(null)
 const hover = ref<Cell | null>(null)
 const dragRect = computed(() => (dragging.value && start.value && hover.value) ? normSpan(start.value, hover.value) : null)
-function onDown(cell: Cell) { start.value = hover.value = cell; dragging.value = true; window.addEventListener('pointerup', onUp) }
-function onEnter(cell: Cell) { if (dragging.value) hover.value = cell }
+function cellAt(e: PointerEvent): Cell | null {
+  const el = gridRef.value; if (!el) return null
+  const r = el.getBoundingClientRect()
+  const c = Math.floor(((e.clientX - r.left) / r.width) * cols.value)
+  const rr = Math.floor(((e.clientY - r.top) / r.height) * rows.value)
+  return { r: Math.max(0, Math.min(rows.value - 1, rr)), c: Math.max(0, Math.min(cols.value - 1, c)) }
+}
+function onMove(e: PointerEvent) { if (dragging.value) { const c = cellAt(e); if (c) hover.value = c } }
 function onUp() {
+  window.removeEventListener('pointermove', onMove)
   window.removeEventListener('pointerup', onUp)
   if (dragging.value && start.value && hover.value) spans.value = applyDrag(spans.value, normSpan(start.value, hover.value))
   dragging.value = false; start.value = hover.value = null
 }
-onBeforeUnmount(() => window.removeEventListener('pointerup', onUp))
+function onDown(e: PointerEvent) {
+  const c = cellAt(e); if (!c) return
+  start.value = hover.value = c; dragging.value = true
+  window.addEventListener('pointermove', onMove); window.addEventListener('pointerup', onUp)
+}
+onBeforeUnmount(onUp)
 
 const slotCount = computed(() => buildPlate(cols.value, rows.value, spans.value).slots.length)
 function apply() { emit('apply', buildPlate(cols.value, rows.value, spans.value)) }
@@ -58,9 +74,8 @@ function apply() { emit('apply', buildPlate(cols.value, rows.value, spans.value)
       <span class="pb-hint">drag to merge · click a merge to split</span>
     </div>
 
-    <div class="pb-grid" :style="gridTmpl">
-      <div v-for="cell in gridCells" :key="`${cell.r}-${cell.c}`" class="pb-cell"
-           @pointerdown.prevent="onDown(cell)" @pointerenter="onEnter(cell)" />
+    <div ref="gridRef" class="pb-grid" :style="gridTmpl" @pointerdown.prevent="onDown">
+      <div v-for="cell in gridCells" :key="`${cell.r}-${cell.c}`" class="pb-cell" />
       <div v-for="(s, i) in spans" :key="`s${i}`" class="pb-span" :style="areaStyle(s)" />
       <div v-if="dragRect" class="pb-drag" :style="areaStyle(dragRect)" />
     </div>

--- a/frontend/src/components/plots/GateOverlay.vue
+++ b/frontend/src/components/plots/GateOverlay.vue
@@ -41,6 +41,18 @@ const cursor = ref('default')
 
 // ── coordinate mapping (data ⇄ px) via the live extents ──
 function size() { const c = canvasEl.value!; return { w: c.clientWidth, h: c.clientHeight } }
+// a white/default gate outline is invisible on the light PDF export — resolve those to the themed
+// `--cc-text` var so they flip DARK-on-white for export and stay white on the dark screen (same trick
+// as the contour ink). Gates with a real pop colour are left as-is (visible on either ground).
+function ink(): string {
+  const el = canvasEl.value
+  const v = el && getComputedStyle(el).getPropertyValue('--cc-text').trim()
+  return v || '#fafafa'
+}
+function gateColour(colour?: string): string {
+  const c = (colour ?? '').trim().toLowerCase()
+  return (!c || c === 'white' || c === '#fff' || c === '#ffffff' || c === '#fafafa') ? ink() : colour!
+}
 function dataToPx(vx: number, vy: number): [number, number] {
   const { w, h } = size(); const { xMin, xMax, yMin, yMax } = props.extents
   const xs = xMax > xMin ? xMax - xMin : 1, ys = yMax > yMin ? yMax - yMin : 1
@@ -191,7 +203,9 @@ function drawHandles(g: GateSpec, colour: string) {
 function paintGates() {
   for (const g of props.gates ?? []) {
     const spec = g.path === editPath && draft.value ? draft.value : g.gate
-    strokeShape(spec, g.colour || '#fafafa')
+    // outline flips for white/default gates (invisible on white export); the label keeps its colour —
+    // it has a dark halo, so white text stays legible on either ground.
+    strokeShape(spec, gateColour(g.colour))
     if (props.showLabels) drawGateLabel(spec, g.path, g.colour || '#fafafa', g.label)
   }
 }

--- a/frontend/src/components/plots/PlotLayers.vue
+++ b/frontend/src/components/plots/PlotLayers.vue
@@ -13,8 +13,9 @@
 -->
 <script setup lang="ts">
 import { watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
-import { densityGrid, densityImageData, outlierPoints, DENSITY_GRID, CONTOUR_LEVELS, type Ext } from '../../plots/density'
+import { densityGrid, pointDensities, outlierPoints, DENSITY_GRID, CONTOUR_LEVELS, type Ext } from '../../plots/density'
 import { densityContours } from '../../plots/contour'
+import { BLUE_HEAT_RGB } from '../../plots/flowColors'
 
 export interface PopLayer { path: string; colour: string; points: Float32Array }
 
@@ -35,6 +36,14 @@ const G = DENSITY_GRID
 const LEVELS = CONTOUR_LEVELS
 
 function size() { const c = canvasEl.value!; return { w: c.clientWidth, h: c.clientHeight } }
+// base contour/outlier ink resolved from the themed CSS var so it flips DARK-on-white for the light PDF
+// export (.cc-light on an ancestor) and light-on-dark on screen — a hardcoded grey was invisible on the
+// white export. Falls back to a mid slate that reads on either ground.
+function ink(): string {
+  const el = canvasEl.value
+  const v = el && getComputedStyle(el).getPropertyValue('--cc-text-dim').trim()
+  return v || '#64748b'
+}
 function toPx(vx: number, vy: number): [number, number] {
   const { w, h } = size(); const { xMin, xMax, yMin, yMax } = props.viewExtents
   const xs = xMax > xMin ? xMax - xMin : 1, ys = yMax > yMin ? yMax - yMin : 1
@@ -46,18 +55,25 @@ function gridToPx(gx: number, gy: number): [number, number] {
   return toPx(xMin + (gx / G) * (xMax - xMin), yMin + (gy / G) * (yMax - yMin))
 }
 
-// FlowJo pseudocolour density raster: build the G×G RGBA image, then upscale (smoothed) to the plot rect
-function drawRaster(points: Float32Array, alpha = 1) {
+// FlowJo/OMIQ pseudocolour DOT plot: each point drawn at its position, coloured by its LOCAL density
+// via the blue-heat ramp — point resolution, no blocky cells. Bucketed by colour so we set fillStyle
+// ~B times, not once per point (fast for 100k+ points).
+const DOT_BUCKETS = 64
+const DOT_R = 0.7
+function drawDensityDots(points: Float32Array, alpha = 1) {
   const c = ctx!
-  const img = densityImageData(points, props.viewExtents, G)
-  const off = document.createElement('canvas'); off.width = G; off.height = G
-  const octx = off.getContext('2d')!
-  const idata = octx.createImageData(G, G); idata.data.set(img.data)   // avoids ImageData-ctor buffer typing
-  octx.putImageData(idata, 0, 0)
-  const { w, h } = size()
-  c.save()
-  c.globalAlpha = alpha; c.imageSmoothingEnabled = true; c.imageSmoothingQuality = 'high'
-  c.drawImage(off, 0, 0, G, G, 0, 0, w, h)
+  const t = pointDensities(points, props.viewExtents)
+  const n = points.length / 2
+  const groups: number[][] = Array.from({ length: DOT_BUCKETS }, () => [])
+  for (let i = 0; i < n; i++) groups[Math.min(DOT_BUCKETS - 1, Math.floor(t[i] * DOT_BUCKETS))].push(i)
+  const s = DOT_R * 2
+  c.save(); c.globalAlpha = alpha
+  for (let b = 0; b < DOT_BUCKETS; b++) {
+    const g = groups[b]; if (!g.length) continue
+    const ci = Math.min(255, Math.round((b / (DOT_BUCKETS - 1)) * 255))
+    c.fillStyle = `rgb(${BLUE_HEAT_RGB[ci * 3]},${BLUE_HEAT_RGB[ci * 3 + 1]},${BLUE_HEAT_RGB[ci * 3 + 2]})`
+    for (const i of g) { const [px, py] = toPx(points[2 * i], points[2 * i + 1]); c.fillRect(px - DOT_R, py - DOT_R, s, s) }
+  }
   c.restore()
 }
 
@@ -89,10 +105,11 @@ function drawDots(points: Float32Array, colour: string, r = 1.5) {
     c.fillRect(px - r, py - r, s, s)
   }
 }
-// "contour + outliers": the sparse-tail points the contours don't enclose, drawn as subtle dots
+// "contour + outliers": the sparse-tail points the contours don't enclose, drawn as clear dots (they
+// were barely visible before — bumped alpha + size so the tail reads like the old WebGL render did)
 function drawOutliers(points: Float32Array, colour: string) {
-  ctx!.globalAlpha = 0.3
-  drawDots(outlierPoints(points, props.viewExtents, G), colour, 0.6)
+  ctx!.globalAlpha = 0.8
+  drawDots(outlierPoints(points, props.viewExtents, G), colour, 1.3)
   ctx!.globalAlpha = 1
 }
 
@@ -101,10 +118,11 @@ function paintContent() {
   const mode = props.renderMode
   // BASE population
   if (props.basePoints?.length) {
-    if (mode === 'points') drawRaster(props.basePoints, props.showPops ? 0.4 : 1)   // dim under pop overlays
+    if (mode === 'points') drawDensityDots(props.basePoints, props.showPops ? 0.4 : 1)   // dim under pop overlays
     else {
-      drawContours(props.basePoints, '#cbd5e1')
-      if (mode === 'outliers') drawOutliers(props.basePoints, '#cbd5e1')
+      const base = ink()
+      drawContours(props.basePoints, base)
+      if (mode === 'outliers') drawOutliers(props.basePoints, base)
     }
   }
   // child POPULATION overlays

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -15,8 +15,10 @@
   cluster numbering; the heatmap pools via setUid).
 -->
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, provide } from 'vue'
 import { useProjectMetaStore } from '../../stores/projectMeta'
+import { useCanvasZoom, CANVAS_ZOOM_KEY } from '../../composables/useCanvasZoom'
+import CanvasZoomControl from '../../components/canvas/CanvasZoomControl.vue'
 import { useProjectStore } from '../../stores/project'
 import { useGatingStore } from '../../stores/gating'
 import { useCanvasPanels, type CanvasItem } from '../../composables/useCanvasPanels'
@@ -67,6 +69,14 @@ for (const p of panels.value) { const a = KIND_ALIASES[p.state.kind]; if (a) p.s
 const { suffix, highlighted, scope, vis: gVis } = useViewState(shared, {
   suffix: 'default', highlighted: [] as string[], scope: 'global' as 'global' | 'local',
   vis: defaultVis() as VisProps })
+
+// visual zoom (shared control): scale the free-floating cluster workspace; drag is zoom-corrected via
+// the injected zoom (CanvasPanel → useFloatingPanel). The population manager stays full-size (outside).
+const zoomRef = ref<HTMLElement | null>(null)
+const { zoom, fitWidth, fitHeight, setZoom, reset: resetZoom } = useCanvasZoom(canvasRef,
+  () => { const el = zoomRef.value; return el ? { w: el.scrollWidth, h: el.scrollHeight } : { w: null, h: 0 } })
+provide(CANVAS_ZOOM_KEY, zoom)
+const zoomStyle = computed(() => zoom.value !== 1 ? { transform: `scale(${zoom.value})`, transformOrigin: 'top left' } : {})
 
 // run list + per-run features/cluster metadata + valid-image resolution + the gating-store drive +
 // highlight→shownPops resolution (shared with the Analysis board via useClusterContext).
@@ -193,6 +203,7 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
           <button v-tooltip.bottom="'Tile in a grid'" @click="arrangeGrid"><i class="pi pi-th-large" /></button>
           <button v-tooltip.bottom="'Cascade windows'" @click="arrangeCascade"><i class="pi pi-clone" /></button>
         </div>
+        <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
         <span class="cp-hint">drag plots by their title · resize from the corner</span>
       </div>
 
@@ -224,6 +235,8 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
                            :vis="activeVis"
                            @update:selected="selectedPop = $event" @update:scope="scope = $event"
                            @update:vis="setVis" @toggle-highlight="toggleHighlight" />
+        <!-- scaled workspace: the plots zoom together; the population manager stays full-size (above) -->
+        <div ref="zoomRef" class="cp-zoom" :style="zoomStyle">
         <template v-for="(p, i) in panels" :key="`${ckey}:${p.id}`">
           <!-- interactive (UMAP, …) → generic InteractivePanel -->
           <InteractivePanel v-if="isInteractiveView(p.state.kind)" :index="i" :arrange="p.arrange"
@@ -239,6 +252,7 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
                             v-bind="clusterPanelProps(p)" :persist-key="`${ckey}:${p.id}`"
                             @activate="activeId = p.id" @remove="remove(p.id)" @duplicate="duplicatePanel(p.state)" />
         </template>
+        </div>
       </div>
     </template>
   </div>
@@ -263,4 +277,6 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button:hover { color: var(--cc-text); }
 .cp-canvas { position: relative; flex: 1; min-height: 70vh; }
+/* the scaled workspace fills the canvas (offsetParent for the floating panels); transform set inline */
+.cp-zoom { position: absolute; inset: 0; }
 </style>

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -66,9 +66,9 @@ for (const p of panels.value) { const a = KIND_ALIASES[p.state.kind]; if (a) p.s
 // Highlighting the eye shows a pop on the UMAP (its colour, other clusters greyed) + breaks the
 // heatmap out per-population. `scope` mirrors gating: GLOBAL = one highlight set for every plot;
 // LOCAL = each plot (panel) has its own (state.hl). All persisted per canvas via the shared bag.
-const { suffix, highlighted, scope, vis: gVis } = useViewState(shared, {
+const { suffix, highlighted, scope, vis: gVis, showManager } = useViewState(shared, {
   suffix: 'default', highlighted: [] as string[], scope: 'global' as 'global' | 'local',
-  vis: defaultVis() as VisProps })
+  vis: defaultVis() as VisProps, showManager: true })
 
 // visual zoom (shared control): scale the free-floating cluster workspace; drag is zoom-corrected via
 // the injected zoom (CanvasPanel → useFloatingPanel). The population manager stays full-size (outside).
@@ -203,6 +203,12 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
           <button v-tooltip.bottom="'Tile in a grid'" @click="arrangeGrid"><i class="pi pi-th-large" /></button>
           <button v-tooltip.bottom="'Cascade windows'" @click="arrangeCascade"><i class="pi pi-clone" /></button>
         </div>
+        <div class="seg">
+          <button :class="{ on: showManager }" @click="showManager = !showManager"
+                  v-tooltip.bottom="showManager ? 'Hide the population manager' : 'Show the population manager'">
+            <i class="pi pi-sitemap" />
+          </button>
+        </div>
         <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
         <span class="cp-hint">drag plots by their title · resize from the corner</span>
       </div>
@@ -229,7 +235,7 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
       </div>
 
       <div ref="canvasRef" class="cp-canvas">
-        <PopulationManager v-if="validUids.length" :selected="selectedPop" :highlighted="activeHL" :scope="scope"
+        <PopulationManager v-if="showManager && validUids.length" :selected="selectedPop" :highlighted="activeHL" :scope="scope"
                            :line-width="1" :gate-labels="false" :axis-from-zero="false"
                            :pop-type="popType" :cluster-ids="clusterIds[suffix] ?? []" :suffix="suffix"
                            :vis="activeVis"
@@ -276,6 +282,7 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
 .seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 5px 9px; cursor: pointer; font-size: 12px; }
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button:hover { color: var(--cc-text); }
+.seg button.on { color: var(--cc-accent); background: var(--cc-surface-1); }
 .cp-canvas { position: relative; flex: 1; min-height: 70vh; }
 /* the scaled workspace fills the canvas (offsetParent for the floating panels); transform set inline */
 .cp-zoom { position: absolute; inset: 0; }

--- a/frontend/src/plots/density.test.ts
+++ b/frontend/src/plots/density.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { densityGrid, densityImageData, outlierPoints, DENSITY_GRID } from './density'
+import { densityGrid, pointDensities, outlierPoints, DENSITY_GRID } from './density'
 
 const ext = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 }
 
@@ -29,20 +29,17 @@ describe('densityGrid', () => {
   })
 })
 
-describe('densityImageData', () => {
-  it('returns G×G RGBA with empty cells transparent and dense cells opaque + coloured', () => {
-    const img = densityImageData(new Float32Array(cluster(400, 0.5, 0.5)), ext)
-    expect(img.width).toBe(DENSITY_GRID)
-    expect(img.height).toBe(DENSITY_GRID)
-    expect(img.data.length).toBe(DENSITY_GRID * DENSITY_GRID * 4)
-    // a corner far from the (0.5,0.5) blob → empty → fully transparent
-    const cornerA = (0 * DENSITY_GRID + 0) * 4
-    expect(img.data[cornerA + 3]).toBe(0)
-    // the centre cell (rows flipped: destRow = G-1-gy, gy≈G/2 → still ≈centre) is opaque + non-black
-    const mid = Math.floor(DENSITY_GRID / 2)
-    const o = (mid * DENSITY_GRID + mid) * 4
-    expect(img.data[o + 3]).toBe(255)
-    expect(img.data[o] + img.data[o + 1] + img.data[o + 2]).toBeGreaterThan(0)
+describe('pointDensities', () => {
+  it('is one 0..1 value per point, highest in the dense core, lowest in the sparse tail', () => {
+    const pts = new Float32Array([...cluster(400, 0.5, 0.5), 0.02, 0.02])   // dense core + 1 lone tail point
+    const t = pointDensities(pts, ext)
+    expect(t.length).toBe(pts.length / 2)
+    for (const v of t) { expect(v).toBeGreaterThanOrEqual(0); expect(v).toBeLessThanOrEqual(1) }
+    expect(t[0]).toBeGreaterThan(t[t.length - 1])   // a core point is denser than the lone tail point
+  })
+  it('gives non-finite points 0 density', () => {
+    const t = pointDensities(new Float32Array([NaN, NaN, 0.5, 0.5]), ext)
+    expect(t[0]).toBe(0)
   })
 })
 

--- a/frontend/src/plots/density.ts
+++ b/frontend/src/plots/density.ts
@@ -1,15 +1,17 @@
-// Density grid + raster image + outlier classification for the gate scatter. The base gating cloud is
-// rendered as a FlowJo/OMIQ-style 2D DENSITY RASTER (no WebGL): bin → blur → blue-heat ramp. The same
-// blurred grid feeds the contour rings (plots/contour.ts). Pure + unit-tested (docs/DEV.md).
-import { BLUE_HEAT_RGB } from './flowColors'
-
+// Density estimation for the gate scatter (no WebGL). The base cloud is a FlowJo/OMIQ pseudocolour DOT
+// plot: `pointDensities` gives each point its local density → the renderer colours it via the blue-heat
+// ramp. The same binning feeds the contour rings (plots/contour.ts) and the outlier tail. Pure +
+// unit-tested (docs/DEV.md).
 export type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
 
-export const DENSITY_GRID = 128            // grid resolution (raster + contour); upscaled smoothly to px
-// blur strength — a few box-blur passes ≈ a Gaussian. Heavier than a single 3×3 so contours read as
-// clean nested rings (FlowJo look) instead of jagged per-cell wiggles.
-export const BLUR_RADIUS = 2
-export const BLUR_PASSES = 3
+// per-point density (dots) estimates on a moderate grid + blur; contours use a coarser, heavily-blurred
+// grid so the rings read as clean nested curves. A few box-blur passes ≈ a Gaussian.
+export const DOT_GRID = 160                // per-point density-colour grid (the dot plot)
+export const DOT_BLUR_RADIUS = 2
+export const DOT_BLUR_PASSES = 2
+export const DENSITY_GRID = 128            // contour / outlier grid
+export const CONTOUR_BLUR_RADIUS = 2
+export const CONTOUR_BLUR_PASSES = 3
 // contour thresholds (normalised 0..1, outer→inner). Geometric-ish spacing: more lines through the
 // sparse shoulder, fewer at the dense core — reads like FlowJo probability contours.
 export const CONTOUR_LEVELS = [0.05, 0.12, 0.24, 0.42, 0.65, 0.88]
@@ -42,8 +44,9 @@ function boxBlur(g: Float32Array, G: number, radius: number, passes: number) {
   }
 }
 
-// bin points into a G×G count grid over `ext`, then blur. Returns the raw blurred grid + its max.
-function binAndBlur(points: Float32Array, ext: Ext, G: number): { grid: Float32Array; max: number } {
+// bin points into a G×G count grid over `ext`, then blur (radius/passes). Returns raw blurred grid + max.
+function binAndBlur(points: Float32Array, ext: Ext, G: number, radius: number, passes: number):
+    { grid: Float32Array; max: number } {
   const xs = ext.xMax > ext.xMin ? ext.xMax - ext.xMin : 1
   const ys = ext.yMax > ext.yMin ? ext.yMax - ext.yMin : 1
   const g = new Float32Array(G * G)
@@ -55,7 +58,7 @@ function binAndBlur(points: Float32Array, ext: Ext, G: number): { grid: Float32A
     if (gx < 0 || gx > G - 1 || gy < 0 || gy > G - 1) continue
     g[gy * G + gx] += 1
   }
-  boxBlur(g, G, BLUR_RADIUS, BLUR_PASSES)
+  boxBlur(g, G, radius, passes)
   let max = 0
   for (let i = 0; i < g.length; i++) if (g[i] > max) max = g[i]
   return { grid: g, max }
@@ -63,32 +66,28 @@ function binAndBlur(points: Float32Array, ext: Ext, G: number): { grid: Float32A
 
 // normalised (0..1) blurred density grid, row-major (gy*G + gx) — used by the contour rings + outliers.
 export function densityGrid(points: Float32Array, ext: Ext, G = DENSITY_GRID): Float32Array {
-  const { grid, max } = binAndBlur(points, ext, G)
+  const { grid, max } = binAndBlur(points, ext, G, CONTOUR_BLUR_RADIUS, CONTOUR_BLUR_PASSES)
   if (max > 0) for (let i = 0; i < grid.length; i++) grid[i] /= max
   return grid
 }
 
-// FlowJo-style pseudocolour raster: RGBA bytes (G×G), each cell coloured by LOG-scaled density via the
-// blue-heat ramp; empty cells transparent. Rows are FLIPPED (yMax at the top) so it draws directly onto
-// a top-left-origin canvas matching the axes. `putImageData` this at G×G then drawImage-upscale (smooth)
-// to the plot rect.
-export function densityImageData(points: Float32Array, ext: Ext, G = DENSITY_GRID):
-    { data: Uint8ClampedArray; width: number; height: number } {
-  const { grid, max } = binAndBlur(points, ext, G)
+// per-point LOG-scaled local density (0..1) — colour each point by this via the blue-heat ramp for the
+// FlowJo pseudocolour DOT plot (point resolution, no blocky cells). Non-finite/out-of-range → 0.
+export function pointDensities(points: Float32Array, ext: Ext, G = DOT_GRID): Float32Array {
+  const { grid, max } = binAndBlur(points, ext, G, DOT_BLUR_RADIUS, DOT_BLUR_PASSES)
   const lmax = Math.log1p(max) || 1
-  const data = new Uint8ClampedArray(G * G * 4)
-  for (let gy = 0; gy < G; gy++) {
-    const destRow = G - 1 - gy                             // flip: high data-y → top row
-    for (let gx = 0; gx < G; gx++) {
-      const raw = grid[gy * G + gx]
-      const o = (destRow * G + gx) * 4
-      if (raw <= 0) { data[o + 3] = 0; continue }          // empty → transparent
-      const c = Math.min(255, Math.max(0, Math.round((Math.log1p(raw) / lmax) * 255)))
-      data[o] = BLUE_HEAT_RGB[c * 3]; data[o + 1] = BLUE_HEAT_RGB[c * 3 + 1]
-      data[o + 2] = BLUE_HEAT_RGB[c * 3 + 2]; data[o + 3] = 255
-    }
+  const xs = ext.xMax > ext.xMin ? ext.xMax - ext.xMin : 1
+  const ys = ext.yMax > ext.yMin ? ext.yMax - ext.yMin : 1
+  const n = points.length / 2
+  const out = new Float32Array(n)
+  for (let i = 0; i < n; i++) {
+    const px = points[2 * i], py = points[2 * i + 1]
+    if (!Number.isFinite(px) || !Number.isFinite(py)) continue
+    const gx = Math.floor(((px - ext.xMin) / xs) * G), gy = Math.floor(((py - ext.yMin) / ys) * G)
+    if (gx < 0 || gx > G - 1 || gy < 0 || gy > G - 1) continue
+    out[i] = Math.log1p(grid[gy * G + gx]) / lmax
   }
-  return { data, width: G, height: G }
+  return out
 }
 
 // interleaved subset of `points` whose smoothed density is below `level` — the sparse tail drawn as


### PR DESCRIPTION
## clustTracks `_tracked` fix + worktree switcher labeling

Two independent changes (separate commits).

### 1. clustTracks: resolve `_tracked` pops via `live`+`:track`
`clustTracks` errored `no tracks for pops=[B/qc/_tracked, T/qc/_tracked]`. After the `popScope="tracks"` picker change, the population picker offers `_tracked` populations — which are **`live`-derived** (`track_id>0` within a cell gate) — but the handler resolved them under `pop_type="track"` (the per-track gate map, which doesn't contain them).

- `_pop_df_tracks` (the `live`+`:track` path) now sources per-track features from `track_props` (motility ⊕ `cell_measures` aggregates) — the **same** source the `track`/`trackclust` gating path uses — so a `_tracked` pop clusters on the identical per-track features (HMM state/transition frequencies, intensity/morphology means), not just motility.
- `pop_df` threads `cell_measures`/`categorical` into the `:track` branch.
- `clustTracks` resolves `popsToCluster` under `live`.

**Test** (real KDIeEm track fixture): `pop_df(:track)` with `cell_measures` produces `{base}.…` per-track columns, same track count, motility + `num_cells` present. Package suite: 845 pass / 0 fail.

### 2. Settings: flag primary worktree + show folder in the switcher
The worktree switcher labeled entries by branch only, so the primary ("main") checkout was unrecognisable when it sat on a feature branch — "main" appeared to vanish from the list.

- Backend flags the first (primary) worktree git lists: `{…, primary}`.
- Dropdown now reads `folder — branch (main) (current)`.

### Notes / limitations
- clustTracks: the Julia stage (membership + feature matrix — the failure point) is verified; the Python/Leiden tail wasn't run end-to-end (needs the pixi env), but the error fired before Python was reached.
- A single clustTracks run assumes one pop-type — genuine per-track-gate/`trackclust` pops mixed with `_tracked` in one run resolve only the `_tracked` ones. Edge case; the tracks-scope picker surfaces `_tracked` as the dominant case.
- Worktree backend field is a one-line tuple addition (shells out to git; no unit test), verified against real porcelain output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)