### PR TITLE
Fix gate flow plots elongating on PDF export (square the dots, not th…

### DIFF
--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -259,12 +259,17 @@ const corrFont = (r: number | null | undefined) => `${Math.round(13 + Math.abs(r
 .gm-grid.cc-light { --cc-text: #111; --cc-text-dim: #555; --cc-border: #c9ccd1; --cc-bg: #fff; --cc-surface-2: #f0f0f3; }
 .gm-cell { display: flex; flex-direction: column; min-height: 0; border: 1px solid var(--cc-border);
   border-radius: 5px; overflow: hidden; background: var(--cc-bg); }
-/* montage plot area is SQUARE. Cap the width in wrap mode so a wide column doesn't make it so tall the
-   x-axis label drops out of view; in matrix mode fill the column so the grid stays aligned. */
-.gm-plot { flex: none; width: 100%; max-width: 320px; aspect-ratio: 1; margin: 0 auto; }
-.gm-grid.matrix .gm-plot { max-width: none; }
+/* montage plot area is SQUARE — but the SQUARE is the DOTS (.panel-plot in GateScatterCell), not this
+   outer box: the capture's axis padding is asymmetric (room for the rotated y-name + the x-name below),
+   so squaring the OUTER box made the dots taller than wide ("flow plots elongate on export"). We size
+   the width here and let GateScatterCell square its .panel-plot; the outer box heights to fit. Cap the
+   width in wrap mode so a wide column doesn't grow the tile too tall.
+   EXCEPTION — the pairs MATRIX keeps a square OUTER box (aspect-ratio:1) so scatter tiles line up with
+   the square diagonal/correlation cells; its axis padding is tiny+near-symmetric so the dots stay square. */
+.gm-plot { flex: none; width: 100%; max-width: 320px; margin: 0 auto; }
+.gm-grid.matrix .gm-plot { max-width: none; aspect-ratio: 1; }
 .gm-grid.single .gm-cell { container-type: size; }
-.gm-grid.single .gm-plot { flex: none; aspect-ratio: 1; min-height: 0; max-width: none;
+.gm-grid.single .gm-plot { flex: none; min-height: 0; max-width: none;
   width: min(100cqw, calc(100cqh - 26px)); margin: 0 auto; }
 /* diagonal label cell (matrix): channel name centred, matches the tile square */
 .gm-diag { align-items: center; justify-content: center; aspect-ratio: 1; background: var(--cc-surface-2);

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -211,12 +211,16 @@ defineExpose({ exportImage, hiRes, getHost: () => hostEl.value })
 /* compact tiles can be smaller than the full-size 150px plot floor — lift it so the plot shrinks to the
    (square) tile instead of overflowing and being clipped by the cell (the pairs matrix packs small tiles). */
 .plot-capture.compact .panel-plot { min-height: 0; }
-/* montage square (gm-plot carries aspect-ratio:1): a min-height OVERRIDES aspect-ratio, so when the
-   cell is narrower than the 218px floor (e.g. a slim slot in the A4-fit PDF export) the plot is pinned
-   tall and stops being square — the "flow plots elongate on export" bug. Drop the floors so the square
-   aspect-ratio always wins; the plot just gets smaller, never stretched. */
-.plot-capture.gm-plot { min-height: 0; }
-.plot-capture.gm-plot .panel-plot { min-height: 0; }
+/* montage tiles (board gating-strategy + wrap): the SQUARE must be the PLOT AREA (.panel-plot, the dots),
+   NOT this outer capture box. The axis padding is asymmetric (84+22 horizontal for the rotated y-name vs
+   18+50 vertical for the x-name), so squaring the outer box left the dots ~38px taller than wide — the
+   "flow plots elongate on export" bug. Square .panel-plot instead and let the capture height to fit; the
+   dots then stay square on screen AND in every export path (single capW/capH + the multi-tile host rect
+   both reflect the real geometry). align-items:flex-start so the aspect-ratio drives the height rather
+   than flex stretch. The pairs MATRIX (.no-axis) keeps its own square-cell alignment — excluded here. */
+.plot-capture.gm-plot:not(.no-axis), .plot-capture.compact:not(.no-axis) { flex: none; min-height: 0; align-items: flex-start; }
+.plot-capture.gm-plot:not(.no-axis) .panel-plot,
+.plot-capture.compact:not(.no-axis) .panel-plot { flex: none; width: 100%; min-height: 0; aspect-ratio: 1; }
 /* no-axis (pairs matrix): no axis-name labels → drop the padding they lived in so the scatter fills
    the tile. Small uniform inset just for the axis lines / tick marks. */
 .plot-capture.no-axis { padding: 6px 6px 10px 12px; }


### PR DESCRIPTION
## Gate flow plots elongating on PDF export — square the dots, not the box

Flow/gate scatter plots are coord-fixed squares on screen but rendered **elongated** in the Analysis-board PDF export.

### Cause
The gating-strategy montage put `aspe* `.gm-plot` box, but `.plot-capture`'s axis padding is asymmetric — `84 + 22 = 106px` horizontal (room for the rotated y-axis name) vs `18 + 50 = 68px` vertical (x-axis name). A  leaves the actual **plot area (thedots) ~38px taller than wide**. (An earlier `min-height:0` fix removed a different distortion but never
touched this one.)

### Fix
Square the **plot area** (`.panel-plot`, the dots) instead of the outer box, and let the capture height to fit around it.

- `GateMontage.vue` — dropped `aspect-ratio:1` from the outer `.gm-plot` (wrap + single). Kept it**only** for the pairs matrix (`.gm-grid.matrix`), which needs square outer cells to line up with the diagonal/correlation cells.
- `GateScatterCell.vue` — `.panel-plot` now carries `aspect-ratio:1` in the montage contexts (`align-items:flex-start` so the ratio drives height, not flex stretch); the matrix (`.no-axis`) isexcluded.

Because every export path measures the real geometry (single-cell export uses the capture box; multi-tile draws each tile at its on-screen host rect), squaring the dots layer fixes it uniformly —**screen, single-cell PDF, and multi-tile PDF** — with no export-code changes. Side benefit: the on-screen board tiles are now truly square too (they were slightly elongated before).

### Notes
- CSS-only; no logic/test surface.
- Verified on the board (single-gate strategy + multi-gate hierarchy). Pairs matrix on the Gate page isuntouched by design but shares these components.