### PR TITLE
Feat/phenotype population summary

### DIFF
--- a/app/src/gating/population_manager.jl
+++ b/app/src/gating/population_manager.jl
@@ -283,8 +283,123 @@ end
 
 # CciaImage convenience (task_dir = img._dir)
 save_pop_map!(m::PopulationMap, img::CciaImage) = save_pop_map!(m, img._dir)
-load_pop_map(img::CciaImage; value_name::AbstractString="default", pop_type::AbstractString="flow") =
-    load_pop_map(img._dir, value_name; pop_type=pop_type)
+
+# ── Co-clustered segmentations + cluster-pop auto-share (docs/todo/CLUSTER_POOLING_PLAN.md) ────────
+# Clustering (clustPops/clustTracks) runs JOINTLY across the selected populations, which may span
+# several segmentations (value_names). The engine writes ONE shared `clusters.{suffix}` column + a
+# `{props}.clustfeatures.json` sidecar (keyed by suffix) into EVERY input segment. So the value_names
+# that took part in a run = those whose clustfeatures sidecar carries `suffix` — the single source of
+# truth for "which segmentations belong to this clustering".
+_clustfeatures_path(props_path::AbstractString) = replace(props_path, r"\.h5ad$" => ".clustfeatures.json")
+function _clustfeatures_suffixes(props_path::AbstractString)::Set{String}
+    s = _clustfeatures_path(props_path)
+    isfile(s) || return Set{String}()
+    try
+        Set{String}(String(k) for k in keys(JSON3.read(read(s, String), Dict{String,Any})))
+    catch
+        Set{String}()
+    end
+end
+
+"""
+    co_clustered_value_names(img, suffix; granularity=:cell) -> Vector{String}
+
+The image's segmentations (value_names) that took part in clustering run `suffix` — i.e. whose
+clustfeatures sidecar (`{props}.clustfeatures.json`) carries `suffix`. `granularity=:track` reads the
+per-track table's sidecar (`trackclust`), `:cell` the cell table's (`clust`). First-appearance order
+of `versioned_keys(img.label_props)`. Falls back to the active value_name when nothing is recorded
+(pre-clustfeatures runs), so callers always get at least one segmentation.
+"""
+function co_clustered_value_names(img::CciaImage, suffix::AbstractString;
+                                  granularity::Symbol=:cell)::Vector{String}
+    out = String[]
+    for vn in versioned_keys(img.label_props)
+        v = String(vn)
+        p = granularity === :track ? img_track_props_path(img, v) : img_label_props_path(img, v)
+        String(suffix) in _clustfeatures_suffixes(p) && push!(out, v)
+    end
+    isempty(out) ? String[String(get(img.label_props, "_active", "default"))] : out
+end
+
+_is_cluster_pop_type(pop_type)::Bool = String(pop_type) in ("clust", "trackclust")
+
+# Suffixes a cluster pop map's filters reference (each pop's `filter_measure` = "clusters.{suffix}").
+function _referenced_cluster_suffixes(m::PopulationMap)::Set{String}
+    out = Set{String}()
+    for p in values(m.pops)
+        fm = p.filter_measure
+        (fm === nothing || !startswith(String(fm), "clusters.")) && continue
+        push!(out, String(fm)[ncodeunits("clusters.")+1:end])
+    end
+    out
+end
+
+# AUTO-SHARE: a segmentation that took part in a joint clustering but has no OWN named cluster-pop
+# sidecar (the names were authored under a sibling value_name — e.g. under B while T got only the
+# shared `clusters.{suffix}` column) borrows the sibling's map, RELABELED to itself so membership
+# resolves over ITS own table. Guarded: only borrow when this vn shares the sibling map's referenced
+# `clusters.{suffix}` (so we never fabricate cluster pops for a segmentation not in the run). Returns
+# nothing when there's nothing to borrow. Read-side only — the SAVE path stays per-vn (editing under a
+# borrowing vn materialises its own real sidecar: plain copy semantics).
+function _borrow_cluster_pop_map(img::CciaImage, value_name::AbstractString,
+                                 pop_type::AbstractString)::Union{PopulationMap,Nothing}
+    granularity = pop_type == "trackclust" ? :track : :cell
+    p = granularity === :track ? img_track_props_path(img, value_name) : img_label_props_path(img, value_name)
+    my_suffixes = _clustfeatures_suffixes(p)
+    isempty(my_suffixes) && return nothing              # this vn wasn't clustered → nothing to share
+    for vn in versioned_keys(img.label_props)
+        v = String(vn); v == value_name && continue
+        sib = load_pop_map(img._dir, v; pop_type=pop_type)
+        isempty(sib.pops) && continue
+        ref = _referenced_cluster_suffixes(sib)
+        (isempty(ref) || !(ref ⊆ my_suffixes)) && continue
+        sib.value_name = value_name
+        for pop in values(sib.pops); pop.value_name = value_name; end
+        return sib
+    end
+    nothing
+end
+
+function load_pop_map(img::CciaImage; value_name::AbstractString="default", pop_type::AbstractString="flow")
+    m = load_pop_map(img._dir, value_name; pop_type=pop_type)
+    # cluster pop_types with no own sidecar → try to borrow from a co-clustered sibling (auto-share)
+    (_is_cluster_pop_type(pop_type) && isempty(m.pops)) || return m
+    something(_borrow_cluster_pop_map(img, String(value_name), String(pop_type)), m)
+end
+
+# Old-R `popDT(popType="clust", pops=c("A","B","C"))` returned those cluster pops across ALL
+# segmentations used in the clustering run — pooled, tagged by value_name. Cluster pops are GLOBAL to a
+# run (one shared `clusters.{suffix}` column across its segments), NOT per-segmentation like gates. So a
+# BARE cluster-pop reference (root-relative `/A`, no value_name prefix) expands to EVERY co-clustered
+# value_name; membership is then evaluated against each segment's own table (own or auto-shared def) and
+# the rows pooled + value_name-tagged by the normal pop_df machinery. A value_name-prefixed ref
+# ("T/A") is explicit and passes through unchanged (so a single-segmentation request still works). The
+# run is identified from the pop's own definition (`filter_measure = clusters.{suffix}`).
+function _expand_cluster_pops(img::CciaImage, pops, pop_type::AbstractString, default_vn::AbstractString)
+    _is_cluster_pop_type(pop_type) || return pops
+    granularity = pop_type == "trackclust" ? :track : :cell
+    vns = versioned_keys(img.label_props)
+    out = String[]
+    for p0 in pops
+        p = String(p0)
+        if !(startswith(p, "/") || is_root(p)); push!(out, p); continue; end   # explicit "vn/path" → keep
+        is_root(p) && (push!(out, p); continue)                                # root has no cluster expansion
+        # find the run this pop belongs to: a value_name whose OWN sidecar defines it as a cluster filter
+        suffix = nothing
+        for vn in vns
+            m = load_pop_map(img._dir, String(vn); pop_type=pop_type)
+            has_pop(m, p) || continue
+            fm = m.pops[p].filter_measure
+            (fm !== nothing && startswith(String(fm), "clusters.")) || continue
+            suffix = String(fm)[ncodeunits("clusters.")+1:end]; break
+        end
+        suffix === nothing && (push!(out, p); continue)                        # unknown → leave to default_vn
+        for vn in co_clustered_value_names(img, suffix; granularity=granularity)
+            push!(out, "$(vn)$(p)")                                            # "/A" → "B/A", "T/A", …
+        end
+    end
+    unique(out)
+end
 
 # ── pop_df — unified population accessor (pop_type-agnostic) ─────────────────────
 #
