### PR TITLE
Feat/board fontsize gate pad umap legend

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -101,9 +101,14 @@ slots capture the live viewer via `/api/napari/screenshot` (backend restart to a
 reproduces the layout exactly (spans, plates, gaps), and `plots/pdf.ts` lays out **exact A4** pages
 (per-board orientation) via `pdf-lib`.
 
+- **Per-slot title (figure caption)**: each filled slot has an editable title line (`.lc-slot-cap`,
+  persisted in the slot's `state.title`), shown above the plot on-screen and drawn above the slot image
+  in the PDF (`pdf.ts` reserves `SLOT_TITLE_H` only when a title is set). Empty by default.
 - **Light theme**: dark theme is on-screen only. Each plot exposes `exportImage()` → a plot-only
   **light-theme** PNG (summary via `PlotChart.toImageURL(_, light)`; interactive/cluster via a
   `forceLight`/`.cc-light` re-render). Chrome is excluded (the plot host is captured, not the slot).
+  `UmapView` also drops its plot bounding-box border under `forceLight` so the exported figure is
+  frameless.
 - **Hi-res raster**: WebGL scatters (UMAP, gating cell) would export soft at screen backing size. The
   **shared** helpers `rasterExportScale` + `rasterPlotToImageURL` (`plots/export.ts`) target a fixed
   ~2200px long side (scale 4–14×) and re-render the point cloud at that scale via each view's `hiRes`

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -569,6 +569,14 @@ points, no fetch). In matrix mode `GateScatterCell` gets `hideAxisLabels` (the d
 channel, so per-tile axis labels only clutter/clip). Add a new gate-montage view by building `PanelDef[]`
 and rendering `<GateMontage>` — never a second gate renderer.
 
+The gate scatter's axis chrome is HTML (tick labels + rotated axis names), so it doesn't inherit
+Plot's `style.fontSize`. It takes an explicit **`fontSize`** prop (default 11) exposed as the
+`--gate-font` CSS var and used by the tick/axis-name rules (so the vis **Font size** slider works on
+the board's gating-strategy plot); `GatingStrategyView` forwards `vis.fontSize` through `GateMontage`.
+Gate `%` labels (`GateOverlay.drawGateLabel`) are clamped to the plot box on **both** axes — vertical
+fallback (above→below→inside) plus a horizontal clamp on the centred text — so a gate at the edge
+doesn't clip the trailing `…%`.
+
 ### Generic plot-integration interface (reuse across surfaces)
 
 A plot is defined **once** and appears on any surface — module page, **Analysis board**, and (future)
@@ -631,7 +639,8 @@ squashed by a stack of dropdowns (the squashed plot exported as a clipped sliver
   render as absolute overlay strips over the body; a **pin** toggle (`pi-thumbtack`, next to the drag
   icon) keeps them visible. Pin/collapse are transient local refs (chrome preferences), not persisted.
 - **Interactive views whose toolbar lives INSIDE the body** (`GatingStrategyView` `.gs-bar`, `UmapView`
-  `.uv-ctrl`, `ImageStripView` `.is-bar`) opt in by tagging that bar `.cc-panel-controls` **and** giving
+  `.uv-ctrl` — which carries the cluster-label **and** population-legend toggles, each persisted per
+  panel in `state`, `ImageStripView` `.is-bar`) opt in by tagging that bar `.cc-panel-controls` **and** giving
   their root `position: relative` — the global rule in `style.css` (`.panel:hover`/`.panel.controls-pinned`)
   then auto-hides it by the same trigger. One mechanism for every control surface; don't add a second.
 - **Opt OUT with `:auto-hide="false"`** where you interact with the plot constantly and controls popping

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -169,6 +169,11 @@ function addPlot(i: number, val: string) {
 }
 function clearSlot(i: number) { layout.setContent(props.canvasKey, i, null) }
 
+// per-slot title (figure caption) — persisted in the slot's own state bag (survives navigation with the
+// rest of the layout). Empty by default; drawn above the plot in the PDF export.
+const slotTitle = (i: number): string => (entry.value.contents[i]?.state.title as string) ?? ''
+function setSlotTitle(i: number, v: string) { const c = entry.value.contents[i]; if (c) c.state.title = v }
+
 // duplicate a slot's plot into the NEXT EMPTY slot (deep-copy its state so you can tweak one thing);
 // no-op if the grid is full.
 function nextEmpty(from: number): number {
@@ -286,7 +291,7 @@ const interactiveRefs = new Map<number, ExportRef>()
 function setSummaryRef(i: number, el: unknown) { if (el) summaryRefs.set(i, el as SummaryRef); else summaryRefs.delete(i) }
 function setInteractiveRef(i: number, el: unknown) { if (el) interactiveRefs.set(i, el as ExportRef); else interactiveRefs.delete(i) }
 
-type PdfSlotOut = { rect: { x: number; y: number; w: number; h: number }; png: string | null; name: string; csv?: string | null }
+type PdfSlotOut = { rect: { x: number; y: number; w: number; h: number }; png: string | null; name: string; title?: string; csv?: string | null }
 async function capturePage() {
   const gridEl = gridRef.value
   if (!gridEl) return { aspect: 1, slots: [] as PdfSlotOut[] }
@@ -315,7 +320,7 @@ async function capturePage() {
       const sr = el.getBoundingClientRect()
       const rect = { x: (sr.left - gr.left) / gr.width, y: (sr.top - gr.top) / gr.height,
                      w: sr.width / gr.width, h: sr.height / gr.height }
-      slots.push({ rect, png, name: labelFor(c), csv })
+      slots.push({ rect, png, name: labelFor(c), title: (c.state.title as string) || undefined, csv })
     }
   } finally { capturing.value = false }
   return { aspect: gr.width / Math.max(1, gr.height), slots }
@@ -448,6 +453,12 @@ defineExpose({ capturePage, collectCsvs })
                @dragstart="dragFrom.i = i" @dragend="dragFrom.i = -1"
                @dragover.prevent @drop.prevent="onDrop(i)"
                @mousedown="layout.setActive(canvasKey, i)">
+            <!-- per-slot title (figure caption) — persisted in the slot's state, drawn above the plot
+                 in the PDF export (pdf.ts). Only for filled slots. -->
+            <input v-if="entry.contents[i]" class="lc-slot-cap" :value="slotTitle(i)"
+                   @input="setSlotTitle(i, ($event.target as HTMLInputElement).value)"
+                   @mousedown.stop placeholder="Add a title…" />
+            <div class="lc-slot-plot">
             <!-- summary plot -->
             <SummaryPanel v-if="entry.contents[i]?.kind === 'summary' && specById[entry.contents[i]!.ref]"
                           :ref="el => setSummaryRef(i, el)"
@@ -491,6 +502,7 @@ defineExpose({ capturePage, collectCsvs })
                 </optgroup>
               </select>
               <span class="lc-add-hint">empty slot</span>
+            </div>
             </div>
           </div>
         </div>
@@ -564,7 +576,14 @@ defineExpose({ capturePage, collectCsvs })
 .lc-zoom { display: block; }
 .lc-grid { flex: 1; display: grid; gap: 8px; padding: 4px; overflow: hidden; }
 .lc-slot { position: relative; border: 1px dashed var(--cc-border); border-radius: 6px; overflow: hidden;
-  display: flex; min-width: 0; min-height: 0; background: var(--cc-bg); }
+  display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--cc-bg); }
+/* per-slot title (figure caption): a plain-looking, centred, editable line above the plot */
+.lc-slot-cap { flex: 0 0 auto; width: 100%; box-sizing: border-box; border: none; background: transparent;
+  color: var(--cc-text); font-size: 12px; font-weight: 600; text-align: center; padding: 3px 6px 1px; }
+.lc-slot-cap::placeholder { color: var(--cc-text-dim); font-weight: 400; opacity: 0.55; }
+.lc-slot-cap:focus { outline: none; background: var(--cc-surface-2); }
+/* the plot area fills the rest of the slot (was the slot itself before the caption was added) */
+.lc-slot-plot { flex: 1; min-width: 0; min-height: 0; display: flex; position: relative; }
 .lc-slot.filled { border-style: solid; }
 /* selection = amber, matching CanvasPanel .panel.active and every module page (was a clashing violet).
    A FILLED slot's panel already draws the amber border + glow, so don't double it there — only an empty

--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -43,9 +43,10 @@ const props = withDefaults(defineProps<{
   // bump to force a data refresh when tiles are unchanged but membership moved (ancestor gate edit,
   // napari selection) — the parent's point cloud can change without any def changing.
   reloadKey?: string | number
+  fontSize?: number                              // axis font size (px) forwarded to each tile (vis slider)
 }>(), {
   renderMode: 'points', gateLabels: true, gateLineWidth: 1.5,
-  highlight: () => [], cols: null, axisFromZero: true, reloadKey: 0,
+  highlight: () => [], cols: null, axisFromZero: true, reloadKey: 0, fontSize: 11,
 })
 // true when ≥1 tile's preferred transform was auto-linearised (host shows an amber hint on its control)
 const emit = defineEmits<{ coerced: [boolean] }>()
@@ -219,7 +220,7 @@ const corrFont = (r: number | null | undefined) => `${Math.round(13 + Math.abs(r
                          :pop-layers="panelData[d.key].popLayers" :show-pops="(highlight?.length ?? 0) > 0"
                          :render-mode="renderMode" mode="off" :gate-labels="gateLabels"
                          :gate-line-width="gateLineWidth" :compact="!single" :readonly="true"
-                         :hide-axis-labels="cols != null" />
+                         :hide-axis-labels="cols != null" :font-size="fontSize" />
         <div v-else class="gm-loading">…</div>
       </div>
     </template>

--- a/frontend/src/components/plots/GateOverlay.vue
+++ b/frontend/src/components/plots/GateOverlay.vue
@@ -177,14 +177,18 @@ function drawGateLabel(g: GateSpec, path: string, colour: string, label?: string
   // normally sit just ABOVE the gate's top edge; if a gate near the plot top would push the label
   // off-canvas at the top (it was getting clipped), put it just BELOW the gate instead; only if that
   // would also clip (a gate spanning the full height) fall back to just inside the top edge.
-  const { h } = size(); const LABEL_H = 15             // ~12px glyphs + halo
+  const { w, h } = size(); const LABEL_H = 15          // ~12px glyphs + halo
   let y: number, baseline: CanvasTextBaseline
   if (top - 4 >= LABEL_H) { y = top - 4; baseline = 'bottom' }
   else if (bottom + 4 + LABEL_H <= h) { y = bottom + 4; baseline = 'top' }
   else { y = top + 4; baseline = 'top' }
   c.textBaseline = baseline
-  c.strokeText(name, cx, y)
-  c.fillStyle = colour; c.fillText(name, cx, y); c.restore()
+  // clamp horizontally so a gate near the left/right edge doesn't push the (centred) label — and its
+  // trailing "…%" — off-canvas where it gets clipped. Keep the whole label inside the plot area.
+  const halfW = c.measureText(name).width / 2 + 3
+  const x = Math.max(halfW, Math.min(w - halfW, cx))
+  c.strokeText(name, x, y)
+  c.fillStyle = colour; c.fillText(name, x, y); c.restore()
 }
 function drawHandles(g: GateSpec, colour: string) {
   const c = ctx!; c.fillStyle = '#fff'; c.strokeStyle = colour; c.lineWidth = 1.5

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -45,10 +45,12 @@ const props = withDefaults(defineProps<{
   hideAxisLabels?: boolean                       // drop the x/y axis-name labels (pairs matrix — the
                                                  // diagonal names each channel, so per-tile labels only
                                                  // clutter/clip); also reclaims their padding
+  fontSize?: number                              // base axis font size (px) — the vis slider; scales the
+                                                 // tick labels + axis names (--gate-font). Default 11.
 }>(), {
   gates: () => [], popLayers: () => [], renderMode: 'points', showPops: false,
   mode: 'off', gateLineWidth: 1.5, gateLabels: false, viewTick: 0, loading: false, compact: false, readonly: false,
-  hideAxisLabels: false,
+  hideAxisLabels: false, fontSize: 11,
 })
 const emit = defineEmits<{ draw: [Partial<GateSpec>]; edit: [{ path: string; gate: GateSpec }]; cancel: [] }>()
 
@@ -100,7 +102,8 @@ defineExpose({ exportImage, hiRes })
 </script>
 
 <template>
-  <div ref="hostEl" class="plot-capture" :class="{ compact, 'no-axis': hideAxisLabels }">
+  <div ref="hostEl" class="plot-capture" :class="{ compact, 'no-axis': hideAxisLabels }"
+       :style="{ '--gate-font': `${fontSize}px` }">
     <div class="panel-plot">
       <!-- base cloud (density raster / contours), child-pop overlays, and outliers — all 2D, no WebGL -->
       <PlotLayers ref="layersRef" :view-extents="viewExtents" :render-mode="renderMode" :base-points="points"
@@ -136,8 +139,8 @@ defineExpose({ exportImage, hiRes })
 /* compact: tight chrome for small montage squares (gating-strategy) — smaller padding, no min-height,
    axis names pulled in, tick labels hidden to avoid crowding */
 .plot-capture.compact { min-height: 0; padding: 10px 8px 20px 30px; }
-.plot-capture.compact .axis-x { bottom: -15px; font-size: 10px; }
-.plot-capture.compact .axis-y { left: -24px; font-size: 10px; }
+.plot-capture.compact .axis-x { bottom: -15px; font-size: calc(var(--gate-font, 11px) - 1px); }
+.plot-capture.compact .axis-y { left: -24px; font-size: calc(var(--gate-font, 11px) - 1px); }
 .plot-capture.compact .xtick-lbl, .plot-capture.compact .ytick-lbl { display: none; }
 /* compact tiles can be smaller than the full-size 150px plot floor — lift it so the plot shrinks to the
    (square) tile instead of overflowing and being clipped by the cell (the pairs matrix packs small tiles). */
@@ -152,13 +155,13 @@ defineExpose({ exportImage, hiRes })
 .axisline-y { left: 0; top: 0; bottom: 0; width: 1px; }
 .xtick { position: absolute; bottom: 0; transform: translate(-50%, 100%); display: flex; flex-direction: column; align-items: center; pointer-events: none; }
 .xtick-mark { width: 1px; height: 5px; background: var(--cc-text-dim); }
-.xtick-lbl { margin-top: 3px; font-size: 10px; color: var(--cc-text-dim); white-space: nowrap; }
+.xtick-lbl { margin-top: 3px; font-size: calc(var(--gate-font, 11px) - 1px); color: var(--cc-text-dim); white-space: nowrap; }
 .ytick { position: absolute; left: 0; transform: translate(-100%, -50%); display: flex; align-items: center; pointer-events: none; }
 .ytick-mark { width: 5px; height: 1px; background: var(--cc-text-dim); }
-.ytick-lbl { margin-right: 3px; font-size: 10px; color: var(--cc-text-dim); white-space: nowrap; }
-.axis-x { position: absolute; bottom: -40px; left: 50%; transform: translateX(-50%); font-size: 13px; font-weight: 600; color: var(--cc-text); }
+.ytick-lbl { margin-right: 3px; font-size: calc(var(--gate-font, 11px) - 1px); color: var(--cc-text-dim); white-space: nowrap; }
+.axis-x { position: absolute; bottom: -40px; left: 50%; transform: translateX(-50%); font-size: calc(var(--gate-font, 11px) + 2px); font-weight: 600; color: var(--cc-text); }
 /* vertical text via writing-mode (rotate's origin offsets by half the text width → overlap) */
 .axis-y { position: absolute; left: -66px; top: 50%; transform: translateY(-50%) rotate(180deg);
-  writing-mode: vertical-rl; font-size: 13px; font-weight: 600; color: var(--cc-text); }
+  writing-mode: vertical-rl; font-size: calc(var(--gate-font, 11px) + 2px); font-weight: 600; color: var(--cc-text); }
 .panel-loading { position: absolute; top: 4px; right: 6px; font-size: 11px; color: var(--cc-text-dim); }
 </style>

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -159,9 +159,11 @@ defineExpose({ exportImage, hiRes })
 .ytick { position: absolute; left: 0; transform: translate(-100%, -50%); display: flex; align-items: center; pointer-events: none; }
 .ytick-mark { width: 5px; height: 1px; background: var(--cc-text-dim); }
 .ytick-lbl { margin-right: 3px; font-size: calc(var(--gate-font, 11px) - 1px); color: var(--cc-text-dim); white-space: nowrap; }
