### PR TITLE
Extract generic napari layer helpers (cecelia.utils.napari_utils)

### DIFF
--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -97,6 +97,24 @@ Errors are returned as `{"type": "error", "msg": "..."}` — `send()` raises on 
 
 ---
 
+## Shared layer helpers (`cecelia.utils.napari_utils`)
+
+The bridge keeps **all** its brain — disk load of label zarr / label-props HDF5, populations, per-layer
+reconciliation + signature caching, colour-by columns, timestamp, scale-bar, 3D — but the final
+`viewer.add_image` / `add_labels` / `add_tracks` calls are delegated to the **generic, array-level**
+helpers in `python/cecelia/utils/napari_utils.py` (`add_image`, `add_labels`, `add_tracks`,
+`set_contrast_from_sample`). Those take arrays + `scale`/`units` only (no disk, no project state) and
+own the display *conventions* — per-channel colormaps + additive blending, labels `opacity=0.7`, track
+colour/tail params, contrast-from-a-middle-sample.
+
+This exists so the conventions live in **one** place: the sibling **coastal** project imports the same
+helpers from `coastal/napari_viz.py` (coastal already installs cecelia editable and uses its IO
+helpers), so both viewers render identically without duplicating the logic. `napari_utils` imports only
+numpy at load and imports napari lazily inside the functions (napari is an environment dep, not in the
+`pip install cecelia` light tier). See `../coastal/docs/todo/CECELIA_NAPARI_UPSTREAM_PLAN.md`.
+
+---
+
 ## Opening an image
 
 The full call chain for "eye button clicked":

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -118,28 +118,17 @@ class NapariState:
             unit = _read_unit_from_ome_xml(path)
             self._im_units = tuple(unit for _ in self._im_scale)
 