@@ -920,6 +1035,9 @@ function pop_df(img::CciaImage, pop_type::AbstractString, pops;
         error("pop_df: granularity must be :cell or :track (got :$granularity)")
     # value_name=nothing → active segmentation key (same resolution as label_props(img))
     resolved_vn = something(value_name, get(img.label_props, "_active", "default"))
+    # cluster pops are GLOBAL to a run → a bare ref spans all co-clustered segmentations (R popDT
+    # parity); value_name-prefixed refs are untouched. No-op for non-cluster pop_types.
+    pops = _expand_cluster_pops(img, pops, String(pop_type), resolved_vn)
 
     ckey = _pop_df_cache_key(img, pop_type, resolved_vn, pops, pop_cols, include_x, include_obs,
                              unique_labels, drop_na, raw_channel_names, granularity,

--- a/app/src/plotDefinitions/population_summary.json
+++ b/app/src/plotDefinitions/population_summary.json
@@ -1,0 +1,16 @@
+{
+  "id": "population_summary",
+  "label": "Population summary",
+  "module": "phenotype",
+  "family": "summary",
+  "chartTypes": ["count"],
+  "whiteboardCompatible": true,
+  "dataSource": {
+    "popType": "flow",
+    "granularity": "cell"
+  },
+  "scopeModes": ["per_image", "summarised", "by_attr"],
+  "params": [
+    { "key": "normalize", "label": "As proportion", "type": "bool", "default": true }
+  ]
+}

--- a/app/src/plotDefinitions/population_summary_clust.json
+++ b/app/src/plotDefinitions/population_summary_clust.json
@@ -1,12 +1,12 @@
 {
-  "id": "population_summary",
-  "label": "Population summary",
-  "module": "phenotype",
+  "id": "population_summary_clust",
+  "label": "Population summary (cell clusters)",
+  "module": "clustPops",
   "family": "summary",
   "chartTypes": ["boxplot", "strip", "violin", "bar", "count"],
   "whiteboardCompatible": true,
   "dataSource": {
-    "popType": "flow",
+    "popType": "clust",
     "granularity": "cell"
   },
   "scopeModes": ["per_image", "summarised", "by_attr"],

--- a/app/src/plotDefinitions/population_summary_trackclust.json
+++ b/app/src/plotDefinitions/population_summary_trackclust.json
@@ -1,13 +1,13 @@
 {
-  "id": "population_summary",
-  "label": "Population summary",
-  "module": "phenotype",
+  "id": "population_summary_trackclust",
+  "label": "Population summary (track clusters)",
+  "module": "clustTracks",
   "family": "summary",
   "chartTypes": ["boxplot", "strip", "violin", "bar", "count"],
   "whiteboardCompatible": true,
   "dataSource": {
-    "popType": "flow",
-    "granularity": "cell"
+    "popType": "trackclust",
+    "granularity": "track"
   },
   "scopeModes": ["per_image", "summarised", "by_attr"],
   "params": [

--- a/app/src/plotDefinitions/population_summary_tracks.json
+++ b/app/src/plotDefinitions/population_summary_tracks.json
@@ -1,13 +1,13 @@
 {
-  "id": "population_summary",
-  "label": "Population summary",
-  "module": "phenotype",
+  "id": "population_summary_tracks",
+  "label": "Population summary (tracks)",
+  "module": "behaviourAnalysis",
   "family": "summary",
   "chartTypes": ["boxplot", "strip", "violin", "bar", "count"],
   "whiteboardCompatible": true,
   "dataSource": {
-    "popType": "flow",
-    "granularity": "cell"
+    "popType": "live",
+    "granularity": "track"
   },
   "scopeModes": ["per_image", "summarised", "by_attr"],
   "params": [

--- a/app/src/plotting/plot_data.jl
+++ b/app/src/plotting/plot_data.jl
@@ -150,14 +150,32 @@ _var_measure_set(imgs::AbstractVector{<:CciaImage}, value_name)::Set{String} =
 # per-image rows to the normal distribution builders (boxplot/violin/strip/bar) makes each IMAGE a
 # data point grouped by pop → within-pop variability + between-pop comparison (R popsSummary port).
 const _POP_METRIC_COL = "__pop_metric"
-function _population_metric_frame(df::DataFrame; normalize::Symbol=:none)::DataFrame
+function _population_metric_frame(df::DataFrame; normalize::Symbol=:none,
+                                  col::AbstractString=_POP_METRIC_COL)::DataFrame
     has_uid = :uID in propertynames(df); has_vn = :value_name in propertynames(df)
     vn  = has_vn  ? String.(df.value_name) : fill("", nrow(df))
     pop = String.(df.pop)
     uid = has_uid ? String.(df.uID) : fill("", nrow(df))
-    cnt = Dict{Tuple{String,String,String},Int}(); order = Tuple{String,String,String}[]
+    # count per (value_name, pop, uID), tracking first-appearance order of pops/images per segmentation.
+    cnt = Dict{Tuple{String,String,String},Int}()
+    vn_order = String[]; seen_vn = Set{String}()
+    pop_order = Dict{String,Vector{String}}(); uid_order = Dict{String,Vector{String}}()
     for i in 1:nrow(df)
-        k = (vn[i], pop[i], uid[i]); haskey(cnt, k) || push!(order, k); cnt[k] = get(cnt, k, 0) + 1
+        v = vn[i]; p = pop[i]; u = uid[i]
+        cnt[(v, p, u)] = get(cnt, (v, p, u), 0) + 1
+        if !(v in seen_vn); push!(vn_order, v); push!(seen_vn, v); pop_order[v] = String[]; uid_order[v] = String[]; end
+        p in pop_order[v] || push!(pop_order[v], p)
+        u in uid_order[v] || push!(uid_order[v], u)
+    end
+    # COMPLETE CASES (R tidyr::complete / expand.grid): within each segmentation (value_name), every
+    # population seen in ANY image gets a row for EVERY image that has that segmentation — a missing
+    # (pop, image) is a genuine 0, not absent data. Without this, the boxplot/strip of a cluster's
+    # per-image count/proportion silently DROPS the images lacking that cluster, biasing the
+    # distribution (n too small, median/mean shifted up). Universe is derived per value_name (pops seen
+    # under vn × images seen under vn), so we never fabricate a 0 for an image not segmented for that vn.
+    order = Tuple{String,String,String}[]
+    for v in vn_order, p in pop_order[v], u in uid_order[v]
+        k = (v, p, u); haskey(cnt, k) || (cnt[k] = 0); push!(order, k)
     end
     # proportion denominator = the tracked population's total per image → keyed by (uID, value_name),
     # so clusters within B and within T are each normalised to their OWN population (not pooled B+T).
@@ -170,7 +188,7 @@ function _population_metric_frame(df::DataFrame; normalize::Symbol=:none)::DataF
         d = frac ? get(tot, (k[3], k[1]), 0) : 0
         push!(vals, frac ? (d == 0 ? 0.0 : n / d) : Float64(n))
     end
-    DataFrame("value_name" => vns, "pop" => pops, "uID" => uids, _POP_METRIC_COL => vals)
+    DataFrame("value_name" => vns, "pop" => pops, "uID" => uids, String(col) => vals)
 end
 
 # Shared aggregation core over an already-built pop_df frame. `by_image` → one series per source
@@ -203,8 +221,10 @@ function _summary_agg(df::DataFrame, chart_type::AbstractString;
     # values (series = pop, points = images) → boxplot/violin/strip/beeswarm/bar show within-pop
     # variability and compare pops. `count` keeps its per-(pop, image) bar view (handled below).
     if measure === nothing && chart_type in ("boxplot", "violin", "strip", "points", "bar")
-        df = _population_metric_frame(df; normalize=normalize)
-        measure = _POP_METRIC_COL
+        # friendly axis label (also the df column name so the builders read it) — count vs proportion
+        metric_label = normalize in (:fraction, :total) ? "proportion" : "count"
+        df = _population_metric_frame(df; normalize=normalize, col=metric_label)
+        measure = metric_label
         by_image = false           # pool images into the pop series as individual points
         normalize = :none
     end

--- a/app/src/plotting/plot_data.jl
+++ b/app/src/plotting/plot_data.jl
@@ -250,10 +250,22 @@ function _summary_agg(df::DataFrame, chart_type::AbstractString;
         # cell count per timepoint per image — the temporal-consistency time series (drops/spikes are
         # visible). Series shape mirrors `bar` (`value` = count) so the frontend renders it as a bar
         # or a line over the ordered group (t). See docs/PLOTS.md → Segmentation QC plot.
+        #
+        # `normalize` (:fraction/:total) → each series' FRACTION of that image's plotted total (its
+        # uID bucket): for mutually-exclusive populations (e.g. the clustered pops) that's each pop's
+        # share of the image's cells, plotted across images — the "population summary" plot. Pooled
+        # (scope=summarised, uID="") normalises over the whole pooled set.
         groups = sgroups(df)
-        series = [merge(base(g), Dict("value" => Float64(nrow(g.sub)), "n" => nrow(g.sub)))
-                  for g in groups]
+        frac = normalize == :fraction || normalize == :total
+        totals = Dict{String,Int}()
+        frac && for g in groups; totals[g.uid] = get(totals, g.uid, 0) + nrow(g.sub); end
+        series = map(groups) do g
+            n = nrow(g.sub)
+            v = frac ? (get(totals, g.uid, 0) == 0 ? 0.0 : n / totals[g.uid]) : Float64(n)
+            merge(base(g), Dict("value" => v, "n" => n))
+        end
         return withgb(Dict{String,Any}("chartType" => "count", "measureType" => "numeric",
+                                "normalize" => String(normalize),
                                 "granularity" => String(granularity), "series" => series))
 
     elseif chart_type == "boxplot"

--- a/app/src/plotting/plot_data.jl
+++ b/app/src/plotting/plot_data.jl
@@ -159,13 +159,16 @@ function _population_metric_frame(df::DataFrame; normalize::Symbol=:none)::DataF
     for i in 1:nrow(df)
         k = (vn[i], pop[i], uid[i]); haskey(cnt, k) || push!(order, k); cnt[k] = get(cnt, k, 0) + 1
     end
+    # proportion denominator = the tracked population's total per image → keyed by (uID, value_name),
+    # so clusters within B and within T are each normalised to their OWN population (not pooled B+T).
     frac = normalize in (:fraction, :total)
-    tot = Dict{String,Int}()
-    frac && for (k, n) in cnt; tot[k[3]] = get(tot, k[3], 0) + n; end
+    tot = Dict{Tuple{String,String},Int}()   # (uid, vn) → total
+    frac && for (k, n) in cnt; tk = (k[3], k[1]); tot[tk] = get(tot, tk, 0) + n; end
     vns = String[]; pops = String[]; uids = String[]; vals = Float64[]
     for k in order
         n = cnt[k]; push!(vns, k[1]); push!(pops, k[2]); push!(uids, k[3])
-        push!(vals, frac ? (tot[k[3]] == 0 ? 0.0 : n / tot[k[3]]) : Float64(n))
+        d = frac ? get(tot, (k[3], k[1]), 0) : 0
+        push!(vals, frac ? (d == 0 ? 0.0 : n / d) : Float64(n))
     end
     DataFrame("value_name" => vns, "pop" => pops, "uID" => uids, _POP_METRIC_COL => vals)
 end
@@ -288,17 +291,17 @@ function _summary_agg(df::DataFrame, chart_type::AbstractString;
         # visible). Series shape mirrors `bar` (`value` = count) so the frontend renders it as a bar
         # or a line over the ordered group (t). See docs/PLOTS.md → Segmentation QC plot.
         #
-        # `normalize` (:fraction/:total) → each series' FRACTION of that image's plotted total (its
-        # uID bucket): for mutually-exclusive populations (e.g. the clustered pops) that's each pop's
-        # share of the image's cells, plotted across images — the "population summary" plot. Pooled
-        # (scope=summarised, uID="") normalises over the whole pooled set.
+        # `normalize` (:fraction/:total) → each series' FRACTION of the plotted total WITHIN its own
+        # tracked population, per image: the denominator is keyed by (uID, value_name), so a plot
+        # spanning several segmentations/tracked pops (e.g. B and T) reports each cluster's share of
+        # *that* population's cells — not pooled across B+T. Pooled scope (uID="") folds over images.
         groups = sgroups(df)
         frac = normalize == :fraction || normalize == :total
-        totals = Dict{String,Int}()
-        frac && for g in groups; totals[g.uid] = get(totals, g.uid, 0) + nrow(g.sub); end
+        totals = Dict{Tuple{String,String},Int}()
+        frac && for g in groups; k = (g.uid, g.vn); totals[k] = get(totals, k, 0) + nrow(g.sub); end
         series = map(groups) do g
-            n = nrow(g.sub)
-            v = frac ? (get(totals, g.uid, 0) == 0 ? 0.0 : n / totals[g.uid]) : Float64(n)
+            n = nrow(g.sub); tot = get(totals, (g.uid, g.vn), 0)
+            v = frac ? (tot == 0 ? 0.0 : n / tot) : Float64(n)
             merge(base(g), Dict("value" => v, "n" => n))
         end
         return withgb(Dict{String,Any}("chartType" => "count", "measureType" => "numeric",

--- a/app/src/plotting/plot_data.jl
+++ b/app/src/plotting/plot_data.jl
@@ -144,6 +144,32 @@ end
 _var_measure_set(imgs::AbstractVector{<:CciaImage}, value_name)::Set{String} =
     isempty(imgs) ? Set{String}() : _var_measure_set(first(imgs), value_name)
 
+# POPULATION SUMMARY backbone: collapse a cell/track pop_df to ONE ROW PER (value_name, pop, uID),
+# whose value is the population's COUNT — or, when `normalize`, its FRACTION of that image's plotted
+# total (across the plotted pops; pooled over the whole set when there's no uID). Feeding these
+# per-image rows to the normal distribution builders (boxplot/violin/strip/bar) makes each IMAGE a
+# data point grouped by pop → within-pop variability + between-pop comparison (R popsSummary port).
+const _POP_METRIC_COL = "__pop_metric"
+function _population_metric_frame(df::DataFrame; normalize::Symbol=:none)::DataFrame
+    has_uid = :uID in propertynames(df); has_vn = :value_name in propertynames(df)
+    vn  = has_vn  ? String.(df.value_name) : fill("", nrow(df))
+    pop = String.(df.pop)
+    uid = has_uid ? String.(df.uID) : fill("", nrow(df))
+    cnt = Dict{Tuple{String,String,String},Int}(); order = Tuple{String,String,String}[]
+    for i in 1:nrow(df)
+        k = (vn[i], pop[i], uid[i]); haskey(cnt, k) || push!(order, k); cnt[k] = get(cnt, k, 0) + 1
+    end
+    frac = normalize in (:fraction, :total)
+    tot = Dict{String,Int}()
+    frac && for (k, n) in cnt; tot[k[3]] = get(tot, k[3], 0) + n; end
+    vns = String[]; pops = String[]; uids = String[]; vals = Float64[]
+    for k in order
+        n = cnt[k]; push!(vns, k[1]); push!(pops, k[2]); push!(uids, k[3])
+        push!(vals, frac ? (tot[k[3]] == 0 ? 0.0 : n / tot[k[3]]) : Float64(n))
+    end
+    DataFrame("value_name" => vns, "pop" => pops, "uID" => uids, _POP_METRIC_COL => vals)
+end
+
 # Shared aggregation core over an already-built pop_df frame. `by_image` → one series per source
 # image (cross-image comparison); else images (if any) are pooled. Used by both the single-image
 # and the multi-image `plot_summary_data` methods so the chart logic lives in one place.
@@ -167,6 +193,17 @@ function _summary_agg(df::DataFrame, chart_type::AbstractString;
         return _matrix_agg(df; mode = String(matrix_mode), measures = ms, category = category,
                            separator = separator, zscore = zscore, normalize = matrix_normalize,
                            granularity = granularity)
+    end
+    # POPULATION SUMMARY — a distribution/bar chart with NO cell `measure`: each IMAGE becomes one data
+    # point whose value is the pop's count (or its fraction of the image's plotted total). Pre-aggregate
+    # to per-(value_name, pop, uID) rows, then run the normal distribution builder over those per-image
+    # values (series = pop, points = images) → boxplot/violin/strip/beeswarm/bar show within-pop
+    # variability and compare pops. `count` keeps its per-(pop, image) bar view (handled below).
+    if measure === nothing && chart_type in ("boxplot", "violin", "strip", "points", "bar")
+        df = _population_metric_frame(df; normalize=normalize)
+        measure = _POP_METRIC_COL
+        by_image = false           # pool images into the pop series as individual points
+        normalize = :none
     end
     # `group` is the optional categorical sub-axis level (e.g. an HMM state) — "" when not grouping.
     base(g) = Dict{String,Any}("pop" => g.sid, "value_name" => g.vn, "uID" => g.uid, "group" => g.grp)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2735,6 +2735,29 @@ end
         @test length(rc0["series"]) == 1 && rc0["series"][1]["n"] == 6
     end
 
+    @testset "plot count (raw + proportion normalize) — population summary" begin
+        # two pops in two images; count → raw row counts; normalize=:fraction → each pop's share of
+        # its image's plotted total (the population-summary plot). Deterministic frame — no fixture.
+        df = DataFrame("value_name" => fill("A", 10),
+                       "pop" => ["/p","/p","/p","/q","/q", "/p","/q","/q","/q","/p"],
+                       "uID" => ["x","x","x","x","x",       "y","y","y","y","y"])
+        # image x: /p=3, /q=2 (total 5); image y: /p=2, /q=3 (total 5)
+        bykey(r) = Dict((s["uID"], s["pop"]) => s["value"] for s in r["series"])
+        raw = Cecelia._summary_agg(df, "count"; measure=nothing, granularity=:cell, nbins=0,
+                                   normalize=:none, by_image=true)
+        @test raw["chartType"] == "count"
+        rk = bykey(raw)
+        @test rk[("x","A/p")] == 3.0 && rk[("x","A/q")] == 2.0
+        @test rk[("y","A/p")] == 2.0 && rk[("y","A/q")] == 3.0
+        prop = Cecelia._summary_agg(df, "count"; measure=nothing, granularity=:cell, nbins=0,
+                                    normalize=:fraction, by_image=true)
+        @test prop["normalize"] == "fraction"
+        pk = bykey(prop)
+        @test pk[("x","A/p")] ≈ 0.6 && pk[("x","A/q")] ≈ 0.4     # 3/5, 2/5
+        @test pk[("y","A/p")] ≈ 0.4 && pk[("y","A/q")] ≈ 0.6     # 2/5, 3/5
+        @test Dict((s["uID"], s["pop"]) => s["n"] for s in prop["series"])[("x","A/p")] == 3
+    end
+
     @testset "plot matrix (heatmap: profile + crosstab)" begin
         # PROFILE: rows = measures, cols = category levels; cell = mean(measure | level). Pools the whole
         # frame into one grid (no series). Deterministic synthetic frame — no fixture.

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2223,6 +2223,53 @@ end
         @test !("/clusterA" in tncpaths) && "/TEST" in tncpaths
     end
 
+    # ── Cluster-pop auto-share across co-clustered segmentations (CLUSTER_POOLING_PLAN.md) ─────
+    @testset "cluster pop auto-share (co-clustered value_names)" begin
+        td = mktempdir()
+        lpdir = joinpath(td, "labelProps"); mkpath(lpdir)
+        # B & T were clustered together (both track sidecars carry suffix "movement"); C was not.
+        for vn in ("B", "T")
+            open(joinpath(lpdir, "$(vn)__tracks.clustfeatures.json"), "w") do f
+                JSON3.write(f, Dict("movement" => Dict("features" => ["live.track.speed"], "partOf" => ["u1"])))
+            end
+        end
+        # named trackclust pops authored ONLY under B (filter the shared clusters.movement column)
+        bm = PopulationMap(pop_type="trackclust", value_name="B")
+        add_pop!(bm, "Directed"; filter_measure="clusters.movement", filter_fun="in", filter_values=[3], colour="#c061cb")
+        add_pop!(bm, "Scanning"; filter_measure="clusters.movement", filter_fun="in", filter_values=[0], colour="#62a0ea")
+        save_pop_map!(bm, td)
+
+        img = CciaImage(; dir=td)
+        img.label_props = Dict("B" => "B.h5ad", "T" => "T.h5ad", "C" => "C.h5ad", "_active" => "B")
+
+        # co-clustered segmentations for run "movement" (track granularity) = B and T (not C)
+        @test Set(Cecelia.co_clustered_value_names(img, "movement"; granularity=:track)) == Set(["B", "T"])
+
+        # B has its OWN sidecar → loaded verbatim
+        mb = load_pop_map(img; value_name="B", pop_type="trackclust")
+        @test Set(keys(mb.pops)) == Set(["/Directed", "/Scanning"]) && mb.value_name == "B"
+
+        # T has NO sidecar but IS co-clustered → BORROWS B's named pops, relabeled to T so
+        # membership resolves over T's own track table
+        mt = load_pop_map(img; value_name="T", pop_type="trackclust")
+        @test Set(keys(mt.pops)) == Set(["/Directed", "/Scanning"])
+        @test mt.value_name == "T" && all(p.value_name == "T" for p in values(mt.pops))
+        @test mt.pops["/Directed"].filter_measure == "clusters.movement"
+
+        # C was NOT part of the run (no clustfeatures suffix) → no borrow (empty map)
+        mc = load_pop_map(img; value_name="C", pop_type="trackclust")
+        @test isempty(mc.pops)
+
+        # BARE cluster-pop ref expands across ALL co-clustered segmentations (R popDT parity)
+        @test Set(Cecelia._expand_cluster_pops(img, ["/Directed"], "trackclust", "B")) ==
+              Set(["B/Directed", "T/Directed"])
+        # explicit value_name-prefixed ref is untouched (single-segmentation request still works)
+        @test Cecelia._expand_cluster_pops(img, ["T/Scanning"], "trackclust", "B") == ["T/Scanning"]
+        # unknown pop → left as-is (falls back to default_vn downstream); non-cluster type → no-op
+        @test Cecelia._expand_cluster_pops(img, ["/Nope"], "trackclust", "B") == ["/Nope"]
+        @test Cecelia._expand_cluster_pops(img, ["/x"], "flow", "B") == ["/x"]
+    end
+
     # ── Gating engine: recompute, membership, filtered (tracked) pops ─────────
     @testset "recompute! + cells_in_pop" begin
         df = DataFrame(label=[1, 2, 3, 4, 5], x=[1.0, 6, 6, 9, 9], track_id=[0, 5, 9, 0, 7])
@@ -2782,6 +2829,22 @@ end
         @test p2[("x","B/Dir")] ≈ 2/3 && p2[("x","B/Mea")] ≈ 1/3   # within B (image x: B tot 3)
         @test p2[("x","T/Dir")] ≈ 1/2 && p2[("x","T/Mea")] ≈ 1/2   # within T (image x: T tot 2)
         @test p2[("y","B/Dir")] ≈ 1/2 && p2[("y","T/Mea")] ≈ 2/3   # within B / T (image y)
+
+        # COMPLETE CASES (R tidyr::complete): image y has no /q — it must still contribute a 0 to /q's
+        # distribution, not be dropped. Without completion /q would have n=1 (only x) and median 1.
+        df3 = DataFrame("value_name" => fill("A", 5),
+                        "pop" => ["/p","/p","/q", "/p","/p"],
+                        "uID" => ["x","x","x",    "y","y"])          # x: p=2 q=1 ; y: p=2 q=0 (missing)
+        bx3 = Cecelia._summary_agg(df3, "boxplot"; measure=nothing, granularity=:cell, nbins=10,
+                                   normalize=:none, by_image=true)
+        by3 = Dict(s["pop"] => s for s in bx3["series"])
+        @test by3["A/q"]["n"] == 2 && by3["A/q"]["median"] == 0.5    # /q points [1(x), 0(y)]
+        @test by3["A/p"]["n"] == 2 && by3["A/p"]["median"] == 2.0
+        # proportion completes too: /q in image y = 0 / (y's A total 2) = 0 → points [1/3, 0]
+        pr3 = Cecelia._summary_agg(df3, "boxplot"; measure=nothing, granularity=:cell, nbins=10,
+                                   normalize=:fraction, by_image=true)
+        by3f = Dict(s["pop"] => s for s in pr3["series"])
+        @test by3f["A/q"]["n"] == 2 && by3f["A/q"]["median"] ≈ 1/6
     end
 
     @testset "plot matrix (heatmap: profile + crosstab)" begin

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2770,6 +2770,18 @@ end
         br = Cecelia._summary_agg(df, "bar"; measure=nothing, granularity=:cell, nbins=10,
                                   normalize=:none, by_image=true)
         @test Dict(s["pop"] => s["value"] for s in br["series"])["A/p"] == 2.5
+
+        # SPLIT BY POPULATION: two tracked pops (value_names B, T) each with clusters — proportion is
+        # normalised WITHIN each value_name per image, not pooled across B+T.
+        df2 = DataFrame("value_name" => ["B","B","B","T","T", "B","B","T","T","T"],
+                        "pop" => ["/Dir","/Dir","/Mea","/Dir","/Mea", "/Dir","/Mea","/Dir","/Mea","/Mea"],
+                        "uID" => ["x","x","x","x","x",              "y","y","y","y","y"])
+        pr2 = Cecelia._summary_agg(df2, "count"; measure=nothing, granularity=:cell, nbins=0,
+                                   normalize=:fraction, by_image=true)
+        p2 = Dict((s["uID"], s["pop"]) => s["value"] for s in pr2["series"])
+        @test p2[("x","B/Dir")] ≈ 2/3 && p2[("x","B/Mea")] ≈ 1/3   # within B (image x: B tot 3)
+        @test p2[("x","T/Dir")] ≈ 1/2 && p2[("x","T/Mea")] ≈ 1/2   # within T (image x: T tot 2)
+        @test p2[("y","B/Dir")] ≈ 1/2 && p2[("y","T/Mea")] ≈ 2/3   # within B / T (image y)
     end
 
     @testset "plot matrix (heatmap: profile + crosstab)" begin

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2756,6 +2756,20 @@ end
         @test pk[("x","A/p")] ≈ 0.6 && pk[("x","A/q")] ≈ 0.4     # 3/5, 2/5
         @test pk[("y","A/p")] ≈ 0.4 && pk[("y","A/q")] ≈ 0.6     # 2/5, 3/5
         @test Dict((s["uID"], s["pop"]) => s["n"] for s in prop["series"])[("x","A/p")] == 3
+
+        # no measure + a DISTRIBUTION chart → each IMAGE is a point (its pop count), grouped by pop:
+        # boxplot/beeswarm show within-pop variability and compare pops. A/p counts = [3(x),2(y)],
+        # A/q = [2(x),3(y)] → each pop has 2 points (images), median 2.5.
+        bx = Cecelia._summary_agg(df, "boxplot"; measure=nothing, granularity=:cell, nbins=10,
+                                  normalize=:none, by_image=true)
+        @test bx["chartType"] == "boxplot"
+        bybp = Dict(s["pop"] => s for s in bx["series"])
+        @test Set(keys(bybp)) == Set(["A/p", "A/q"])
+        @test bybp["A/p"]["n"] == 2 && bybp["A/p"]["median"] == 2.5
+        # bar over the same per-image counts → mean (A/p mean of [3,2] = 2.5)
+        br = Cecelia._summary_agg(df, "bar"; measure=nothing, granularity=:cell, nbins=10,
+                                  normalize=:none, by_image=true)
+        @test Dict(s["pop"] => s["value"] for s in br["series"])["A/p"] == 2.5
     end
 
     @testset "plot matrix (heatmap: profile + crosstab)" begin

--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -154,14 +154,29 @@ frontend renders it as a bar, or a line over the ordered `group` (t).
 the image's cells**. Exposed as the panel's **Proportion** toggle (now shown for `count`, not just
 `frequency`). This is the **population summary** plot.
 
-### Population summary plot
+### Population summary plot (counts / proportion per population)
 
-`app/src/plotDefinitions/population_summary.json` (`module: "phenotype"`, `family: "summary"`,
-`chartTypes: ["count"]`, `popType: "flow"`) — cell counts / proportion of each **gated** population
-across images. Hosted on the **Phenotype** page (`PhenotypeModule.vue` → `<SummaryCanvas module="phenotype">`,
-route `/phenotype`) — the analysis counterpart to **Gate**, exactly as **Behaviour** is to **Track**.
-Because the page's summary canvas is popType-homogeneous, the page sorts the popType (Phenotype = `flow`
-gated cells); the same `count`+`normalize` backbone serves gated pops here and label counts on Segment.
+One **generalised backbone**, one spec per popType. The plot summarises **population membership** (not
+a cell measure): how many cells/tracks are in each population, or each pop's proportion of its image's
+total. Two views, both from the same backbone:
+
+- **`count`** → one bar per `(pop, image)` (`normalize` → fraction of the image's plotted total).
+- **`boxplot` / `violin` / `strip` / `bar`** with **no `measure`** → each **image** is one data point
+  (its pop count/proportion), grouped by pop, so you see **within-pop variability across images** and
+  **compare pops**. `plot_data.jl`'s `_population_metric_frame` collapses the pop_df to one row per
+  `(value_name, pop, uID)`, then the normal distribution builders run over those per-image rows
+  (`_summary_agg` detects `measure===nothing` + a distribution chart). Port of R `popsSummary`
+  (boxplot / `geom_quasirandom` / jitter over `pop.n` / `pop.freq`).
+
+Specs (each carries ONE popType so a page's summary canvas — and the board's manager — is
+homogeneous): `population_summary` (Phenotype, `flow`), `population_summary_tracks`
+(Behaviour, `live`), `population_summary_clust` (Cluster cells, `clust`), `population_summary_trackclust`
+(Cluster tracks, `trackclust`). The **Phenotype** page (`/phenotype`, `PhenotypeModule.vue`) is the
+analysis counterpart to **Gate** (as Behaviour is to Track); the cluster pages host the same via a
+collapsible `SummaryCanvas` below the cluster canvas. All are `whiteboardCompatible`. **Board caveat**:
+the universal board's summary canvas resolves ONE popType (from its specs), so only that popType's
+population-summary surfaces its pops there — the popType is properly sorted on the per-module pages.
+The frontend hides the measure picker for a measure-less (population) spec and never sends a measure.
 
 ### Segmentation QC plot
 

--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -149,6 +149,20 @@ as `bar`), needing **no** `measure`. It's the segmentation-integrity headline: w
 **cell count per timepoint** — the temporal-consistency time series (drops/spikes are visible). The
 frontend renders it as a bar, or a line over the ordered `group` (t).
 
+`normalize` (`:fraction`) turns each series into its **fraction of its image's plotted total** (its
+`uID` bucket; pooled → the whole set) — for mutually-exclusive populations that's each pop's **% of
+the image's cells**. Exposed as the panel's **Proportion** toggle (now shown for `count`, not just
+`frequency`). This is the **population summary** plot.
+
+### Population summary plot
+
+`app/src/plotDefinitions/population_summary.json` (`module: "phenotype"`, `family: "summary"`,
+`chartTypes: ["count"]`, `popType: "flow"`) — cell counts / proportion of each **gated** population
+across images. Hosted on the **Phenotype** page (`PhenotypeModule.vue` → `<SummaryCanvas module="phenotype">`,
+route `/phenotype`) — the analysis counterpart to **Gate**, exactly as **Behaviour** is to **Track**.
+Because the page's summary canvas is popType-homogeneous, the page sorts the popType (Phenotype = `flow`
+gated cells); the same `count`+`normalize` backbone serves gated pops here and label counts on Segment.
+
 ### Segmentation QC plot
 
 The segmentation-integrity plot is a **normal registry plot**, not a bespoke preset (see *Hosting*

--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -119,6 +119,22 @@ the UI restricts writes to the selected `partOf` images. The frontend applies th
 per-image `pop/add`/`pop/update`/… calls across those images (the gating store's `mirrorUids`); the
 old R `propagatePopMap` "populate to set" crutch is gone.
 
+**Cluster pops are GLOBAL to a run, across all its segmentations (docs/todo/CLUSTER_POOLING_PLAN.md).**
+A single clustering run may span several segmentations (value_names) — e.g. `clustTracks` over
+`B/qc/_tracked` + `T/qc/_tracked` writes ONE shared `clusters.{suffix}` column into *each* segment's
+table (and a per-segment clustfeatures sidecar keyed by suffix). The *named* cluster pops, however,
+are authored under one value_name (whichever was active). Two mechanisms make them behave as run-global
+(matching old R `popDT(popType="clust", pops=c("A","B","C"))`, which returned those pops across every
+clustered segmentation):
+- **Auto-share** — `load_pop_map(img; pop_type=clust|trackclust)` for a value_name with no OWN sidecar
+  BORROWS a co-clustered sibling's named pops, relabeled to itself, so the picker and membership both
+  surface them. Read-side only (save still writes a per-vn sidecar). Guarded by the clustfeatures
+  suffix so a segmentation not in the run never gets fabricated pops.
+- **Bare-pop pooling** — `pop_df(popType=clust|trackclust, pops=["/A", …])` expands a bare (root-
+  relative) cluster-pop ref to EVERY co-clustered value_name, pooled and value_name-tagged; a
+  value_name-prefixed ref (`"T/A"`) stays scoped to that one segmentation. `co_clustered_value_names`
+  is the source of truth (the value_names whose clustfeatures sidecar carries the run's suffix).
+
 ## `pop_df` — unified accessor
 
 > **Home:** `pop_df`/`_pop_df` live in `gating/population_manager.jl`, alongside the `pop_map`

--- a/docs/todo/CLUSTER_POOLING_PLAN.md
+++ b/docs/todo/CLUSTER_POOLING_PLAN.md
@@ -1,0 +1,80 @@
+# Parked plan — Cluster page: pool across all co-clustered segmentations
+
+Status snapshot / design lock. See `docs/todo/README.md` for the convention. Branch:
+`feat/phenotype-population-summary` (rides with the population-summary work).
+
+## Problem
+
+Track/cell clustering (`clustTracks.cluster` / `clustPops.cluster`) runs **jointly** across the
+selected populations, which may span several **segmentations** (value_names) — e.g. `B/qc/_tracked`
++ `T/qc/_tracked`. The engine writes ONE shared `clusters.{suffix}` column (and a shared
+`X_umap.{suffix}`) back into **each** segment's per-(uID, value_name) table, and a
+`{props}.clustfeatures.json` sidecar per segment (keyed by suffix → `{features, partOf}`).
+
+But the cluster **page** (and board) is single-segmentation:
+- UMAP (`api_plots_umap`) and heatmap read ONE value_name (`_resolve_vn` → `_active`, e.g. `B`).
+- The named cluster pops (`__trackclust.json` → Scanning/Directed/Meandering) are authored under ONE
+  value_name (whichever was active when named), so the picker + pop-summary only ever show B.
+- Net: on `4kS67f`/`3w4IY5` the user sees **B only** everywhere on the cluster page, even though
+  T was part of the same run and its data sits in `T__tracks.h5ad` in the same cluster space.
+
+Behaviour pages don't have this: their pops are stored per value_name (both B & T exist), and there
+is no single-value_name UMAP/heatmap.
+
+## Decision (user)
+
+**Pool everything across ALL segmentations used to create the clustering.** UMAP shows all segments'
+points together (in the shared embedding), heatmap aggregates across them, and the named cluster pops
+apply to every co-clustered segmentation (picker + summary). "All at the same time."
+
+## Key concept — co-clustered value_names
+
+For an (image, suffix, granularity): the value_names whose per-vn props table carries
+`clusters.{suffix}` — equivalently, whose `{props}.clustfeatures.json` has the `suffix` key. This is
+exactly the set of segmentations that went into the run (the engine writes the column + sidecar to
+every input segment). Source of truth = the clustfeatures sidecar (cheap JSON, no h5ad read).
+
+## Build sequence
+
+### Stage 1 — backend foundation (package, Revise-tracked, headless-testable)  ← START HERE
+- `co_clustered_value_names(img, suffix; granularity) -> Vector{String}` in `population_manager.jl`
+  (or a small clustering util): scan the image's value_names; keep those whose clustfeatures sidecar
+  (track table for `:track`, cell table for `:cell`) has `suffix`. Stable order; fallback to the
+  active vn when no sidecar (pre-clustfeatures runs). TEST with the `4kS67f` shape (or synthetic
+  sidecars) → returns `["B","T"]`.
+
+### Stage 2 — cluster-pop auto-share (fixes the pop summary split, the original ask)
+- `load_pop_map(img; value_name, pop_type)` (CciaImage method ONLY — not the task_dir base, which
+  save uses): for cluster pop_types (`clust`/`trackclust`) when the requested vn has NO own sidecar,
+  BORROW a co-clustered sibling's map, relabeled to the requested vn (set `m.value_name` + each
+  `pop.value_name`), so BOTH the picker (`plot_population_groups`) and membership (`pop_df`) resolve
+  the named cluster pops over the requested vn's own table. Guard: only borrow when the requested vn
+  shares the sibling map's referenced `clusters.{suffix}` (from each pop's `filter_measure`) per
+  Stage-1. Own sidecar always wins; editing+saving under T materialises a real T sidecar (copy
+  semantics — acceptable). TEST: borrow round-trips; membership over T's table.
+
+### Stage 3 — UMAP pooling (`api_plots_umap`)
+- Pool `obsm[X_umap.suffix]` + `clusters.suffix` across `co_clustered_value_names`. Binary becomes
+  `[x, y, code, segIdx]` per point (segIdx into a returned value_name list — via an `X-Value-Names`
+  response header, keeping the body pure binary). Pop subset resolves membership per vn. Frontend
+  (regl-scatterplot UMAP view) reads segIdx → optional tint/split by segmentation; default colours by
+  cluster code as today. Drop NaN-embedding rows as now.
+
+### Stage 4 — heatmap pooling
+- The cluster heatmap aggregates features per cluster from one vn's table → pool rows across
+  co-clustered vns before aggregation (find the heatmap data path; likely `plot_summary_data`
+  matrix/profile over the cluster column, or a dedicated endpoint). Keep the shared cluster-id
+  universe (`_cluster_ids` already pools across member IMAGES; extend to VALUE_NAMES via Stage-1).
+
+### Stage 5 — frontend cluster page
+- Consume pooled UMAP/heatmap; surface "segmentations: B, T" info; no per-vn selector needed.
+  Pop picker/manager keeps editing under the primary vn (auto-share covers the rest). Optional:
+  colour-by-segmentation toggle on the UMAP.
+
+## Notes / invariants
+- `api/src/*.jl` (umap/heatmap endpoints) are NOT Revise-tracked → server restart to test Stages 3-4.
+- `app/src/` (Stages 1-2) IS Revise-tracked; `pixi run test-pkg` must stay green (868 base + new).
+- Don't touch the SAVE path — borrow is READ-side only (CciaImage `load_pop_map`), so a user edit
+  still writes a normal per-vn sidecar.
+- Pop colours are stable per (valueName, path); the frontend colour map already accumulates
+  (see population-summary work) so pooled/borrowed pops render in their manager colours.

--- a/docs/todo/POPULATION_SUMMARY_PLAN.md
+++ b/docs/todo/POPULATION_SUMMARY_PLAN.md
@@ -1,0 +1,74 @@
+# Parked plan — Population summary plot + open UX queue
+
+Status snapshot for a session compaction. See `docs/todo/README.md` for the convention.
+
+## A. Population summary plot — IN FLIGHT on branch `feat/phenotype-population-summary` (NOT merged)
+
+**Goal.** One generalised "population summary" plot — cell/track **counts / proportion per
+population, across images** — hosted per popType on the module pages + the analysis board. Port of
+the old R `popsSummary` (boxplot / `geom_quasirandom` / jitter over `pop.n` / `pop.freq`).
+
+### Locked decisions
+- **One backbone, split by module page** (each spec carries ONE popType, so a page's summary canvas —
+  and the board's picker — is popType-homogeneous). The board then follows the ACTIVE slot's popType.
+- Two views from the same backbone:
+  - `count` → one bar per `(pop, image)`; `normalize` (Proportion toggle) → fraction.
+  - `boxplot`/`violin`/`strip`/`bar` with **no cell measure** → each **image** is a data point (its
+    pop count/proportion), grouped by pop → within-pop variability + between-pop comparison.
+- **Proportion denominator = `(uID, value_name)`** — clusters within B and within T each normalise to
+  their OWN tracked population per image (NOT pooled B+T). ("split by pop".)
+- **Keep the legend** (user reconsidered — needed when split by pop).
+
+### Done (committed on the branch)
+- Backend `app/src/plotting/plot_data.jl`: `_population_metric_frame` (per-`(value_name,pop,uID)`
+  count/fraction) + `_summary_agg` detects `measure===nothing` + distribution chart → runs the normal
+  distribution builders over per-image rows; `count` branch honours `normalize`; denominator keyed by
+  `(uID, value_name)`. Tests in `app/test/runtests.jl` ("plot count ... population summary").
+- Specs `app/src/plotDefinitions/population_summary{,_tracks,_clust,_trackclust}.json` — modules
+  `phenotype`(flow) / `behaviourAnalysis`(live,track) / `clustPops`(clust) / `clustTracks`(trackclust);
+  chartTypes `[boxplot,strip,violin,bar,count]`; `normalize` param; all `whiteboardCompatible`.
+- Frontend: new **Phenotype** page (`PhenotypeModule.vue`, route `/phenotype`, sidebar after Gate);
+  cluster pages host a collapsible `SummaryCanvas` below the cluster canvas; `SummaryPanel` hides the
+  measure picker + sends no measure for a measure-less (population) spec, and shows the Proportion
+  toggle for these; boxplot/strip raw points get a themed `stroke` so whitish colours read on the
+  white PDF/light ground.
+- Board: `useSummaryData` takes `activeSpecId` → popType/granularity follow the active slot's spec
+  (LayoutCanvas passes it). Prune-vanished-pops watches are **popType-aware** (only prune the current
+  popType's keys) so activating a trackclust slot no longer wipes the live/track plots' selections.
+- Board rail (`.lc-rail`) got right padding.
+- Docs: `docs/PLOTS.md` (population summary section).
+
+### OPEN / to verify after reload
+1. **Cluster pages missing the section?** User reported the population summary missing on Cluster
+   cells / Cluster tracks. Wiring looks correct (specs valid, module strings match, `#below-table`
+   renders); likely below-the-fold under the tall cluster canvas OR needs a page reload to fetch the
+   new spec JSONs. CONFIRM: is the "Population summary" collapsible present (scroll below the cluster
+   canvas)? If absent → render/hosting bug; if empty dropdown → backend not serving the clust specs.
+2. **Dot contrast** shipped as a themed stroke (outlines all points). If the user wants a true BLACK
+   FILL only for whitish series (not an outline on everything), that needs a per-series darkened
+   point colour — Plot shares one color scale per plot, so it needs a second identity color channel
+   or precomputed per-point fill. Refinement, not done.
+3. **Board mixed-popType colour degradation** (known limitation, not a reset): while a plot of popType
+   X is active, `popColors` only holds X's colours, so other-popType plots keep their selections but
+   may show pops in the fallback grey. Clean fix = per-slot pop data on the board (bigger refactor).
+4. **Verify end-to-end** on project `XcPcu8` (board: pop summary track clusters + behaviour track
+   measures/HMM) and `4kS67f`/img `3w4IY5` (B/T trackclust): (a) selecting the pop-summary slot no
+   longer resets other track plots; (b) proportions split by B/T; (c) boxplots render.
+- After merge: clean up `main`, delete the branch.
+
+## B. Pending UX queue (separate branches; from the running task list)
+
+- **#32 Image strip: channel colour legend** — optional legend on the image strip pulling each
+  channel's colour from the napari image layers + channel names (coloured caption like the reference).
+- **#36 Image strip: screengrab provenance + zoom-to-source** — store which image/timepoint/napari
+  viewer state a screengrab came from (napari-animation serialises viewer state), add a zoom button
+  next to re-grab to reopen that exact state.
+- **#37 Napari: movie/recorder toggle** — a "show recorder" button that pops up napari-animation to
+  record an animation. (#32/#36/#37 are the image-strip/napari batch — need napari running to verify.)
+
+## C. Notes
+- Backend `plot_data.jl` is Revise-tracked (reload picks it up); plot-definition JSONs are read from
+  disk per request (no restart). `api/src/*.jl` need a restart.
+- Task tracker drift: `#48` (module-page drag) is DONE (merged PR #121); `#39` done (Phenotype).
+- Every population-summary change must keep `pixi run test-pkg` (currently 868 pass, 1 pre-existing
+  broken) and `frontend` typecheck + 85 vitest green.

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -48,6 +48,7 @@ const groups: { heading: string; items: NavItem[] }[] = [
     items: [
       { to: '/segment', label: 'Segment', icon: 'pi-th-large',    tip: 'Run cell segmentation (Cellpose, StarDist, …).', requiresProject: true },
       { to: '/gate',    label: 'Gate',    icon: 'pi-chart-scatter',tip: 'FlowJo-style manual gating on segmented populations.', requiresProject: true },
+      { to: '/phenotype', label: 'Phenotype', icon: 'pi-percentage', tip: 'Summarise gated-cell populations — counts / proportion of each population across images (the analysis counterpart to Gate).', requiresProject: true },
       { to: '/track',   label: 'Track',   icon: 'pi-share-alt',   tip: 'Track segmented or gated cells over time (btrack).', requiresProject: true },
       { to: '/behaviour', label: 'Behaviour', icon: 'pi-chart-bar', tip: 'Summary plots of cell/track measures (speed, HMM states, …).', requiresProject: true },
       { to: '/clust-cells',  label: 'Cluster cells',  icon: 'pi-palette', tip: 'Leiden cluster cells (intensities + morphology), then define populations from clusters.', requiresProject: true },

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -123,6 +123,12 @@ const {
 } = useSummaryData({
   projectUid, imageUids: computed(() => props.imageUids), setUid, module: props.module,
   shared: computed(() => entry.value.shared),
+  // the board is mixed-popType: point the picker at the ACTIVE summary slot's spec so it surfaces that
+  // plot's popType (each population-summary spec carries one popType — split per module page).
+  activeSpecId: computed(() => {
+    const c = entry.value.contents[entry.value.activeIndex]
+    return c && c.kind === 'summary' ? c.ref : null
+  }),
 })
 
 // ── slot content: active slot, add/clear, drag-swap ──────────────────────────────────────────────

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -607,5 +607,5 @@ defineExpose({ capturePage, collectCsvs })
    dragstart bubbles to .lc-slot (@dragstart above). No absolute overlay grip here anymore. */
 .lc-add { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; }
 .lc-add-hint { color: var(--cc-text-dim); font-size: 11px; opacity: 0.6; }
-.lc-rail { flex-shrink: 0; width: 300px; overflow-y: auto; }
+.lc-rail { flex-shrink: 0; width: 300px; overflow-y: auto; padding-right: 10px; box-sizing: content-box; }
 </style>

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -607,5 +607,9 @@ defineExpose({ capturePage, collectCsvs })
    dragstart bubbles to .lc-slot (@dragstart above). No absolute overlay grip here anymore. */
 .lc-add { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; }
 .lc-add-hint { color: var(--cc-text-dim); font-size: 11px; opacity: 0.6; }
-.lc-rail { flex-shrink: 0; width: 300px; overflow-y: auto; padding-right: 10px; box-sizing: content-box; }
+/* stick to the top of the scroll viewport so the pop manager stays reachable as the (tall) board
+   scrolls past — otherwise you must scroll back up to change the selection. align-self so the sticky
+   box hugs the top of the flex row; its own overflow-y scrolls a manager taller than the viewport. */
+.lc-rail { flex-shrink: 0; width: 300px; overflow-y: auto; padding-right: 10px; box-sizing: content-box;
+  position: sticky; top: 8px; align-self: flex-start; max-height: calc(100vh - 16px); }
 </style>

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -117,7 +117,7 @@ watch(imageUid, () => nextTick(fitWidthIfOverflow), { immediate: true })
 
 // shared summary-plot data + view-state (same composable the free-floating canvas uses)
 const {
-  specs, specById, segPops, seriesColor, reloadToken, validSelKeys,
+  specs, specById, segPops, seriesColor, reloadToken, validSelKeys, popType,
   compareMode, compareAttr, compareAttr2, scope, gSel, gVis, poolGroups,
   canCompare, panelSetUid, panelImageUids, panelScope, panelGroupAttr, attrOptions2, setAttrs,
 } = useSummaryData({
@@ -277,10 +277,14 @@ function clusterPanelProps(i: number) {
 
 // prune vanished pops from every slot's local selection (the composable prunes the global one). Guard on
 // a non-empty segPops — it's transiently [] during load/image-switch, and pruning then would wipe (and
-// then persist-empty) a restored per-slot selection.
+// then persist-empty) a restored per-slot selection. popType-AWARE (mixed board): segPops holds only the
+// active slot's popType, so only prune keys of THAT popType — else selecting e.g. a trackclust slot would
+// wipe the live/track selections of the other (track-measure) plots.
 watch(segPops, () => {
   if (!segPops.value.length) return
-  for (const c of entry.value.contents) if (c && Array.isArray(st(c).sel)) st(c).sel = st(c).sel.filter(k => validSelKeys.value.has(k))
+  const valid = validSelKeys.value, pt = popType.value
+  const keep = (k: string) => parseTkey(k).popType !== pt || valid.has(k)
+  for (const c of entry.value.contents) if (c && Array.isArray(st(c).sel)) st(c).sel = st(c).sel.filter(keep)
 })
 
 // ── PDF export: capture each filled slot to a PNG (hiding the drag grips), keyed by its grid-area ──

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -69,7 +69,7 @@ provide(CANVAS_ZOOM_KEY, zoom)
 const { workspaceStyle } = useCanvasWorkspace(canvasRef, zoom)
 // shared summary-plot data + canvas-level view-state (identical whether plots float or sit in a grid)
 const {
-  specs, specById, segPops, seriesColor, reloadToken, validSelKeys,
+  specs, specById, segPops, seriesColor, reloadToken, validSelKeys, popType,
   compareMode, compareAttr, compareAttr2, scope, gSel, gVis, poolGroups,
   canCompare, panelSetUid, panelImageUids, panelScope, panelGroupAttr, attrOptions2, setAttrs,
 } = useSummaryData({ projectUid, imageUids: computed(() => props.imageUids), setUid, module: props.module, shared })
@@ -116,7 +116,12 @@ function explodePanel(src: { state: PanelState }, measures: string[]) {
 }
 
 // useSummaryData prunes the GLOBAL selection when pops vanish; prune each panel's LOCAL selection here.
-watch(segPops, () => { for (const p of panels.value) p.state.sel = p.state.sel.filter(k => validSelKeys.value.has(k)) })
+// popType-aware (keep other-popType keys) for parity with the board's mixed-popType prune.
+watch(segPops, () => {
+  const valid = validSelKeys.value, pt = popType.value
+  const keep = (k: string) => parseTkey(k).popType !== pt || valid.has(k)
+  for (const p of panels.value) p.state.sel = p.state.sel.filter(keep)
+})
 </script>
 
 <template>

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -512,7 +512,8 @@ defineExpose({ getCsv, exportImage })
               <option value="sd">SD</option>
             </select>
           </label>
-          <label v-else-if="chartType === 'frequency'" class="sp-pop-row">
+          <label v-else-if="chartType === 'frequency' || chartType === 'count'" class="sp-pop-row"
+                 v-tooltip.left="chartType === 'count' ? 'Plot each population’s FRACTION of its image’s (plotted) total instead of the raw count' : ''">
             <span>Proportion</span>
             <input type="checkbox" v-model="normalize" />
           </label>

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -88,6 +88,10 @@ const measureOpts = computed(() => {
 })
 // each option reads the persisted panel state, falling back to the spec default; writing persists it.
 const measure = computed<string>({ get: () => props.ui.measure ?? props.spec.dataSource.measure, set: v => (props.ui.measure = v) })
+// a spec with NO measure is a POPULATION SUMMARY (count / proportion of each pop) — no measure picker,
+// and never send a measure (the backend then treats boxplot/violin/strip/bar as a per-image count
+// distribution, and count as per-image bars). See plot_data.jl _population_metric_frame.
+const hasMeasure = computed(() => !!props.spec.dataSource.measure)
 // drop a persisted/selected measure that isn't available for the current data (avoids a 400 fetch).
 // Only act once columns have loaded (measuresFromData needs varCols; otherwise the transient fallback
 // list would reset the user's pick mid-load and it'd "cycle"). No-op writes are skipped by the guard.
@@ -349,8 +353,9 @@ async function fetchData() {
         projectUid: props.projectUid,
         popType: pt, granularity: props.spec.dataSource.granularity,
         chartType: be.chartType,
-        // count is a row count — no measure. Sending one would just fetch an unused column.
-        ...(chartType.value === 'count' ? {} : { measure: measure.value }),
+        // count is a row count — no measure. A measure-less (population summary) spec sends none for
+        // any chart, so the backend runs the per-image count/proportion distribution. Else send it.
+        ...(chartType.value === 'count' || !hasMeasure.value ? {} : { measure: measure.value }),
         series: targets.map(t => ({ valueName: t.valueName, pop: t.pop })),
         bins: bins.value,
         normalize: be.normalize ?? normalize.value,
@@ -442,7 +447,7 @@ defineExpose({ getCsv, exportImage })
     <template #actions>
       <!-- primary: what to plot + how (the single-measure picker is irrelevant for the matrix grid and
            for a row count) -->
-      <select v-if="chartType !== 'heatmap' && chartType !== 'count'" v-model="measure" class="sp-measure" v-tooltip.bottom="'Measure to plot'">
+      <select v-if="chartType !== 'heatmap' && chartType !== 'count' && hasMeasure" v-model="measure" class="sp-measure" v-tooltip.bottom="'Measure to plot'">
         <option v-for="m in measureOpts" :key="m" :value="m">{{ m }}</option>
       </select>
       <select v-if="validCharts.length > 1" v-model="chartType" class="sp-chart"
@@ -512,8 +517,8 @@ defineExpose({ getCsv, exportImage })
               <option value="sd">SD</option>
             </select>
           </label>
-          <label v-else-if="chartType === 'frequency' || chartType === 'count'" class="sp-pop-row"
-                 v-tooltip.left="chartType === 'count' ? 'Plot each population’s FRACTION of its image’s (plotted) total instead of the raw count' : ''">
+          <label v-else-if="chartType === 'frequency' || chartType === 'count' || !hasMeasure" class="sp-pop-row"
+                 v-tooltip.left="hasMeasure && chartType === 'frequency' ? '' : 'Plot each population’s FRACTION of its image’s (plotted) total instead of the raw count'">
             <span>Proportion</span>
             <input type="checkbox" v-model="normalize" />
           </label>

--- a/frontend/src/composables/useSummaryData.ts
+++ b/frontend/src/composables/useSummaryData.ts
@@ -85,24 +85,59 @@ export function useSummaryData(opts: {
     try { specs.value = await (await fetch(`/api/plots/definitions${q}`)).json() } catch { specs.value = [] }
   }
 
-  // populations across the selected images, grouped by segmentation
+  // populations across the selected images, grouped by segmentation (drives the picker — holds ONLY the
+  // active popType on the mixed board, since it follows the active slot).
   const segPops = ref<SegmentationPops[]>([])
-  const popColors = computed(() => {
-    const m = new Map<string, string>()
-    for (const g of segPops.value) for (const p of g.populations) m.set(`${g.valueName}${p.path}`, p.colour)
-    return m
-  })
-  async function loadPops() {
-    if (!imageUid.value && !imageUids.value.length) { segPops.value = []; return }
-    const p = new URLSearchParams({ projectUid: projectUid.value, popType: popType.value, granularity: granularity.value })
+  // Population colours, ACCUMULATING across popTypes (keyed `${valueName}${path}`; colours are stable).
+  // A plain computed(segPops) would drop every OTHER popType's colours the moment the active slot
+  // switches — so the non-active slots (and a full-board PDF export) render grey. We instead MERGE each
+  // load into a persistent map so once a popType's colours have loaded they stay available for its
+  // slots even while another popType is active; popmap reload re-merges to refresh any changed colour.
+  const popColors = ref(new Map<string, string>())
+  function mergeColors(groups: SegmentationPops[]) {
+    if (!groups.length) return
+    const m = new Map(popColors.value)
+    for (const g of groups) for (const p of g.populations) m.set(`${g.valueName}${p.path}`, p.colour)
+    popColors.value = m
+  }
+  function popsUrl(pt: string, gran: string) {
+    const p = new URLSearchParams({ projectUid: projectUid.value, popType: pt, granularity: gran })
     if (setUid.value) { p.set('setUid', setUid.value); if (imageUids.value.length) p.set('imageUids', imageUids.value.join(',')) }
     else if (imageUid.value) p.set('imageUid', imageUid.value)
-    try { segPops.value = await (await fetch(`/api/plots/populations?${p}`)).json() }
+    return `/api/plots/populations?${p}`
+  }
+  async function loadPops() {
+    if (!imageUid.value && !imageUids.value.length) { segPops.value = []; return }
+    try { segPops.value = await (await fetch(popsUrl(popType.value, granularity.value))).json() }
     catch { segPops.value = [] }
+    mergeColors(segPops.value)
+    warmColors()
+  }
+  // Pre-warm colours for EVERY (popType, granularity) among the specs — the board hosts a mix, but
+  // loadPops only fetches the ACTIVE slot's popType. Without this, a slot never made active has no
+  // colours, so a full-board PDF export paints it grey. Colours are stable → a single seed each is
+  // enough. No-op on module pages (one combo, already covered by loadPops).
+  async function warmColors() {
+    if (!imageUid.value && !imageUids.value.length) return
+    const combos = new Map<string, { pt: string; gran: string }>()
+    for (const s of specs.value)
+      combos.set(`${s.dataSource.popType}|${s.dataSource.granularity}`,
+                 { pt: s.dataSource.popType, gran: s.dataSource.granularity })
+    if (combos.size <= 1) return
+    await Promise.all([...combos.values()].map(async c => {
+      try { mergeColors(await (await fetch(popsUrl(c.pt, c.gran))).json()) } catch { /* ignore */ }
+    }))
   }
 
-  // series colour = the POPULATION colour so a population reads identically across images
-  function seriesColor(s: PlotSeries): string { return popColors.value.get(s.pop) ?? '#7c93b8' }
+  // series colour = the POPULATION colour so a population reads identically across images. A COMPUTED
+  // returning the resolver (not a plain function) so its IDENTITY changes whenever popColors updates →
+  // the panel's buildOpts (which captures colorOf) recomputes and the plot re-renders. A stable
+  // function reference would leave colours grey until the next data change — the "grey on load until I
+  // toggle a population" bug (colours arrive from loadPops AFTER the first render).
+  const seriesColor = computed(() => {
+    const m = popColors.value
+    return (s: PlotSeries): string => m.get(s.pop) ?? '#7c93b8'
+  })
 
   // live updates: the server broadcasts gating:popmap after any gate mutation — refetch pops + bump a
   // token so panels re-pull data (membership may change with no prop change). Prune vanished selections.

--- a/frontend/src/composables/useSummaryData.ts
+++ b/frontend/src/composables/useSummaryData.ts
@@ -20,6 +20,11 @@ export function useSummaryData(opts: {
   setUid: Ref<string | null>
   module: string | null | undefined
   shared: Ref<Record<string, unknown>>
+  // OPTIONAL: the id of the ACTIVE slot's spec (the universal board). When set, the population picker's
+  // popType/granularity follow the ACTIVE plot's spec instead of the first registered spec — so a mixed
+  // board (flow / live / clust / trackclust) surfaces the RIGHT pops for whichever plot is selected.
+  // Omitted on the per-module canvases (their specs share a popType, so specs[0] is correct).
+  activeSpecId?: Ref<string | null>
 }) {
   const { projectUid, imageUids, setUid, module } = opts
   const ws = useWsStore()
@@ -68,8 +73,13 @@ export function useSummaryData(opts: {
   // available plot specs (per-module registry; null module = universal → all specs)
   const specs = ref<PlotSpec[]>([])
   const specById = computed(() => Object.fromEntries(specs.value.map(s => [s.id, s])))
-  const popType = computed(() => specs.value[0]?.dataSource.popType ?? 'live')
-  const granularity = computed(() => specs.value.some(s => s.dataSource.granularity === 'track') ? 'track' : 'cell')
+  // active plot's spec (board only; each spec carries ONE popType because the plots are split per
+  // module page) — its popType/granularity drive the picker so a mixed board surfaces the right pops.
+  const activeSpec = computed(() => opts.activeSpecId?.value ? specById.value[opts.activeSpecId.value] : undefined)
+  const popType = computed(() => activeSpec.value?.dataSource.popType ?? specs.value[0]?.dataSource.popType ?? 'live')
+  const granularity = computed(() =>
+    activeSpec.value?.dataSource.granularity
+      ?? (specs.value.some(s => s.dataSource.granularity === 'track') ? 'track' : 'cell'))
   async function loadSpecs() {
     const q = module ? `?module=${encodeURIComponent(module)}` : ''
     try { specs.value = await (await fetch(`/api/plots/definitions${q}`)).json() } catch { specs.value = [] }

--- a/frontend/src/composables/useSummaryData.ts
+++ b/frontend/src/composables/useSummaryData.ts
@@ -2,7 +2,7 @@ import { ref, computed, watch, onMounted, onUnmounted, type Ref } from 'vue'
 import { useWsStore } from '../stores/ws'
 import { useDataRefresh } from './useDataRefresh'
 import { useViewState } from './useViewState'
-import { tkey } from '../plots/series'
+import { tkey, parseTkey } from '../plots/series'
 import { defaultVis, type VisProps } from '../plots/plot'
 import type { PlotSpec, PlotSeries, SegmentationPops } from '../plots/types'
 
@@ -126,7 +126,15 @@ export function useSummaryData(opts: {
   // prune the selection to populations that still exist — but ONLY once we actually have populations.
   // segPops is transiently [] during load / image-switch / a failed fetch; pruning then would wipe a
   // restored selection (and it would save back empty). Guard so an empty segPops never clears gSel.
-  watch(segPops, () => { if (segPops.value.length) gSel.value = gSel.value.filter(k => validSelKeys.value.has(k)) })
+  // popType-AWARE: only prune keys of the CURRENTLY-LOADED popType. On the mixed board (popType follows
+  // the active slot), segPops holds only one popType at a time — pruning blindly would drop the OTHER
+  // plots' selections (e.g. selecting a trackclust pop-summary slot wiped the track-measure plots'
+  // live/track pops). Keep any key whose popType isn't the current one; it belongs to another slot.
+  watch(segPops, () => {
+    if (!segPops.value.length) return
+    const valid = validSelKeys.value, pt = popType.value
+    gSel.value = gSel.value.filter(k => parseTkey(k).popType !== pt || valid.has(k))
+  })
   onMounted(async () => { ws.on('gating:popmap', onPopmap); await loadSpecs(); await loadPops(); await loadAttrs() })
   onUnmounted(() => ws.off('gating:popmap', onPopmap))
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -22,6 +22,7 @@ const router = createRouter({
     { path: '/cleanup',   component: () => import('./modules/CleanupModule.vue'),       meta: { label: 'Cleanup' } },
     { path: '/segment',   component: () => import('./modules/SegmentModule.vue'),       meta: { label: 'Segment' } },
     { path: '/gate',      component: () => import('./modules/GatingModule.vue'),        meta: { label: 'Gate' } },
+    { path: '/phenotype', component: () => import('./modules/PhenotypeModule.vue'),     meta: { label: 'Phenotype' } },
     { path: '/track',     component: () => import('./modules/TrackingModule.vue'),      meta: { label: 'Track' } },
     { path: '/behaviour', component: () => import('./modules/BehaviourModule.vue'),     meta: { label: 'Behaviour' } },
     { path: '/clust-cells',  component: () => import('./modules/ClusterCellsModule.vue'),  meta: { label: 'Cluster cells' } },

--- a/frontend/src/modules/ClusterCellsModule.vue
+++ b/frontend/src/modules/ClusterCellsModule.vue
@@ -12,6 +12,8 @@
 import ModuleLayout from '../components/ModuleLayout.vue'
 import TaskRunner from '../tasks/TaskRunner.vue'
 import ClusterPlots from './cluster/ClusterPlots.vue'
+import CollapsibleSection from '../components/CollapsibleSection.vue'
+import SummaryCanvas from '../components/canvas/SummaryCanvas.vue'
 import { useTaskDefs } from '../composables/useTaskDefs'
 
 const { defs: clustDefs, reload: reloadDefs } = useTaskDefs('clustPops')
@@ -30,6 +32,13 @@ const { defs: clustDefs, reload: reloadDefs } = useTaskDefs('clustPops')
     </template>
     <template #plots="{ selectedUids, selectUids }">
       <ClusterPlots :image-uids="selectedUids" :select-uids="selectUids" pop-type="clust" />
+    </template>
+    <!-- population summary of the cluster pops (counts / proportion per image; boxplot/beeswarm/bar) —
+         same backbone as Phenotype/Behaviour, popType clust so it's homogeneous here -->
+    <template #below-table="{ selectedUids }">
+      <CollapsibleSection label="Population summary" max-height="none" :storage-key="'cc-popsum-open:clustPops'">
+        <SummaryCanvas :image-uids="selectedUids" module="clustPops" />
+      </CollapsibleSection>
     </template>
   </ModuleLayout>
 </template>

--- a/frontend/src/modules/ClusterTracksModule.vue
+++ b/frontend/src/modules/ClusterTracksModule.vue
@@ -12,6 +12,8 @@
 import ModuleLayout from '../components/ModuleLayout.vue'
 import TaskRunner from '../tasks/TaskRunner.vue'
 import ClusterPlots from './cluster/ClusterPlots.vue'
+import CollapsibleSection from '../components/CollapsibleSection.vue'
+import SummaryCanvas from '../components/canvas/SummaryCanvas.vue'
 import { useTaskDefs } from '../composables/useTaskDefs'
 
 const { defs: clustDefs, reload: reloadDefs } = useTaskDefs('clustTracks')
@@ -30,6 +32,13 @@ const { defs: clustDefs, reload: reloadDefs } = useTaskDefs('clustTracks')
     </template>
     <template #plots="{ selectedUids, selectUids }">
       <ClusterPlots :image-uids="selectedUids" :select-uids="selectUids" pop-type="trackclust" />
+    </template>
+    <!-- population summary of the track-cluster pops (counts / proportion per image; boxplot/beeswarm/bar)
+         — same backbone as Phenotype/Behaviour, popType trackclust so it's homogeneous here -->
+    <template #below-table="{ selectedUids }">
+      <CollapsibleSection label="Population summary" max-height="none" :storage-key="'cc-popsum-open:clustTracks'">
+        <SummaryCanvas :image-uids="selectedUids" module="clustTracks" />
+      </CollapsibleSection>
     </template>
   </ModuleLayout>
 </template>

--- a/frontend/src/modules/PhenotypeModule.vue
+++ b/frontend/src/modules/PhenotypeModule.vue
@@ -1,0 +1,18 @@
+<!--
+  Phenotype module page — the analysis counterpart to Gate, exactly as Behaviour is to Track. Pick one
+  OR MORE images (multi-select), then phenotype the GATED populations in the summary-plot canvas below
+  the table: counts / proportion of each gated population, per image or pooled. Per-module canvas: only
+  `phenotype` plot specs are offered (popType `flow` — any gated cell, not just the derived `live`).
+-->
+<script setup lang="ts">
+import ModuleLayout from '../components/ModuleLayout.vue'
+import SummaryCanvas from '../components/canvas/SummaryCanvas.vue'
+</script>
+
+<template>
+  <ModuleLayout module="phenotype" :show-attrs="true" :show-filter="true">
+    <template #plots="{ selectedUids }">
+      <SummaryCanvas :image-uids="selectedUids" module="phenotype" />
+    </template>
+  </ModuleLayout>
+</template>

--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -722,6 +722,9 @@ function boxplot(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts,
                         fillOpacity: 0.55, stroke: 'currentColor', strokeWidth: 0.8, title: 'tip', tip: true, ...f }), // box
       RulePos(stat, { [a.posLo]: 'xlo', [a.posHi]: 'xhi', [a.meas]: 'median', stroke: 'currentColor', strokeWidth: 1.6, ...f }), // median
       ...(pts.length ? [Plot.dot(pts, { [a.pos]: 'xj', [a.meas]: 'value', r: o.pointSize, fill: ptFill,
+                                        // themed outline so a whitish series colour still reads on the
+                                        // white PDF / light ground (currentColor = dark there)
+                                        stroke: 'currentColor', strokeWidth: 0.5, strokeOpacity: 0.55,
                                         fillOpacity: o.pointOpacity, ...f })] : []),
       Plot.dot(stat, { [a.pos]: 'xi', [a.meas]: 'mean', symbol: 'diamond', fill: 'currentColor', r: 3.2, ...f }),  // mean
     ],
@@ -776,6 +779,8 @@ function strip(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts,
     [a.meas]: { label: r.measure, grid: false, ...logY },
     marks: [
       Plot.dot(rows, { [a.pos]: 'xj', [a.meas]: 'value', r: o.pointSize, fill: o.colorData ? 'series' : 'currentColor',
+                       // themed outline so whitish series colours read on the white PDF / light ground
+                       stroke: 'currentColor', strokeWidth: 0.5, strokeOpacity: 0.55,
                        fillOpacity: o.pointOpacity, ...fxCh(o) }),
     ],
   }

--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -300,12 +300,13 @@ export function buildPlotOptions(Plot: PlotModule, r: PlotDataResponse, o: Build
   if (!opts) return null
 
   // theme_classic L-shaped axis lines (Observable Plot draws ticks/labels but no domain line) —
-  // a single frame stroke on the left + bottom of every facet. `currentColor` picks up the theme ink.
+  // a single frame stroke on the left + bottom. `currentColor` picks up the theme ink. When FACETING
+  // (small multiples), Plot repeats each frame PER facet, so the left anchor becomes a vertical divider
+  // at every facet boundary — drop it and keep only the shared bottom baseline (the y-axis ticks still
+  // render on the leftmost facet).
   if (Array.isArray(opts.marks)) {
-    (opts.marks as unknown[]).push(
-      Plot.frame({ anchor: 'left', stroke: 'currentColor', strokeWidth: 1 }),
-      Plot.frame({ anchor: 'bottom', stroke: 'currentColor', strokeWidth: 1 }),
-    )
+    (opts.marks as unknown[]).push(Plot.frame({ anchor: 'bottom', stroke: 'currentColor', strokeWidth: 1 }))
+    if (!o.facet) (opts.marks as unknown[]).push(Plot.frame({ anchor: 'left', stroke: 'currentColor', strokeWidth: 1 }))
   }
 
   // ── generic post-process: layout / label / font knobs (R plotHelpers adjustments) ──


### PR DESCRIPTION
## Population summary + cluster pops go run-global

Builds on the population-summary work; the headline is that **cluster populations
(`clust`/`trackclust`) are now global to a clustering run across every segmentation
it spanned** — matching the old R `cciaObj$popDT(popType="clust", pops=c("A","B","C"))`,
which returned those pops across all clustered segmentations.

### Cluster pops: run-global
A single run (e.g. `clustTracks` over `B/qc/_tracked` + `T/qc/_tracked`) writes ONE
shared `clusters.{suffix}` column into each segment's table, but the *named* cluster
pops are authored under only one value_name. Two mechanisms make them run-global:
- **`co_clustered_value_names`** — the value_names whose clustfeatures sidecar carries
  the run's suffix (single source of truth for "which segmentations belong to a run").
- **Auto-share** — `load_pop_map(img; pop_type=clust|trackclust)` for a value_name with
  no own sidecar borrows a co-clustered sibling's named pops, relabeled to itself
  (read-side only; save still writes a per-vn sidecar). Reaches both the picker and
  `pop_df`. Guarded by the shared suffix so an unrelated segmentation never gets pops.
- **Bare-pop pooling** — `pop_df(popType=clust|trackclust, pops=["/A", …])` spans all
  co-clustered value_names, pooled + value_name-tagged; a `"T/A"` ref stays scoped.

### Population summary
- **Complete cases** (R `tidyr::complete`): a cluster missing in an image contributes a
  genuine **0**, not a dropped point — the distribution isn't biased.
- Friendly axis label (**count** / **proportion**) instead of the internal `__pop_metric`.

### Frontend
- Pop colours **accumulate across popTypes + pre-warm** on the board, and `seriesColor`
  is a computed so colours **repaint on load** (no more grey until you toggle a pop).
- **Sticky pop manager** on the board (follows the scroll).
- Faceting by segmentation no longer draws **vertical dividers** between facets.

### Docs / tests
- `docs/POPULATION.md` — run-global cluster pops. `docs/todo/CLUSTER_POOLING_PLAN.md` —
  staged plan (UMAP/heatmap pooling still to do).
- +auto-share & bare-pop expansion tests, +complete-cases. **881 pkg pass**, typecheck + **85 vitest** green.

### Not done yet (next)
UMAP + heatmap on the cluster page still show the active segmentation only — Stages 3–5
of `CLUSTER_POOLING_PLAN.md` (pool UMAP/heatmap across co-clustered segments) are the
follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)