-.axis-x { position: absolute; bottom: -40px; left: 50%; transform: translateX(-50%); font-size: calc(var(--gate-font, 11px) + 2px); font-weight: 600; color: var(--cc-text); }
+/* nowrap so a long channel name (e.g. "Bcells-ubiTom") stays on ONE line in the axis gutter instead of
+   wrapping into the plot; it sits in the .plot-capture padding, which overflows visibly if needed */
+.axis-x { position: absolute; bottom: -40px; left: 50%; transform: translateX(-50%); white-space: nowrap; font-size: calc(var(--gate-font, 11px) + 2px); font-weight: 600; color: var(--cc-text); }
 /* vertical text via writing-mode (rotate's origin offsets by half the text width → overlap) */
 .axis-y { position: absolute; left: -66px; top: 50%; transform: translateY(-50%) rotate(180deg);
-  writing-mode: vertical-rl; font-size: calc(var(--gate-font, 11px) + 2px); font-weight: 600; color: var(--cc-text); }
+  writing-mode: vertical-rl; white-space: nowrap; font-size: calc(var(--gate-font, 11px) + 2px); font-weight: 600; color: var(--cc-text); }
 .panel-loading { position: absolute; top: 4px; right: 6px; font-size: 11px; color: var(--cc-text-dim); }
 </style>

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -211,7 +211,7 @@ defineExpose({ exportImage })
 
     <GateMontage ref="montageRef" :project-uid="projectUid" :image-uid="imageUid" :value-name="valueName"
                  :pop-type="popType" :defs="panelDefs" :col-label="colLabel" :render-mode="renderMode"
