### PR TITLE
Image-strip channel-colour legend (#00073)

### DIFF
--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -13,6 +13,7 @@ import { ref, computed, watch, useTemplateRef, nextTick, onMounted, onUnmounted 
 import { elementToImageURL } from '../../plots/export'
 import TeleportPopover from '../TeleportPopover.vue'
 import { useWsStore } from '../../stores/ws'
+import { napariColormapHex } from '../../utils/napariColormap'
 
 const ws = useWsStore()
 
@@ -26,7 +27,7 @@ const ws = useWsStore()
 interface Cell { assetId?: string; src?: string; caption?: string; snapshot?: Record<string, unknown>; imageUid?: string | null }
 const props = defineProps<{
   projectUid: string; imageUids: string[]; setUid: string | null
-  state: { cells?: Cell[]; orientation?: 'h' | 'v'; separator?: 'straight' | 'angled'; sepAngle?: number; sepThick?: number; capSize?: number }
+  state: { cells?: Cell[]; orientation?: 'h' | 'v'; separator?: 'straight' | 'angled'; sepAngle?: number; sepThick?: number; capSize?: number; showLegend?: boolean }
 }>()
 
 // seed defaults into the persisted state bag (the slot starts as {})
@@ -42,6 +43,8 @@ const skew = computed({ get: () => props.state.sepAngle ?? 22, set: v => (props.
 const thick = computed({ get: () => props.state.sepThick ?? 2, set: v => (props.state.sepThick = v) })
 // caption text size (px) — driven into the caption overlay via a CSS var
 const capSize = computed({ get: () => props.state.capSize ?? 13, set: v => (props.state.capSize = v) })
+// optional channel-colour legend, read from the frame's snapshot (napari layer colormaps). Off by default.
+const showLegend = computed({ get: () => props.state.showLegend ?? false, set: v => (props.state.showLegend = v) })
 // angled separators are horizontal-only (the clip leans across the row) — snap back to straight if the
 // strip is switched to vertical.
 watch(orientation, o => { if (o === 'v' && separator.value === 'angled') separator.value = 'straight' })
@@ -77,6 +80,20 @@ async function capture(i: number) {
     c.imageUid = data.imageUid ?? null
   } catch (e) { err.value = e instanceof Error ? e.message : String(e) }
   finally { capturing.value = -1 }
+}
+
+// channel-colour legend for a frame, from its snapshot's napari layers: visible layers whose colormap
+// is a single-hue channel colour (skips continuous maps / labels / tracks). See docs/todo/ANIMATION_PLAN.md C.
+interface LegendItem { name: string; hex: string }
+function legendFor(c: Cell): LegendItem[] {
+  const layers = (c.snapshot?.layers ?? {}) as Record<string, { colormap?: string; visible?: boolean }>
+  const out: LegendItem[] = []
+  for (const [name, l] of Object.entries(layers)) {
+    if (l?.visible === false) continue
+    const hex = napariColormapHex(l?.colormap)
+    if (hex) out.push({ name, hex })
+  }
+  return out
 }
 
 // resolve a cell's <img> src: during PDF export, the inlined data URL (html2canvas can't draw a served
@@ -236,6 +253,8 @@ defineExpose({ exportImage })
             <label class="is-slider">caption
               <input type="range" min="8" max="28" :value="capSize" @input="capSize = +($event.target as HTMLInputElement).value" />
               <span class="is-val">{{ capSize }}</span></label>
+            <label class="is-check"><input type="checkbox" :checked="showLegend"
+              @change="showLegend = ($event.target as HTMLInputElement).checked" /> channel legend</label>
             <template v-if="separator === 'angled' && orientation === 'h'">
               <label class="is-slider">angle
                 <input type="range" min="0" max="80" :value="skew" @input="skew = +($event.target as HTMLInputElement).value" />
@@ -254,7 +273,13 @@ defineExpose({ exportImage })
     <div ref="stripRef" class="is-strip" :class="[orientation === 'h' ? 'row' : 'col', separator, { capturing: capturingStrip }]" :style="stripStyle">
       <div v-for="(c, i) in cells" :key="i" class="is-cell" :style="{ clipPath: clipFor(i) }">
         <img v-if="c.assetId || c.src" :src="cellSrc(c)" class="is-img" alt="napari screenshot" />
-        <button v-else class="is-capture" @click="capture(i)" :disabled="capturing === i"
+        <!-- optional channel-colour legend (swatch + channel name), from the frame's snapshot -->
+        <div v-if="showLegend && (c.assetId || c.src) && legendFor(c).length" class="is-legend">
+          <span v-for="it in legendFor(c)" :key="it.name" class="is-legend-item">
+            <span class="is-swatch" :style="{ background: it.hex }" />{{ it.name }}
+          </span>
+        </div>
+        <button v-if="!(c.assetId || c.src)" class="is-capture" @click="capture(i)" :disabled="capturing === i"
                 v-tooltip.bottom="'Capture the current napari view'">
           <i class="pi pi-camera" /> {{ capturing === i ? 'capturing…' : 'napari view' }}
         </button>
@@ -295,6 +320,14 @@ defineExpose({ exportImage })
 .is-err { color: #fca5a5; font-size: 11px; }
 .is-slider { display: inline-flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: 11px; }
 .is-slider input[type="range"] { width: 4.5rem; }
+.is-check { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim); font-size: 11px; }
+/* channel-colour legend: swatch + channel name, overlaid bottom-left of the frame (z above the
+   auto-hide toolbar like the caption/actions); included in the PDF export (not hidden while capturing). */
+.is-legend { position: absolute; bottom: 6px; left: 6px; display: flex; flex-direction: column; gap: 2px;
+  padding: 3px 5px; border-radius: 3px; background: rgba(0,0,0,0.45); pointer-events: none; z-index: 7; }
+.is-legend-item { display: flex; align-items: center; gap: 4px; color: #fff; font-size: 10px;
+  font-weight: 600; text-shadow: 0 1px 2px rgba(0,0,0,0.85); white-space: nowrap; }
+.is-swatch { width: 9px; height: 9px; border-radius: 2px; flex-shrink: 0; }
 .is-strip { flex: 1; min-height: 0; display: flex; padding: 6px; gap: 0; overflow: auto; }
 .is-strip.col { flex-direction: column; }
 /* straight: no box around each frame — just a thin rule BETWEEN frames */

--- a/frontend/src/utils/napariColormap.test.ts
+++ b/frontend/src/utils/napariColormap.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { napariColormapHex } from './napariColormap'
+
+describe('napariColormapHex', () => {
+  it('maps single-hue channel colormaps', () => {
+    expect(napariColormapHex('red')).toBe('#ff0000')
+    expect(napariColormapHex('green')).toBe('#00ff00')
+    expect(napariColormapHex('magenta')).toBe('#ff00ff')
+    expect(napariColormapHex('bop blue')).toBe('#1e6fff')
+  })
+
+  it('is case-insensitive', () => {
+    expect(napariColormapHex('Red')).toBe('#ff0000')
+    expect(napariColormapHex('BOP Orange')).toBe('#ff7f0e')
+  })
+
+  it('maps gray/grey to a light swatch', () => {
+    expect(napariColormapHex('gray')).toBe('#d4d4d4')
+    expect(napariColormapHex('grey')).toBe('#d4d4d4')
+  })
+
+  it('returns null for continuous maps and unknowns (not a channel tint)', () => {
+    expect(napariColormapHex('viridis')).toBeNull()
+    expect(napariColormapHex('turbo')).toBeNull()
+    expect(napariColormapHex('magma')).toBeNull()
+    expect(napariColormapHex('')).toBeNull()
+    expect(napariColormapHex(null)).toBeNull()
+    expect(napariColormapHex(undefined)).toBeNull()
+  })
+})

--- a/frontend/src/utils/napariColormap.ts
+++ b/frontend/src/utils/napariColormap.ts
@@ -1,0 +1,20 @@
+// napari colormap NAME → a representative hex "colour" for a legend swatch.
+//
+// Covers the single-hue channel colormaps used for image channels (red/green/blue/…, napari's `bop`
+// set, and a few single-colour extras). Continuous maps (viridis/turbo/magma/…) and unknown names
+// return null — they aren't a channel tint, so the channel legend skips them. Pure + unit-tested.
+const NAPARI_COLORMAP_HEX: Record<string, string> = {
+  red: '#ff0000', green: '#00ff00', blue: '#0000ff',
+  magenta: '#ff00ff', cyan: '#00ffff', yellow: '#ffff00',
+  gray: '#d4d4d4', grey: '#d4d4d4',
+  // napari `bop` single-hue colormaps (representative full-intensity colours)
+  'bop blue': '#1e6fff', 'bop orange': '#ff7f0e', 'bop purple': '#9b30ff',
+  // single-colour extras some pipelines use
+  'i blue': '#0000ff', 'i green': '#00ff00', 'i red': '#ff0000',
+}
+
+/** Hex for a napari colormap name (case-insensitive), or null if it isn't a single-hue channel colour. */
+export function napariColormapHex(name: string | null | undefined): string | null {
+  if (!name) return null
+  return NAPARI_COLORMAP_HEX[name] ?? NAPARI_COLORMAP_HEX[name.toLowerCase()] ?? null
+}


### PR DESCRIPTION
## What
An optional **channel-colour legend** on each image-strip frame: a swatch + channel name, read from the frame's **view snapshot** (napari layer colormaps captured in #134).

- Shows visible layers whose colormap is a **single-hue channel colour** (red/green/blue/magenta/cyan/yellow/gray/`bop *`); continuous maps (viridis/turbo/…) and labels/tracks are skipped.
- Toggle in the ⚙ popover — **off by default**, persisted in the slot state.
- Overlaid **bottom-left**; included in the PDF export (not hidden during capture).

New testable util `utils/napariColormap.ts` (napari colormap name → hex) + unit tests. `ImageStripView` adds `legendFor()` + the overlay + toggle.

Phase C of `docs/todo/ANIMATION_PLAN.md`. *Population/feature* colours in this legend arrive with split-by-feature (G).

## Verification
Typecheck ✓; frontend unit tests ✓ (94, incl. `napariColormap`). Eyeballed on-screen (hot-reload).

## Notes
- Only frames captured **after #134** carry a snapshot, so the legend appears on new captures, not pre-existing ones.
- The name→hex map covers the common napari channel colormaps; a custom/unusual colormap won't map and that channel is omitted (extend the map if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)