### PR TITLE
Fix track-measures (and any single-group) plots ignoring pop colours

### DIFF
--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -266,7 +266,11 @@ export function buildPlotOptions(Plot: PlotModule, r: PlotDataResponse, o: Build
   let color = colourScale(r.series, keyOf, o.colorOf)
   // When sub-split by a groupBy column (e.g. HMM state) the levels have no population-manager colour,
   // so 'standard' would paint every level the same pop colour — fall back to distinct hues instead.
-  const groupColouring = !!r.groupBy && o.palette === 'standard'
+  // Gate on the series ACTUALLY varying by group (d.grp), not merely on r.groupBy being present: a
+  // groupBy that yields one level per series (e.g. track measures come back with a groupBy set but
+  // `group=""`) must keep the population colours, not get distinct hues (the "track measures show
+  // red/green instead of the pop colours" bug).
+  const groupColouring = d.grp && o.palette === 'standard'
   // palette override (R adjustColors): assign palette/user/distinct colours by series order;
   // 'standard' keeps the population-manager colours from colorOf (consistent across images).
   if (o.palette === 'user') {


### PR DESCRIPTION
## Summary

Track-measures summary plots showed the distinct palette (red/green) instead of the population colours (blue/white), though `seriesColor` returned the correct colours and other plots were fine.

`plot.ts` reassigned the colour range to the distinct palette whenever the response carried a `groupBy` (`groupColouring = !!r.groupBy && palette==='standard'`). Track-measures series vary by **segmentation** (B/T), not by a group level (their `group` is `""`), yet still come back with a `groupBy` set — so their correct pop colours got overwritten with distinct hues. Now `groupColouring` is gated on the series **actually** varying by group (`d.grp`); pop-keyed series keep their population colours, genuine group-split plots (HMM states) keep distinct hues.

## Reservations
- Root-caused live with a temporary console log (now removed). Typecheck + 85 vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)