-        # napari rejects a list for `name` when channel_axis is None
-        name = channel_names
-        if isinstance(name, list) and self._channel_axis is None:
-            name = name[0] if name else None
-
-        self._viewer.add_image(
-            self._im_data,
-            channel_axis=self._channel_axis,
-            name=name,
-            colormap=channel_colormaps,
-            scale=self._im_scale,
-            units=self._im_units,
-            visible=visible,
+        # Delegate the actual layer creation to the SHARED generic helper (cecelia.utils.napari_utils,
+        # which coastal mirrors): per-channel colormaps, additive blending, contrast-from-sample and the
+        # list-name guard live there so both projects render identically. The bridge keeps all the
+        # disk/scale/units logic above. See docs/todo/CECELIA_NAPARI_UPSTREAM_PLAN.md.
+        from cecelia.utils import napari_utils
+        napari_utils.add_image(
+            self._viewer, self._im_data,
+            scale=self._im_scale, units=self._im_units,
+            channel_axis=self._channel_axis, channel_names=channel_names,
+            colormaps=channel_colormaps, contrast=True, visible=visible,
         )
-
-        # set contrast limits on all added layers
-        for layer in self._viewer.layers:
-            try:
-                if layer.visible:
-                    _set_contrast_from_sample(layer)
-            except Exception:
-                pass
 
         # label the viewer's sliders/axes with the dimension names (t/z/y/x) instead of the
         # default -1/-2/… indices. The viewer dims exclude the channel axis (split into layers).
@@ -270,10 +259,10 @@ class NapariState:
                     raise RuntimeError(f"no label arrays loaded from {labels_path}")
 
                 _remove_layer(self._viewer, layer_name)
-                layer = self._viewer.add_labels(
-                    arrays if len(arrays) > 1 else arrays[0],
-                    name=layer_name, scale=self._im_scale,
-                    units=self._im_units, opacity=0.7,
+                from cecelia.utils import napari_utils
+                layer = napari_utils.add_labels(
+                    self._viewer, arrays if len(arrays) > 1 else arrays[0],
+                    name=layer_name, scale=self._im_scale, units=self._im_units, opacity=0.7,
                 )
                 print(f"[show_labels] added {layer_name}: shape={layer.data.shape} "
                       f"scale={self._im_scale}", flush=True)
@@ -642,18 +631,18 @@ class NapariState:
                 props = {"track_id": sub[:, 0].astype(int).tolist()}
                 if use_cby:
                     props[use_cby] = col_vals[mask].tolist()
-                # MUST pass scale AND units matching the image/Points layers — otherwise napari warns
-                # "Inconsistent units across layers" and disables unit-aware rendering for ALL layers.
-                kw = dict(color_by=(use_cby or "track_id"), tail_width=tail_width,
-                          tail_length=tail_length, blending="additive", visible=visible,
-                          scale=self._im_scale, units=self._im_units, properties=props)
-                # categorical colour-by → the per-level Okabe–Ito colormap (consistent with labels);
-                # otherwise a named colormap (viridis continuous / turbo by track_id)
-                if use_cby and col_cmaps_dict is not None:
-                    kw["colormaps_dict"] = col_cmaps_dict
-                else:
-                    kw["colormap"] = col_cmap or "turbo"
-                self._viewer.add_tracks(sub, name=name, **kw)
+                # Delegate to the shared helper (passes scale AND units so napari keeps unit-aware
+                # rendering across layers). Categorical colour-by → the per-level Okabe–Ito
+                # `colormaps_dict` (consistent with labels); otherwise a named colormap (viridis
+                # continuous / turbo by track_id). See docs/todo/CECELIA_NAPARI_UPSTREAM_PLAN.md.
+                from cecelia.utils import napari_utils
+                napari_utils.add_tracks(
+                    self._viewer, sub, name=name,
+                    scale=self._im_scale, units=self._im_units, properties=props,
+                    color_by=(use_cby or "track_id"), tail_width=tail_width, tail_length=tail_length,
+                    colormap=(col_cmap or "turbo"),
+                    colormaps_dict=(col_cmaps_dict if use_cby else None),
+                )
             self._track_sigs[name] = sig
 
     # ── Spatial cell selection → POST back to Julia (linked brushing) ─────────
@@ -966,38 +955,8 @@ def _series_base(path: str) -> str:
     return path
 
 
-def _set_contrast_from_sample(layer) -> None:
-    """Compute contrast limits from a middle-z sample and set them directly.
-    Falls back to reset_contrast_limits() if sampling fails.
-    Avoids relying on napari's auto-contrast which can silently set [0, dtype_max]
-    for dask arrays that haven't been computed yet.
-    """
-    try:
-        raw = layer.data
-        if isinstance(raw, list):
-            raw = raw[-1]  # coarsest scale level — a contrast SAMPLE only, so read the
-                           # smallest pyramid level (orders of magnitude less I/O than the
-                           # full-res level, and per-channel this runs once per visible layer)
-        ndim = raw.ndim
-        # Build index that selects middle position along all axes except the last two (y, x)
-        idx = tuple(
-            n // 2 if ax < ndim - 2 else slice(None)
-            for ax, n in enumerate(raw.shape)
-        )
-        sample = np.asarray(raw[idx]).ravel()
-        valid  = sample[sample > 0]
-        if len(valid) > 100:
-            cmin = float(np.percentile(valid, 1.0))
-            cmax = float(np.percentile(valid, 99.9))
-            if cmax > cmin:
-                layer.contrast_limits = [cmin, cmax]
-                return
-    except Exception:
-        pass
-    try:
-        layer.reset_contrast_limits()
-    except Exception:
-        pass
+# contrast-from-sample moved to the shared cecelia.utils.napari_utils.set_contrast_from_sample
+# (open_image delegates via napari_utils.add_image(contrast=True)); coastal mirrors it.
 
 
 def _open_zarr_multiscale(path: str, as_dask: bool = True) -> list:

--- a/python/cecelia/tests/test_napari_utils.py
+++ b/python/cecelia/tests/test_napari_utils.py
@@ -1,0 +1,145 @@
+"""Unit tests for the generic napari display helpers (cecelia.utils.napari_utils).
+
+Headless / napari-free: we patch `require_napari` and pass a fake viewer + duck-typed layer, so these
+run without importing napari (per docs/todo/CECELIA_NAPARI_UPSTREAM_PLAN.md). They pin the wrapping
+conventions the cecelia bridge AND coastal both rely on: the list-name guard, contrast-from-sample
+percentiles, and the kwargs forwarded to viewer.add_image / add_labels / add_tracks.
+"""
+import unittest
+import numpy as np
+
+from cecelia.utils import napari_utils
+
+
+class FakeLayer:
+    def __init__(self, data, visible=True):
+        self.data = data
+        self.visible = visible
+        self.contrast_limits = None
+        self.reset_called = False
+
+    def reset_contrast_limits(self):
+        self.reset_called = True
+
+
+class FakeViewer:
+    def __init__(self, image_result=None):
+        self.calls = {}
+        self._image_result = image_result
+
+    def add_image(self, data, **kw):
+        self.calls['add_image'] = (data, kw)
+        return self._image_result
+
+    def add_labels(self, data, **kw):
+        self.calls['add_labels'] = (data, kw)
+        return FakeLayer(data)
+
+    def add_tracks(self, data, **kw):
+        self.calls['add_tracks'] = (data, kw)
+        return FakeLayer(data)
+
+
+class ImageLayerNameTest(unittest.TestCase):
+    def test_list_collapses_when_no_channel_axis(self):
+        self.assertEqual(napari_utils.image_layer_name(['A', 'B'], None), 'A')
+        self.assertIsNone(napari_utils.image_layer_name([], None))
+
+    def test_list_kept_with_channel_axis(self):
+        self.assertEqual(napari_utils.image_layer_name(['A', 'B'], 1), ['A', 'B'])
+
+    def test_scalar_passthrough(self):
+        self.assertEqual(napari_utils.image_layer_name('X', None), 'X')
+        self.assertIsNone(napari_utils.image_layer_name(None, None))
+
+
+class ContrastTest(unittest.TestCase):
+    def test_percentiles_from_positive_middle_sample(self):
+        # [T, Z, Y, X]; the middle T=1, Z=1 plane holds a 1..1000 ramp, the rest is background (0)
+        vol = np.zeros((3, 3, 40, 40), dtype=np.float64)
+        ramp = np.linspace(1, 1000, 40 * 40)
+        vol[1, 1] = ramp.reshape(40, 40)
+        layer = FakeLayer(vol)
+        napari_utils.set_contrast_from_sample(layer)
+        self.assertIsNotNone(layer.contrast_limits)
+        lo, hi = layer.contrast_limits
+        self.assertGreater(hi, lo)
+        self.assertAlmostEqual(lo, float(np.percentile(ramp, 1.0)), delta=1.0)
+        self.assertAlmostEqual(hi, float(np.percentile(ramp, 99.9)), delta=1.0)
+
+    def test_multiscale_uses_coarsest_level(self):
+        # a LIST of pyramid levels → the coarsest ([-1]) is sampled; all-equal → cmax==cmin → reset
+        layer = FakeLayer([np.zeros((2, 2, 50, 50)), np.full((2, 2, 12, 12), 5.0)])
+        napari_utils.set_contrast_from_sample(layer)
+        self.assertIsNone(layer.contrast_limits)
+        self.assertTrue(layer.reset_called)
+
+    def test_fallback_on_bad_data(self):
+        layer = FakeLayer(None)   # None has no .ndim → sampling raises → reset fallback
+        napari_utils.set_contrast_from_sample(layer)
+        self.assertTrue(layer.reset_called)
+
+
+class AddHelpersTest(unittest.TestCase):
+    def setUp(self):
+        self._orig = napari_utils.require_napari
+        napari_utils.require_napari = lambda: None   # headless: never import napari
+
+    def tearDown(self):
+        napari_utils.require_napari = self._orig
+
+    def test_add_image_forwards_and_guards_name(self):
+        v = FakeViewer(image_result=FakeLayer(np.zeros((2, 2)), visible=False))
+        napari_utils.add_image(v, 'DATA', scale=(1, 2, 3), units=('um', 'um', 'um'),
+                               channel_axis=None, channel_names=['only'], colormaps='red')
+        data, kw = v.calls['add_image']
+        self.assertEqual(data, 'DATA')
+        self.assertEqual(kw['name'], 'only')            # list collapsed (no channel axis)
+        self.assertEqual(kw['blending'], 'additive')
+        self.assertEqual(kw['scale'], (1, 2, 3))
+        self.assertEqual(kw['units'], ('um', 'um', 'um'))
+        self.assertIsNone(kw['channel_axis'])
+
+    def test_add_image_contrast_skips_invisible(self):
+        layer = FakeLayer(np.zeros((4, 4)), visible=False)
+        v = FakeViewer(image_result=layer)
+        napari_utils.add_image(v, 'D', scale=(1, 1), contrast=True)
+        self.assertIsNone(layer.contrast_limits)        # invisible → not sampled
+        self.assertFalse(layer.reset_called)
+
+    def test_add_image_omits_units_when_none(self):
+        v = FakeViewer(image_result=[])
+        napari_utils.add_image(v, 'D', scale=(1, 1), contrast=False)
+        _, kw = v.calls['add_image']
+        self.assertNotIn('units', kw)
+
+    def test_add_labels_defaults(self):
+        v = FakeViewer()
+        napari_utils.add_labels(v, 'L', scale=(1, 2, 3), name='seg')
+        _, kw = v.calls['add_labels']
+        self.assertEqual(kw['opacity'], 0.7)
+        self.assertEqual(kw['name'], 'seg')
+        self.assertEqual(kw['scale'], (1, 2, 3))
+
+    def test_add_tracks_categorical_wins_over_named(self):
+        v = FakeViewer()
+        napari_utils.add_tracks(v, 'T', scale=(1, 1, 1, 1), colormaps_dict={0: (1, 1, 1, 1)})
+        _, kw = v.calls['add_tracks']
+        self.assertIn('colormaps_dict', kw)
+        self.assertNotIn('colormap', kw)
+
+    def test_add_tracks_named_colormap_and_defaults(self):
+        v = FakeViewer()
+        napari_utils.add_tracks(v, 'T', scale=(1, 1, 1, 1), colormap='viridis',
+                                properties={'track_id': [1, 2]})
+        _, kw = v.calls['add_tracks']
+        self.assertEqual(kw['colormap'], 'viridis')
+        self.assertNotIn('colormaps_dict', kw)
+        self.assertEqual(kw['color_by'], 'track_id')
+        self.assertEqual(kw['tail_width'], 4)
+        self.assertEqual(kw['tail_length'], 30)
+        self.assertEqual(kw['properties'], {'track_id': [1, 2]})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/cecelia/utils/napari_utils.py
+++ b/python/cecelia/utils/napari_utils.py
@@ -1,0 +1,146 @@
+"""
+Generic napari display helpers — add images, labels and tracks to a viewer from plain arrays.
+
+These are the SHARED, project-agnostic layer builders: they take arrays + a per-axis ``scale`` (µm),
+with NO disk paths and NO project/pipeline state. cecelia's napari bridge
+(``napari/napari_bridge.py``) keeps all of its brain — disk load of label zarr / label-props HDF5,
+populations, per-layer reconciliation + signature caching, colour-by columns, timestamp, scale-bar —
+and delegates only the final ``viewer.add_*`` calls here, so the display conventions live in ONE
+documented place.
+
+The sibling ``coastal`` project **imports these helpers** — its ``coastal/napari_viz.py`` delegates its
+``add_*`` calls here and keeps only coastal-specific orchestration (viewer setup, array unpacking, its
+µm→pixel track matrix). coastal already installs cecelia editable and uses cecelia's IO helpers, so the
+napari layer conventions are single-sourced here rather than duplicated — coastal renders identically
+by SHARING this code, not mirroring it. See ``docs/todo/CECELIA_NAPARI_UPSTREAM_PLAN.md``.
+
+Conventions (kept consistent across EVERY layer so napari's unit-aware rendering stays enabled — a
+mismatch makes napari warn "Inconsistent units across layers" and disable it for ALL layers):
+  - ``scale``: per-axis µm/pixel from the image's pixel resolution, e.g. a [T, Z, Y, X] array →
+    ``(1, z, y, x)``; pass the SAME scale to images, labels AND tracks.
+  - ``units``: set consistently across layers (cecelia reads them from OME-XML).
+  - images: one layer per channel (``channel_axis``), per-channel colormaps, ``blending='additive'``,
+    contrast from a middle sample.
+  - labels: ``opacity=0.7``.
+  - tracks: ``[track_id, t, (z), y, x]`` matrix in PIXEL coords (``scale`` supplies the µm
+    conversion); ``color_by='track_id'`` → turbo; categorical colour-by → Okabe–Ito (via
+    ``colormaps_dict``); continuous → viridis; ``tail_width=4``, ``tail_length=30``.
+
+napari is a heavy ENVIRONMENT dependency (the pixi env ships it; ``pip install cecelia`` does not), so
+it is imported LAZILY inside the functions — this module imports only numpy at load time, like
+cecelia's other heavy helpers.
+"""
+
+import numpy as np
+
+# Default per-channel colormaps (extend if a movie has > 4 channels).
+CHANNEL_COLORMAPS = ['red', 'green', 'blue', 'yellow']
+
+
+def require_napari():
+  """Return the ``napari`` module, or raise a clear message. The ONE place napari is imported — callers
+  (cecelia's bridge, coastal's viz) go through here + ``new_viewer`` so they never import napari
+  directly (napari is an environment dep, not in the ``pip install cecelia`` light tier)."""
+  try:
+    import napari
+  except ImportError as e:  # pragma: no cover - environment-dependent
+    raise ImportError(
+      "napari is required here — it is an environment dependency (the pixi env ships napari + pyqt); "
+      "`pip install cecelia` does not include it."
+    ) from e
+  return napari
+
+
+def new_viewer(**kwargs):
+  """Create a napari ``Viewer`` — so callers never import napari directly to make one."""
+  return require_napari().Viewer(**kwargs)
+
+
+def image_layer_name(channel_names, channel_axis):
+  """napari rejects a LIST ``name`` when there is no channel axis (a single layer). Collapse a list to
+  its first element in that case; otherwise pass it through. Pure (no napari)."""
+  if isinstance(channel_names, list) and channel_axis is None:
+    return channel_names[0] if channel_names else None
+  return channel_names
+
+
+def set_contrast_from_sample(layer, low_pct=1.0, high_pct=99.9, min_valid=100):
+  """Set a layer's contrast limits from a middle sample of its data.
+
+  Reads a mid-position slice (middle index along every axis except the last two Y/X, coarsest pyramid
+  level if multiscale) and uses the ``[low_pct, high_pct]`` percentiles of the positive values. Avoids
+  napari's auto-contrast, which can silently set ``[0, dtype_max]`` for dask arrays that haven't been
+  computed yet. Falls back to ``reset_contrast_limits()`` if sampling fails. Pure w.r.t. napari — takes
+  a duck-typed layer (``.data``, ``.contrast_limits``, ``.reset_contrast_limits``)."""
+  try:
+    raw = layer.data
+    if isinstance(raw, list):
+      raw = raw[-1]  # coarsest scale level — a contrast SAMPLE only, so read the smallest pyramid
+                     # level (orders of magnitude less I/O than full-res); runs once per visible layer
+    ndim = raw.ndim
+    # index that selects the middle position along all axes except the last two (y, x)
+    idx = tuple(n // 2 if ax < ndim - 2 else slice(None) for ax, n in enumerate(raw.shape))
+    sample = np.asarray(raw[idx]).ravel()
+    valid = sample[sample > 0]
+    if len(valid) > min_valid:
+      cmin = float(np.percentile(valid, low_pct))
+      cmax = float(np.percentile(valid, high_pct))
+      if cmax > cmin:
+        layer.contrast_limits = [cmin, cmax]
+        return
+  except Exception:
+    pass
+  try:
+    layer.reset_contrast_limits()
+  except Exception:
+    pass
+
+
+def add_image(viewer, data, *, scale, units=None, channel_axis=None, channel_names=None,
+              colormaps=None, contrast=True, blending='additive', visible=True):
+  """Add a (possibly multi-channel) image — one layer per channel via ``channel_axis``, per-channel
+  ``colormaps``, additive ``blending``, and (optionally) contrast from a middle sample. Returns the
+  added layer, or the list of per-channel layers when ``channel_axis`` is set."""
+  require_napari()
+  kw = dict(channel_axis=channel_axis, name=image_layer_name(channel_names, channel_axis),
+            colormap=colormaps, scale=scale, visible=visible)
+  if units is not None:
+    kw['units'] = units
+  if blending is not None:
+    kw['blending'] = blending
+  result = viewer.add_image(data, **kw)
+  if contrast:
+    for layer in (result if isinstance(result, list) else [result]):
+      if getattr(layer, 'visible', True):
+        set_contrast_from_sample(layer)
+  return result
+
+
+def add_labels(viewer, labels, *, scale, units=None, opacity=0.7, name='Labels', visible=True):
+  """Add an instance/label layer (0 = background) at ``opacity`` (0.7 by default). Returns the layer."""
+  require_napari()
+  kw = dict(name=name, scale=scale, opacity=opacity, visible=visible)
+  if units is not None:
+    kw['units'] = units
+  return viewer.add_labels(labels, **kw)
+
+
+def add_tracks(viewer, tracks, *, scale, units=None, color_by='track_id', colormap='turbo',
+               colormaps_dict=None, tail_width=4, tail_length=30, properties=None,
+               blending='additive', visible=True, name='Tracks'):
+  """Add a tracks layer from a ``[track_id, t, (z), y, x]`` matrix in PIXEL coords (``scale`` supplies
+  the µm conversion, matching the image/labels layers). ``color_by='track_id'`` → the named
+  ``colormap`` (turbo); pass ``colormaps_dict`` (per-value RGBA) for a categorical colour-by (Okabe–Ito)
+  and it wins over ``colormap``. Returns the layer."""
+  require_napari()
+  kw = dict(name=name, scale=scale, color_by=color_by, tail_width=tail_width,
+            tail_length=tail_length, blending=blending, visible=visible)
+  if units is not None:
+    kw['units'] = units
+  if properties is not None:
+    kw['properties'] = properties
+  if colormaps_dict is not None:
+    kw['colormaps_dict'] = colormaps_dict
+  else:
+    kw['colormap'] = colormap
+  return viewer.add_tracks(tracks, **kw)


### PR DESCRIPTION
## Generic napari layer helpers — `cecelia.utils.napari_utils`

A small, **generic** napari display layer — `add_image` / `add_labels` / `add_tracks` (+ `set_contrast_from_sample`, `require_napari`, `new_viewer`) that take **arrays + scale/units only**, no disk or project state. Extracted from the logic inline in `napari/napari_bridge.py`.

### Why
- **De-dup the bridge** and pin the display conventions (per-channel colormaps + additive blending, labels `opacity=0.7`, track colour/tail params, contrast-from-a-middle-sample) in one documented place.
- The sibling **coastal** project **imports these same helpers** (it already installs cecelia editable + uses cecelia's IO helpers), so both viewers render identically without duplicating the convention logic. napari is imported **lazily** (env dep, not in the `pip install cecelia` light tier); `require_napari`/`new_viewer` are the single place it's imported, so callers never touch napari directly.

### Changes
- `python/cecelia/utils/napari_utils.py` (new) — generic helpers + shared contrast sampler (2-space, lazy napari).
- `napari/napari_bridge.py` — `open_image` / `show_labels` / `show_tracks` delegate their `viewer.add_*` call; removed the bridge's local `_set_contrast_from_sample` and the inline name-guard / contrast loop. All disk/state/reconciliation logic unchanged.
- `python/cecelia/tests/test_napari_utils.py` (new) — 12 headless tests (patched `require_napari` + fake viewer/layer).
- `docs/NAPARI.md` — shared-layer section.

Pairs with the coastal PR that switches `coastal/napari_viz.py` to delegate here. Plan: `../coastal/docs/todo/CECELIA_NAPARI_UPSTREAM_PLAN.md`.

### To verify / flag
- **Not run in napari** — verified by compile + the 12 headless unit tests (mocked viewer). A real image open still wants a manual check; `napari_bridge.py` isn't hot-reloaded, so kill the bridge process to pick up the delegation.
- **Deliberate visual change:** `open_image` now sets `blending='additive'` (the shared default; the bridge set none before). Standard for multi-channel fluorescence + matches coastal — revert with `blending=None` from the bridge if undesired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