-                 :gate-labels="true">
+                 :gate-labels="true" :font-size="vis?.fontSize ?? 11">
       <template #empty>
         No gate to show for “{{ rootPop }}”.
         {{ showHierarchy ? 'No gated populations beneath it — draw gates on the Gate page first.'

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -286,7 +286,11 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
       <!-- during export the inner ground MUST be transparent, else the overlay pass (host→SVG) paints
            this opaque div OVER the transparent hi-res points (the points-missing bug). On-screen it
            carries the scatter ground for the letterbox margins. -->
-      <div class="uv-plot" :style="{ background: forceLight ? 'transparent' : scatterGround }">
+      <!-- forceLight = board/PDF export: drop the plot's bounding-box border (+ rounding) so the
+           exported figure has no frame around the UMAP; on-screen it keeps the border. -->
+      <div class="uv-plot" :style="{ background: forceLight ? 'transparent' : scatterGround,
+                                     border: forceLight ? 'none' : undefined,
+                                     borderRadius: forceLight ? '0' : undefined }">
         <template v-if="points && points.length">
           <canvas ref="dotsEl" class="uv-canvas" />
           <span v-for="c in centroids" v-show="labels" :key="c.label" class="uv-label"

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -27,10 +27,13 @@ const props = defineProps<{
   // rest. Empty → plain colour-by-cluster. Live from the gating store via ClusterPlots' viewContext.
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
   vis?: VisProps                 // canvas plot styling — here we honour the dark-theme knob
-  state: { labels?: boolean }
+  state: { labels?: boolean; legend?: boolean }
 }>()
 const log = useLogStore()
 const labels = computed({ get: () => props.state.labels !== false, set: v => (props.state.labels = v) })
+// show/hide the population legend — persisted per panel (default on). On the Analysis canvas it can
+// eat ~half the plot, so let the user reclaim that space.
+const showLegend = computed({ get: () => props.state.legend !== false, set: v => (props.state.legend = v) })
 const unit = computed(() => (props.popType === 'trackclust' ? 'tracks' : 'cells'))
 
 // `forceLight` flips to a light render for the board's PDF export (dark theme is on-screen only) —
@@ -263,6 +266,8 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
     <div class="uv-ctrl cc-panel-controls">
       <button class="cc-btn cc-btn-ghost" :class="{ on: labels }" @click="labels = !labels"
               v-tooltip.bottom="'Toggle cluster-number labels'"><i class="pi pi-tag" /> #</button>
+      <button class="cc-btn cc-btn-ghost" :class="{ on: showLegend }" @click="showLegend = !showLegend"
+              v-tooltip.bottom="'Toggle the population legend'"><i class="pi pi-list" /></button>
       <span class="uv-spacer" />
       <span v-if="total" class="uv-count">{{ total.toLocaleString() }} {{ unit }} · {{ legend.length }} clusters</span>
     </div>
@@ -281,7 +286,7 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
           <p>{{ loading ? 'Loading…' : (err || 'Select clustered image(s) to view the UMAP.') }}</p>
         </div>
       </div>
-      <div v-if="legend.length" class="uv-legend" :style="{ color: legendInk, background: legendBg }">
+      <div v-if="showLegend && legend.length" class="uv-legend" :style="{ color: legendInk, background: legendBg }">
         <div v-for="l in legend" :key="l.label" class="leg-row">
           <span class="leg-dot" :style="{ background: l.colour }" />
           <span class="leg-lbl">{{ l.label }}</span>

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -75,8 +75,20 @@ const extents = ref({ xMin: 0, xMax: 1, yMin: 0, yMax: 1 })
 const loading = ref(false)
 const err = ref('')
 const total = computed(() => (points.value ? points.value.length / 2 : 0))
-const lx = (x: number) => `${((x - extents.value.xMin) / Math.max(1e-9, extents.value.xMax - extents.value.xMin)) * 100}%`
-const ly = (y: number) => `${(1 - (y - extents.value.yMin) / Math.max(1e-9, extents.value.yMax - extents.value.yMin)) * 100}%`
+// current on-screen plot box (px) — tracked so the label map matches the canvas one under resize
+const boxW = ref(0), boxH = ref(0)
+// data→px with a SINGLE uniform scale (letterboxed/centred), so the embedding stays isotropic — a UMAP
+// warps if x and y stretch independently to fill a non-square box (e.g. after hiding the legend). Used
+// by BOTH the dot canvas and the HTML labels so they stay aligned.
+function mapPx(x: number, y: number, w: number, h: number): [number, number] {
+  const { xMin, xMax, yMin, yMax } = extents.value
+  const xr = xMax > xMin ? xMax - xMin : 1, yr = yMax > yMin ? yMax - yMin : 1
+  const sc = Math.min(w / xr, h / yr) || 0
+  const offX = (w - xr * sc) / 2, offY = (h - yr * sc) / 2
+  return [offX + (x - xMin) * sc, offY + (yMax - y) * sc]   // y flips (screen down)
+}
+const lx = (x: number) => `${mapPx(x, 0, boxW.value, boxH.value)[0]}px`
+const ly = (y: number) => `${mapPx(0, y, boxW.value, boxH.value)[1]}px`
 
 // ── 2D dot render (no WebGL) ──────────────────────────────────────────────────────────────────────
 // Draw each point via the SAME data→px map as the labels (lx/ly), so cluster labels sit exactly on
@@ -89,8 +101,6 @@ const DOT_R = 2
 function paintDots(c: CanvasRenderingContext2D, w: number, h: number) {
   const pts = points.value, cats = categories.value, pal = palette.value
   if (!pts || !cats || !pal.length) return
-  const { xMin, xMax, yMin, yMax } = extents.value
-  const xr = xMax > xMin ? xMax - xMin : 1, yr = yMax > yMin ? yMax - yMin : 1
   const n = pts.length / 2, s = DOT_R * 2
   const groups: number[][] = pal.map(() => [])
   for (let i = 0; i < n; i++) { const g = groups[cats[i]]; if (g) g.push(i) }
@@ -99,7 +109,7 @@ function paintDots(c: CanvasRenderingContext2D, w: number, h: number) {
     const g = groups[gi]; if (!g.length) continue
     c.fillStyle = pal[gi]
     for (const i of g) {
-      const px = ((pts[2 * i] - xMin) / xr) * w, py = (1 - (pts[2 * i + 1] - yMin) / yr) * h
+      const [px, py] = mapPx(pts[2 * i], pts[2 * i + 1], w, h)
       c.fillRect(px - DOT_R, py - DOT_R, s, s)
     }
   }
@@ -111,6 +121,7 @@ function redraw() {
   if (!dctx) return
   const dpr = window.devicePixelRatio || 1
   const w = el.clientWidth, h = el.clientHeight
+  boxW.value = w; boxH.value = h   // keep the label map in sync with the canvas box
   el.width = Math.max(1, w * dpr); el.height = Math.max(1, h * dpr)
   dctx.setTransform(dpr, 0, 0, dpr, 0, 0)
   dctx.clearRect(0, 0, w, h)

--- a/frontend/src/plots/pdf.ts
+++ b/frontend/src/plots/pdf.ts
@@ -10,13 +10,13 @@ import { downloadBlob } from './export'
 
 // Each slot carries a NORMALISED rect (0..1) measured from the on-screen board, so the PDF reproduces
 // the real layout (spans, plates, row height, gaps) rather than a re-derived uniform grid.
-export interface PdfSlot { rect: { x: number; y: number; w: number; h: number }; png: string | null; csv?: string | null; name?: string }
+export interface PdfSlot { rect: { x: number; y: number; w: number; h: number }; png: string | null; csv?: string | null; name?: string; title?: string }
 export interface PdfPage { title: string; aspect: number; slots: PdfSlot[] }
 
 // A4 in points (1pt = 1/72"): 210×297mm → 595.28 × 841.89. Each page picks the ORIENTATION that best
 // fits its board (wide board → landscape, tall board → portrait) so the sheet stays true A4 either way.
 // Tight margins — the board proportions (not padding) drive the spacing.
-const A4_SHORT = 595.28, A4_LONG = 841.89, MARGIN = 16, TITLE_H = 18, PAD = 2
+const A4_SHORT = 595.28, A4_LONG = 841.89, MARGIN = 16, TITLE_H = 18, PAD = 2, SLOT_TITLE_H = 14
 
 function dataUrlToBytes(dataUrl: string): Uint8Array {
   const b64 = dataUrl.slice(dataUrl.indexOf(',') + 1)
@@ -29,8 +29,9 @@ function dataUrlToBytes(dataUrl: string): Uint8Array {
 const safe = (s: string) => s.replace(/[^\w.-]+/g, '_')
 
 export async function exportTabsToPdf(pages: PdfPage[], filename = 'analysis.pdf') {
-  const { PDFDocument } = await import('pdf-lib')
+  const { PDFDocument, StandardFonts } = await import('pdf-lib')
   const doc = await PDFDocument.create()
+  const font = await doc.embedFont(StandardFonts.Helvetica)   // for centring slot titles (needs width metrics)
   for (const page of pages) {
     // A4, oriented to the board: wide (aspect ≥ 1) → landscape, tall → portrait
     const landscape = (page.aspect || 1) >= 1
@@ -56,14 +57,24 @@ export async function exportTabsToPdf(pages: PdfPage[], filename = 'analysis.pdf
       const w = slot.rect.w * bw - 2 * PAD
       const h = slot.rect.h * bh - 2 * PAD
 
+      // optional per-slot title (figure caption): a centred line at the top of the slot; the image area
+      // shrinks below it. Reserve nothing when there's no title.
+      const capH = slot.title ? SLOT_TITLE_H : 0
+      if (slot.title) {
+        const size = 9
+        const tw = font.widthOfTextAtSize(slot.title, size)
+        p.drawText(slot.title, { x: sx + Math.max(0, (w - tw) / 2), y: PAGE_H - syTop - size, size, font })
+      }
+      const imgTop = syTop + capH, imgH = h - capH
+
       if (slot.png) {
         try {
           const img = await doc.embedPng(dataUrlToBytes(slot.png))
-          const s = Math.min(w / img.width, h / img.height)
+          const s = Math.min(w / img.width, imgH / img.height)
           const iw = img.width * s, ih = img.height * s
-          // centre the (aspect-preserved) image in its slot rect; PDF origin is bottom-left
+          // centre the (aspect-preserved) image in its slot rect (below the title); PDF origin is bottom-left
           const x = sx + (w - iw) / 2
-          const y = PAGE_H - (syTop + (h - ih) / 2) - ih
+          const y = PAGE_H - (imgTop + (imgH - ih) / 2) - ih
           p.drawImage(img, { x, y, width: iw, height: ih })
         } catch { /* skip an unembeddable image */ }
       }


### PR DESCRIPTION
## Summary

Analysis-board plot polish — gating axis fixes, UMAP display/export, and per-slot figure titles.

### Gating plots
- **Axis-label font-size slider now works** (#33). The gate scatter's axis chrome is HTML (tick labels + rotated names), so it never inherited Observable Plot's `style.fontSize`. `GateScatterCell` takes a `fontSize` prop → `--gate-font` CSS var driving the tick/axis-name sizes; `GatingStrategyView` forwards `vis.fontSize` through `GateMontage`. Default 11 reproduces the old 10px/13px sizes exactly.
- **Gate `%` labels no longer clipped at the edge** (#34). `GateOverlay.drawGateLabel` already had a vertical fallback; added a horizontal clamp of the centred text so a gate near the left/right edge keeps its trailing `…%` on-canvas.
- **Axis channel names stay on one line** — long names (e.g. `Bcells-ubiTom`) wrapped onto two rows into the plot; the x/y axis names are now

### UMAP
- **Legend show/hide toggle** (#35), persisted per panel (default on) — the legend could eat ~half the   plot on the board. Hidden legend is aexport.
- **Kept isotropic** — the 2D dot map stretched x/y independently to fill the panel, so a non-square box warped the cloud (exposed by the hidered scale (`mapPx`), shared by dotsand labels; wide panels letterbox instead of stretching.                                            - **Frameless export** — `UmapView` drder under `forceLight`, so theboard/PDF export has no frame around the UMAP (on-screen + standalone PNG keep it).                 
### Board                                                                                           - **Per-slot title (figure caption)**itable title line (`.lc-slot-cap`,persisted in `state.title`), shown above the plot on-screen and drawn above the slot image in the PD(`pdf.ts` reserves title height only  centre it).
                                                                                                    Docs: UI.md, ANALYSIS.md.
                                                                                                    ## Reservations
- Browser-untested by me (typecheck + 85 vitest green).                                             - #33 only takes visible effect whered (board gating-strategy); the moduleGate page has no such slider.                                                                       - #34 / nowrap: a single gate/axis-nan't fit — it stays centred / overflows the gutter (unavoidable edge case).                                                                 - UMAP letterboxing shows empty side nels — correct for an embedding.
- Frameless UMAP applies to the export/PDF path only (`forceLight`); on-screen + standalone PNG keepborder.
- Per-slot caption input always shows on filled slots (placeholder), so it reserves ~20px even when empty; PDF only reserves title heightcreen vs PDF proportions areapproximate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)