### PR TITLE
Cluster UMAP faceting + coord-fixed 1:1 square plots

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -185,6 +185,27 @@ For a host with a **hover-reveal** row action, target the inner button with `:de
 `ViewerPanel`). The louder **named** text confirms for whole-image / whole-set deletion (`ImageTable`,
 `SetBar`: "Delete NAME? [Confirm] [Cancel]") are a deliberate higher tier and stay as-is.
 
+### Coord-fixed plots — 1:1 square
+
+Plots whose axes must stay isotropic (the cluster **UMAP**, the **gating** scatter) render as a
+**1:1 square**, so the embedding/flow cloud never warps and HTML overlays (centroid labels, facet
+titles, gate labels) line up with the canvas dots.
+
+- **`components/plots/SquarePlot.vue`** — the shared square *primitive*: a container-query box sized to
+  `min(100cqw, 100cqh)`, centred. Use it to square a plot whose canvas fills the box with no internal
+  padding (UMAP wraps its plot in it).
+- **Gating** can't use `SquarePlot`: (a) its axis labels live in the capture box's asymmetric padding
+  and the PNG export reads `.panel-plot`'s `offsetLeft/Top` (zoom-immune), so a positioned wrapper /
+  squaring the *outer* box would break the export or leave the *dots* rectangular; (b) `SquarePlot`'s
+  container-query needs a **definite parent height**, which the montage tiles (content-driven height)
+  don't have. So `GateScatterCell` squares **`.panel-plot`** with **`aspect-ratio: 1`** — ONE method
+  across both gating contexts (the gate module page *and* the montage tiles).
+- **`CanvasPanel :square="true"`** — the shared **resize-box** logic: snaps a *free-floating* panel's
+  height to its width on resize so the square plot fills it with no blank space. Used identically by the
+  gate plot + pairs panels (pass it directly) and the UMAP (opts in via `interactiveViews.ts` →
+  `square: true`, forwarded by `InteractivePanel`). No-op when docked (the board grid owns slot size) or
+  collapsed. This is the "same 1:1 resize box for gating and UMAP".
+
 ---
 
 ## Pinia array reactivity

--- a/docs/todo/UMAP_COLOUR_FACET_PLAN.md
+++ b/docs/todo/UMAP_COLOUR_FACET_PLAN.md
@@ -1,8 +1,9 @@
 # Cluster UMAP — colour-by & facet-by (populations / image attributes)
 
-Status: in-progress — branch `feat/umap-colour-facet`. **Phase 1 + 2 built** (colour-by cluster /
-population / attribute); Phase 3 (facet small-multiples) pending. Works for BOTH `clust` (static/cell)
-and `trackclust` (track) embeddings — grain-matched via `pop_df`.
+Status: **all phases built.** Phase 1+2 (colour-by cluster / population / attribute) merged in #127.
+Phase 3 (facet small-multiples) on branch `feat/umap-facet`. Works for BOTH `clust` (static/cell) and
+`trackclust` (track) embeddings — grain-matched via `pop_df`. Promote the durable bits to a permanent
+doc (PLOTS.md / ANALYSIS.md) and delete this plan once Phase 3 merges.
 
 ## Goal
 
@@ -70,9 +71,13 @@ attribute} × **facet by** {none | attribute | population}.
   (persisted state). `population` → pop picker → refetch with `colourPops`, colour by `popIdx`,
   legend from `X-Colour-Pops`. `attribute` → attr picker (shared composable) → client uid→attr colour.
   Reuse `paletteRange` + the existing legend/centroid render.
-- **Phase 3 — facet-by (figure 2).** `facetBy: none | attribute | population` → partition points into
-  facets, render a grid of sub-plots on the one 2D canvas (shared extents + colour map + single
-  legend), titled per facet value. Export path already composites the canvas — extend to the grid.
+- **Phase 3 — facet-by (figure 2).** ✅ BUILT (branch `feat/umap-facet`). `facetBy: none | attribute |
+  population` partitions points into `facets` (a computed, O(n) via a precomputed per-image/per-popIdx
+  label source); `paintDots` draws each facet into a grid cell via `mapRect` (shared `extents` +
+  shared `categories`/`palette` → comparable + one legend); HTML `facetTitles` per cell (composited in
+  export like the centroid labels). Centroid labels are suppressed while faceting. `usePopIdx` (colour
+  OR facet by population) drives the `colourPops` fetch + pop-picker visibility, so figure 2 = colour
+  by population × facet by attribute works. No backend change (image-attr faceting is client-side).
 
 ## Invariants / notes
 - `api/src/*.jl` not Revise-tracked → restart to test Phase 1.

--- a/frontend/src/components/canvas/CanvasPanel.vue
+++ b/frontend/src/components/canvas/CanvasPanel.vue
@@ -31,7 +31,11 @@ const props = withDefaults(defineProps<{
   // there and popping controls over the canvas would fight the gate tools. Interactive views whose
   // toolbar lives INSIDE the body opt in by tagging it `.cc-panel-controls` (see style.css / docs/UI.md).
   autoHide?: boolean
-}>(), { active: false, removable: true, arrange: null, docked: false, autoHide: true })
+  // coord-fixed plots (gate scatter, UMAP) want a 1:1 box so the square plot fills it with no blank
+  // space — snap the free-floating panel's height to its width on resize. No-op when docked (the board
+  // grid owns slot size) or collapsed.
+  square?: boolean
+}>(), { active: false, removable: true, arrange: null, docked: false, autoHide: true, square: false })
 const emit = defineEmits<{ activate: [number]; remove: [] }>()
 
 const collapsed = ref(false)
@@ -41,6 +45,7 @@ const pinned = ref(false)
 const slots = useSlots()
 const hasControls = computed(() => !!slots.actions || !!slots.footer)
 const root = useTemplateRef<HTMLElement>('root')
+const mainEl = useTemplateRef<HTMLElement>('mainEl')   // .panel-main — the plot region kept square by :square
 const store = useCanvasPanelsStore()
 const saved = props.persistKey ? store.getGeom(props.persistKey) : undefined
 // the host canvas may apply a visual zoom (transform:scale); inject it so drag deltas are zoom-correct
@@ -55,6 +60,16 @@ const { pos, startDrag } = useFloatingPanel(root, {
 
 // persist geometry (position + the CSS-resized size) so the layout survives navigation.
 let ro: ResizeObserver | null = null
+// keep the PLOT REGION (.panel-main) square by adjusting the box height, so a coord-fixed plot fills it
+// with no blank space AND fixed in-flow controls (e.g. the gate axis selectors) are accounted for — the
+// plot stays 1:1 and its x-axis is never clipped. Overlay (auto-hide) controls don't reserve height, so
+// this reduces to a square box for them. Guarded by a >1px diff so we don't loop the ResizeObserver.
+function enforceSquare() {
+  if (!props.square || props.docked || collapsed.value || !root.value || !mainEl.value) return
+  const chromeH = root.value.offsetHeight - mainEl.value.offsetHeight   // head + in-flow controls/footer + borders
+  const target = mainEl.value.offsetWidth + chromeH                     // → main becomes square (w × w)
+  if (Math.abs(root.value.offsetHeight - target) > 1) root.value.style.height = target + 'px'
+}
 function persist() {
   if (!props.persistKey || !root.value) return
   if (collapsed.value) return   // collapsed height is transient — don't overwrite the saved size
@@ -64,8 +79,9 @@ watch(pos, persist, { deep: true })           // covers drag + Tile/Cascade
 onMounted(() => {
   if (props.docked) return   // docked panels fill their slot; no saved geometry / resize tracking
   if (saved && root.value) { root.value.style.width = saved.w + 'px'; root.value.style.height = saved.h + 'px' }
+  enforceSquare()            // square an odd saved geometry on first mount
   if (props.persistKey && root.value && typeof ResizeObserver !== 'undefined') {
-    ro = new ResizeObserver(persist); ro.observe(root.value)   // covers manual resize
+    ro = new ResizeObserver(() => { enforceSquare(); persist() }); ro.observe(root.value)   // covers manual resize
   }
 })
 onBeforeUnmount(() => { ro?.disconnect(); ro = null })
@@ -104,7 +120,7 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
     <!-- IN-FLOW controls (auto-hide OFF, e.g. the gate-drawing page): own rows so they never clip -->
     <div v-if="!autoHide && slots.actions && !collapsed" class="panel-controls inflow"><slot name="actions" /></div>
     <!-- body always gets the whole box; in auto-hide mode the controls overlay it (see .cc-panel-controls) -->
-    <div v-show="!collapsed" class="panel-main">
+    <div v-show="!collapsed" ref="mainEl" class="panel-main">
       <div class="panel-body"><slot /></div>
       <template v-if="autoHide">
         <div v-if="slots.actions" class="panel-controls cc-panel-controls"><slot name="actions" /></div>

--- a/frontend/src/components/canvas/InteractivePanel.vue
+++ b/frontend/src/components/canvas/InteractivePanel.vue
@@ -37,7 +37,7 @@ defineExpose({ exportImage })
 
 <template>
   <CanvasPanel :index="index" :active="active" :arrange="arrange" :persist-key="persistKey" :docked="docked"
-               :title="entry?.label ?? view"
+               :title="entry?.label ?? view" :square="entry?.square ?? false"
                @activate="emit('activate', $event)" @remove="emit('remove')">
     <component v-if="entry" :is="entry.component" ref="viewRef" v-bind="context" :state="state" />
     <div v-else class="ip-missing">Unknown interactive plot “{{ view }}”.</div>

--- a/frontend/src/components/canvas/interactiveViews.ts
+++ b/frontend/src/components/canvas/interactiveViews.ts
@@ -17,12 +17,13 @@ export interface InteractiveView {
   component: Component
   clusterPage?: boolean     // offered on the Cluster module page's +Plot picker (UMAP only)
   analysisBoard?: boolean   // offered on the Analysis board's +Plot picker
+  square?: boolean          // coord-fixed plot → free-floating panel snaps to a 1:1 box (no blank space)
 }
 
 // `clusterPage` / `analysisBoard` are the surface "checkboxes": each host builds its picker by filtering
 // on its own flag, so a view appears on a surface with no host-side wiring (see docs/UI.md).
 export const INTERACTIVE_VIEWS: Record<string, InteractiveView> = {
-  umap: { label: 'UMAP', component: UmapView, clusterPage: true, analysisBoard: true },
+  umap: { label: 'UMAP', component: UmapView, clusterPage: true, analysisBoard: true, square: true },
   gatingStrategy: { label: 'Gating strategy', component: GatingStrategyView, analysisBoard: true },
   filmstrip: { label: 'Image / strip', component: ImageStripView, analysisBoard: true },
 }

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -221,6 +221,16 @@ defineExpose({ exportImage, hiRes, getHost: () => hostEl.value })
 .plot-capture.gm-plot:not(.no-axis), .plot-capture.compact:not(.no-axis) { flex: none; min-height: 0; align-items: flex-start; }
 .plot-capture.gm-plot:not(.no-axis) .panel-plot,
 .plot-capture.compact:not(.no-axis) .panel-plot { flex: none; width: 100%; min-height: 0; aspect-ratio: 1; }
+/* GATE MODULE PAGE (the default full-size cell — no gm-plot/compact/no-axis): the DOTS must be a 1:1
+   square too — SAME mechanism as the montage above (aspect-ratio on .panel-plot), so gating has ONE
+   dots-square method across its contexts. (aspect-ratio, not SquarePlot's container-query, because the
+   montage tiles have a content-driven height where cqh is indeterminate; using it here too keeps them
+   uniform. It also keeps .panel-plot a direct offset-child of .plot-capture, which the zoom-immune PNG
+   export relies on.) The square fills the capture width and centres; the panel itself is snapped 1:1 by
+   CanvasPanel :square, so there's no blank space. */
+.plot-capture:not(.gm-plot):not(.compact):not(.no-axis) { align-items: center; justify-content: center; }
+.plot-capture:not(.gm-plot):not(.compact):not(.no-axis) .panel-plot {
+  flex: none; width: 100%; min-height: 0; aspect-ratio: 1; }
 /* no-axis (pairs matrix): no axis-name labels → drop the padding they lived in so the scatter fills
    the tile. Small uniform inset just for the axis lines / tick marks. */
 .plot-capture.no-axis { padding: 6px 6px 10px 12px; }

