### PR TITLE
Generalise popovers into TeleportPopover; CSV zip; gate-export square

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -124,7 +124,9 @@ reproduces the layout exactly (spans, plates, gaps), and `plots/pdf.ts` lays out
     silently clipped to a sub-rectangle → dots cut off (was visible in the board PDF *and* the
     module-page PNG export, since both share `exportCanvas`).
 - **CSV**: each summary/cluster panel exposes `getCsv()` (the shown aggregated data); the standalone CSV
-  button collects them all (→ Prism).
+  button collects them across ALL boards into ONE `analysis_csvs.zip` (one CSV per plot, → Prism) via
+  the dependency-free `utils/zip.ts` (STORE method) — a single download instead of dozens of
+  individual "allow multiple downloads" prompts.
 
 ## Cross-references
 `docs/UI.md` (generic plot-integration contract, `docked`, canvas shell), `docs/PLOTS.md` (summary-plot

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -243,8 +243,21 @@ Every module page uses this same slot, so the plot canvas collapses identically 
 `CollapsibleSection` props:
 - `label` — section heading (uppercased in the toggle bar)
 - `defaultOpen` — whether open on mount (default: `true`)
-- `maxHeight` — CSS `max-height` for the body (default: `'320px'`; pass `'none'` to allow full growth)
+- `maxHeight` — CSS `max-height` for the body (default: `'320px'`; pass `'none'` to allow full growth). With `'none'` the body is `overflow-y: visible` (not a scroll container) so a `position: sticky` descendant sticks to the outer page scroll instead of a box that never scrolls.
 - `storageKey` — when set, the open/closed state persists in localStorage under this key (the `#plots` wrapper uses this so a collapsed canvas stays collapsed across navigation)
+
+**Popovers — use `TeleportPopover`, don't hand-roll an absolute one.** Any ⚙/dropdown popover that
+lives inside a panel (canvas, table, plot) WILL be clipped by the panel's `overflow`/scroll/transform.
+`TeleportPopover` (`components/TeleportPopover.vue`) teleports to `<body>` so it escapes all of that,
+positions `fixed` from an anchor element, re-anchors on scroll/resize, carries the `.cc-dark` theme
+tokens, and dismisses on outside-click/Escape. Usage: `<TeleportPopover v-model="open" :anchor="btnEl"
+placement="bottom-end">…</TeleportPopover>` where `btnEl` is a template ref on the trigger. The
+popover owns only the shell (surface/border/shadow/position); the slot supplies the content + its own
+inner styling. It clamps to the viewport and flips above when there's no room below. Reuse this rather
+than another absolute/fixed popover that will clip or need its own dismiss/positioning logic — it is
+the single implementation, used by the image-strip settings, the image-table run-log cog, the board
+grid-size + custom-plate popovers, the summary-plot options, the gating-strategy options, and the
+gate-pairs channel picker.
 
 ### 2 — Register the route
 

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -10,6 +10,7 @@ import { isExcluded, isIncluded, includedUids } from '../utils/inclusion'
 import { timelapseDuration } from '../utils/imageTable'
 import { useNapariOpen } from '../composables/useNapariOpen'
 import PhysicalSizeDialog from './PhysicalSizeDialog.vue'
+import TeleportPopover from './TeleportPopover.vue'
 
 const props = defineProps<{
   setUid: string
@@ -162,24 +163,18 @@ async function saveNote(img: CciaImage, val: string) {
 const NOTE_KEY = '__note'
 
 // run-history popover (cog after the uid) — automatic per-image provenance (project store `runLog`).
-// position: fixed from the cog so it escapes the table's horizontal scroll clipping.
+// Uses the shared TeleportPopover (escapes the table's scroll clipping; positions from the cog).
 const runLogUid = ref<string | null>(null)
-const runLogPos = ref<Record<string, string>>({})
-// the image whose run-history popover is open (the popover is teleported to <body>, so it reads this)
+const runLogAnchor = ref<HTMLElement | null>(null)   // the clicked cog (drives popover placement)
 const runLogImg = computed(() => runLogUid.value ? (images.value.find(i => i.uid === runLogUid.value) ?? null) : null)
+// v-model for TeleportPopover: open when a uid is set; the component sets false on outside-click/Escape
+const runLogOpen = computed({ get: () => runLogUid.value !== null, set: v => { if (!v) runLogUid.value = null } })
 const fmtRunAt = (at: string) => (at ?? '').replace('T', ' ')
 function toggleRunLog(uid: string, e: MouseEvent) {
   if (runLogUid.value === uid) { runLogUid.value = null; return }
-  const r = (e.currentTarget as HTMLElement).getBoundingClientRect()
-  runLogPos.value = { position: 'fixed', top: `${Math.round(r.bottom + 4)}px`, left: `${Math.round(r.left)}px` }
+  runLogAnchor.value = e.currentTarget as HTMLElement
   runLogUid.value = uid
 }
-function onDocMouseDownRunLog(e: MouseEvent) {
-  const t = e.target as HTMLElement
-  if (runLogUid.value && !t.closest('.runlog-cell') && !t.closest('.runlog-pop')) runLogUid.value = null
-}
-onMounted(() => document.addEventListener('mousedown', onDocMouseDownRunLog))
-onUnmounted(() => document.removeEventListener('mousedown', onDocMouseDownRunLog))
 async function setIncluded(img: CciaImage, included: boolean) {
   const projectUid = projectMeta.current?.uid
   if (!projectUid) return
@@ -727,12 +722,10 @@ onUnmounted(stopResize)
     :set-uid="setUid" :focus-uid="physSizeDialogUid" :selected-uids="[...selected]"
     @close="physSizeDialogUid = null" />
 
-  <!-- run-history popover — teleported to <body> so it escapes the table's scroll/transform
-       containing block (was clipped by the following row); positioned (fixed) from the cog rect -->
-  <Teleport to="body">
-    <!-- carry the theme tokens (--cc-*) on the popover itself: teleported to <body> it's outside the
-         shell's .cc-dark wrapper, so var(--cc-surface-1) etc. would otherwise be undefined (transparent) -->
-    <div v-if="runLogImg" class="runlog-pop cc-dark" :style="runLogPos">
+  <!-- run-history popover — shared TeleportPopover escapes the table's scroll/transform clip and
+       positions from the cog rect (was clipped by the following row) -->
+  <TeleportPopover v-model="runLogOpen" :anchor="runLogAnchor">
+    <div v-if="runLogImg" class="runlog-pop">
       <div class="runlog-hd">Run history</div>
       <div v-if="!runLogImg.runLog || !runLogImg.runLog.length" class="runlog-empty">No functions recorded yet.</div>
       <div v-for="(e, i) in [...(runLogImg.runLog ?? [])].reverse()" :key="i" class="runlog-row">
@@ -741,7 +734,7 @@ onUnmounted(stopResize)
         <span class="runlog-at">{{ fmtRunAt(e.at) }}</span>
       </div>
     </div>
-  </Teleport>
+  </TeleportPopover>
 </template>
 
 <style scoped>
@@ -938,9 +931,8 @@ th:hover .resize-handle::after { opacity: 1; }
 /* run-history cog + popover (fixed so it escapes the table's horizontal scroll) */
 .runlog-cell { position: relative; display: inline-flex; flex-shrink: 0; }
 .runlog-cog.on { color: var(--cc-text); background: var(--cc-surface-2); opacity: 1; }
-.runlog-pop { z-index: 40; min-width: 15rem; max-height: 16rem; overflow-y: auto;
-  padding: 6px 8px; background: var(--cc-surface-1); border: 1px solid var(--cc-border);
-  border-radius: 5px; box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4); }
+/* inner layout only — TeleportPopover provides surface/border/shadow/position */
+.runlog-pop { min-width: 15rem; max-height: 16rem; overflow-y: auto; padding: 6px 8px; }
 .runlog-hd { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--cc-text-dim); margin-bottom: 4px; }
 .runlog-empty { font-size: 0.7rem; color: var(--cc-text-dim); }
 .runlog-row { display: flex; align-items: baseline; gap: 6px; padding: 2px 0; font-size: 0.7rem; }

--- a/frontend/src/components/TeleportPopover.vue
+++ b/frontend/src/components/TeleportPopover.vue
@@ -1,0 +1,101 @@
+<!--
+  Generalised popover: teleported to <body> so it ESCAPES any clipping/scroll/transform ancestor
+  (the recurring "my ⚙ popup gets clipped by the panel" bug — see ImageStripView, the run-log cog).
+  Positioned `fixed` from the anchor element's rect, re-anchored on scroll/resize while open, and
+  closed on outside-click or Escape. Teleported out of the app's `.cc-dark` shell, so it carries the
+  theme tokens itself (var(--cc-*) would otherwise be undefined → transparent).
+
+  Usage:
+    <button ref="gear" @click="open = !open">⚙</button>
+    <TeleportPopover v-model="open" :anchor="gear" placement="bottom-end">
+      …popover content…
+    </TeleportPopover>
+
+  The popover owns ONLY the shell (teleport + position + theme + dismiss); the caller supplies the
+  content + its own inner styling. Reuse this instead of hand-rolling another absolute-positioned
+  popover that will clip.
+-->
+<script setup lang="ts">
+import { ref, computed, watch, onBeforeUnmount, nextTick } from 'vue'
+
+const props = withDefaults(defineProps<{
+  modelValue: boolean
+  anchor: HTMLElement | null            // the trigger element (its rect drives placement)
+  placement?: 'bottom-start' | 'bottom-end'   // left- or right-aligned under the anchor
+  gap?: number                          // px gap between anchor and popover
+}>(), { placement: 'bottom-start', gap: 4 })
+
+const emit = defineEmits<{ 'update:modelValue': [boolean] }>()
+const popEl = ref<HTMLElement | null>(null)
+const pos = ref<{ top: number; left: number }>({ top: 0, left: 0 })
+
+// re-measure from the anchor rect, then clamp to the viewport and flip above when there's no room
+// below — so the popover is never clipped or off-screen regardless of where the (draggable) anchor
+// sits. bottom-end right-aligns to the anchor's right edge (width known post-render); bottom-start
+// left-aligns.
+function reposition() {
+  const a = props.anchor
+  if (!a) return
+  const r = a.getBoundingClientRect()
+  const w = popEl.value?.offsetWidth ?? 0
+  const h = popEl.value?.offsetHeight ?? 0
+  const vw = window.innerWidth, vh = window.innerHeight
+  let left = props.placement === 'bottom-end' ? r.right - w : r.left
+  left = Math.max(4, Math.min(left, vw - w - 4))
+  let top = r.bottom + props.gap
+  if (top + h > vh - 4) top = Math.max(4, r.top - h - props.gap)   // open above if it would overflow below
+  pos.value = { top: Math.round(top), left: Math.round(left) }
+}
+
+const style = computed(() => ({ position: 'fixed' as const, top: `${pos.value.top}px`, left: `${pos.value.left}px` }))
+
+function onDocPointer(e: PointerEvent) {
+  const t = e.target as Node
+  if (popEl.value?.contains(t) || props.anchor?.contains(t)) return   // click inside popover / anchor
+  emit('update:modelValue', false)
+}
+function onKey(e: KeyboardEvent) { if (e.key === 'Escape') emit('update:modelValue', false) }
+
+watch(() => props.modelValue, async (open) => {
+  if (open) {
+    await nextTick()                     // popover mounted → width known for bottom-end
+    reposition()
+    // capture-phase so a click inside a scroll container still dismisses; scroll/resize re-anchor.
+    document.addEventListener('pointerdown', onDocPointer, true)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('scroll', reposition, true)
+    window.addEventListener('resize', reposition)
+  } else {
+    document.removeEventListener('pointerdown', onDocPointer, true)
+    document.removeEventListener('keydown', onKey)
+    window.removeEventListener('scroll', reposition, true)
+    window.removeEventListener('resize', reposition)
+  }
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', onDocPointer, true)
+  document.removeEventListener('keydown', onKey)
+  window.removeEventListener('scroll', reposition, true)
+  window.removeEventListener('resize', reposition)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="modelValue" ref="popEl" class="cc-popover cc-dark" :style="style">
+      <slot />
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+/* teleported out of the shell → carry theme surface/border/shadow here; callers style their content */
+.cc-popover {
+  z-index: 1000;
+  background: var(--cc-surface-1);
+  border: 1px solid var(--cc-border);
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  color: var(--cc-text);
+}
+</style>

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -12,7 +12,7 @@
   under this tab's `canvasKey`; the parent (TabbedCanvas) :keys us by it so a tab switch rebinds.
 -->
 <script setup lang="ts">
-import { computed, watch, ref, provide, nextTick, useTemplateRef, onMounted, onUnmounted } from 'vue'
+import { computed, watch, ref, provide, nextTick, useTemplateRef } from 'vue'
 import { useCanvasZoom, CANVAS_ZOOM_KEY } from '../../composables/useCanvasZoom'
 import CanvasZoomControl from './CanvasZoomControl.vue'
 import { plotHostToImageURL } from '../../plots/export'
@@ -32,6 +32,7 @@ import type { LayoutTemplate } from '../../plots/layoutTemplates'
 import { INTERACTIVE_VIEWS } from './interactiveViews'
 import SeriesPicker from './SeriesPicker.vue'
 import PopulationManager from './PopulationManager.vue'
+import TeleportPopover from '../TeleportPopover.vue'
 import { CLUSTER_PANELS, isClusterPanel } from '../../modules/cluster/clusterPanels'
 
 const props = defineProps<{ imageUids: string[]; module?: string | null; canvasKey: string }>()
@@ -66,19 +67,13 @@ const platePresets = computed(() => {
 })
 
 // grid size + height controls live in a ⚙ popover so the board bar doesn't crowd; close on outside click
+// grid-size + custom-plate popovers use the shared TeleportPopover (escape the bar's clipping; the
+// component handles outside-click/Escape dismiss). Anchor = each trigger button.
 const optsOpen = ref(false)
-const optsRef = useTemplateRef<HTMLElement>('optsRef')
-// custom plate builder popover (Phase 3)
+const optsBtn = useTemplateRef<HTMLElement>('optsBtn')
 const builderOpen = ref(false)
-const builderRef = useTemplateRef<HTMLElement>('builderRef')
+const builderBtn = useTemplateRef<HTMLElement>('builderBtn')
 function applyCustomPlate(t: LayoutTemplate) { layout.applyTemplate(props.canvasKey, t); builderOpen.value = false }
-function onDocClick(e: MouseEvent) {
-  const t = e.target as Node
-  if (optsOpen.value && optsRef.value && !optsRef.value.contains(t)) optsOpen.value = false
-  if (builderOpen.value && builderRef.value && !builderRef.value.contains(t)) builderOpen.value = false
-}
-onMounted(() => document.addEventListener('mousedown', onDocClick))
-onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
 // board natural (unscaled) size — height from rows×rowHeight; width from the A4 page aspect (null in
 // Free mode, where the grid fills the available width).
 const boardH = computed(() => rowHeight.value * entry.value.rows + 8 * (entry.value.rows - 1))
@@ -367,23 +362,25 @@ defineExpose({ capturePage, collectCsvs })
             </button>
           </div>
           <!-- custom grid size + slot height, tucked into a ⚙ popover to keep the bar tidy -->
-          <div ref="optsRef" class="lc-opts">
-            <button class="lc-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+          <div class="lc-opts">
+            <button ref="optsBtn" class="lc-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
                     v-tooltip.bottom="'Grid size & slot height'"><i class="pi pi-sliders-h" /></button>
-            <div v-if="optsOpen" class="lc-pop">
-              <label class="lc-pop-row"><span>cols</span>
-                <input type="range" min="1" max="6" :value="entry.cols"
-                       @input="layout.applyTemplate(canvasKey, uniform(+($event.target as HTMLInputElement).value, entry.rows))" />
-                <span class="lc-val">{{ entry.cols }}</span></label>
-              <label class="lc-pop-row"><span>rows</span>
-                <input type="range" min="1" max="6" :value="entry.rows"
-                       @input="layout.applyTemplate(canvasKey, uniform(entry.cols, +($event.target as HTMLInputElement).value))" />
-                <span class="lc-val">{{ entry.rows }}</span></label>
-              <label class="lc-pop-row"><span>height</span>
-                <input type="range" min="160" max="720" step="10" :value="rowHeight"
-                       @input="rowHeight = +($event.target as HTMLInputElement).value" />
-                <span class="lc-val">{{ rowHeight }}</span></label>
-            </div>
+            <TeleportPopover v-model="optsOpen" :anchor="optsBtn">
+              <div class="lc-pop">
+                <label class="lc-pop-row"><span>cols</span>
+                  <input type="range" min="1" max="6" :value="entry.cols"
+                         @input="layout.applyTemplate(canvasKey, uniform(+($event.target as HTMLInputElement).value, entry.rows))" />
+                  <span class="lc-val">{{ entry.cols }}</span></label>
+                <label class="lc-pop-row"><span>rows</span>
+                  <input type="range" min="1" max="6" :value="entry.rows"
+                         @input="layout.applyTemplate(canvasKey, uniform(entry.cols, +($event.target as HTMLInputElement).value))" />
+                  <span class="lc-val">{{ entry.rows }}</span></label>
+                <label class="lc-pop-row"><span>height</span>
+                  <input type="range" min="160" max="720" step="10" :value="rowHeight"
+                         @input="rowHeight = +($event.target as HTMLInputElement).value" />
+                  <span class="lc-val">{{ rowHeight }}</span></label>
+              </div>
+            </TeleportPopover>
           </div>
           <!-- A4 sheet lock: keep the board at page proportions (WYSIWYG with the PDF) or let it fill -->
           <div class="seg" v-tooltip.bottom="'Sheet — A4 locks the board to page proportions (what you see is the exported page); Free fills the width'">
@@ -440,14 +437,16 @@ defineExpose({ capturePage, collectCsvs })
                     :class="{ on: entry.slotAreas.join('|') === t.slots.join('|') }">{{ t.label }}</button>
           </div>
           <!-- custom plate builder: drag cells to merge into varied-size panels -->
-          <div ref="builderRef" class="lc-opts">
-            <button class="cc-btn cc-btn-ghost lc-custom" :class="{ on: builderOpen }" @click="builderOpen = !builderOpen"
+          <div class="lc-opts">
+            <button ref="builderBtn" class="cc-btn cc-btn-ghost lc-custom" :class="{ on: builderOpen }" @click="builderOpen = !builderOpen"
                     v-tooltip.bottom="'Build a custom plate — drag cells to merge, click a merge to split'">
               <i class="pi pi-th-large" /> Custom…</button>
-            <div v-if="builderOpen" class="lc-pop">
-              <PlateBuilder :cols="entry.cols" :rows="entry.rows" :slot-areas="entry.slotAreas"
-                            @apply="applyCustomPlate" @cancel="builderOpen = false" />
-            </div>
+            <TeleportPopover v-model="builderOpen" :anchor="builderBtn">
+              <div class="lc-pop">
+                <PlateBuilder :cols="entry.cols" :rows="entry.rows" :slot-areas="entry.slotAreas"
+                              @apply="applyCustomPlate" @cancel="builderOpen = false" />
+              </div>
+            </TeleportPopover>
           </div>
         </div>
       </div>
@@ -562,9 +561,8 @@ defineExpose({ capturePage, collectCsvs })
 .lc-gear:hover, .lc-gear.on { color: var(--cc-text); border-color: #7c3aed; }
 .lc-custom { font-size: 11px; padding: 0.22rem 0.55rem; }
 .lc-custom.on { color: var(--cc-text); border-color: #7c3aed; }
-.lc-pop { position: absolute; top: calc(100% + 4px); left: 0; z-index: 20; min-width: 13rem;
-  display: flex; flex-direction: column; gap: 8px; padding: 10px; background: var(--cc-surface-1);
-  border: 1px solid var(--cc-border); border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,0.35); }
+/* inner layout only — TeleportPopover provides surface/border/shadow/position */
+.lc-pop { min-width: 13rem; display: flex; flex-direction: column; gap: 8px; padding: 10px; }
 .lc-pop-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--cc-text-dim); }
 .lc-pop-row span:first-child { width: 3rem; }
 .lc-pop-row input[type="range"] { flex: 1; }

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -10,8 +10,9 @@
   Rendered with Observable Plot (plots/plot.ts builds the options; PlotChart.vue renders + resizes).
 -->
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, onUnmounted, useTemplateRef } from 'vue'
+import { ref, computed, watch, onMounted, useTemplateRef } from 'vue'
 import CanvasPanel from './CanvasPanel.vue'
+import TeleportPopover from '../TeleportPopover.vue'
 import PlotChart from '../plots/PlotChart.vue'
 import PlotSpinner from '../plots/PlotSpinner.vue'
 import { useDelayedLoading } from '../../composables/useDelayedLoading'
@@ -207,40 +208,15 @@ const matrixCategory = computed<string>(() => {
 // the Category dropdown shows the effective default until the user picks one (then it persists).
 const categorySel = computed<string>({ get: () => matrixCategory.value, set: v => (groupBy.value = v) })
 
-// secondary-options popover (Split by + chart-specific control) — keeps the header bar uncluttered
+// secondary-options popover (Split by + chart-specific control) — keeps the header bar uncluttered.
+// Uses the shared TeleportPopover: escapes the panel's `overflow: hidden`, positions from the trigger
+// button, clamps to the viewport + flips above when needed, and self-dismisses. (Was a bespoke
+// fixed-position impl — folded into the one component so there's a single popover everywhere.)
 const optsOpen = ref(false)
-const optsRef = useTemplateRef<HTMLElement>('optsRef')
+const optsBtn = useTemplateRef<HTMLElement>('optsBtn')
 const hasOpts = computed(() => groupByOpts.value.length > 0
   || chartType.value === 'heatmap'
   || (['histogram', 'bar', 'frequency', 'count'] as ChartType[]).includes(chartType.value))
-// The options popover MUST escape the panel's `overflow: hidden` (the card clips the plot area), so it
-// is `position: fixed`, positioned from the trigger button on open and clamped to the viewport — never
-// clipped, regardless of where the (draggable) panel sits or which edge it's near. Any new plot popover
-// should follow this pattern rather than a plain absolute child of the panel. See docs/PLOTS.md §0.
-const popStyle = ref<Record<string, string>>({})
-watch(optsOpen, async open => {
-  if (!open) { popStyle.value = {}; return }
-  // stay OUT OF FLOW while measuring (fixed) so the popover never inflates the wrap — otherwise the
-  // anchor rect grows by the popover's own size and the placement is thrown off.
-  popStyle.value = { position: 'fixed', visibility: 'hidden' }
-  await nextTick()
-  const wrap = optsRef.value                        // inline-flex around just the button (popover is fixed)
-  const pop = wrap?.querySelector('.sp-pop') as HTMLElement | null
-  if (!wrap || !pop) return
-  const a = wrap.getBoundingClientRect(), w = pop.offsetWidth, h = pop.offsetHeight
-  const vw = window.innerWidth, vh = window.innerHeight
-  let left = a.right - w                            // right-aligned to the button…
-  if (left < 4) left = a.left                       // …flipped rightward if that clips the left edge
-  left = Math.max(4, Math.min(left, vw - w - 4))
-  let top = a.bottom + 4
-  if (top + h > vh - 4) top = Math.max(4, a.top - h - 4)   // open above if no room below
-  popStyle.value = { position: 'fixed', top: `${top}px`, left: `${left}px`, right: 'auto', visibility: 'visible' }
-})
-function onDocClick(e: MouseEvent) {
-  if (optsOpen.value && optsRef.value && !optsRef.value.contains(e.target as Node)) optsOpen.value = false
-}
-onMounted(() => document.addEventListener('mousedown', onDocClick))
-onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
 // friendly menu labels (the internal ChartType value stays as-is, e.g. 'strip' renders a beeswarm)
 const CHART_LABELS: Partial<Record<ChartType, string>> = { strip: 'beeswarm', stacked100: '100% stacked', trend: 'trend (mean/t)', count: 'count' }
 const chartLabel = (c: ChartType) => CHART_LABELS[c] ?? c
@@ -456,12 +432,13 @@ defineExpose({ getCsv, exportImage })
       </select>
 
       <!-- secondary options (split-by + chart-specific) tucked into a popover to keep the bar tidy -->
-      <div v-if="hasOpts" ref="optsRef" class="sp-pop-wrap">
-        <button class="sp-iconbtn" type="button" :class="{ on: optsOpen }" @click.stop="optsOpen = !optsOpen"
+      <div v-if="hasOpts" class="sp-pop-wrap">
+        <button ref="optsBtn" class="sp-iconbtn" type="button" :class="{ on: optsOpen }" @click.stop="optsOpen = !optsOpen"
                 v-tooltip.bottom="'Plot options'">
           <i class="pi pi-sliders-h" />
         </button>
-        <div v-if="optsOpen" class="sp-pop" :style="popStyle" @click.stop>
+        <TeleportPopover v-model="optsOpen" :anchor="optsBtn" placement="bottom-end">
+        <div class="sp-pop" @click.stop>
           <!-- generic split-by (sub-axis) for the per-series charts; the heatmap uses Category below -->
           <label v-if="chartType !== 'heatmap' && groupByOpts.length" class="sp-pop-row"
                  v-tooltip.left="'Split the measure by a categorical column (e.g. HMM state)'">
@@ -533,6 +510,7 @@ defineExpose({ getCsv, exportImage })
             </label>
           </template>
         </div>
+        </TeleportPopover>
       </div>
 
     </template>
@@ -609,9 +587,8 @@ defineExpose({ getCsv, exportImage })
    top/left are set inline on open (see the popStyle watcher). fixed here (not just inline) keeps it out
    of flow on the first render frame too, so it never inflates the anchor wrap. Only the box look + this
    positioning mode live here. New plot popovers should reuse this pattern (docs/PLOTS.md §0). */
-.sp-pop { position: fixed; z-index: 40; min-width: 11rem;
-  display: flex; flex-direction: column; gap: 6px; padding: 8px; border: 1px solid var(--cc-border);
-  border-radius: 6px; background: var(--cc-surface-2); box-shadow: 0 6px 18px rgba(0,0,0,0.4); }
+/* inner layout only — TeleportPopover provides surface/border/shadow/position */
+.sp-pop { min-width: 11rem; display: flex; flex-direction: column; gap: 6px; padding: 8px; }
 .sp-pop-row { display: flex; align-items: center; justify-content: space-between; gap: 8px;
   font-size: 12px; color: var(--cc-text-dim); }
 .sp-pop-row select { font-size: 12px; max-width: 7rem; }

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -15,6 +15,7 @@ import { useAnalysisTabsStore } from '../../stores/analysisTabs'
 import { useCanvasPanelsStore } from '../../stores/canvasPanels'
 import { exportTabsToPdf } from '../../plots/pdf'
 import { downloadBlob } from '../../plots/export'
+import { zipTextFiles } from '../../utils/zip'
 import { useLogStore } from '../../stores/log'
 import LayoutCanvas from './LayoutCanvas.vue'
 import ConfirmButton from '../ConfirmButton.vue'
@@ -95,28 +96,32 @@ async function exportPdf() {
   } finally { exporting.value = false }
 }
 
-// Export the shown data of every summary plot as one CSV per plot (ready to re-plot in Prism). Same
-// visit-each-tab dance as the PDF (only the active board is mounted); the browser may prompt once to
-// allow multiple downloads.
+// Export the shown data of every summary plot — collected across all boards into ONE .zip (one CSV
+// per plot, ready to re-plot in Prism). Same visit-each-tab dance as the PDF (only the active board is
+// mounted); a single zip download replaces the old dozens-of-CSVs "allow multiple downloads" prompt.
 async function exportCsv() {
   if (exporting.value || !group.value || !tabs.value.length) return
   exporting.value = true
   const original = group.value.activeId
   try {
-    let n = 0
+    const files: { name: string; text: string }[] = []
     for (const t of tabs.value) {
       tabsStore.setActive(groupKey, t.id)
       await nextTick()
       await new Promise(r => setTimeout(r, 600))   // let the board's plots fetch before reading their data
       for (const { name, csv } of layoutRef.value?.collectCsvs?.() ?? []) {
         if (!csv) continue
-        downloadBlob(`${safe(t.name)}_${safe(name)}.csv`, new Blob([csv], { type: 'text/csv' }))
-        n++
+        files.push({ name: `${safe(t.name)}_${safe(name)}.csv`, text: csv })
       }
     }
     tabsStore.setActive(groupKey, original)
     await nextTick()
-    log.info(n ? `Exported ${n} plot CSV${n === 1 ? '' : 's'}.` : 'No summary-plot data to export.', { source: 'analysis' })
+    if (files.length) {
+      downloadBlob('analysis_csvs.zip', zipTextFiles(files))
+      log.info(`Exported ${files.length} plot CSV${files.length === 1 ? '' : 's'} → analysis_csvs.zip.`, { source: 'analysis' })
+    } else {
+      log.info('No summary-plot data to export.', { source: 'analysis' })
+    }
   } catch (e) {
     log.error(`CSV export failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'analysis' })
   } finally { exporting.value = false }

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -211,6 +211,12 @@ defineExpose({ exportImage, hiRes, getHost: () => hostEl.value })
 /* compact tiles can be smaller than the full-size 150px plot floor — lift it so the plot shrinks to the
    (square) tile instead of overflowing and being clipped by the cell (the pairs matrix packs small tiles). */
 .plot-capture.compact .panel-plot { min-height: 0; }
+/* montage square (gm-plot carries aspect-ratio:1): a min-height OVERRIDES aspect-ratio, so when the
+   cell is narrower than the 218px floor (e.g. a slim slot in the A4-fit PDF export) the plot is pinned
+   tall and stops being square — the "flow plots elongate on export" bug. Drop the floors so the square
+   aspect-ratio always wins; the plot just gets smaller, never stretched. */
+.plot-capture.gm-plot { min-height: 0; }
+.plot-capture.gm-plot .panel-plot { min-height: 0; }
 /* no-axis (pairs matrix): no axis-name labels → drop the padding they lived in so the scatter fills
    the tile. Small uniform inset just for the axis lines / tick marks. */
 .plot-capture.no-axis { padding: 6px 6px 10px 12px; }

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -11,7 +11,8 @@
   GateScatterCell as the Gate page. No second gate renderer, no store mutation.
 -->
 <script setup lang="ts">
-import { ref, computed, watch, useTemplateRef, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, useTemplateRef } from 'vue'
+import TeleportPopover from '../TeleportPopover.vue'
 import type { GateSpec, TransformSpec, PopNode, PopTree } from '../../stores/gating'
 import { useDataRefresh } from '../../composables/useDataRefresh'
 import { orientGate } from '../../plots/gateGeometry'
@@ -39,12 +40,9 @@ const renderMode = computed({ get: () => props.state.renderMode ?? 'points', set
 const showHierarchy = computed({ get: () => props.state.showHierarchy ?? false, set: v => (props.state.showHierarchy = v) })
 const setImageUid = (v: string) => (props.state.imageUid = v)
 
-// size + the hierarchy toggle live in a ⚙ popover; close on an outside click.
+// size + the hierarchy toggle live in a ⚙ popover (shared TeleportPopover — no clip, self-dismissing).
 const optsOpen = ref(false)
-const optsRef = useTemplateRef<HTMLElement>('optsRef')
-function onDocClick(e: MouseEvent) { if (optsOpen.value && optsRef.value && !optsRef.value.contains(e.target as Node)) optsOpen.value = false }
-onMounted(() => document.addEventListener('mousedown', onDocClick))
-onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
+const gearBtn = useTemplateRef<HTMLElement>('gearBtn')
 
 const valueNames = ref<string[]>([])
 // intensity columns + display names (aligned) → resolve raw axis keys (mean_intensity_2) to channel
@@ -198,14 +196,16 @@ defineExpose({ exportImage })
         <option v-for="p in flatPaths" :key="p" :value="p">{{ p }}</option>
       </select>
       <RenderModeToggle v-model="renderMode" />
-      <div ref="optsRef" class="gs-opts">
-        <button class="gs-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+      <div class="gs-opts">
+        <button ref="gearBtn" class="gs-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
                 v-tooltip.bottom="'Plot size & hierarchy'"><i class="pi pi-cog" /></button>
-        <div v-if="optsOpen" class="gs-pop">
-          <label class="gs-check"><input type="checkbox" :checked="showHierarchy"
-                 @change="showHierarchy = ($event.target as HTMLInputElement).checked" />
-            show gating hierarchy</label>
-        </div>
+        <TeleportPopover v-model="optsOpen" :anchor="gearBtn" placement="bottom-end">
+          <div class="gs-pop">
+            <label class="gs-check"><input type="checkbox" :checked="showHierarchy"
+                   @change="showHierarchy = ($event.target as HTMLInputElement).checked" />
+              show gating hierarchy</label>
+          </div>
+        </TeleportPopover>
       </div>
     </div>
 
@@ -233,9 +233,8 @@ defineExpose({ exportImage })
 .gs-gear { background: var(--cc-surface-2); color: var(--cc-text-dim); border: 1px solid var(--cc-border);
   border-radius: 5px; padding: 4px 8px; cursor: pointer; font-size: 12px; }
 .gs-gear.on { background: var(--cc-accent); color: #fff; border-color: var(--cc-accent); }
-.gs-pop { position: absolute; top: calc(100% + 4px); right: 0; z-index: 20; width: 13rem;
-  display: flex; flex-direction: column; gap: 8px; padding: 10px; background: var(--cc-surface-1);
-  border: 1px solid var(--cc-border); border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,0.35); }
+/* inner layout only — TeleportPopover provides surface/border/shadow/position */
+.gs-pop { width: 13rem; display: flex; flex-direction: column; gap: 8px; padding: 10px; }
 .gs-check { display: flex; align-items: center; gap: 6px; color: var(--cc-text); font-size: 12px; }
 .seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
 .seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 4px 8px; cursor: pointer; font-size: 12px; }

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -7,8 +7,9 @@
   parallelograms — cheap because the slot stays rectangular and holds image-only content, decision 10).
 -->
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef, nextTick } from 'vue'
+import { ref, computed, watch, useTemplateRef, nextTick } from 'vue'
 import { elementToImageURL } from '../../plots/export'
+import TeleportPopover from '../TeleportPopover.vue'
 
 interface Cell { src?: string; caption?: string }
 const props = defineProps<{
@@ -36,10 +37,7 @@ watch(orientation, o => { if (o === 'v' && separator.value === 'angled') separat
 // separator options (angle / width) live in a ⚙ popover (like the heatmap panel's options) so they
 // never widen the toolbar; close on an outside click.
 const optsOpen = ref(false)
-const optsRef = useTemplateRef<HTMLElement>('optsRef')
-function onDocClick(e: MouseEvent) { if (optsOpen.value && optsRef.value && !optsRef.value.contains(e.target as Node)) optsOpen.value = false }
-onMounted(() => document.addEventListener('mousedown', onDocClick))
-onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
+const gearEl = useTemplateRef<HTMLElement>('gearEl')   // anchor for the teleported settings popover
 
 const capturing = ref(-1)
 const err = ref('')
@@ -112,22 +110,24 @@ defineExpose({ exportImage })
                 @click="separator = 'angled'"
                 v-tooltip.bottom="orientation === 'v' ? 'Angled separators are horizontal-only' : ''">angled</button>
       </div>
-      <div ref="optsRef" class="is-opts">
-        <button class="is-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+      <div class="is-opts">
+        <button ref="gearEl" class="is-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
                 v-tooltip.bottom="'Caption size & separator'"><i class="pi pi-cog" /></button>
-        <div v-if="optsOpen" class="is-pop">
-          <label class="is-slider">caption
-            <input type="range" min="8" max="28" :value="capSize" @input="capSize = +($event.target as HTMLInputElement).value" />
-            <span class="is-val">{{ capSize }}</span></label>
-          <template v-if="separator === 'angled' && orientation === 'h'">
-            <label class="is-slider">angle
-              <input type="range" min="0" max="80" :value="skew" @input="skew = +($event.target as HTMLInputElement).value" />
-              <span class="is-val">{{ skew }}</span></label>
-            <label class="is-slider">width
-              <input type="range" min="1" max="12" :value="thick" @input="thick = +($event.target as HTMLInputElement).value" />
-              <span class="is-val">{{ thick }}</span></label>
-          </template>
-        </div>
+        <TeleportPopover v-model="optsOpen" :anchor="gearEl" placement="bottom-end">
+          <div class="is-pop">
+            <label class="is-slider">caption
+              <input type="range" min="8" max="28" :value="capSize" @input="capSize = +($event.target as HTMLInputElement).value" />
+              <span class="is-val">{{ capSize }}</span></label>
+            <template v-if="separator === 'angled' && orientation === 'h'">
+              <label class="is-slider">angle
+                <input type="range" min="0" max="80" :value="skew" @input="skew = +($event.target as HTMLInputElement).value" />
+                <span class="is-val">{{ skew }}</span></label>
+              <label class="is-slider">width
+                <input type="range" min="1" max="12" :value="thick" @input="thick = +($event.target as HTMLInputElement).value" />
+                <span class="is-val">{{ thick }}</span></label>
+            </template>
+          </div>
+        </TeleportPopover>
       </div>
       <button class="is-btn" @click="addCell" v-tooltip.bottom="'Add a frame'"><i class="pi pi-plus" /> frame</button>
       <span v-if="err" class="is-err">{{ err }}</span>
@@ -168,9 +168,8 @@ defineExpose({ exportImage })
   border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-2); color: var(--cc-text-dim);
   cursor: pointer; font-size: 0.72rem; }
 .is-gear:hover, .is-gear.on { color: var(--cc-text); border-color: #7c3aed; }
-.is-pop { position: absolute; top: calc(100% + 4px); left: 0; z-index: 30; display: flex; flex-direction: column; gap: 6px;
-  padding: 8px 10px; background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 6px;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.4); }
+/* inner layout only — the teleported TeleportPopover shell provides surface/border/shadow/position */
+.is-pop { display: flex; flex-direction: column; gap: 6px; padding: 8px 10px; }
 .is-val { min-width: 1.2rem; text-align: right; font-weight: 700; color: var(--cc-text); }
 .is-err { color: #fca5a5; font-size: 11px; }
 .is-slider { display: inline-flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: 11px; }
@@ -204,9 +203,11 @@ defineExpose({ exportImage })
 .is-cap-input:focus { outline: none; background: rgba(0,0,0,0.35); }
 .is-cap-input::placeholder { color: rgba(255,255,255,0.55); font-weight: 400; }
 .is-cap-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-/* per-frame actions (recapture / remove): BOTTOM-right, above the auto-hide toolbar (z-index 6) which
-   overlays the TOP of the frame on hover and used to mask them (the "retake button is masked" bug) */
-.is-actions { position: absolute; bottom: 4px; right: 4px; display: flex; gap: 4px; z-index: 7; }
+/* per-frame actions (recapture / remove): TOP-right. The BOTTOM band is owned by the panel footer
+   overlay (Duplicate / Export) — the actions used to collide with the Duplicate button there. The top
+   band only holds the LEFT-aligned strip toolbar, so top-right is clear; z-index 7 keeps them above
+   the auto-hide toolbar (z-index 6) so hovering never masks them (the earlier "retake masked" bug). */
+.is-actions { position: absolute; top: 4px; right: 4px; display: flex; gap: 4px; z-index: 7; }
 .is-mini { width: 1.4rem; height: 1.4rem; display: inline-flex; align-items: center; justify-content: center;
   border: 1px solid var(--cc-border); border-radius: 3px; background: rgba(0,0,0,0.45); color: #fff;
   cursor: pointer; font-size: 0.6rem; }

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -9,7 +9,8 @@
   GateMontage (feedback_use_existing_framework); the tiles come from the pure buildPairDefs.
 -->
 <script setup lang="ts">
-import { ref, computed, watch, useTemplateRef, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, useTemplateRef } from 'vue'
+import TeleportPopover from '../../components/TeleportPopover.vue'
 import { useGatingStore } from '../../stores/gating'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
@@ -66,10 +67,7 @@ const reloadKey = computed(() =>
 
 // channel picker (compact popover)
 const pickOpen = ref(false)
-const pickRef = useTemplateRef<HTMLElement>('pickRef')
-function onDocClick(e: MouseEvent) { if (pickOpen.value && pickRef.value && !pickRef.value.contains(e.target as Node)) pickOpen.value = false }
-onMounted(() => document.addEventListener('mousedown', onDocClick))
-onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
+const pickBtn = useTemplateRef<HTMLElement>('pickBtn')   // anchor for the shared channel-picker popover
 const atCap = computed(() => channels.value.length >= MAX_CHANNELS)
 function toggleChannel(c: string) {
   const cur = channels.value
@@ -135,26 +133,28 @@ function exportPng() {
       </label>
       <div class="ax-row">
         <span class="ax-lbl">chans</span>
-        <div ref="pickRef" class="chan-pick">
-          <button class="chan-btn" :class="{ on: pickOpen }" @click="pickOpen = !pickOpen"
+        <div class="chan-pick">
+          <button ref="pickBtn" class="chan-btn" :class="{ on: pickOpen }" @click="pickOpen = !pickOpen"
                   v-tooltip.bottom="'Choose the channels to plot against each other'">
             {{ channels.length ? `${channels.length} selected` : 'select channels' }} <i class="pi pi-chevron-down" />
           </button>
-          <div v-if="pickOpen" class="chan-pop">
-            <div class="chan-pop-head">
-              <span>{{ channels.length }}/{{ MAX_CHANNELS }}</span>
-              <button class="chan-clear" :disabled="!channels.length" @click="clearChannels">clear</button>
+          <TeleportPopover v-model="pickOpen" :anchor="pickBtn">
+            <div class="chan-pop">
+              <div class="chan-pop-head">
+                <span>{{ channels.length }}/{{ MAX_CHANNELS }}</span>
+                <button class="chan-clear" :disabled="!channels.length" @click="clearChannels">clear</button>
+              </div>
+              <div class="chan-list">
+                <label v-for="c in g.columns" :key="c" class="chan-item"
+                       :class="{ disabled: !channels.includes(c) && atCap }">
+                  <input type="checkbox" :checked="channels.includes(c)"
+                         :disabled="!channels.includes(c) && atCap" @change="toggleChannel(c)" />
+                  <span>{{ g.colLabel(c) }}</span>
+                </label>
+              </div>
+              <div v-if="atCap" class="chan-cap">Max {{ MAX_CHANNELS }} channels ({{ MAX_CHANNELS * (MAX_CHANNELS - 1) / 2 }} scatter plots). Clear one to swap.</div>
             </div>
-            <div class="chan-list">
-              <label v-for="c in g.columns" :key="c" class="chan-item"
-                     :class="{ disabled: !channels.includes(c) && atCap }">
-                <input type="checkbox" :checked="channels.includes(c)"
-                       :disabled="!channels.includes(c) && atCap" @change="toggleChannel(c)" />
-                <span>{{ g.colLabel(c) }}</span>
-              </label>
-            </div>
-            <div v-if="atCap" class="chan-cap">Max {{ MAX_CHANNELS }} channels ({{ MAX_CHANNELS * (MAX_CHANNELS - 1) / 2 }} scatter plots). Clear one to swap.</div>
-          </div>
+          </TeleportPopover>
         </div>
         <select class="tsel" :class="{ 'tsel-amber': coerced }" v-model="transform"
                 v-tooltip.bottom="'Axis transform (per channel; auto-linear where the range needs it)'">
@@ -202,9 +202,8 @@ function exportPng() {
   background: var(--cc-surface-2); color: var(--cc-text); border: 1px solid var(--cc-border);
   border-radius: 5px; padding: 3px 8px; cursor: pointer; font-size: 12px; }
 .chan-btn.on { border-color: var(--cc-accent); }
-.chan-pop { position: absolute; top: calc(100% + 4px); left: 0; z-index: 30; width: 15rem; max-width: 80vw;
-  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 6px;
-  box-shadow: 0 6px 18px rgba(0,0,0,0.35); padding: 6px; }
+/* inner layout only — TeleportPopover provides surface/border/shadow/position */
+.chan-pop { width: 15rem; max-width: 80vw; padding: 6px; }
 .chan-pop-head { display: flex; align-items: center; justify-content: space-between; padding: 2px 4px 6px;
   color: var(--cc-text-dim); font-size: 11px; border-bottom: 1px solid var(--cc-border); }
 .chan-clear { background: none; border: none; color: var(--cc-accent); cursor: pointer; font-size: 11px; }

--- a/frontend/src/utils/zip.test.ts
+++ b/frontend/src/utils/zip.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { crc32, zipTextFiles } from './zip'
+
+const enc = new TextEncoder()
+
+describe('crc32', () => {
+  it('matches the standard "123456789" check value', () => {
+    expect(crc32(enc.encode('123456789'))).toBe(0xcbf43926)
+  })
+  it('is 0 for empty input', () => {
+    expect(crc32(new Uint8Array(0))).toBe(0)
+  })
+})
+
+describe('zipTextFiles', () => {
+  async function bytes(files: { name: string; text: string }[]) {
+    return new Uint8Array(await zipTextFiles(files).arrayBuffer())
+  }
+  const u32 = (b: Uint8Array, o: number) => new DataView(b.buffer, b.byteOffset).getUint32(o, true)
+  const u16 = (b: Uint8Array, o: number) => new DataView(b.buffer, b.byteOffset).getUint16(o, true)
+  const countSig = (b: Uint8Array, sig: number) => {
+    let n = 0
+    for (let i = 0; i + 4 <= b.length; i++) if (u32(b, i) === sig) n++
+    return n
+  }
+
+  it('writes one local + one central record per file and a matching EOCD count', async () => {
+    const b = await bytes([{ name: 'a.csv', text: 'x,y\n1,2\n' }, { name: 'b.csv', text: 'p\n9\n' }])
+    expect(countSig(b, 0x04034b50)).toBe(2)              // local file headers
+    expect(countSig(b, 0x02014b50)).toBe(2)              // central directory records
+    const eocd = b.length - 22                            // no zip comment
+    expect(u32(b, eocd)).toBe(0x06054b50)
+    expect(u16(b, eocd + 10)).toBe(2)                    // total entries
+  })
+
+  it('stores the exact bytes + crc of each file (STORE, no compression)', async () => {
+    const text = 'hello,world\n'
+    const b = await bytes([{ name: 'a.csv', text }])
+    const data = enc.encode(text)
+    expect(u32(b, 8)).toBe(0)                             // method 0 = store
+    expect(u32(b, 14)).toBe(crc32(data))                 // crc in local header
+    expect(u32(b, 18)).toBe(data.length)                 // compressed size == size
+    const nameLen = u16(b, 26)
+    const stored = b.slice(30 + nameLen, 30 + nameLen + data.length)
+    expect(new TextDecoder().decode(stored)).toBe(text)
+  })
+
+  it('disambiguates duplicate names', async () => {
+    const b = await bytes([{ name: 'plot.csv', text: '1' }, { name: 'plot.csv', text: '2' }])
+    const dec = new TextDecoder().decode(b)
+    expect(dec).toContain('plot.csv')
+    expect(dec).toContain('plot (2).csv')
+  })
+})

--- a/frontend/src/utils/zip.ts
+++ b/frontend/src/utils/zip.ts
@@ -1,0 +1,121 @@
+// Minimal, dependency-free ZIP builder (STORE method — no compression). Enough to bundle a handful
+// of text files (e.g. the analysis board's per-plot CSVs) into ONE download instead of dozens of
+// separate "allow multiple downloads" prompts. Store (not deflate) keeps this tiny and dependency-
+// free; CSVs zip is a convenience, not a size optimisation. Format: PKZIP APPNOTE 6.3.2 — local file
+// headers + central directory + end-of-central-directory. Time/date are stamped 0 (we don't thread a
+// clock through the UI, and archive timestamps don't matter here).
+
+// CRC-32 (IEEE 802.3, the polynomial ZIP requires). Lazily-built lookup table.
+let CRC_TABLE: Uint32Array | null = null
+function crcTable(): Uint32Array {
+  if (CRC_TABLE) return CRC_TABLE
+  const t = new Uint32Array(256)
+  for (let n = 0; n < 256; n++) {
+    let c = n
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    t[n] = c >>> 0
+  }
+  CRC_TABLE = t
+  return t
+}
+export function crc32(bytes: Uint8Array): number {
+  const t = crcTable()
+  let c = 0xffffffff
+  for (let i = 0; i < bytes.length; i++) c = t[(c ^ bytes[i]) & 0xff] ^ (c >>> 8)
+  return (c ^ 0xffffffff) >>> 0
+}
+
+interface ZipEntry { name: string; data: Uint8Array; crc: number; offset: number }
+
+// Build a ZIP Blob from named text files. Duplicate names are disambiguated (`x.csv` → `x (2).csv`).
+export function zipTextFiles(files: { name: string; text: string }[]): Blob {
+  const enc = new TextEncoder()
+  const seen = new Map<string, number>()
+  const parts: Uint8Array[] = []
+  const entries: ZipEntry[] = []
+  let offset = 0
+
+  for (const f of files) {
+    let name = f.name
+    const dupe = seen.get(name)
+    if (dupe !== undefined) { const next = dupe + 1; seen.set(name, next); name = uniquify(name, next) }
+    else seen.set(name, 1)
+    const nameBytes = enc.encode(name)
+    const data = enc.encode(f.text)
+    const crc = crc32(data)
+    const header = localHeader(nameBytes, data.length, crc)
+    entries.push({ name, data, crc, offset })
+    parts.push(header, nameBytes, data)
+    offset += header.length + nameBytes.length + data.length
+  }
+
+  const central: Uint8Array[] = []
+  let cdSize = 0
+  for (const e of entries) {
+    const nameBytes = enc.encode(e.name)
+    const rec = centralHeader(nameBytes, e.data.length, e.crc, e.offset)
+    central.push(rec, nameBytes)
+    cdSize += rec.length + nameBytes.length
+  }
+  const eocd = endOfCentralDir(entries.length, cdSize, offset)
+  // cast: TS's BlobPart wants ArrayBufferView<ArrayBuffer>, but our Uint8Arrays infer as
+  // Uint8Array<ArrayBufferLike>; they're plain ArrayBuffer-backed, so this is safe.
+  return new Blob([...parts, ...central, eocd] as BlobPart[], { type: 'application/zip' })
+}
+
+// `x.csv` (n=2) → `x (2).csv`; extensionless → `x (2)`
+function uniquify(name: string, n: number): string {
+  const dot = name.lastIndexOf('.')
+  return dot > 0 ? `${name.slice(0, dot)} (${n})${name.slice(dot)}` : `${name} (${n})`
+}
+
+function localHeader(nameBytes: Uint8Array, size: number, crc: number): Uint8Array {
+  const b = new Uint8Array(30); const v = new DataView(b.buffer)
+  v.setUint32(0, 0x04034b50, true)  // local file header signature
+  v.setUint16(4, 20, true)          // version needed
+  v.setUint16(6, 0, true)           // flags
+  v.setUint16(8, 0, true)           // method: store
+  v.setUint16(10, 0, true)          // mod time
+  v.setUint16(12, 0, true)          // mod date
+  v.setUint32(14, crc, true)
+  v.setUint32(18, size, true)       // compressed size (== uncompressed for store)
+  v.setUint32(22, size, true)       // uncompressed size
+  v.setUint16(26, nameBytes.length, true)
+  v.setUint16(28, 0, true)          // extra length
+  return b
+}
+
+function centralHeader(nameBytes: Uint8Array, size: number, crc: number, offset: number): Uint8Array {
+  const b = new Uint8Array(46); const v = new DataView(b.buffer)
+  v.setUint32(0, 0x02014b50, true)  // central dir header signature
+  v.setUint16(4, 20, true)          // version made by
+  v.setUint16(6, 20, true)          // version needed
+  v.setUint16(8, 0, true)           // flags
+  v.setUint16(10, 0, true)          // method: store
+  v.setUint16(12, 0, true)          // mod time
+  v.setUint16(14, 0, true)          // mod date
+  v.setUint32(16, crc, true)
+  v.setUint32(20, size, true)
+  v.setUint32(24, size, true)
+  v.setUint16(28, nameBytes.length, true)
+  v.setUint16(30, 0, true)          // extra length
+  v.setUint16(32, 0, true)          // comment length
+  v.setUint16(34, 0, true)          // disk number start
+  v.setUint16(36, 0, true)          // internal attrs
+  v.setUint32(38, 0, true)          // external attrs
+  v.setUint32(42, offset, true)     // local header offset
+  return b
+}
+
+function endOfCentralDir(count: number, cdSize: number, cdOffset: number): Uint8Array {
+  const b = new Uint8Array(22); const v = new DataView(b.buffer)
+  v.setUint32(0, 0x06054b50, true)  // EOCD signature
+  v.setUint16(4, 0, true)           // disk number
+  v.setUint16(6, 0, true)           // cd start disk
+  v.setUint16(8, count, true)       // entries this disk
+  v.setUint16(10, count, true)      // entries total
+  v.setUint32(12, cdSize, true)
+  v.setUint32(16, cdOffset, true)
+  v.setUint16(20, 0, true)          // comment length
+  return b
+}


### PR DESCRIPTION
## Generalise popovers into one component; CSV zip; gate-export square

### One popover implementation
New `components/TeleportPopover.vue` — the canonical popover: teleports to
`<body>` (escapes any clipping/scroll/transform ancestor), positions `fixed` from
an anchor element, **clamps to the viewport + flips above** when there's no room
below, carries `.cc-dark` tokens, and dismisses on outside-click/Escape. Migrated
**every** bespoke popover onto it and deleted their hand-rolled
positioning/outside-click/CSS:
- image-strip settings, image-table **run-log cog**, board **grid-size** +
  **custom-plate**, **summary-plot options** (folded its bespoke fixed-clamp logic
  into the component), **gating-strategy options**, **gate-pairs channel picker**.

No more 2–3 variants of the same thing; reuse `TeleportPopover` for any new one.

### Image strip
Moved the per-frame capture/actions from bottom-right → **top-right** so they no
longer collide with the panel footer's Duplicate button (bottom band = footer;
top band only has the left-aligned toolbar).

### Analysis board CSV → single zip
The CSV button now bundles every plot's data across all boards into ONE
**`analysis_csvs.zip`** (one CSV per plot) instead of dozens of individual
"allow multiple downloads" prompts. Dependency-free `utils/zip.ts` (STORE +
CRC32), unit-tested.

### Gate PDF export — flow plots stay square
Flow plots elongated on export because the montage square (`.gm-plot`,
`aspect-ratio: 1`) inherited `.plot-capture`'s `min-height: 218px`, and a
`min-height` **overrides** `aspect-ratio` once the slot is narrower than the
floor. Dropped the `min-height` floors on `.gm-plot` so the square aspect always
wins (the plot just shrinks on a narrow slot, never stretches).

### Docs / tests
`docs/UI.md` (popover convention + full user list), `docs/ANALYSIS.md` (CSV zip).
+`utils/zip` tests (crc32 check value + zip structure). **typecheck clean, 90 vitest.**

### Not browser-verified
Popover open/placement/dismiss/flip (esp. SummaryPanel + gate-pairs), the
image-strip top-right actions, and the gate-export square on a narrow slot — worth
a quick visual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)