### PR TITLE
View-legend backbone: shared ViewLegend model + component (S1)

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -231,6 +231,24 @@ the **napari Viewer controls** are its first consumer — mounted in `App.vue`, 
 - Rationale: the viewer controls grew (populations, tracks, colour-by + legend) and crowded the left
   nav; a floating panel frees the nav and lets you place the controls beside the napari window.
 
+## View legend — `ViewLegend` + `utils/viewLegend`
+
+The shared **legend backbone** for describing what a napari view shows as colour swatches — image
+**channels** (by colormap), **populations**, and a categorical **colour-by**. One model, many consumers
+(the analysis-board image strip, the animation page, later movie overlays), so a colour reads the same
+everywhere.
+
+- **`utils/viewLegend.ts`** (pure, unit-tested) — `LegendItem`/`LegendSection` types; `channelLegend(layers)`
+  (visible single-hue channel layers → swatches, via `napariColormap.ts`); `viewLegendSections({channels,
+  populations, colourBy})` (drops empty groups, stable channel→pop→colour-by order).
+- **`components/ViewLegend.vue`** — presentational: renders `LegendSection[]` as grouped swatches.
+  Style-light (text inherits `color`, sizes with parent `font-size`), so each host styles it via its
+  container (e.g. the image-strip overlay makes it white-on-dark). Section headings show only when there
+  is more than one section.
+
+The viewer panel's **colour-by** legend is deliberately NOT this component — it's an *editor*
+(recolourable swatches), not a static legend.
+
 ## Pinia array reactivity
 
 Use `splice()` to mutate arrays in place inside setup stores.

--- a/docs/todo/ANIMATION_PLAN.md
+++ b/docs/todo/ANIMATION_PLAN.md
@@ -124,6 +124,10 @@ matches how figures are actually made; F2 is the advanced follow-on.
   a button reopens the image + applies the snapshot. Durable across sessions.
 - **C. Strip legend (#00032)** *(needs A, G)* — render channel + population/feature colours (swatch +
   name / µm) below each frame, from the snapshot; toggle in the ⚙ popover.