--- a/frontend/src/components/plots/SquarePlot.vue
+++ b/frontend/src/components/plots/SquarePlot.vue
@@ -1,0 +1,22 @@
+<!--
+  Generalised square plot area — the ONE way to render a coord-fixed plot (UMAP, gating scatter) as a
+  1:1 square, centred in whatever (possibly rectangular) space it's given. The inner square is sized to
+  the SMALLER of the container's width/height via container-query units, so it stays square on any
+  resize and never overflows. Slot content fills the square (position it `absolute; inset:0`).
+
+  Why a component: D wants the same square enforced across UMAP + gating modules, not re-derived per
+  plot (the montage single-cell already used this container-query trick — this promotes it to a shared
+  primitive). A square plot area also removes the letterbox ambiguity that desynced HTML overlays
+  (centroid labels / facet titles) from the canvas dots.
+-->
+<template>
+  <div class="sq-outer"><div class="sq-inner"><slot /></div></div>
+</template>
+
+<style scoped>
+/* container-query context; centre the square in the leftover space */
+.sq-outer { flex: 1; min-width: 0; min-height: 0; container-type: size;
+  display: flex; align-items: center; justify-content: center; }
+/* the square: as large as possible while fitting BOTH dimensions (min of the two container sides) */
+.sq-inner { position: relative; aspect-ratio: 1; width: min(100cqw, 100cqh); height: min(100cqw, 100cqh); }
+</style>

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -25,6 +25,7 @@ import { paletteRange, type VisProps } from '../../plots/plot'
 import { tkey, parseTkey } from '../../plots/series'
 import type { SegmentationPops } from '../../plots/types'
 import TeleportPopover from '../TeleportPopover.vue'
