### PR TITLE
Fetch bioformats2raw at install time (slim the release bundle)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,24 +34,15 @@ jobs:
           npm ci
           npm run build
 
-      - name: Vendor bioformats2raw (image import; Java comes from the Pixi env)
-        run: |
-          url=$(curl -fsSL https://api.github.com/repos/glencoesoftware/bioformats2raw/releases/latest \
-                | grep -oE 'https://[^"]*bioformats2raw-[0-9.]+\.zip' | head -1)
-          echo "bioformats2raw release: $url"
-          curl -fsSL "$url" -o b2r.zip
-          unzip -q b2r.zip
-          rm b2r.zip
-          mv bioformats2raw-*/ bioformats2raw
-          test -x bioformats2raw/bin/bioformats2raw && echo "vendored ok"
-
+      # bioformats2raw (~190 MB) is NOT bundled — install.sh/install.ps1 fetch the latest release
+      # into <install>/bioformats2raw at install time (keeps the bundle ~6 MB). See docs/SHIPPING.md.
       - name: Package portable bundle
         run: |
           mkdir -p out
           echo "${{ github.ref_name }}" > VERSION   # so the installed app knows its version
           tar -czf out/cecelia.tar.gz \
             api app python app.py pixi.toml pixi.lock VERSION \
-            napari/napari_bridge.py frontend/dist bioformats2raw \
+            napari/napari_bridge.py frontend/dist \
             install.sh install.ps1 README.md docs
           ls -lh out/
 

--- a/app/src/config.jl
+++ b/app/src/config.jl
@@ -84,9 +84,10 @@ end
 
 projects_dir()::String = _cfg_dir("projects", "/path/to/projects")
 
-# Resolve the bioformats2raw launcher: explicit config override → bundled copy (vendored into
-# release bundles; Java comes from the Pixi env) → PATH → the (likely-missing) default. Run via
-# `pixi run` so the bundled `bioformats2raw` script finds `java`. See docs/SHIPPING.md.
+# Resolve the bioformats2raw launcher: explicit config override → the copy the installer fetched
+# alongside the app (`<install>/bioformats2raw/`; ~190 MB, so downloaded at install time rather than
+# shipped in the release bundle — Java comes from the Pixi env) → PATH → the (likely-missing)
+# default. Run via `pixi run` so the `bioformats2raw` script finds `java`. See docs/SHIPPING.md.
 function bioformats2raw_bin()::String
     exe = Sys.iswindows() ? "bioformats2raw.bat" : "bioformats2raw"
     d   = get(get(cecelia_conf(), "dirs", Dict{String,Any}()), "bioformats2raw", "")

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -111,8 +111,16 @@ OS-independent:
    docs). It excludes `.pixi`/`node_modules`/`.CondaPkg` — those are provisioned/regenerated on the
    user's machine. **Note:** `python/` must ship — `run_py` resolves task scripts under
    `python/cecelia/` and the editable `cecelia` dep points there; omitting it breaks every Python
-   task on the installed app.
+   task on the installed app. The bundle is **~6 MB** (frontend/dist dominates).
 3. Publish a GitHub Release with `cecelia.tar.gz` + `install.sh` + `install.ps1` as assets.
