### PR TITLE
Fix/imagetable runlog popover collapse

### DIFF
--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -730,7 +730,9 @@ onUnmounted(stopResize)
   <!-- run-history popover — teleported to <body> so it escapes the table's scroll/transform
        containing block (was clipped by the following row); positioned (fixed) from the cog rect -->
   <Teleport to="body">
-    <div v-if="runLogImg" class="runlog-pop" :style="runLogPos">
+    <!-- carry the theme tokens (--cc-*) on the popover itself: teleported to <body> it's outside the
+         shell's .cc-dark wrapper, so var(--cc-surface-1) etc. would otherwise be undefined (transparent) -->
+    <div v-if="runLogImg" class="runlog-pop cc-dark" :style="runLogPos">
       <div class="runlog-hd">Run history</div>
       <div v-if="!runLogImg.runLog || !runLogImg.runLog.length" class="runlog-empty">No functions recorded yet.</div>
       <div v-for="(e, i) in [...(runLogImg.runLog ?? [])].reverse()" :key="i" class="runlog-row">

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -165,6 +165,8 @@ const NOTE_KEY = '__note'
 // position: fixed from the cog so it escapes the table's horizontal scroll clipping.
 const runLogUid = ref<string | null>(null)
 const runLogPos = ref<Record<string, string>>({})
+// the image whose run-history popover is open (the popover is teleported to <body>, so it reads this)
+const runLogImg = computed(() => runLogUid.value ? (images.value.find(i => i.uid === runLogUid.value) ?? null) : null)
 const fmtRunAt = (at: string) => (at ?? '').replace('T', ' ')
 function toggleRunLog(uid: string, e: MouseEvent) {
   if (runLogUid.value === uid) { runLogUid.value = null; return }
@@ -173,7 +175,8 @@ function toggleRunLog(uid: string, e: MouseEvent) {
   runLogUid.value = uid
 }
 function onDocMouseDownRunLog(e: MouseEvent) {
-  if (runLogUid.value && !(e.target as HTMLElement).closest('.runlog-cell')) runLogUid.value = null
+  const t = e.target as HTMLElement
+  if (runLogUid.value && !t.closest('.runlog-cell') && !t.closest('.runlog-pop')) runLogUid.value = null
 }
 onMounted(() => document.addEventListener('mousedown', onDocMouseDownRunLog))
 onUnmounted(() => document.removeEventListener('mousedown', onDocMouseDownRunLog))
@@ -621,15 +624,6 @@ onUnmounted(stopResize)
               <button class="row-icon-btn runlog-cog" :class="{ on: runLogUid === img.uid }"
                 @click.stop="toggleRunLog(img.uid, $event)"
                 v-tooltip.right="'Functions run on this image'"><i class="pi pi-cog" /></button>
-              <div v-if="runLogUid === img.uid" class="runlog-pop" :style="runLogPos">
-                <div class="runlog-hd">Run history</div>
-                <div v-if="!img.runLog || !img.runLog.length" class="runlog-empty">No functions recorded yet.</div>
-                <div v-for="(e, i) in [...(img.runLog ?? [])].reverse()" :key="i" class="runlog-row">
-                  <span class="runlog-fun">{{ e.fun }}</span>
-                  <span v-if="e.valueName" class="runlog-vn">{{ e.valueName }}</span>
-                  <span class="runlog-at">{{ fmtRunAt(e.at) }}</span>
-                </div>
-              </div>
             </span>
           </span>
           <span class="uid-row">
@@ -732,6 +726,20 @@ onUnmounted(stopResize)
   <PhysicalSizeDialog v-if="physSizeDialogUid"
     :set-uid="setUid" :focus-uid="physSizeDialogUid" :selected-uids="[...selected]"
     @close="physSizeDialogUid = null" />
+
+  <!-- run-history popover — teleported to <body> so it escapes the table's scroll/transform
+       containing block (was clipped by the following row); positioned (fixed) from the cog rect -->
+  <Teleport to="body">
+    <div v-if="runLogImg" class="runlog-pop" :style="runLogPos">
+      <div class="runlog-hd">Run history</div>
+      <div v-if="!runLogImg.runLog || !runLogImg.runLog.length" class="runlog-empty">No functions recorded yet.</div>
+      <div v-for="(e, i) in [...(runLogImg.runLog ?? [])].reverse()" :key="i" class="runlog-row">
+        <span class="runlog-fun">{{ e.fun }}</span>
+        <span v-if="e.valueName" class="runlog-vn">{{ e.valueName }}</span>
+        <span class="runlog-at">{{ fmtRunAt(e.at) }}</span>
+      </div>
+    </div>
+  </Teleport>
 </template>
 
 <style scoped>

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -302,7 +302,8 @@ const visibleUids = computed<string[]>(() =>
 
         <!-- scrollable body: image table + below-table content -->
         <div class="panel-scroll">
-          <CollapsibleSection label="Images" max-height="none">
+          <CollapsibleSection label="Images" max-height="none"
+            :storage-key="`cc-images-open:${module ?? 'default'}`">
             <div v-if="!activeSet" class="no-set">
               <i class="pi pi-folder-open" style="font-size:2rem; opacity:0.2" />
               <p>No set selected.</p>


### PR DESCRIPTION
## Summary

Two image-table cleanups.

- **Run-history cog popover no longer clipped.** It was rendered inside the row, so a scrolling/transformed ancestor turned its `position: fixed` into a containing block and the next row clipped it. Now a single popover for the active row is `Teleport`ed to `<body>` (immune to any ancestor clip), positioned from the cog rect; click-outside ignores clicks inside the popover.
- **"Images" table collapse persists across navigation.** The `CollapsibleSection` wrapping the table had no `storage-key`, so it always re-expanded. Added `cc-images-open:<module>` (same `localStorage` mechanism as the plots section) — per-module, survives navigation and reload.

## Reservations
- Browser-untested by me (typecheck + 85 vitest green).
- The popover is positioned at open time, so it won't follow the table if you scroll while it's open — but any outside click closes it, so it's a non-issue.
- Since the popover is teleported outside the shell's `.cc-dark` wrapper, it carries the `cc-dark` class itself so the `--cc-*` theme tokens resolve (else it rendered with a transparent background).

🤖 Generated with [Claude Code](https://claude.com/claude-code)