+  - **Backbone DONE (S1):** the shared legend model `utils/viewLegend.ts` (`LegendSection`,
+    `channelLegend`, `viewLegendSections`) + presentational `components/ViewLegend.vue`, reused by the
+    image strip (channel section, live now) and the animation page. Populations + colour-by sections
+    plug into the same model once the snapshot carries them (next). Unit-tested (`viewLegend.test.ts`).
 - **D. Capture quality** *(independent, quick)* — D1 hi-res screenshot (`scale`/`size` on
   `viewer.screenshot`); D2 fix edge clipping (strip `object-fit: cover` → `contain`/match aspect, so
   scale bar/timestamp aren't cropped).

--- a/frontend/src/components/ViewLegend.vue
+++ b/frontend/src/components/ViewLegend.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+// Presentational legend for a napari view — renders LegendSection[] (see utils/viewLegend.ts) as
+// grouped colour swatches. Style-light: text inherits `color`, size scales with the parent font-size,
+// so each host (image-strip overlay, animation page, viewer panel) styles it via its own container.
+// Section headings show only when there's more than one section (a lone group needs no title).
+import type { LegendSection } from '../utils/viewLegend'
+
+withDefaults(defineProps<{ sections: LegendSection[]; swatch?: number }>(), { swatch: 10 })
+</script>
+
+<template>
+  <div class="view-legend">
+    <div v-for="sec in sections" :key="sec.title" class="vl-section">
+      <div v-if="sections.length > 1" class="vl-title">{{ sec.title }}</div>
+      <div class="vl-items">
+        <span v-for="it in sec.items" :key="it.label" class="vl-item">
+          <span class="vl-swatch" :style="{ background: it.colour, width: swatch + 'px', height: swatch + 'px' }" />
+          {{ it.label }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.view-legend { display: flex; flex-direction: column; gap: 3px; }
+.vl-section { display: flex; flex-direction: column; gap: 1px; }
+.vl-title { font-size: 0.82em; font-weight: 700; opacity: 0.65; text-transform: uppercase; letter-spacing: 0.04em; }
+.vl-items { display: flex; flex-wrap: wrap; gap: 1px 8px; }
+.vl-item { display: inline-flex; align-items: center; gap: 4px; font-size: 0.9em; white-space: nowrap; }
+.vl-swatch { border-radius: 2px; flex-shrink: 0; border: 1px solid rgba(128, 128, 128, 0.4); }
+</style>

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -13,7 +13,8 @@ import { ref, computed, watch, useTemplateRef, nextTick, onMounted, onUnmounted 
 import { elementToImageURL } from '../../plots/export'
 import TeleportPopover from '../TeleportPopover.vue'
 import { useWsStore } from '../../stores/ws'
-import { napariColormapHex } from '../../utils/napariColormap'
+import { channelLegend, viewLegendSections } from '../../utils/viewLegend'
+import ViewLegend from '../ViewLegend.vue'
 
 const ws = useWsStore()
 
@@ -80,18 +81,12 @@ async function capture(i: number) {
   finally { capturing.value = -1 }
 }
 
-// channel-colour legend for a frame, from its snapshot's napari layers: visible layers whose colormap
-// is a single-hue channel colour (skips continuous maps / labels / tracks). See docs/todo/ANIMATION_PLAN.md C.
-interface LegendItem { name: string; hex: string }
-function legendFor(c: Cell): LegendItem[] {
+// per-frame legend, built on the shared view-legend backbone (utils/viewLegend + <ViewLegend>). Today
+// it derives the CHANNEL section from the frame's snapshot layers; populations + colour-by sections plug
+// into the same model once the snapshot carries them. See docs/todo/ANIMATION_PLAN.md C.
+function legendSections(c: Cell) {
   const layers = (c.snapshot?.layers ?? {}) as Record<string, { colormap?: string; visible?: boolean }>
-  const out: LegendItem[] = []
-  for (const [name, l] of Object.entries(layers)) {
-    if (l?.visible === false) continue
-    const hex = napariColormapHex(l?.colormap)
-    if (hex) out.push({ name, hex })
-  }
-  return out
+  return viewLegendSections({ channels: channelLegend(layers) })
 }
 
 // resolve a cell's <img> src: during PDF export, the inlined data URL (html2canvas can't draw a served
@@ -266,12 +261,9 @@ defineExpose({ exportImage })
     <div ref="stripRef" class="is-strip" :class="[orientation === 'h' ? 'row' : 'col', separator, { capturing: capturingStrip }]" :style="stripStyle">
       <div v-for="(c, i) in cells" :key="i" class="is-cell" :style="{ clipPath: clipFor(i) }">
         <img v-if="c.assetId || c.src" :src="cellSrc(c)" class="is-img" alt="napari screenshot" />
-        <!-- optional channel-colour legend (swatch + channel name), from the frame's snapshot -->
-        <div v-if="showLegend && (c.assetId || c.src) && legendFor(c).length" class="is-legend">
-          <span v-for="it in legendFor(c)" :key="it.name" class="is-legend-item">
-            <span class="is-swatch" :style="{ background: it.hex }" />{{ it.name }}
-          </span>
-        </div>
+        <!-- optional view legend (channels now; pops + colour-by plug in later), from the frame snapshot -->
+        <ViewLegend v-if="showLegend && (c.assetId || c.src) && legendSections(c).length"
+                    :sections="legendSections(c)" :swatch="9" class="is-legend" />
         <button v-if="!(c.assetId || c.src)" class="is-capture" @click="capture(i)" :disabled="capturing === i"
                 v-tooltip.bottom="'Capture the current napari view'">
           <i class="pi pi-camera" /> {{ capturing === i ? 'capturing…' : 'napari view' }}
@@ -307,13 +299,12 @@ defineExpose({ exportImage })
 .is-slider { display: inline-flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: 11px; }
 .is-slider input[type="range"] { width: 4.5rem; }
 .is-check { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim); font-size: 11px; }
-/* channel-colour legend: swatch + channel name, overlaid bottom-left of the frame (z above the
-   auto-hide toolbar like the caption/actions); included in the PDF export (not hidden while capturing). */
-.is-legend { position: absolute; bottom: 6px; left: 6px; display: flex; flex-direction: column; gap: 2px;
-  padding: 3px 5px; border-radius: 3px; background: rgba(0,0,0,0.45); pointer-events: none; z-index: 7; }
-.is-legend-item { display: flex; align-items: center; gap: 4px; color: #fff; font-size: 10px;
-  font-weight: 600; text-shadow: 0 1px 2px rgba(0,0,0,0.85); white-space: nowrap; }
-.is-swatch { width: 9px; height: 9px; border-radius: 2px; flex-shrink: 0; }
+/* view legend (shared <ViewLegend>): overlaid bottom-left of the frame (z above the auto-hide toolbar
+   like the caption/actions); included in the PDF export (not hidden while capturing). The container
+   sets the on-image styling (white text, shadow, dark chip); ViewLegend inherits color + font-size. */
+.is-legend { position: absolute; bottom: 6px; left: 6px; padding: 3px 5px; border-radius: 3px;
+  background: rgba(0,0,0,0.45); pointer-events: none; z-index: 7;
+  color: #fff; font-size: 10px; font-weight: 600; text-shadow: 0 1px 2px rgba(0,0,0,0.85); }
 .is-strip { flex: 1; min-height: 0; display: flex; padding: 6px; gap: 0; overflow: auto; }
 .is-strip.col { flex-direction: column; }
 /* straight: no box around each frame — just a thin rule BETWEEN frames */

--- a/frontend/src/utils/viewLegend.test.ts
+++ b/frontend/src/utils/viewLegend.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { channelLegend, viewLegendSections } from './viewLegend'
+
+describe('channelLegend', () => {
+  it('maps visible single-hue channel layers to swatches', () => {
+    const legend = channelLegend({
+      gBT: { colormap: 'green', visible: true },
+      SHG: { colormap: 'gray', visible: true },
+    })
+    expect(legend).toEqual([
+      { label: 'gBT', colour: '#00ff00' },
+      { label: 'SHG', colour: '#d4d4d4' },
+    ])
+  })
+
+  it('skips hidden layers and non-channel (continuous / unknown) colormaps', () => {
+    const legend = channelLegend({
+      gBT: { colormap: 'green', visible: false },   // hidden
+      heat: { colormap: 'viridis', visible: true }, // continuous → no channel colour
+      lbl: { visible: true },                        // no colormap
+    })
+    expect(legend).toEqual([])
+  })
+
+  it('tolerates missing / empty layers', () => {
+    expect(channelLegend(undefined)).toEqual([])
+    expect(channelLegend(null)).toEqual([])
+    expect(channelLegend({})).toEqual([])
+  })
+})
+
+describe('viewLegendSections', () => {
+  it('keeps non-empty sections in channel → population → colour-by order', () => {
+    const secs = viewLegendSections({
+      colourBy: [{ label: 'Directed', colour: '#ff1493' }],
+      channels: [{ label: 'gBT', colour: '#00ff00' }],
+      populations: [{ label: 'T cells', colour: '#00bfff' }],
+    })
+    expect(secs.map(s => s.title)).toEqual(['Channels', 'Populations', 'Colour by'])
+  })
+
+  it('drops empty groups (no bare headings)', () => {
+    const secs = viewLegendSections({ channels: [{ label: 'gBT', colour: '#00ff00' }], populations: [] })
+    expect(secs).toHaveLength(1)
+    expect(secs[0].title).toBe('Channels')
+  })
+})

--- a/frontend/src/utils/viewLegend.ts
+++ b/frontend/src/utils/viewLegend.ts
@@ -1,0 +1,42 @@
+// The shared "view legend" model — the backbone for describing what a napari view shows, as
+// colour swatches: image channels (by colormap), populations, and a categorical colour-by. One model
+// feeds every legend: the analysis-board image strip, the animation page, and (later) movie overlays.
+// Pure + unit-tested; the presentational <ViewLegend> component renders a LegendSection[].
+// See docs/todo/ANIMATION_PLAN.md (Phase C — the legend derives from the view snapshot).
+import { napariColormapHex } from './napariColormap'
+
+export interface LegendItem { label: string; colour: string }
+export interface LegendSection { title: string; items: LegendItem[] }
+
+/**
+ * Channel legend from a view snapshot's napari layers: visible layers whose colormap is a single-hue
+ * channel colour (continuous maps / labels / tracks return no colour and are skipped). Ported from
+ * `ImageStripView.legendFor` so the strip and everything else derive channels the same way.
+ */
+export function channelLegend(
+  layers: Record<string, { colormap?: string; visible?: boolean }> | undefined | null,
+): LegendItem[] {
+  const out: LegendItem[] = []
+  for (const [name, l] of Object.entries(layers ?? {})) {
+    if (l?.visible === false) continue
+    const colour = napariColormapHex(l?.colormap)
+    if (colour) out.push({ label: name, colour })
+  }
+  return out
+}
+
+/**
+ * Assemble the non-empty legend sections in a stable order (channels → populations → colour-by) for
+ * `<ViewLegend>`. Empty groups are dropped so a legend never shows a bare heading.
+ */
+export function viewLegendSections(parts: {
+  channels?: LegendItem[]
+  populations?: LegendItem[]
+  colourBy?: LegendItem[]
+}): LegendSection[] {
+  const sections: LegendSection[] = []
+  if (parts.channels?.length)    sections.push({ title: 'Channels', items: parts.channels })
+  if (parts.populations?.length) sections.push({ title: 'Populations', items: parts.populations })
+  if (parts.colourBy?.length)    sections.push({ title: 'Colour by', items: parts.colourBy })
+  return sections
+}


### PR DESCRIPTION
## What

A shared **legend backbone** for describing what a napari view shows as colour swatches — image **channels** (by colormap), **populations**, and a categorical **colour-by** — so one model feeds every legend (the analysis-board image strip, the coming animation page, later movie overlays). First step toward the elaborate per-image legend on the board's image strip.

- **`utils/viewLegend.ts`** (pure, unit-tested) — `LegendItem`/`LegendSection` types; `channelLegend(layers)` (visible single-hue channel layers → swatches, via `napariColormap.ts`); `viewLegendSections({channels, populations, colourBy})` (drops empty groups; channels → pops → colour-by order).
- **`components/ViewLegend.vue`** — presentational, style-light (inherits `color` + `font-size`), section headings only when there's >1 section.
- **`ImageStripView`** refactored onto it — the channel legend now comes from the backbone; the overlay container just styles white-on-dark.
- Docs: ANIMATION_PLAN phase C + a UI.md entry.

## Tests
`viewLegend.test.ts` (5 cases); **frontend 99 tests, typecheck, build** all green. Frontend-only — live on reload, no napari needed.

## Notes
- This is the **backbone + channel unification**; the strip legend is functionally unchanged (channels only) — no regression. The **populations** and **colour-by** sections plug into the same `viewLegendSections({...})` call, but need the frame's snapshot to carry that data — that's the next slice (S1b), then the animation page (S2) builds on the same model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
