### PR TITLE
Fix module-canvas drag: keep the workspace ≥ viewport (min 100%)

### DIFF
--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -214,5 +214,8 @@ watch(segPops, () => { for (const p of panels.value) p.state.sel = p.state.sel.f
 .sc-canvas { position: relative; flex: 1; min-height: 70vh; }
 /* the scaled workspace (offsetParent for the floating panels); size + transform set inline by
    useCanvasWorkspace — grows to viewport/zoom when zoomed out so the whole page stays usable */
-.sc-zoom { position: absolute; top: 0; left: 0; }
+/* min 100% so the workspace always at least fills the viewport (like the old inset:0) even before the
+   JS size lands — else a 0 measurement collapses it and the panels' offsetParent is ~0-wide, pinning
+   drag to the top-left. useCanvasWorkspace only EXTENDS it (width/height) when zoomed out. */
+.sc-zoom { position: absolute; top: 0; left: 0; min-width: 100%; min-height: 100%; }
 </style>

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -287,6 +287,8 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
 .seg button.on { color: var(--cc-accent); background: var(--cc-surface-1); }
 .cp-canvas { position: relative; flex: 1; min-height: 70vh; }
 /* the scaled workspace fills the canvas (offsetParent for the floating panels); transform set inline */
-/* scaled workspace (offsetParent for panels); size + transform set inline by useCanvasWorkspace */
-.cp-zoom { position: absolute; top: 0; left: 0; }
+/* scaled workspace (offsetParent for panels); size + transform set inline by useCanvasWorkspace.
+   min 100% so it always at least fills the viewport (like the old inset:0) even before the JS size
+   lands — else a 0 measurement collapses it and drag pins panels to the top-left. */
+.cp-zoom { position: absolute; top: 0; left: 0; min-width: 100%; min-height: 100%; }
 </style>

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -309,6 +309,8 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
 /* free-floating plot workspace: panels + manager are absolutely positioned within */
 .gp-canvas { position: relative; flex: 1; min-height: 70vh; }
 /* the scaled workspace fills the canvas (offsetParent for the floating plot panels); transform inline */
-/* scaled workspace (offsetParent for panels); size + transform set inline by useCanvasWorkspace */
-.gp-zoom { position: absolute; top: 0; left: 0; }
+/* scaled workspace (offsetParent for panels); size + transform set inline by useCanvasWorkspace.
+   min 100% so it always at least fills the viewport (like the old inset:0) even before the JS size
+   lands — else a 0 measurement collapses it and drag pins panels to the top-left. */
+.gp-zoom { position: absolute; top: 0; left: 0; min-width: 100%; min-height: 100%; }
 </style>


### PR DESCRIPTION
## Summary

Fixes a regression from the zoom-workspace change (#28): floating plot panels on the module pages snapped to the top-left of the canvas and couldn't be dragged.

`.xx-zoom` (the panels' `offsetParent`) used to fill the viewport via `inset: 0`, but its size now comes from a JS measurement (`useCanvasWorkspace` `vpW/vpH`). When that measures 0 (ResizeObserver/layout timing), the workspace collapses to ~1px, so the panels' offsetParent is ~0-wide and `useFloatingPanel`'s clamp pins every panel to the top-left. Added `min-width/height: 100%` to `.sc-zoom` / `.gp-zoom` / `.cp-zoom` so CSS always keeps the workspace at least viewport-sized (like the old `inset: 0`); the JS size only *extends* it when zoomed out.

## Reservations
- Cause inferred, then confirmed live; the `min: 100%` guarantees the offsetParent is always ≥ viewport. Panels persisted at 0,0 during the broken state will start top-left but are draggable again.
- CSS-only; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)