+import SquarePlot from './SquarePlot.vue'
 
 const props = defineProps<{
   projectUid: string; imageUids: string[]; setUid: string | null
@@ -34,17 +35,23 @@ const props = defineProps<{
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
   vis?: VisProps                 // canvas plot styling — we honour the dark-theme knob + the palette choice
   // colourBy: how to colour the embedding — 'cluster' (default), 'population' (membership of the picked
-  // populations — colourPops tkeys), or 'attribute' (each point's image attribute — colourAttr). See
-  // docs/todo/UMAP_COLOUR_FACET_PLAN.md.
+  // populations — colourPops tkeys), or 'attribute' (each point's image attribute — colourAttr).
+  // facetBy: split into small multiples — 'none' (default), 'attribute' (facetAttr) or 'population'.
+  // See docs/todo/UMAP_COLOUR_FACET_PLAN.md.
   state: { labels?: boolean; legend?: boolean
            colourBy?: 'cluster' | 'population' | 'attribute'
-           colourPops?: string[]; colourAttr?: string }
+           colourPops?: string[]; colourAttr?: string
+           facetBy?: 'none' | 'attribute' | 'population'; facetAttr?: string }
 }>()
 const log = useLogStore()
 const project = useProjectStore()
 const colourBy = computed({ get: () => props.state.colourBy ?? 'cluster', set: v => (props.state.colourBy = v) })
 const colourPops = computed<string[]>({ get: () => props.state.colourPops ?? [], set: v => (props.state.colourPops = v) })
 const colourAttr = computed({ get: () => props.state.colourAttr ?? '', set: v => (props.state.colourAttr = v) })
+const facetBy = computed({ get: () => props.state.facetBy ?? 'none', set: v => (props.state.facetBy = v) })
+const facetAttr = computed({ get: () => props.state.facetAttr ?? '', set: v => (props.state.facetAttr = v) })
+// the population dimension (popIdx) is needed whenever EITHER colour OR facet is by population
+const usePopIdx = computed(() => colourBy.value === 'population' || facetBy.value === 'population')
 const labels = computed({ get: () => props.state.labels !== false, set: v => (props.state.labels = v) })
 // show/hide the population legend — persisted per panel (default on). On the Analysis canvas it can
 // eat ~half the plot, so let the user reclaim that space.
@@ -81,6 +88,9 @@ const PALETTE = [
   '#fb7185', '#2dd4bf', '#fbbf24', '#60a5fa',
 ]
 const UNCLUSTERED = '#555a6e'
+// faint whole-cloud backdrop behind each facet — dark grey on the dark ground, light grey on the light
+// (export) ground, so it always reads as a subtle "shape" layer rather than competing with the dots.
+const ghostColour = () => (dark.value ? '#3a3f4b' : '#d4d7dd')
 const points = ref<Float32Array | null>(null)
 const categories = ref<Float32Array | null>(null)
 const palette = ref<string[]>([])
