### PR TITLE
Generalise delete confirmation into one ConfirmDeleteButton

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -158,8 +158,32 @@ if direct children of the host.
 ```
 
 `needsConfirm=false` makes `arm` fire immediately with no arm step (e.g. closing an already-empty
-board). Used by the sidebar/Settings **Quit**, the board close in `TabbedCanvas`, and the
-metadata-attribute delete. For a bigger modal decision (not a single button), use `BaseModal`.
+board). Used by the sidebar/Settings **Quit** and the board close in `TabbedCanvas`. For a bigger
+modal decision (not a single button), use `BaseModal`.
+
+#### Delete affordance — `ConfirmDeleteButton` (the app-wide standard)
+
+For a **destructive icon delete** (label set, population, attribute, notebook, chain, node, …) use
+**`frontend/src/components/ConfirmDeleteButton.vue`** — the ONE delete affordance. It's a single icon
+button that arms on the first click (**trash → warning triangle, solid danger fill**) and fires
+`@confirm` on the second (the ViewerPanel labels pattern D picked as the standard). It **wraps**
+`ConfirmButton` for the arm/confirm/dismiss logic and renders its own self-contained chrome (`.cc-del`)
+— self-styled *because* it must look identical everywhere (and hosts' scoped `.opt-btn`/`.pm-icon`/
+`.wb-btn` classes can't reach a button rendered inside it anyway). Don't hand-roll a per-site
+icon-flip or a Confirm+Cancel pair for deletes; that inconsistency is exactly what this replaced.
+
+```vue
+<ConfirmDeleteButton title="Delete population"
+                     armed-title="Click again to delete this population"
+                     @confirm="deletePop(path)" />
+```
+
+Props: `title` / `armedTitle` (tooltips), `disabled`, `needsConfirm`, `autoDismissMs`; default slot →
+a text label beside the icon (e.g. "Delete set"). Tooltip position is PrimeVue's default + its
+out-of-bounds flip (a `tip` prop can't drive position — dynamic directive modifiers aren't possible).
+For a host with a **hover-reveal** row action, target the inner button with `:deep(.cc-del)` (see
+`ViewerPanel`). The louder **named** text confirms for whole-image / whole-set deletion (`ImageTable`,
+`SetBar`: "Delete NAME? [Confirm] [Cancel]") are a deliberate higher tier and stay as-is.
 
 ---
 

--- a/frontend/src/components/ConfirmDeleteButton.vue
+++ b/frontend/src/components/ConfirmDeleteButton.vue
@@ -1,0 +1,57 @@
+<!--
+  The ONE delete affordance for the whole app — a single icon button that ARMS on the first click
+  (trash → warning, solid danger fill) and fires @confirm on the second (the ViewerPanel labels
+  pattern D picked as the standard). Before this, delete confirmations diverged: some flipped one icon,
+  some sprouted a Confirm+Cancel pair, some deleted instantly. Use this everywhere a destructive icon
+  action needs an inline "are you sure" (docs/UI.md → confirm-delete).
+
+  It WRAPS ConfirmButton for the arm/confirm/cancel + auto-dismiss + outside-click logic (so that
+  logic lives in exactly one place) and adds the standard, self-contained chrome — self-styled because
+  hosts' button classes (opt-btn / pm-icon / wb-btn / btn-danger) are component-scoped and can't reach
+  a button rendered here; a single owned style is also what makes the affordance identical app-wide.
+
+  <ConfirmDeleteButton title="Delete label set from disk"
+                       armed-title="Click again to permanently delete"
+                       @confirm="deleteLabel(vn)" />
+  Optional default slot → a text label beside the icon (e.g. "Delete set"). Tooltip position is left to
+  PrimeVue's default + out-of-bounds flip (dynamic modifiers can't be set from a prop).
+-->
+<script setup lang="ts">
+import ConfirmButton from './ConfirmButton.vue'
+
+withDefaults(defineProps<{
+  title?: string            // tooltip while idle (the verb, e.g. "Delete population")
+  armedTitle?: string       // tooltip once armed
+  disabled?: boolean
+  needsConfirm?: boolean     // false → deletes on the FIRST click (no arm step)
+  autoDismissMs?: number
+}>(), {
+  title: 'Delete', armedTitle: 'Click again to confirm', disabled: false,
+  needsConfirm: true, autoDismissMs: 3500,
+})
+defineEmits<{ confirm: [] }>()
+</script>
+
+<template>
+  <ConfirmButton :needs-confirm="needsConfirm" :auto-dismiss-ms="autoDismissMs" @confirm="$emit('confirm')"
+                 v-slot="{ armed, arm, confirm }">
+    <button type="button" class="cc-del" :class="{ armed }" :disabled="disabled"
+            @click.stop="armed ? confirm() : arm()"
+            v-tooltip="{ value: armed ? armedTitle : title }">
+      <i class="pi" :class="armed ? 'pi-exclamation-triangle' : 'pi-trash'" />
+      <span v-if="$slots.default" class="cc-del-lbl"><slot /></span>
+    </button>
+  </ConfirmButton>
+</template>
+
+<style scoped>
+/* compact, self-contained danger icon button (dim by default → danger on hover → solid danger when
+   armed), so it reads the same in every toolbar/row/footer. */
+.cc-del { display: inline-flex; align-items: center; gap: 5px; background: none;
+  border: 1px solid transparent; border-radius: 5px; color: var(--cc-text-dim); cursor: pointer;
+  padding: 4px 6px; font-size: 12px; line-height: 1; }
+.cc-del:hover:not(:disabled) { color: var(--cc-danger); background: var(--cc-surface-2); }
+.cc-del.armed { color: #fff; background: var(--cc-danger); border-color: var(--cc-danger); }
+.cc-del:disabled { opacity: 0.35; cursor: not-allowed; }
+.cc-del-lbl { white-space: nowrap; }
+</style>

--- a/frontend/src/components/NotebookTable.vue
+++ b/frontend/src/components/NotebookTable.vue
@@ -4,6 +4,7 @@
 // examples are read-only (duplicate-into-project only). See docs/todo/NOTEBOOK_PLAYGROUND_PLAN.md.
 import { ref, onMounted, watch } from 'vue'
 import { useLogStore } from '../stores/log'
+import ConfirmDeleteButton from './ConfirmDeleteButton.vue'
 
 const props = defineProps<{
   projectUid: string
@@ -142,10 +143,7 @@ async function restore(nb: Notebook) {
 }
 
 // Two-click delete confirm (no modal dependency).
-const confirmingDelete = ref<string | null>(null)
-async function remove(nb: Notebook) {
-  if (confirmingDelete.value !== nb.file) { confirmingDelete.value = nb.file; return }
-  confirmingDelete.value = null
+async function remove(nb: Notebook) {   // confirmation handled by ConfirmDeleteButton
   busy.value = true
   try {
     // force: the two-click confirm IS the user's confirmation; satisfies the server-running guard.
@@ -252,14 +250,9 @@ defineExpose({ refresh })
               <i class="pi pi-history" />
             </button>
 
-            <button v-if="nb.scope === 'project'"
-                    class="cc-btn cc-btn-ghost" :class="{ 'nbt-danger': confirmingDelete === nb.file }"
-                    :disabled="busy" @click="remove(nb)"
-                    v-tooltip.top="confirmingDelete === nb.file
-                      ? (serverRunning ? 'Server running — close this notebook in Pluto first, then click to confirm' : 'Click again to confirm')
-                      : 'Delete'">
-              <i class="pi" :class="confirmingDelete === nb.file ? 'pi-check' : 'pi-trash'" />
-            </button>
+            <ConfirmDeleteButton v-if="nb.scope === 'project'" :disabled="busy" title="Delete"
+                    :armed-title="serverRunning ? 'Server running — close this notebook in Pluto first, then click to confirm' : 'Click again to confirm'"
+                    @confirm="remove(nb)" />
           </td>
         </tr>
 

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -5,6 +5,7 @@ import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import { useWsStore } from '../stores/ws'
 import { useLogStore } from '../stores/log'
+import ConfirmDeleteButton from './ConfirmDeleteButton.vue'
 
 const projectStore = useProjectStore()
 const projectMeta  = useProjectMetaStore()
@@ -299,22 +300,7 @@ async function toggleLabel(valueName: string) {
   }
 }
 
-// Inline two-click delete confirmation (no browser popup): first click arms the row (the trash flips
-// to a warning icon), a second click within a few seconds actually deletes; otherwise it disarms.
-const confirmDeleteVn = ref<string | null>(null)
-let confirmTimer: ReturnType<typeof setTimeout> | null = null
-function onDeleteClick(valueName: string) {
-  if (confirmDeleteVn.value === valueName) {        // second click → confirmed
-    if (confirmTimer) { clearTimeout(confirmTimer); confirmTimer = null }
-    confirmDeleteVn.value = null
-    deleteLabel(valueName)
-  } else {                                          // first click → arm, auto-disarm after 3.5s
-    confirmDeleteVn.value = valueName
-    if (confirmTimer) clearTimeout(confirmTimer)
-    confirmTimer = setTimeout(() => { confirmDeleteVn.value = null; confirmTimer = null }, 3500)
-  }
-}
-
+// two-click delete → the shared ConfirmDeleteButton (arms trash → warning, second click deletes).
 async function deleteLabel(valueName: string) {
   const uid        = projectStore.napariImageUid
   const projectUid = projectMeta.current?.uid
@@ -485,11 +471,10 @@ onUnmounted(() => {
             @click="toggleTrack(vn)"
             v-tooltip.right="trackVns[vn] ? 'Hide this segmentation\'s tracks' : 'Show this segmentation\'s tracks'"
           ><i class="pi pi-share-alt" /></button>
-          <button
-            class="opt-btn danger row-act" :class="{ 'confirm': confirmDeleteVn === vn }"
-            @click="onDeleteClick(vn)"
-            v-tooltip.right="confirmDeleteVn === vn ? 'Click again to permanently delete this label set' : 'Delete label set from disk'"
-          ><i :class="confirmDeleteVn === vn ? 'pi pi-exclamation-triangle' : 'pi pi-trash'" /></button>
+          <ConfirmDeleteButton class="row-act"
+            title="Delete label set from disk"
+            armed-title="Click again to permanently delete this label set"
+            @confirm="deleteLabel(vn)" />
         </div>
       </div>
     </template>
@@ -634,9 +619,11 @@ onUnmounted(() => {
 /* row action icons (eye / directions / trash): hidden until the row is hovered to keep the narrow
    sidebar uncluttered; an ACTIVE toggle (shown layer/tracks) stays visible so state is readable */
 .row-act { opacity: 0; transition: opacity 0.12s; }
-.viewer-label-row:hover .row-act, .row-act.active, .row-act.confirm { opacity: 1; }
-/* armed delete: clearly red so the second-click-to-confirm state is obvious */
-.opt-btn.danger.confirm { color: #fff; background: #ef4444; border-color: #ef4444; }
+.viewer-label-row:hover .row-act, .row-act.active { opacity: 1; }
+/* the delete affordance is the shared ConfirmDeleteButton (its own .cc-del button); apply the same
+   hover-reveal to it via :deep, and keep it visible while armed so the confirm step never vanishes. */
+.viewer-label-row :deep(.cc-del) { opacity: 0; transition: opacity 0.12s; }
+.viewer-label-row:hover :deep(.cc-del), .viewer-label-row :deep(.cc-del.armed) { opacity: 1; }
 
 /* ── Option toggles ──────────────────────────────────────────────────── */
 

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -20,6 +20,7 @@ import { useLogStore } from '../../stores/log'
 import { useProjectStore } from '../../stores/project'
 import { useSettingsStore } from '../../stores/settings'
 import PopulationPanelShell from './PopulationPanelShell.vue'
+import ConfirmDeleteButton from '../ConfirmDeleteButton.vue'
 import type { VisProps } from '../../plots/plot'
 
 const props = withDefaults(defineProps<{
@@ -171,10 +172,9 @@ async function addClusterPopulation() {
                   @click.stop="toggleNapari(p)">
             <i class="pi pi-images" />
           </button>
-          <button v-if="!p.transient && !readonly" class="pm-icon danger" v-tooltip.left="'Delete population'"
-                  @click.stop="g.deletePop(p.path)">
-            <i class="pi pi-trash" />
-          </button>
+          <ConfirmDeleteButton v-if="!p.transient && !readonly"
+                  title="Delete population" armed-title="Click again to delete this population"
+                  @confirm="g.deletePop(p.path)" />
           <!-- the napari selection is transient (never persisted) — this clears it so it doesn't
                linger forever; there's no persisted pop to delete. -->
           <button v-else class="pm-icon danger" v-tooltip.left="'Clear napari selection'"

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -17,6 +17,7 @@ import ChainLiveNode from '../components/ChainLiveNode.vue'
 import ChainLiveLabel from '../components/ChainLiveLabel.vue'
 import ChainQcNode from '../components/ChainQcNode.vue'
 import SummaryCanvas from '../components/canvas/SummaryCanvas.vue'
+import ConfirmDeleteButton from '../components/ConfirmDeleteButton.vue'
 import ParamRenderer from '../tasks/ParamRenderer.vue'
 import CollapsibleSection from '../components/CollapsibleSection.vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
@@ -1188,14 +1189,10 @@ onActivated(async () => {
           >
             <i class="pi pi-plus" />
           </button>
-          <button
-            class="wb-btn wb-btn-danger"
-            :disabled="!activeChain"
-            @click="removeChain"
-            v-tooltip.right="'Delete this chain template from disk.'"
-          >
-            <i class="pi pi-trash" />
-          </button>
+          <ConfirmDeleteButton :disabled="!activeChain"
+            title="Delete this chain template from disk."
+            armed-title="Click again to permanently delete this chain"
+            @confirm="removeChain" />
           <button
             class="wb-btn"
             :disabled="!activeChain || hasStartNode"
@@ -1386,13 +1383,10 @@ onActivated(async () => {
 
         <div class="config-header">
           <div class="config-title">{{ selectedNode.type === 'start' ? 'Start node' : 'Node' }}</div>
-          <button
-            class="wb-btn wb-btn-danger"
-            @click="deleteSelectedNode"
-            v-tooltip.left="'Remove this node and its connections from the chain.'"
-          >
-            <i class="pi pi-trash" />
-          </button>
+          <ConfirmDeleteButton
+            title="Remove this node and its connections from the chain."
+            armed-title="Click again to remove this node"
+            @confirm="deleteSelectedNode" />
         </div>
 
         <div v-if="selectedNode.type === 'start'" class="config-section">

--- a/frontend/src/modules/metadata/MetadataPanel.vue
+++ b/frontend/src/modules/metadata/MetadataPanel.vue
@@ -8,7 +8,7 @@ import { buildFieldRegex, buildLookaroundRegex, extractWith,
          type FieldPos, type CtxClass, type ExtractKind } from '../../utils/regexBuilder'
 import { usePanelResize } from '../../composables/usePanelResize'
 import PhysicalSizeDialog from '../../components/PhysicalSizeDialog.vue'
-import ConfirmButton from '../../components/ConfirmButton.vue'
+import ConfirmDeleteButton from '../../components/ConfirmDeleteButton.vue'
 
 // resizable sidebar width (persisted) — same behaviour as the TaskRunner functions panel
 const { width: panelWidth, onResizeStart } =
@@ -314,15 +314,10 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
           <option value="">— select attribute —</option>
           <option v-for="n in attrNames" :key="n" :value="n">{{ n }}</option>
         </select>
-        <ConfirmButton @confirm="deleteAttr" v-slot="{ armed, arm, confirm, cancel }">
-          <button v-if="!armed" class="btn-danger btn-sm" :disabled="!selectedAttr" @click="arm"
-            v-tooltip.bottom="'Delete this attribute from all images.'"><i class="pi pi-trash" /></button>
-          <template v-else>
-            <button class="btn-danger btn-sm" @click="confirm"
-              v-tooltip.bottom="`Permanently delete '${selectedAttr}' from every image.`">Confirm</button>
-            <button class="btn-ghost btn-sm" @click="cancel">Cancel</button>
-          </template>
-        </ConfirmButton>
+        <ConfirmDeleteButton :disabled="!selectedAttr"
+          title="Delete this attribute from all images."
+          :armed-title="`Click again to permanently delete '${selectedAttr}' from every image.`"
+          @confirm="deleteAttr" />
       </div>
     </section>
 


### PR DESCRIPTION
## Generalise the delete confirmation

Delete confirmations diverged across the app:
- **icon-flip** — labels (`ViewerPanel`), notebooks (`NotebookTable`)
- **Confirm + Cancel pair** — metadata attribute (`MetadataPanel`)
- **instant, no confirm at all** — population (`PopulationManager`), chain template + node (`ChainModule`)

Standardise on the ViewerPanel labels pattern D picked: **a single icon button that arms on the first click (trash → warning triangle, solid danger fill) and deletes on the second** (auto-dismiss + outside-click cancel).

### `ConfirmDeleteButton`
Wraps the existing `ConfirmButton` for the arm/confirm/dismiss logic (kept in one place) and renders its own self-contained chrome (`.cc-del`) — self-styled *because* it must look identical everywhere, and hosts' component-scoped button classes (`opt-btn`/`pm-icon`/`wb-btn`) can't reach a button rendered inside it anyway.

```vue
<ConfirmDeleteButton title="Delete population"
                     armed-title="Click again to delete this population"
                     @confirm="deletePop(path)" />
```

### Migrated
`ViewerPanel` (label set) · `NotebookTable` · `MetadataPanel` (attribute) · `PopulationManager` (population) · `ChainModule` (chain template + node). ViewerPanel keeps its hover-reveal via `:deep(.cc-del)`. Documented in `docs/UI.md`.

### Left as-is (deliberate)
The louder **named** text confirms for whole-image / whole-set deletion (`ImageTable`, `SetBar`: "Delete NAME? [Confirm] [Cancel]") — a higher tier, already mutually consistent.

### Notes / to eyeball
- Not yet visually verified: the shared `.cc-del` button in tight toolbars (PopulationManager/ChainModule/ViewerPanel), the `:deep` hover-reveal, and the now-default tooltip position (a `tip` prop can't drive PrimeVue position — dynamic directive modifiers aren't possible).
- **Behaviour change:** PopulationManager + ChainModule deletes now require a confirm click (were instant). ChainModule's keyboard Delete/Backspace stays instant (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