+
+**bioformats2raw is NOT in the bundle.** The image-import binary (its `lib/` of Bio-Formats JARs +
+native codecs) is ~190 MB — it would have dwarfed the ~6 MB of actual app. Instead `install.sh` /
+`install.ps1` fetch the latest bioformats2raw release into `<install>/bioformats2raw/` at install
+time (skipped if one is already on PATH), where `bioformats2raw_bin()` (config.jl) resolves it. Java
+comes from the Pixi env, so only the JARs are downloaded. This also means the **`dev` channel now
+gets bioformats2raw too** — the branch tarball never contained it (it's not in git), so before this
+the dev channel had no working image import.
 
 Users bootstrap the installer from `raw.githubusercontent.com/…/main/install.{sh,ps1}` — **not**
 `releases/latest/download/…`. GitHub's `releases/latest` endpoint only ever resolves to a

--- a/install.ps1
+++ b/install.ps1
@@ -89,6 +89,28 @@ if ($Channel -eq 'dev') {
 }
 Remove-Item $Tmp
 
+# ── bioformats2raw (image import) ───────────────────────────────────────────────
+# ~190 MB, so fetched here rather than shipped in the bundle. The app resolves it at
+# <install>\bioformats2raw\bin (bioformats2raw_bin() in config.jl); Java comes from the Pixi env.
+# Skipped if a system bioformats2raw is already on PATH (the app falls back to PATH).
+if (Get-Command bioformats2raw -ErrorAction SilentlyContinue) {
+  Say 'Using bioformats2raw already on PATH.'
+} else {
+  # Pinned version (reproducible installs — not their `latest`, so our import engine can't change
+  # under us on an upstream release). Override with $env:CECELIA_BIOFORMATS2RAW_VERSION.
+  $B2rVersion = if ($env:CECELIA_BIOFORMATS2RAW_VERSION) { $env:CECELIA_BIOFORMATS2RAW_VERSION } else { '0.12.1' }
+  $B2rUrl = "https://github.com/glencoesoftware/bioformats2raw/releases/download/v$B2rVersion/bioformats2raw-$B2rVersion.zip"
+  Say "Fetching bioformats2raw $B2rVersion (image import; ~190 MB)..."
+  $b2rZip = Join-Path ([System.IO.Path]::GetTempPath()) ('b2r-' + [System.IO.Path]::GetRandomFileName() + '.zip')
+  $b2rTmp = Join-Path ([System.IO.Path]::GetTempPath()) ('b2r-' + [System.IO.Path]::GetRandomFileName())
+  Invoke-WebRequest -Uri $B2rUrl -OutFile $b2rZip
+  Expand-Archive -Path $b2rZip -DestinationPath $b2rTmp -Force
+  $b2rSrc = Get-ChildItem -Path $b2rTmp -Directory | Where-Object { $_.Name -like 'bioformats2raw-*' } | Select-Object -First 1
+  Move-Item -Path $b2rSrc.FullName -Destination (Join-Path $InstallDir 'bioformats2raw')
+  Remove-Item $b2rZip; Remove-Item -Recurse -Force $b2rTmp
+  Say 'Installed bioformats2raw.'
+}
+
 # ── Provision ───────────────────────────────────────────────────────────────────
 Push-Location $InstallDir
 Say 'Installing the Python environment (downloads a few GB on first run)...'

--- a/install.sh
+++ b/install.sh
@@ -95,6 +95,26 @@ else
   tar -xzf "$TMP/cecelia.tar.gz" -C "$INSTALL_DIR"
 fi
 
+# ── bioformats2raw (image import) ─────────────────────────────────────────────
+# ~190 MB, so fetched here rather than shipped in the bundle. The app resolves it at
+# <install>/bioformats2raw/bin (bioformats2raw_bin() in config.jl); Java comes from the Pixi env.
+# Skipped if a system bioformats2raw is already on PATH (the app falls back to PATH).
+if have bioformats2raw; then
+  say "Using bioformats2raw already on PATH ($(command -v bioformats2raw))."
+else
+  have unzip || err "unzip is required to install bioformats2raw."
+  # Pinned version (reproducible installs — not their `latest`, so our import engine can't change
+  # under us on an upstream release). Override with CECELIA_BIOFORMATS2RAW_VERSION.
+  B2R_VERSION="${CECELIA_BIOFORMATS2RAW_VERSION:-0.12.1}"
+  B2R_URL="https://github.com/glencoesoftware/bioformats2raw/releases/download/v$B2R_VERSION/bioformats2raw-$B2R_VERSION.zip"
+  say "Fetching bioformats2raw $B2R_VERSION (image import; ~190 MB)…"
+  curl -fSL "$B2R_URL" -o "$TMP/b2r.zip" || err "bioformats2raw download failed ($B2R_URL)."
+  unzip -q "$TMP/b2r.zip" -d "$TMP/b2r"
+  mv "$TMP"/b2r/bioformats2raw-*/ "$INSTALL_DIR/bioformats2raw"
+  [ -x "$INSTALL_DIR/bioformats2raw/bin/bioformats2raw" ] || err "bioformats2raw missing after unpack."
+  say "Installed bioformats2raw."
+fi
+
 # ── Provision ────────────────────────────────────────────────────────────────
 cd "$INSTALL_DIR"
 say "Installing the Python environment (downloads a few GB on first run)…"


### PR DESCRIPTION
## Why

`cecelia.tar.gz` was **197 MB** — and ~190 MB of that was **bioformats2raw** alone (its `lib/` of Bio-Formats JARs + native compression codecs). Everything that is actually Cecelia — `frontend/dist`, `app`, `python`, `api`, `docs` — totals ~6 MB. So every release shipped, and every reinstall/update re-downloaded, ~190 MB of Java to carry ~6 MB of app.

## What

Stop vendoring bioformats2raw into the bundle; fetch it at install time instead.

- **`release.yml`** — remove the "Vendor bioformats2raw" step and drop `bioformats2raw` from the tar. **Bundle: ~197 MB → ~6 MB.**
- **`install.sh` / `install.ps1`** — after extraction, download a **pinned** bioformats2raw (**v0.12.1**, overridable via `CECELIA_BIOFORMATS2RAW_VERSION`) into `<install>/bioformats2raw/`. Skipped if a system `bioformats2raw` is already on PATH. Java still comes from the Pixi env — only the JARs are fetched.
- **`config.jl` / `SHIPPING.md`** — `bioformats2raw_bin()` already resolves `<install>/bioformats2raw/bin`; updated the comment + docs to reflect install-time fetch.

## Bonus fix

The **dev channel** never had bioformats2raw at all — it's not in git, and was only vendored by `release.yml`, so the `main` branch tarball the dev installer pulls had no import engine (image import silently broken). Fetching in the installer fixes stable **and** dev.

## Notes / caveats

- Pinned (not upstream `latest`) so the import engine can't change under us on an upstream release.
- Extra ~190 MB network fetch at install time — install already requires the network (Pixi/Juliaup/env), so no new offline regression.
- `install.ps1` path mirrors the linted `sh` path but is unverified on real Windows (as noted in its header).
- Doesn't affect the already-tagged rc6 (fat bundle); the slim bundle proves out in the next rc.

## Verify

- `sh -n install.sh` ✓, `release.yml` YAML valid ✓, pinned download URL returns HTTP 200 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