@@ -105,27 +115,109 @@ function mapPx(x: number, y: number, w: number, h: number): [number, number] {
 const lx = (x: number) => `${mapPx(x, 0, boxW.value, boxH.value)[0]}px`
 const ly = (y: number) => `${mapPx(0, y, boxW.value, boxH.value)[1]}px`
 
+// ── faceting: split points into small multiples by an attribute value / population ──────────────────
+// facetBy='attribute' groups by each point's image attribute (facetAttr); 'population' by its popIdx;
+// 'none' → one facet. All facets share the SAME extents + colour map (comparable), and a single legend.
+const FACET_TITLE_H = 15   // px reserved at each cell's top for its title
+// facets present in the data (first-appearance order; the 'n/a'/'other' catch-all sorts last). The
+// per-point label source is precomputed once per pass (attr: per-IMAGE value; population: per-popIdx
+// label) so this stays O(n), not O(n·images).
+const facets = computed<{ label: string; idx: number[] }[]>(() => {
+  const pts = points.value, img = pointImg.value
+  if (!pts || facetBy.value === 'none') return [{ label: '', idx: [] }]   // idx unused when single
+  const n = pts.length / 2
+  const attrByImg = facetBy.value === 'attribute'
+    ? props.imageUids.map(uid => project.imageAttr(uid)[facetAttr.value] || 'n/a') : null
+  const popLabel = facetBy.value === 'population'
+    ? colourPops.value.map(k => popLabelForKey(k)) : null
+  const labelOf = (i: number): string => {
+    if (attrByImg) return attrByImg[img?.[i] ?? -1] ?? 'n/a'
+    if (popLabel) { const k = popIdxRef.value ? popIdxRef.value[i] : -1; return k >= 0 ? (popLabel[k] ?? 'other') : 'other' }
+    return ''
+  }
+  const order: string[] = [], byLabel = new Map<string, number[]>()
+  for (let i = 0; i < n; i++) {
+    const l = labelOf(i)
+    let a = byLabel.get(l); if (!a) { a = []; byLabel.set(l, a); order.push(l) }
+    a.push(i)
+  }
+  const tail = (l: string) => (l === 'n/a' || l === 'other' ? 1 : 0)
+  order.sort((a, b) => tail(a) - tail(b))
+  return order.map(l => ({ label: l, idx: byLabel.get(l)! }))
+})
+const facetGrid = (nf: number) => { const cols = Math.ceil(Math.sqrt(nf)); return { cols, rows: Math.ceil(nf / cols) } }
+// cell rect + inner plot sub-rect (below the title strip) for facet fi in a w×h box
+function facetCell(fi: number, nf: number, w: number, h: number) {
+  const { cols } = facetGrid(nf)
+  const col = fi % cols, row = Math.floor(fi / cols)
+  const cw = w / cols, ch = h / facetGrid(nf).rows
+  const ox = col * cw, oy = row * ch, th = nf > 1 ? FACET_TITLE_H : 0, pad = nf > 1 ? 4 : 0
+  return { ox, oy, cw, ch, px: ox + pad, py: oy + th, pw: cw - 2 * pad, ph: ch - th - pad }
+}
+// data→px into an arbitrary sub-rect, SHARED extents (uniform isotropic scale, letterboxed)
+function mapRect(x: number, y: number, r: { px: number; py: number; pw: number; ph: number }): [number, number] {
+  const { xMin, xMax, yMin, yMax } = extents.value
+  const xr = xMax > xMin ? xMax - xMin : 1, yr = yMax > yMin ? yMax - yMin : 1
+  const sc = Math.min(r.pw / xr, r.ph / yr) || 0
+  const offX = (r.pw - xr * sc) / 2, offY = (r.ph - yr * sc) / 2
+  return [r.px + offX + (x - xMin) * sc, r.py + offY + (yMax - y) * sc]
+}
+// facet titles as HTML overlay (CSS px), composited into the export like the centroid labels/legend
+const facetTitles = computed(() => {
+  const fs = facets.value
+  if (facetBy.value === 'none' || fs.length <= 1) return []
+  return fs.map((f, fi) => { const c = facetCell(fi, fs.length, boxW.value, boxH.value)
+    return { label: f.label, x: c.ox + c.cw / 2, y: c.oy + 1 } })
+})
+
 // ── 2D dot render (no WebGL) ──────────────────────────────────────────────────────────────────────
 // Draw each point via the SAME data→px map as the labels (lx/ly), so cluster labels sit exactly on
 // their dots — regl-scatterplot's aspectRatio fill drifted from the HTML-stretched labels. Colour by
 // category (palette index), bucketed so fillStyle is set once per cluster.
 const dotsEl = useTemplateRef<HTMLCanvasElement>('dotsEl')
+// the square plot box — ALWAYS rendered (unlike the canvas, which is behind v-if until data loads), so
+// the ResizeObserver attaches at mount and resizes actually fire redraw (the "labels don't reposition"
+// bug: the observer was on the conditional canvas and never attached when the panel started empty).
+const plotBoxEl = useTemplateRef<HTMLElement>('plotBoxEl')
 let dctx: CanvasRenderingContext2D | null = null
 let dro: ResizeObserver | null = null
 const DOT_R = 2
-function paintDots(c: CanvasRenderingContext2D, w: number, h: number) {
-  const pts = points.value, cats = categories.value, pal = palette.value
-  if (!pts || !cats || !pal.length) return
-  const n = pts.length / 2, s = DOT_R * 2
+// centroid labels + facet titles scale with the pop-manager font-size slider (vis.fontSize)
+const labelFont = computed(() => props.vis?.fontSize ?? 11)
+// paint a set of point indices via `toPx`, bucketed by category so fillStyle is set once per colour
+function paintInto(c: CanvasRenderingContext2D, idx: number[], toPx: (i: number) => [number, number]) {
+  const cats = categories.value!, pal = palette.value, s = DOT_R * 2
   const groups: number[][] = pal.map(() => [])
-  for (let i = 0; i < n; i++) { const g = groups[cats[i]]; if (g) g.push(i) }
-  c.globalAlpha = 0.9
+  for (const i of idx) { const g = groups[cats[i]]; if (g) g.push(i) }
   for (let gi = 0; gi < pal.length; gi++) {
     const g = groups[gi]; if (!g.length) continue
     c.fillStyle = pal[gi]
-    for (const i of g) {
-      const [px, py] = mapPx(pts[2 * i], pts[2 * i + 1], w, h)
-      c.fillRect(px - DOT_R, py - DOT_R, s, s)
+    for (const i of g) { const [px, py] = toPx(i); c.fillRect(px - DOT_R, py - DOT_R, s, s) }
+  }
+}
+function paintDots(c: CanvasRenderingContext2D, w: number, h: number) {
+  const pts = points.value, cats = categories.value, pal = palette.value
+  if (!pts || !cats || !pal.length) return
+  c.globalAlpha = 0.9
+  const fs = facets.value
+  if (facetBy.value === 'none' || fs.length <= 1) {
+    const n = pts.length / 2, groups: number[][] = pal.map(() => [])
+    for (let i = 0; i < n; i++) { const g = groups[cats[i]]; if (g) g.push(i) }
+    for (let gi = 0; gi < pal.length; gi++) {
+      const g = groups[gi]; if (!g.length) continue
+      c.fillStyle = pal[gi]
+      for (const i of g) { const [px, py] = mapPx(pts[2 * i], pts[2 * i + 1], w, h); c.fillRect(px - DOT_R, py - DOT_R, DOT_R * 2, DOT_R * 2) }
+    }
+  } else {
+    const n = pts.length / 2
+    for (let fi = 0; fi < fs.length; fi++) {
+      const cell = facetCell(fi, fs.length, w, h)
+      // GHOST: the whole cloud in faint grey behind each facet, so the UMAP shape stays legible and
+      // facets are comparable (you see where this facet's points sit within the full embedding).
+      c.globalAlpha = 0.6; c.fillStyle = ghostColour()
+      for (let i = 0; i < n; i++) { const [px, py] = mapRect(pts[2 * i], pts[2 * i + 1], cell); c.fillRect(px - 1, py - 1, 2, 2) }
+      c.globalAlpha = 0.9
+      paintInto(c, fs[fi].idx, i => mapRect(pts[2 * i], pts[2 * i + 1], cell))
     }
   }
   c.globalAlpha = 1
@@ -162,11 +254,12 @@ let sumX = new Map<number, number>(), sumY = new Map<number, number>()   // per-
 // per-point POPULATION index (colour-by-population; -1 = in none of the picked pops) and per-point
 // IMAGE index into props.imageUids (colour-by-attribute joins this → the image's attr client-side).
 const popIdxRef = ref<Float32Array | null>(null)
-let pointImg: Uint16Array | null = null
+const pointImg = ref<Uint16Array | null>(null)   // reactive so facets/attr colouring recompute on load
 
 // ── colour-by pickers (populations + image attributes), reusing the shared endpoints/helpers ────────
-const pickerOpen = ref(false)
-const popPickBtn = useTemplateRef<HTMLElement>('popPickBtn')
+// colour + facet controls live in ONE options popover (the bar gets crowded, esp. docked on the board)
+const optsOpen = ref(false)
+const optsBtn = useTemplateRef<HTMLElement>('optsBtn')
 // populations available to colour by — GRANULARITY-matched to the embedding (trackclust → track-grained
 // pops, clust → cell-grained), clusters excluded (we colour by the INPUT cell-type pops, not the
 // clusters). Same /api/plots/populations picker the summary canvas uses.
@@ -228,7 +321,7 @@ function recolourByKey(keyArr: ArrayLike<number>, labelFor: (k: number) => strin
 // colour-by-attribute: build a per-point key from each point's image attribute value (distinct values
 // → 0..m-1, empty → -1), then colour by key. Uses the client-side uid→attr join (project store).
 function recolourByAttr() {
-  const img = pointImg, pts = points.value
+  const img = pointImg.value, pts = points.value
   if (!img || !pts) return
   const vals: string[] = [], keyOf = new Map<string, number>()
   const key = new Int32Array(pts.length / 2)
@@ -298,7 +391,7 @@ async function load() {
     // wire = flat Float32 [x, y, clusterCode, popIdx] per point (16 B). We fetch per image (so we can
     // tag each point with its image → colour/facet by attribute) and concatenate. colourPops (only in
     // population mode) asks the server to resolve per-point membership → popIdx.
-    const cp = colourBy.value === 'population' ? colourPops.value.map(popToken).filter(Boolean) : []
+    const cp = usePopIdx.value ? colourPops.value.map(popToken).filter(Boolean) : []
     const quads: number[] = []
     const imgOf: number[] = []
     for (let ui = 0; ui < props.imageUids.length; ui++) {
@@ -330,7 +423,7 @@ async function load() {
     points.value = pts
     codesRef.value = codes
     popIdxRef.value = popIdx
-    pointImg = img
+    pointImg.value = img
     countsMap = new Map<number, number>()
     for (let i = 0; i < n; i++) countsMap.set(codes[i], (countsMap.get(codes[i]) ?? 0) + 1)
     distinctCodes = [...countsMap.keys()].sort((a, b) => a - b)
@@ -356,16 +449,28 @@ watch(() => JSON.stringify((props.shownPops ?? []).map(p => [p.colour, p.cluster
 watch(() => [props.vis?.palette, props.vis?.userColors], recolour)
 // colour-by: switching to population needs the per-point popIdx (refetch); cluster/attribute just
 // recolour from cached data. Changing the picked populations refetches (server resolves membership).
-watch(colourBy, v => { v === 'population' ? load() : recolour() })
-watch(() => colourPops.value.join(','), () => { if (colourBy.value === 'population') load() })
+// colour-by re-colours from cached data; the fetch (for popIdx) is driven by usePopIdx below, so this
+// avoids a double load when switching to population also flips usePopIdx.
+watch(colourBy, () => recolour())
+watch(() => colourPops.value.join(','), () => { if (usePopIdx.value) load() })
 watch(colourAttr, () => { if (colourBy.value === 'attribute') recolour() })
-// lazily fill the population picker when that mode is first entered (attrs is a store-derived computed)
-watch(colourBy, v => { if (v === 'population' && !popGroups.value.length) loadPopGroups() }, { immediate: true })
-// redraw the 2D dots when the data / colouring / extents change
+// usePopIdx flips (colour OR facet by population toggled on/off) → refetch to get/drop popIdx
+watch(usePopIdx, () => load())
+// facet controls only re-partition + redraw (no refetch, except the popIdx case above); attribute
+// faceting reads the store-derived facets computed, so a redraw is enough
+watch([facetBy, facetAttr, facets], () => nextTick(redraw))
+// lazily fill the population picker when population mode (colour or facet) is first entered
+watch(usePopIdx, v => { if (v && !popGroups.value.length) loadPopGroups() }, { immediate: true })
+// redraw the 2D dots when the data / colouring / extents change; also on theme flip (the facet ghost
+// backdrop is theme-coloured — dark grey on dark, light grey on light/export)
 watch([points, categories, palette, extents], () => nextTick(redraw), { deep: true })
+watch(dark, () => nextTick(redraw))
 onMounted(() => {
   load()
-  if (dotsEl.value) { dro = new ResizeObserver(redraw); dro.observe(dotsEl.value); redraw() }
+  // observe the STABLE square box (present from mount) so a panel resize always repaints + repositions
+  // the HTML labels/titles (which read boxW/boxH set in redraw)
+  if (plotBoxEl.value) { dro = new ResizeObserver(() => redraw()); dro.observe(plotBoxEl.value) }
+  nextTick(redraw)
 })
 onBeforeUnmount(() => { dro?.disconnect(); dro = null })
 
@@ -405,66 +510,84 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
               v-tooltip.bottom="'Toggle centroid labels'"><i class="pi pi-tag" /> #</button>
       <button class="cc-btn cc-btn-ghost" :class="{ on: showLegend }" @click="showLegend = !showLegend"
               v-tooltip.bottom="'Toggle the legend'"><i class="pi pi-list" /></button>
-      <!-- colour the embedding by cluster (default), by the picked populations' membership, or by an
-           image attribute — reproduces the paper's "where do the tracked pops / treatments fall". -->
-      <label class="uv-cby" v-tooltip.bottom="'Colour points by'">
-        <i class="pi pi-palette" />
-        <select v-model="colourBy">
-          <option value="cluster">cluster</option>
-          <option value="population">population</option>
-          <option value="attribute">attribute</option>
-        </select>
-      </label>
-      <!-- population mode: pick which populations to colour by (grouped by segmentation) -->
-      <template v-if="colourBy === 'population'">
-        <button ref="popPickBtn" class="cc-btn cc-btn-ghost" :class="{ on: pickerOpen }"
-                @click="pickerOpen = !pickerOpen" v-tooltip.bottom="'Choose populations'">
-          <i class="pi pi-sitemap" /> {{ colourPops.length || 'pick' }}
-        </button>
-        <TeleportPopover v-model="pickerOpen" :anchor="popPickBtn" placement="bottom-start">
-          <div class="uv-pop">
-            <div v-if="!popGroups.length" class="uv-pop-empty">No populations in the clustered segmentations.</div>
-            <template v-for="grp in popGroups" :key="grp.valueName">
-              <div v-if="grp.populations.length" class="uv-pop-head">{{ grp.valueName }}</div>
-              <div v-for="p in grp.populations" :key="p.popType + grp.valueName + p.path"
-                   class="uv-pop-row" :class="{ on: isPopOn(grp.valueName, p.path, p.popType) }"
-                   @click="togglePop(grp.valueName, p.path, p.popType)">
-                <i :class="isPopOn(grp.valueName, p.path, p.popType) ? 'pi pi-check-square' : 'pi pi-stop'" />
-                <span class="uv-pop-name">{{ p.name }}</span>
-                <span v-if="p.popType !== 'live'" class="uv-pop-tag">{{ p.popType }}</span>
-              </div>
-            </template>
-          </div>
-        </TeleportPopover>
-      </template>
-      <!-- attribute mode: pick which image attribute to colour by -->
-      <select v-else-if="colourBy === 'attribute'" v-model="colourAttr" class="uv-attr"
-              v-tooltip.bottom="'Image attribute'">
-        <option value="" disabled>attribute…</option>
-        <option v-for="a in attrs" :key="a.name" :value="a.name">{{ a.name }}</option>
-      </select>
+      <!-- colour + facet controls live in a single options popover to keep the (often docked) bar tidy -->
+      <button ref="optsBtn" class="cc-btn cc-btn-ghost" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+              v-tooltip.bottom="'Colour & facet options'"><i class="pi pi-palette" /> options</button>
+      <TeleportPopover v-model="optsOpen" :anchor="optsBtn" placement="bottom-start">
+        <div class="uv-opts">
+          <label class="uv-opt"><span>Colour by</span>
+            <select v-model="colourBy">
+              <option value="cluster">cluster</option>
+              <option value="population">population</option>
+              <option value="attribute">attribute</option>
+            </select>
+          </label>
+          <label v-if="colourBy === 'attribute'" class="uv-opt"><span>Colour attribute</span>
+            <select v-model="colourAttr">
+              <option value="" disabled>attribute…</option>
+              <option v-for="a in attrs" :key="a.name" :value="a.name">{{ a.name }}</option>
+            </select>
+          </label>
+          <label class="uv-opt"><span>Facet by</span>
+            <select v-model="facetBy">
+              <option value="none">no facet</option>
+              <option value="attribute">attribute</option>
+              <option value="population">population</option>
+            </select>
+          </label>
+          <label v-if="facetBy === 'attribute'" class="uv-opt"><span>Facet attribute</span>
+            <select v-model="facetAttr">
+              <option value="" disabled>attribute…</option>
+              <option v-for="a in attrs" :key="a.name" :value="a.name">{{ a.name }}</option>
+            </select>
+          </label>
+          <!-- populations to colour/facet by (shown whenever EITHER uses population) -->
+          <template v-if="usePopIdx">
+            <div class="uv-opt-sep">Populations</div>
+            <div class="uv-pop">
+              <div v-if="!popGroups.length" class="uv-pop-empty">No populations in the clustered segmentations.</div>
+              <template v-for="grp in popGroups" :key="grp.valueName">
+                <div v-if="grp.populations.length" class="uv-pop-head">{{ grp.valueName }}</div>
+                <div v-for="p in grp.populations" :key="p.popType + grp.valueName + p.path"
+                     class="uv-pop-row" :class="{ on: isPopOn(grp.valueName, p.path, p.popType) }"
+                     @click="togglePop(grp.valueName, p.path, p.popType)">
+                  <i :class="isPopOn(grp.valueName, p.path, p.popType) ? 'pi pi-check-square' : 'pi pi-stop'" />
+                  <span class="uv-pop-name">{{ p.name }}</span>
+                  <span v-if="p.popType !== 'live'" class="uv-pop-tag">{{ p.popType }}</span>
+                </div>
+              </template>
+            </div>
+          </template>
+        </div>
+      </TeleportPopover>
       <span class="uv-spacer" />
       <span v-if="total" class="uv-count">{{ total.toLocaleString() }} {{ unit }} · {{ legend.length }} {{ colourBy === 'cluster' ? 'clusters' : 'groups' }}</span>
     </div>
     <div ref="plotEl" class="uv-body">
-      <!-- during export the inner ground MUST be transparent, else the overlay pass (host→SVG) paints
-           this opaque div OVER the transparent hi-res points (the points-missing bug). On-screen it
-           carries the scatter ground for the letterbox margins. -->
-      <!-- forceLight = board/PDF export: drop the plot's bounding-box border (+ rounding) so the
-           exported figure has no frame around the UMAP; on-screen it keeps the border. -->
-      <div class="uv-plot" :style="{ background: forceLight ? 'transparent' : scatterGround,
-                                     border: forceLight ? 'none' : undefined,
-                                     borderRadius: forceLight ? '0' : undefined }">
-        <template v-if="points && points.length">
-          <canvas ref="dotsEl" class="uv-canvas" />
-          <span v-for="c in centroids" v-show="labels" :key="c.label" class="uv-label"
-                :style="{ left: lx(c.x), top: ly(c.y), ...labelStyle }">{{ c.label }}</span>
-        </template>
-        <div v-else class="uv-empty">
-          <i :class="['pi', loading ? 'pi-spin pi-spinner' : 'pi-chart-scatter']" />
-          <p>{{ loading ? 'Loading…' : (err || 'Select clustered image(s) to view the UMAP.') }}</p>
+      <!-- SquarePlot keeps the embedding a 1:1 square (centred in the panel), so it never warps and the
+           HTML overlays (centroid labels / facet titles) line up with the canvas dots exactly. -->
+      <SquarePlot class="uv-square">
+        <!-- during export the inner ground MUST be transparent, else the overlay pass (host→SVG) paints
+             this opaque div OVER the transparent hi-res points. forceLight = board/PDF export: drop the
+             bounding-box border so the exported figure has no frame; on-screen it keeps the border. -->
+        <div ref="plotBoxEl" class="uv-plot" :style="{ background: forceLight ? 'transparent' : scatterGround,
+                                       border: forceLight ? 'none' : undefined,
+                                       borderRadius: forceLight ? '0' : undefined }">
+          <template v-if="points && points.length">
+            <canvas ref="dotsEl" class="uv-canvas" />
+            <!-- centroid labels only when NOT faceted (their full-box positions don't map into cells) -->
+            <span v-for="c in centroids" v-show="labels && facetBy === 'none'" :key="c.label" class="uv-label"
+                  :style="{ left: lx(c.x), top: ly(c.y), fontSize: labelFont + 'px', ...labelStyle }">{{ c.label }}</span>
+            <!-- per-facet titles (small multiples) -->
+            <span v-for="(t, ti) in facetTitles" :key="'f'+ti" class="uv-facet-title"
+                  :style="{ left: t.x + 'px', top: t.y + 'px', fontSize: labelFont + 'px', color: legendInk }">{{ t.label }}</span>
+          </template>
+          <div v-else class="uv-empty">
+            <i :class="['pi', loading ? 'pi-spin pi-spinner' : 'pi-chart-scatter']" />
+            <p>{{ loading ? 'Loading…' : (err || 'Select clustered image(s) to view the UMAP.') }}</p>
+          </div>
         </div>
-      </div>
+      </SquarePlot>
       <div v-if="showLegend && legend.length" class="uv-legend" :style="{ color: legendInk, background: legendBg }">
         <div v-for="l in legend" :key="l.label" class="leg-row">
           <span class="leg-dot" :style="{ background: l.colour }" />
@@ -484,12 +607,14 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
 .uv-ctrl .cc-btn.on { background: var(--cc-accent); border-color: var(--cc-accent); color: #fff; }
 .uv-spacer { flex: 1; }
 .uv-count { font-variant-numeric: tabular-nums; }
-/* colour-by controls */
-.uv-cby { display: inline-flex; align-items: center; gap: 4px; color: var(--cc-text-dim); }
-.uv-cby select, .uv-attr { font-size: 12px; padding: 2px 4px; }
-.uv-attr { max-width: 9rem; }
-/* population picker popover (inner layout only — TeleportPopover gives surface/border/shadow) */
-.uv-pop { width: 15rem; max-height: 18rem; overflow-y: auto; }
+/* colour & facet options popover (inner layout only — TeleportPopover gives surface/border/shadow) */
+.uv-opts { width: 15rem; display: flex; flex-direction: column; gap: 8px; padding: 10px; }
+.uv-opt { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12px; color: var(--cc-text-dim); }
+.uv-opt select { font-size: 12px; padding: 2px 4px; max-width: 8.5rem; }
+.uv-opt-sep { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--cc-text-dim);
+  border-top: 1px solid var(--cc-border); padding-top: 6px; margin-top: 2px; }
+/* population checklist (inside the options popover) */
+.uv-pop { max-height: 14rem; overflow-y: auto; border: 1px solid var(--cc-border); border-radius: 5px; }
 .uv-pop-empty { padding: 10px; color: var(--cc-text-dim); font-size: 12px; }
 .uv-pop-head { padding: 4px 8px; background: var(--cc-surface-2); color: var(--cc-text-dim);
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; position: sticky; top: 0; }
@@ -499,10 +624,14 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
 .uv-pop-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .uv-pop-tag { font-size: 9px; text-transform: uppercase; color: var(--cc-text-dim); border: 1px solid var(--cc-border); border-radius: 3px; padding: 0 3px; }
 .uv-body { display: flex; flex: 1; min-height: 0; gap: 8px; padding: 0 6px 6px; }
-.uv-plot { position: relative; flex: 1; min-height: 0; background: #0d0b1a; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
+/* .uv-square (SquarePlot) provides the centred 1:1 box; .uv-plot fills it and carries the ground/frame */
+.uv-plot { position: absolute; inset: 0; background: #0d0b1a; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
 .uv-canvas { position: absolute; inset: 0; width: 100%; height: 100%; }
-.uv-label { position: absolute; transform: translate(-50%, -50%); pointer-events: none; font-size: 11px; font-weight: 700;
+.uv-label { position: absolute; transform: translate(-50%, -50%); pointer-events: none; font-weight: 700;
   color: #111; background: rgba(255,255,255,0.85); border: 1px solid rgba(0,0,0,0.35); border-radius: 3px; padding: 0 4px; line-height: 1.4; z-index: 2; }
+/* small-multiples facet title: centred at the top of each cell (positioned in CSS px from facetTitles) */
+.uv-facet-title { position: absolute; transform: translateX(-50%); pointer-events: none; z-index: 2;
+  font-size: 10px; font-weight: 700; white-space: nowrap; }
 .uv-empty { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; color: var(--cc-text-dim); text-align: center; padding: 1rem; }
 .uv-empty .pi { font-size: 1.4rem; opacity: 0.6; }
 .uv-empty p { margin: 0; font-size: 0.8rem; max-width: 22rem; }

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -111,22 +111,14 @@ function exportPng() {
 <template>
   <!-- auto-hide OFF: sibling of the gate-drawing panel; keep its controls in flow, not on hover -->
   <CanvasPanel :index="index" :active="props.active" :arrange="props.arrange" :title="`Pairs ${channels.length}×${channels.length}`"
-               :persist-key="props.persistKey" :auto-hide="false"
+               :persist-key="props.persistKey" :auto-hide="false" :square="true"
                @activate="emit('activate', $event)" @remove="emit('remove')">
+    <!-- controls FIXED (in-flow); CanvasPanel :square squares the plot region below them — see GatePlotPanel -->
     <template #actions>
       <span class="ro-tag" v-tooltip.bottom="'Read-only — compare channels; draw gates on a single plot'">read-only</span>
       <span class="ctrl-sep" />
       <RenderModeToggle v-model="renderMode" />
-    </template>
-    <template #footer>
-      <select class="gp-export" v-tooltip.top="'Export the matrix'" :disabled="!channels.length"
-              @change="($event.target as HTMLSelectElement).value === 'png' && exportPng(); ($event.target as HTMLSelectElement).value = ''">
-        <option value="">⤓ Export</option>
-        <option value="png">Image (PNG)</option>
-      </select>
-    </template>
-
-    <div class="panel-ctrl">
+      <div class="panel-ctrl">
       <label class="ax-row"><span class="ax-lbl">pop</span>
         <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to compare; its gates are shown'">
           <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select>
@@ -163,7 +155,15 @@ function exportPng() {
         <i v-if="coerced" class="pi pi-exclamation-triangle ax-warn"
            v-tooltip.bottom="`Some channels’ range is too small for ${transform} — those shown linear`" />
       </div>
-    </div>
+      </div>
+    </template>
+    <template #footer>
+      <select class="gp-export" v-tooltip.top="'Export the matrix'" :disabled="!channels.length"
+              @change="($event.target as HTMLSelectElement).value === 'png' && exportPng(); ($event.target as HTMLSelectElement).value = ''">
+        <option value="">⤓ Export</option>
+        <option value="png">Image (PNG)</option>
+      </select>
+    </template>
 
     <div v-if="heavy" class="pairs-warn" v-tooltip.bottom="heavyTip">
       <i class="pi pi-exclamation-triangle" /> Large matrix — may be slow to load
@@ -187,8 +187,8 @@ function exportPng() {
   color: var(--cc-warn, #f59e0b); background: color-mix(in srgb, var(--cc-warn, #f59e0b) 12%, transparent);
   border-bottom: 1px solid var(--cc-border); cursor: help; }
 .ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
-.panel-ctrl { display: flex; flex-direction: column; gap: 6px; padding: 6px 8px;
-  border-bottom: 1px solid var(--cc-border); font-size: 12px; }
+/* axis controls now live in the auto-hide overlay (#actions) — full line below the icon tools */
+.panel-ctrl { flex-basis: 100%; display: flex; flex-direction: column; gap: 6px; font-size: 12px; }
 .ax-row { display: flex; align-items: center; gap: 6px; }
 .ax-lbl { width: 2.6rem; color: var(--cc-text-dim); flex-shrink: 0; }
 .ax-chan { width: 12rem; flex: none; }

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -289,9 +289,12 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
   <!-- auto-hide OFF: you draw gates on this canvas constantly, so the render-mode / gate tools stay
        in flow rather than popping over the plot on hover -->
   <CanvasPanel :index="index" :active="props.active" :arrange="props.arrange" :title="`Plot ${index + 1}`"
-               :persist-key="props.persistKey" :auto-hide="false"
+               :persist-key="props.persistKey" :auto-hide="false" :square="true"
                @activate="emit('activate', $event)" @remove="emit('remove')">
-    <!-- header tools (render mode + gate-draw tools) sit in the panel title bar -->
+    <!-- Controls are FIXED (in-flow, above the plot) — you draw gates with the cursor ON the plot, so
+         auto-hiding on hover would cover the very area you're drawing. CanvasPanel :square squares the
+         PLOT REGION (.panel-main) below these fixed controls, so the plot stays 1:1 with a visible
+         x-axis and no blank space. All controls sit in #actions (one in-flow block). -->
     <template #actions>
       <RenderModeToggle v-model="renderMode" />
       <span class="ctrl-sep" />
@@ -300,6 +303,25 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
       <button class="cc-btn cc-btn-ghost" :class="{ on: mode === 'polygon' }"
               v-tooltip.bottom="'Polygon gate (click vertices, double-click to close)'"
               @click="mode = mode === 'polygon' ? 'off' : 'polygon'"><i class="pi pi-share-alt" /></button>
+      <!-- axis (X, Y) + displayed population — one row each, stacked so they don't wrap awkwardly -->
+      <div class="panel-ctrl">
+        <label class="ax-row"><span class="ax-lbl">X</span>
+          <select class="ax-chan" v-model="xChan"><option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option></select>
+          <select class="tsel" :class="{ 'tsel-amber': xCoerced }" v-model="xtSel" v-tooltip.bottom="'Axis transform'">
+            <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
+          <i v-if="xCoerced" class="pi pi-exclamation-triangle ax-warn"
+             v-tooltip.bottom="`${g.colLabel(xChan)}’s range is too small for ${xt} — shown linear`" /></label>
+        <label class="ax-row"><span class="ax-lbl">Y</span>
+          <select class="ax-chan" v-model="yChan"><option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option></select>
+          <select class="tsel" :class="{ 'tsel-amber': yCoerced }" v-model="ytSel" v-tooltip.bottom="'Axis transform'">
+            <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
+          <i v-if="yCoerced" class="pi pi-exclamation-triangle ax-warn"
+             v-tooltip.bottom="`${g.colLabel(yChan)}’s range is too small for ${yt} — shown linear`" /></label>
+        <label class="ax-row"><span class="ax-lbl">pop</span>
+          <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to display; new gates are its children'">
+          <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select>
+          <span v-if="mode !== 'off' && !pending" class="gate-hint">hold <kbd>Shift</kbd> to adjust gates</span></label>
+      </div>
     </template>
     <!-- utility actions (export) in the footer, like the summary / cluster panels -->
     <template #footer>
@@ -309,26 +331,6 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
         <option value="png">Image (PNG)</option>
       </select>
     </template>
-    <!-- controls: one row per axis (X, Y) + the displayed population, stacked so they don't wrap -->
-    <div class="panel-ctrl">
-      <label class="ax-row"><span class="ax-lbl">X</span>
-        <select class="ax-chan" v-model="xChan"><option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option></select>
-        <select class="tsel" :class="{ 'tsel-amber': xCoerced }" v-model="xtSel" v-tooltip.bottom="'Axis transform'">
-          <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
-        <i v-if="xCoerced" class="pi pi-exclamation-triangle ax-warn"
-           v-tooltip.bottom="`${g.colLabel(xChan)}’s range is too small for ${xt} — shown linear`" /></label>
-      <label class="ax-row"><span class="ax-lbl">Y</span>
-        <select class="ax-chan" v-model="yChan"><option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option></select>
-        <select class="tsel" :class="{ 'tsel-amber': yCoerced }" v-model="ytSel" v-tooltip.bottom="'Axis transform'">
-          <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
-        <i v-if="yCoerced" class="pi pi-exclamation-triangle ax-warn"
-           v-tooltip.bottom="`${g.colLabel(yChan)}’s range is too small for ${yt} — shown linear`" /></label>
-      <label class="ax-row"><span class="ax-lbl">pop</span>
-        <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to display; new gates are its children'">
-        <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select>
-        <!-- affordance beside the pop selector (out of the plot): the draw tool stays armed, hold Shift to grab/move/resize -->
-        <span v-if="mode !== 'off' && !pending" class="gate-hint">hold <kbd>Shift</kbd> to adjust gates</span></label>
-    </div>
     <GateScatterCell ref="cell" :points="points" :extents="extents" :view-extents="viewExtents"
                      :x-ticks="xTicks" :y-ticks="yTicks" :gates="currentGates"
                      :x-label="g.colLabel(xChan)" :y-label="g.colLabel(yChan)"
@@ -359,9 +361,9 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
    below are gating-specific: the axis controls, the plot body, ticks/axes, and the header tools
    passed into CanvasPanel's #actions slot (.seg / .ctrl-sep / .cc-btn.on — slot content keeps
    this component's scoped styles). */
-/* one row per axis so the controls don't wrap into a floating line as the panel narrows */
-.panel-ctrl { display: flex; flex-direction: column; gap: 6px; padding: 6px 8px;
-  border-bottom: 1px solid var(--cc-border); font-size: 12px; }
+/* axis controls now live in the auto-hide overlay (#actions); take a full line below the icon tools
+   (flex-basis:100% within the flex-wrap overlay), one row per axis so they don't wrap awkwardly */
+.panel-ctrl { flex-basis: 100%; display: flex; flex-direction: column; gap: 6px; font-size: 12px; }
 .ax-row { display: flex; align-items: center; gap: 6px; }
 .ax-lbl { width: 1.8rem; color: var(--cc-text-dim); flex-shrink: 0; }
 /* fixed widths so the controls don't stretch when the plot is resized */


### PR DESCRIPTION
## Cluster UMAP faceting + coord-fixed 1:1 square plots

Two related pieces of plot polish, developed together (interleaved in `UmapView`, so shipped as one PR).

### UMAP faceting (paper figure 2)
- **facet-by**: `none` | `attribute` | `population` → **small multiples** in the one 2D canvas, sharing extents + colour map + a single legend, with per-cell HTML titles.
- Each facet draws the **whole cloud faintly behind** its coloured subset (theme-aware grey — dark on dark, light on light/export) so the embedding shape stays legible and facets are comparable.
- `usePopIdx` (colour **or** facet by population) drives the `colourPops` fetch + the pop picker, so *colour by population × facet by attribute* (the figure-2 combo) works.
- Colour + facet controls moved into **one options popover** to declutter the (often docked) bar; centroid labels + facet titles scale with `vis.fontSize`.

### Coord-fixed 1:1 square plots (UMAP + gating), generalised
- **`SquarePlot.vue`** — shared container-query square primitive (UMAP wraps its plot in it).
- **`GateScatterCell`** squares `.panel-plot` with `aspect-ratio` — one gating dots-square method across the gate page + montage. (Not `SquarePlot`: montage tiles have content-driven height where container-query can't apply, and the PNG export needs `.panel-plot` a direct offset-child.)
- **`CanvasPanel :square`** snaps a free-floating panel so the **plot region (`.panel-main`) is 1:1**, measuring the chrome (header + fixed controls + footer) → plot square, x-axis visible, no blank space. Opted in by UMAP (registry flag) + the gate/pairs panels.
- Gate panels keep **fixed in-flow controls** (you draw with the cursor on the plot, so hover-hide would cover the drawing area); the footer stays below the plot region so it never covers the x-axis.

### Also fixes
- UMAP resize observer was attached to the conditional canvas (`null` on an empty panel), so resizes didn't reposition the HTML labels — now observes the stable plot box.

Frontend-only. See `docs/todo/UMAP_COLOUR_FACET_PLAN.md` + `docs/UI.md`.

### Verified / to check
- Verified in-browser: faceting, ghost dots, square UMAP + gate plots, resize snap, options popover, gate x-axis clear of the footer.
- Worth a check: gate **PDF export** still square (export path unchanged; not re-checked this round); board *docked* slots aren't square-snapped (grid-owned — square plot centres there by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
