### PR TITLE
Feat/board cluster vis rotate slider

### DIFF
--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -259,11 +259,14 @@ docs/TODO.md.)
    plot panels (CanvasPanel chevron).
 7. **Plot adjustments** ported from the old R `plotChartsServer.R` / `plotHelpers.R`, grouped into
    collapsible sub-sections in the `SeriesPicker` Options (Layout / Points / Colours / Labels),
-   governed by the global/local scope (`VisProps`): legend, log scale, gridlines, rotate-X-labels,
+   governed by the global/local scope (`VisProps`): legend, log scale, gridlines, rotate-X-labels
+   (with an **angle slider**, `rotateXAngle`, 0–90°; the bottom margin scales with the angle),
    **facet** (small multiples per series), **dark theme**, Y-range override; jitter type
    (beeswarm/random/none), colour-data, point size/opacity; **palette** (Okabe-Ito, Tol bright/
-   muted/light, user list); title, X/Y axis labels, font size. All builder ink is `currentColor` so
-   the dark theme flips with one `style.color`.
+   muted/light, `distinct`, user list); title, X/Y axis labels, font size. All builder ink is
+   `currentColor` so the dark theme flips with one `style.color`. The **cluster UMAP** (`UmapView`)
+   honours the same `palette` choice for colour-by-cluster (via `paletteRange`; `standard` falls back
+   to its built-in palette).
 8. **Track populations in the picker** — a track-granularity plot's picker unions `live` (cell gates
    + derived `/_tracked`) and `track` gates (per-track-measure gates from `{vn}__tracks.json`), each
    tagged with its `popType`; the panel groups series by popType and fetches one `/api/plot_data` per

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -199,7 +199,10 @@ function onDrop(i: number) { if (dragFrom.i >= 0) layout.swap(props.canvasKey, d
 const panelSel = (c: SlotContent) => scope.value === 'global' ? gSel.value : (st(c).sel ?? [])
 const panelVis = (c: SlotContent) => scope.value === 'global' ? gVis.value : (st(c).vis ?? defaultVis())
 const activeSel = computed(() => scope.value === 'global' ? gSel.value : (activeContent.value ? st(activeContent.value).sel : []))
-const activeVis = computed(() => scope.value === 'global' ? gVis.value : (activeContent.value ? st(activeContent.value).vis : defaultVis()))
+// fall back to defaultVis() when the active slot has no local vis yet (matches ClusterPlots) — else the
+// pop manager's `vis` is undefined and the whole PlotOptions styling block is hidden (the "cluster-tracks
+// manager has no plot params" bug).
+const activeVis = computed(() => scope.value === 'global' ? gVis.value : (activeContent.value ? (st(activeContent.value).vis ?? defaultVis()) : defaultVis()))
 const toggle = (arr: string[], v: string) => arr.includes(v) ? arr.filter(x => x !== v) : [...arr, v]
 function toggleTarget(valueName: string, pop: string, pt: string) {
   const k = tkey(pt, valueName, pop)

--- a/frontend/src/components/canvas/PlotOptions.vue
+++ b/frontend/src/components/canvas/PlotOptions.vue
@@ -37,8 +37,12 @@ const has = (s: string) => props.sections.includes(s as 'layout')
           <input type="checkbox" :checked="vis.logScale" @change="set({ logScale: ($event.target as HTMLInputElement).checked })" /></label>
         <label class="po-row"><span>Gridlines</span>
           <input type="checkbox" :checked="vis.grid" @change="set({ grid: ($event.target as HTMLInputElement).checked })" /></label>
-        <label class="po-row" v-tooltip.left="'Rotate x tick labels 45°'"><span>Rotate X labels</span>
+        <label class="po-row" v-tooltip.left="'Rotate the x tick labels (angle below)'"><span>Rotate X labels</span>
           <input type="checkbox" :checked="vis.rotateXLabel" @change="set({ rotateXLabel: ($event.target as HTMLInputElement).checked })" /></label>
+        <label v-if="vis.rotateXLabel" class="po-row" v-tooltip.left="'X tick-label angle (degrees)'"><span>X angle</span>
+          <input type="range" min="0" max="90" step="5" :value="vis.rotateXAngle ?? 45"
+                 @input="set({ rotateXAngle: parseInt(($event.target as HTMLInputElement).value) })" />
+          <span class="po-val">{{ vis.rotateXAngle ?? 45 }}°</span></label>
         <label class="po-row" v-tooltip.left="'Flip 90° — measure on X, series labels on Y (R coord_flip)'"><span>Rotate 90°</span>
           <input type="checkbox" :checked="vis.rotate"
                  @change="set({ rotate: ($event.target as HTMLInputElement).checked, ...(($event.target as HTMLInputElement).checked ? { facet: false } : {}) })" /></label>

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -18,7 +18,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick, useTemplate
 import { useLogStore } from '../../stores/log'
 import { useDataRefresh } from '../../composables/useDataRefresh'
 import { plotHostToImageURL, rasterPlotToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
-import type { VisProps } from '../../plots/plot'
+import { paletteRange, type VisProps } from '../../plots/plot'
 
 const props = defineProps<{
   projectUid: string; imageUids: string[]; setUid: string | null
@@ -26,7 +26,7 @@ const props = defineProps<{
   // populations whose eye is on in the manager: colour their clusters in the pop colour, grey the
   // rest. Empty → plain colour-by-cluster. Live from the gating store via ClusterPlots' viewContext.
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
-  vis?: VisProps                 // canvas plot styling — here we honour the dark-theme knob
+  vis?: VisProps                 // canvas plot styling — we honour the dark-theme knob + the palette choice
   state: { labels?: boolean; legend?: boolean }
 }>()
 const log = useLogStore()
@@ -163,8 +163,11 @@ function recolour() {
     const otherN = distinct.filter(c => !shownIds.has(c)).reduce((s, c) => s + (counts.get(c) ?? 0), 0)
     legend.value = otherN ? [...popN, { label: 'other', colour: UNCLUSTERED, n: otherN }] : popN
   } else {
+    // colour-by-cluster: honour the pop manager's palette choice (vis.palette / userColors — e.g.
+    // "distinct"); fall back to the built-in PALETTE for the default 'standard' (paletteRange → null).
+    const pal = (props.vis ? paletteRange(props.vis, distinct.filter(c => c >= 0).length) : null) ?? PALETTE
     let pi = 0
-    distinct.forEach((c, i) => { idxOf.set(c, i); colourFor.set(c, c < 0 ? UNCLUSTERED : PALETTE[pi++ % PALETTE.length]) })
+    distinct.forEach((c, i) => { idxOf.set(c, i); colourFor.set(c, c < 0 ? UNCLUSTERED : pal[pi++ % pal.length]) })
     legend.value = distinct.map(c => ({ label: c < 0 ? 'unclustered' : `cluster ${c}`, colour: colourFor.get(c)!, n: counts.get(c)! }))
   }
   const cats = new Float32Array(codes.length)
@@ -235,6 +238,8 @@ watch([() => props.projectUid, () => props.imageUids.join(','), () => props.popT
 useDataRefresh(() => props.imageUids, load)   // refetch when a task finishes on one of THESE images
 // highlight a pop / tick clusters → recolour from cached codes (no refetch)
 watch(() => JSON.stringify((props.shownPops ?? []).map(p => [p.colour, p.clusterIds])), recolour)
+// re-colour when the pop manager's palette choice changes (e.g. standard → distinct)
+watch(() => [props.vis?.palette, props.vis?.userColors], recolour)
 // redraw the 2D dots when the data / colouring / extents change
 watch([points, categories, palette, extents], () => nextTick(redraw), { deep: true })
 onMounted(() => {

--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -127,6 +127,17 @@ export interface BuildOpts extends VisProps {
 
 // ── theme_classic look (ggplot) — applied as Plot top-level options ───────────────
 const FONT = 'Helvetica, Arial, sans-serif'
+
+// Measure rendered text width (memoised canvas) so margins fit labels exactly instead of guessing by
+// char count (which over-reserved and left a gap). Falls back to a rough estimate outside the browser.
+let _measCtx: CanvasRenderingContext2D | null = null
+function textWidth(text: string, fontPx: number): number {
+  if (typeof document === 'undefined') return text.length * fontPx * 0.55
+  if (!_measCtx) _measCtx = document.createElement('canvas').getContext('2d')
+  if (!_measCtx) return text.length * fontPx * 0.55
+  _measCtx.font = `${fontPx}px ${FONT}`
+  return _measCtx.measureText(text).width
+}
 const THEME = {
   style: { background: 'white', color: '#111', fontFamily: FONT, fontSize: '11px' },
   marginLeft: 56, marginBottom: 44, marginTop: 12, marginRight: 12,
@@ -392,9 +403,10 @@ function buildHeatmap(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts): Reco
   // the top row of cells — and a touch more when a title (top-left) shares the band.
   const topPad = o.legend ? (o.title ? 52 : 46) : (o.title ? 34 : 12)
   // left margin fits the longest y tick label (feature names like "live.track.meanTurningAngle" were
-  // clipped at a fixed 120). Approx char width ≈ 0.6·fontSize; clamp so it never eats the whole plot.
-  const longestY = (r.yLabels ?? []).reduce((m, s) => Math.max(m, String(s).length), 0)
-  const marginLeft = Math.round(Math.min(260, Math.max(120, longestY * (o.fontSize || 11) * 0.6 + 18)))
+  // clipped at a fixed 120). MEASURE the rendered width so it fits exactly (a char-count estimate
+  // over-reserved → a big left gap); +14 for the tick mark + gap, clamped so it never eats the plot.
+  const longestYW = (r.yLabels ?? []).reduce((m, s) => Math.max(m, textWidth(String(s), o.fontSize || 11)), 0)
+  const marginLeft = Math.round(Math.min(260, Math.max(48, longestYW + 14)))
   const opts: Record<string, unknown> = {
     ...THEME, marginLeft, marginBottom: 64, marginTop: topPad, marginRight: 16,
     style: { background: bg, color: fg, fontFamily: FONT, fontSize: `${o.fontSize || 11}px` },

--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -71,7 +71,8 @@ export interface VisProps {
   // layout / scale
   logScale: boolean                          // log measure axis (R scaleLog10)
   grid: boolean                              // show gridlines (R noGrid inverted; default off = classic)
-  rotateXLabel: boolean                      // rotate x tick labels 45° (R rotateXLabel)
+  rotateXLabel: boolean                      // rotate x tick labels (R rotateXLabel); angle = rotateXAngle
+  rotateXAngle?: number                       // x tick-label rotation angle in degrees (default 45)
   rotate: boolean                            // flip plot 90° — measure on X, series on Y (R coord_flip)
   darkTheme: boolean                         // dark plot ground + light ink (R darkTheme)
   facet: boolean                             // small multiples — one panel per series (R faceting)
@@ -99,9 +100,16 @@ export function paletteRange(vis: Pick<VisProps, 'palette' | 'userColors'>, n: n
   const pal = PALETTES[vis.palette]
   return pal ? Array.from({ length: n }, (_, i) => pal[i % pal.length]) : null
 }
+// x tick-label rotation: the angle (negative = tilt down-right, ggplot-style) and the bottom margin
+// needed so the rotated labels aren't clipped. The base margin is per-chart (empirically fits 45°);
+// scale it with the angle (0.5×base at 0° → 1×base at 45° → 1.5×base at 90°).
+const xTickRotate = (o: { rotateXAngle?: number }) => -(o.rotateXAngle ?? 45)
+const xRotMargin = (base: number, o: { rotateXAngle?: number }) =>
+  Math.round(base * (0.5 + 0.5 * Math.abs(o.rotateXAngle ?? 45) / 45))
+
 export const defaultVis = (): VisProps => ({
   jitter: 'beeswarm', pointSize: 2, pointOpacity: 0.5, colorData: true,
-  legend: true, logScale: false, grid: false, rotateXLabel: false, rotate: false, darkTheme: true, facet: false,
+  legend: true, logScale: false, grid: false, rotateXLabel: false, rotateXAngle: 45, rotate: false, darkTheme: true, facet: false,
   yMin: '', yMax: '', palette: 'standard', userColors: '', title: '', labX: '', labY: '', fontSize: 11,
 })
 
@@ -323,9 +331,9 @@ export function buildPlotOptions(Plot: PlotModule, r: PlotDataResponse, o: Build
                      ...(o.labY ? { label: o.labY } : {}), ...(measDomain ? { domain: measDomain } : {}) }
   opts[posAxis] = { ...(opts[posAxis] as object ?? {}), grid: o.grid,
                     ...(o.labX ? { label: o.labX } : {}),
-                    ...(o.rotateXLabel && !o.rotate ? { tickRotate: -45 } : {}) }
+                    ...(o.rotateXLabel && !o.rotate ? { tickRotate: xTickRotate(o) } : {}) }
   // room for rotated x labels (else clipped by the panel border); room for series labels on Y when flipped
-  if (o.rotateXLabel && !o.rotate) opts.marginBottom = 76
+  if (o.rotateXLabel && !o.rotate) opts.marginBottom = xRotMargin(76, o)
   if (o.rotate) opts.marginLeft = 104
 
   // NB: the title is drawn by PlotChart as an overlay (NOT `opts.title`) — Plot's title forces an
@@ -386,7 +394,7 @@ function buildHeatmap(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts): Reco
   const opts: Record<string, unknown> = {
     ...THEME, marginLeft: 120, marginBottom: 64, marginTop: topPad, marginRight: 16,
     style: { background: bg, color: fg, fontFamily: FONT, fontSize: `${o.fontSize || 11}px` },
-    x: { domain: r.xLabels ?? [], label: o.labX || xLab, tickRotate: o.rotateXLabel ? -45 : 0 },
+    x: { domain: r.xLabels ?? [], label: o.labX || xLab, tickRotate: o.rotateXLabel ? xTickRotate(o) : 0 },
     y: { domain: [...(r.yLabels ?? [])].reverse(), label: o.labY || yLab },   // first row at the top
     color: colorScale,
     marks: [
@@ -395,7 +403,7 @@ function buildHeatmap(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts): Reco
       Plot.text(cells, { x: 'x', y: 'y', text: valFmt, fill: textInk, fontSize: Math.max(8, (o.fontSize || 11) - 2) }),
     ],
   }
-  if (o.rotateXLabel) opts.marginBottom = 84
+  if (o.rotateXLabel) opts.marginBottom = xRotMargin(84, o)
   // continuous legend (PlotChart draws it as an overlay, reading `_colorLegend`)
   ;(opts as Record<string, unknown>)._colorLegend = { color: colorScale }
   return opts
@@ -511,12 +519,12 @@ function buildTrendLine(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts): Re
   const opts: Record<string, unknown> = {
     ...THEME, color, marginTop: topPad,
     style: { background: bg, color: fg, fontFamily: FONT, fontSize: `${o.fontSize || 11}px` },
-    x: { label: o.labX || r.groupBy || 't', grid: o.grid, ...(o.rotateXLabel ? { tickRotate: -45 } : {}) },
+    x: { label: o.labX || r.groupBy || 't', grid: o.grid, ...(o.rotateXLabel ? { tickRotate: xTickRotate(o) } : {}) },
     y: { label: o.labY || `${base} (loess)`, grid: o.grid,
          ...(o.logScale ? { type: 'log' } : {}), domain: [o.logScale ? 1 : 0, yhi > 0 ? yhi : 1] },
     marks,
   }
-  if (o.rotateXLabel) opts.marginBottom = 64
+  if (o.rotateXLabel) opts.marginBottom = xRotMargin(64, o)
   ;(opts as Record<string, unknown>)._legend = legend
   return opts
 }

--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -391,8 +391,12 @@ function buildHeatmap(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts): Reco
   // reserve a top band for the colour-ramp legend (drawn top-right as an overlay) so it never covers
   // the top row of cells — and a touch more when a title (top-left) shares the band.
   const topPad = o.legend ? (o.title ? 52 : 46) : (o.title ? 34 : 12)
+  // left margin fits the longest y tick label (feature names like "live.track.meanTurningAngle" were
+  // clipped at a fixed 120). Approx char width ≈ 0.6·fontSize; clamp so it never eats the whole plot.
+  const longestY = (r.yLabels ?? []).reduce((m, s) => Math.max(m, String(s).length), 0)
+  const marginLeft = Math.round(Math.min(260, Math.max(120, longestY * (o.fontSize || 11) * 0.6 + 18)))
   const opts: Record<string, unknown> = {
-    ...THEME, marginLeft: 120, marginBottom: 64, marginTop: topPad, marginRight: 16,
+    ...THEME, marginLeft, marginBottom: 64, marginTop: topPad, marginRight: 16,
     style: { background: bg, color: fg, fontFamily: FONT, fontSize: `${o.fontSize || 11}px` },
     x: { domain: r.xLabels ?? [], label: o.labX || xLab, tickRotate: o.rotateXLabel ? xTickRotate(o) : 0 },
     y: { domain: [...(r.yLabels ?? [])].reverse(), label: o.labY || yLab },   // first row at the top


### PR DESCRIPTION
## Summary

Analysis-board cluster/plot-styling fixes.

- **Cluster / trackclust pop manager shows its plot params on the board.** The board's `activeVis` returned `undefined` in local scope (no `defaultVis()` fallback, unlike the module page), so `PopulationPanelShell` hid the whole PlotOptions styling block. Added the fallback.
- **UMAP honours the pop manager's palette.** Colour-by-cluster now uses `vis.palette`/`userColors` (e.g. `distinct`) via `paletteRange`; `standard` keeps the built-in palette, so nothing changes by default. Reacts live to palette changes. (Highlight-to-pop-colour behaviour unchanged.)
- **Rotate-X-label angle slider.** `Rotate X labels` reveals a 0–90° angle slider (`VisProps.rotateXAngle`); `plot.ts` applies the angle (`xTickRotate`) across the distribution / matrix / frequency builders and scales the bottom margin with it (`xRotMargin`) so steep labels aren't clipped.
- **Heatmap left margin fits the labels.** Long y-axis feature names (e.g. `live.track.meanTurningAngle`) were clipped at a fixed `marginLeft: 120`; it's now the **measured** width of the longest y label (memoised canvas `textWidth`, +14 for the tick), clamped to [48, 260] — so it neither clips nor leaves a gap.

Docs: PLOTS.md.

## Reservations
- Browser-untested by me (typecheck + 85 vitest green).
- The cluster-params fix is the local-scope `activeVis` fallback; in global scope the params already showed — worth confirming a trackclus
- Rotate margins are heuristic (scaled per-chart base), not measured — a very long label at a steep angle could still crowd.
- Heatmap margin caps at 260px; an extremely long feature name beyond that would still clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)