### PR TITLE
Animation timeline editor: keyframe row/track matrix (F2 UI)

### DIFF
--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -1,16 +1,15 @@
 <script setup lang="ts">
-// Animation page — capture napari "view snapshots" and turn them into movies. Each snapshot is the
-// current napari view (channels/contrast/colour-by/camera + T/Z), captured via the same screenshot
-// path as the board strip (sidecar PNG + view state), shown with the shared <ViewLegend>. "Record
-// movie" re-applies a snapshot to the open image and records the T-sweep (F1.1 record engine). MVP of
-// the F2 animation page; batch across images is the follow-on. See docs/todo/ANIMATION_PLAN.md.
+// Animation page — a "super-simple OpenShot": a per-image TIMELINE of view snapshots (keyframes) with a
+// row/track matrix. Columns = keyframes (captured napari views + duration); rows = channels /
+// populations / camera, all INFERRED from each keyframe's viewState (layers by type + camera). Capture
+// establishes a base "look" (contrast/colormap/framing); add-keyframe copies it; a cell toggle overrides
+// that keyframe's layer.visible. Render interpolates between keyframes → mp4 (POST record-animation).
+// The data model is just an ordered list of viewStates. See docs/todo/ANIMATION_PLAN.md (F2).
 import { ref, computed } from 'vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useProjectStore } from '../stores/project'
 import { useLogStore } from '../stores/log'
 import { useAnimationStore, type AnimSnapshot } from '../stores/animation'
-import { channelLegend, viewLegendSections } from '../utils/viewLegend'
-import ViewLegend from '../components/ViewLegend.vue'
 import ConfirmDeleteButton from '../components/ConfirmDeleteButton.vue'
 
 const projectMeta = useProjectMetaStore()
@@ -23,7 +22,7 @@ const hasProject = computed(() => projectMeta.hasProject)
 const openImageUid = computed(() => projectStore.napariImageUid)
 
 const capturing = ref(false)
-const recordingId = ref<string | null>(null)
+const rendering = ref(false)
 
 function imageName(uid: string | null | undefined): string {
   if (!uid) return '(unknown image)'
@@ -33,17 +32,43 @@ function imageName(uid: string | null | undefined): string {
   }
   return uid
 }
-
 function assetUrl(s: AnimSnapshot): string {
   return s.assetId ? `/api/board-assets?projectUid=${projectUid.value}&assetId=${s.assetId}` : ''
 }
 
-function legendSections(s: AnimSnapshot) {
-  const layers = (s.snapshot?.layers ?? {}) as Record<string, { colormap?: string; visible?: boolean }>
-  return viewLegendSections({ channels: channelLegend(layers) })
+// a timeline is per-image: the keyframes of whichever image is open in napari, in list order
+const frames = computed(() => anim.snapshots.filter(s => s.imageUid === openImageUid.value))
+
+type Layers = Record<string, { visible?: boolean; colormap?: string }>
+const layersOf = (s: AnimSnapshot) => (s.snapshot?.layers ?? {}) as Layers
+// overlays (populations / tracks / labels) are napari layers whose name is parenthesised
+// ("(popType) (vn) …", "(vn) Labels"); image channels are the plain-named layers.
+const isOverlay = (name: string) => name.startsWith('(')
+
+// row sets = the union of layer names across this image's keyframes, split into channels vs overlays
+function unionRows(pred: (n: string) => boolean): string[] {
+  const set = new Set<string>()
+  for (const f of frames.value) for (const n of Object.keys(layersOf(f))) if (pred(n)) set.add(n)
+  return [...set]
+}
+const channelRows = computed(() => unionRows(n => !isOverlay(n)))
+const popRows = computed(() => unionRows(isOverlay))
+
+// cell state: is a layer visible in a keyframe? null = the layer isn't in that keyframe at all
+function cellState(s: AnimSnapshot, name: string): boolean | null {
+  const l = layersOf(s)[name]
+  return l === undefined ? null : l.visible !== false
+}
+function toggleCell(s: AnimSnapshot, name: string) {
+  const l = layersOf(s)[name]
+  if (l) l.visible = l.visible === false   // flip; deep autosave persists the edited viewState
+}
+const cameraZoom = (s: AnimSnapshot) => {
+  const z = (s.snapshot?.camera as { zoom?: number } | undefined)?.zoom
+  return typeof z === 'number' ? z.toFixed(1) : '—'
 }
 
-// capture the CURRENT napari view (screenshot → sidecar PNG + view state) as a new snapshot
+// capture the CURRENT napari view as a new keyframe (a base "look")
 async function capture() {
   if (!projectUid.value || !openImageUid.value || capturing.value) return
   capturing.value = true
@@ -52,63 +77,58 @@ async function capture() {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ projectUid: projectUid.value }),
     })
-    if (!res.ok) {
-      const j = await res.json().catch(() => ({}))
-      log.error(`Capture failed: ${j?.error ?? res.status}`, { source: 'napari' }); return
-    }
+    if (!res.ok) { log.error(`Capture failed: ${(await res.json().catch(() => ({}))).error ?? res.status}`, { source: 'napari' }); return }
     const j = (await res.json()) as { assetId?: string; viewState?: Record<string, unknown>; imageUid?: string }
-    anim.add({
-      id: crypto.randomUUID(),
-      assetId: j.assetId,
-      snapshot: j.viewState,
-      imageUid: j.imageUid ?? openImageUid.value,
-      imageName: imageName(j.imageUid ?? openImageUid.value),
-      title: `${imageName(j.imageUid ?? openImageUid.value)} view`,
-    })
+    const uid = j.imageUid ?? openImageUid.value
+    anim.add({ id: crypto.randomUUID(), assetId: j.assetId, snapshot: j.viewState,
+               imageUid: uid, imageName: imageName(uid), duration: 1 })
   } catch (e) {
     log.error(`Capture failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'napari' })
-  } finally {
-    capturing.value = false
-  }
+  } finally { capturing.value = false }
 }
 
-// re-apply a snapshot to the open image, then record the T-sweep to an mp4. Only when the snapshot's
-// image is the one currently open in napari (applying a view to a different image is meaningless).
-const canRecord = (s: AnimSnapshot) => !!openImageUid.value && s.imageUid === openImageUid.value
-async function record(s: AnimSnapshot) {
-  if (!canRecord(s) || recordingId.value) return
-  recordingId.value = s.id
-  log.info(`Recording "${s.title ?? 'view'}"… (this can take a moment)`, { source: 'napari' })
-  try {
-    if (s.snapshot) {
-      await fetch('/api/napari/apply-view-state', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ viewState: s.snapshot }),
-      })
-    }
-    const res = await fetch('/api/napari/record-timelapse', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectUid: projectUid.value, imageUid: s.imageUid }),
-    })
-    const j = await res.json().catch(() => ({}))
-    if (!res.ok) { log.error(`Record failed: ${j?.error ?? res.status}`, { source: 'napari' }); return }
-    log.info(`Recorded ${j.frames ?? '?'} frames → ${j.path ?? 'movies/'}`, { source: 'napari' })
-  } catch (e) {
-    log.error(`Record failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'napari' })
-  } finally {
-    recordingId.value = null
-  }
+// add a keyframe by duplicating the last one (a copy to vary via the rows — no re-capture needed)
+function addKeyframe() {
+  const last = frames.value[frames.value.length - 1]
+  if (!last) { capture(); return }   // nothing yet → capture a base
+  anim.add({
+    id: crypto.randomUUID(), assetId: last.assetId, imageUid: last.imageUid, imageName: last.imageName,
+    duration: last.duration ?? 1,
+    snapshot: JSON.parse(JSON.stringify(last.snapshot ?? {})),   // deep copy of the viewState
+  })
 }
 
-// remove a snapshot + best-effort delete its sidecar PNG so it doesn't orphan in board-assets/
-async function deleteSnapshot(s: AnimSnapshot) {
-  if (s.assetId) {
+async function deleteKeyframe(s: AnimSnapshot) {
+  // only drop the sidecar PNG if no OTHER keyframe still references it (add-keyframe shares the asset)
+  if (s.assetId && !anim.snapshots.some(o => o.id !== s.id && o.assetId === s.assetId)) {
     fetch('/api/board-assets/delete', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ projectUid: projectUid.value, assetId: s.assetId }),
-    }).catch(() => { /* best-effort */ })
+    }).catch(() => {})
   }
   anim.remove(s.id)
+}
+
+const canRender = computed(() => !!openImageUid.value && frames.value.length >= 2 && !rendering.value)
+async function render() {
+  if (!canRender.value) return
+  rendering.value = true
+  log.info('Rendering animation… (this can take a moment)', { source: 'napari' })
+  try {
+    const keyframes = frames.value.map(f => ({
+      viewState: f.snapshot,
+      steps: Math.max(1, Math.round((f.duration ?? 1) * anim.fps)),
+    }))
+    const res = await fetch('/api/napari/record-animation', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid: projectUid.value, imageUid: openImageUid.value, keyframes, fps: anim.fps }),
+    })
+    const j = await res.json().catch(() => ({}))
+    if (!res.ok) { log.error(`Render failed: ${j?.error ?? res.status}`, { source: 'napari' }); return }
+    log.info(`Rendered ${j.frames ?? '?'} frames → ${j.path ?? 'movies/'}`, { source: 'napari' })
+  } catch (e) {
+    log.error(`Render failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'napari' })
+  } finally { rendering.value = false }
 }
 </script>
 
@@ -117,72 +137,138 @@ async function deleteSnapshot(s: AnimSnapshot) {
     <header class="anim-head">
       <div>
         <h1>Animation</h1>
-        <p class="anim-sub">Capture napari view snapshots (channels, populations, colour-by, camera) and
-          record them as movies. Snapshots are saved with the project.</p>
+        <p class="anim-sub">A timeline of napari view snapshots. Capture a base look, add keyframes, toggle
+          channels/populations per keyframe, then render — the movie interpolates between keyframes.</p>
       </div>
-      <button class="btn-primary" :disabled="!openImageUid || capturing" @click="capture"
-              v-tooltip.bottom="openImageUid ? 'Capture the current napari view as a snapshot'
-                                             : 'Open an image in napari first'">
-        <i :class="['pi', capturing ? 'pi-spin pi-spinner' : 'pi-camera']" />
-        {{ capturing ? 'capturing…' : 'Capture current view' }}
-      </button>
+      <div class="anim-head-ctl">
+        <label class="anim-fps" v-tooltip.bottom="'Output frames per second'">
+          fps <input type="number" min="1" max="60" step="1" :value="anim.fps"
+                     @change="anim.fps = Math.min(60, Math.max(1, Number(($event.target as HTMLInputElement).value) || 15))" />
+        </label>
+        <button class="btn-primary" :disabled="!canRender" @click="render"
+                v-tooltip.bottom="canRender ? 'Render the timeline to an mp4'
+                  : 'Need ≥2 keyframes for this image, open in napari'">
+          <i :class="['pi', rendering ? 'pi-spin pi-spinner' : 'pi-play']" /> Render
+        </button>
+      </div>
     </header>
 
-    <p v-if="!hasProject" class="anim-empty">Open a project to capture view snapshots.</p>
-    <p v-else-if="!anim.snapshots.length" class="anim-empty">
-      No snapshots yet. Open an image in napari, set up the view, then <strong>Capture current view</strong>.
-    </p>
+    <p v-if="!hasProject" class="anim-empty">Open a project to build an animation.</p>
+    <p v-else-if="!openImageUid" class="anim-empty">Open an image in napari to start capturing keyframes.</p>
 
-    <div v-else class="anim-grid">
-      <div v-for="s in anim.snapshots" :key="s.id" class="anim-card">
-        <div class="anim-thumb">
-          <img v-if="s.assetId" :src="assetUrl(s)" :alt="s.title" />
-          <div v-else class="anim-noimg">no image</div>
-          <ViewLegend v-if="legendSections(s).length" :sections="legendSections(s)" :swatch="9" class="anim-legend" />
-        </div>
-        <input class="anim-title" :value="s.title" @change="s.title = ($event.target as HTMLInputElement).value" />
-        <div class="anim-meta">{{ s.imageName }}</div>
-        <div class="anim-actions">
-          <button class="btn-sm" :disabled="!canRecord(s) || !!recordingId" @click="record(s)"
-                  v-tooltip.bottom="canRecord(s) ? 'Apply this view and record the timelapse → mp4'
-                                                 : 'Open this snapshot\'s image in napari to record it'">
-            <i :class="['pi', recordingId === s.id ? 'pi-spin pi-spinner' : 'pi-video']" />
-            {{ recordingId === s.id ? 'recording…' : 'Record movie' }}
-          </button>
-          <ConfirmDeleteButton title="Delete snapshot" armed-title="Click again to delete"
-                               @confirm="deleteSnapshot(s)" />
-        </div>
+    <template v-else>
+      <div class="anim-toolbar">
+        <span class="anim-img">{{ imageName(openImageUid) }}</span>
+        <button class="btn-sm" :disabled="capturing" @click="capture"
+                v-tooltip.bottom="'Capture the current napari view as a keyframe (a base look)'">
+          <i :class="['pi', capturing ? 'pi-spin pi-spinner' : 'pi-camera']" /> Capture view
+        </button>
+        <button class="btn-sm" :disabled="!frames.length" @click="addKeyframe"
+                v-tooltip.bottom="'Duplicate the last keyframe to vary it via the rows'">
+          <i class="pi pi-plus" /> Add keyframe
+        </button>
       </div>
-    </div>
+
+      <p v-if="!frames.length" class="anim-empty">No keyframes yet — set up the view in napari and
+        <strong>Capture view</strong>.</p>
+
+      <div v-else class="anim-timeline">
+        <table class="tl">
+          <thead>
+            <tr>
+              <th class="tl-rowhead"></th>
+              <th v-for="(f, i) in frames" :key="f.id" class="tl-col">
+                <div class="tl-thumb"><img v-if="f.assetId" :src="assetUrl(f)" :alt="`keyframe ${i+1}`" /></div>
+                <div class="tl-colctl">
+                  <button class="tl-ico" :disabled="i === 0" @click="anim.move(f.id, -1)" v-tooltip.bottom="'Move earlier'"><i class="pi pi-chevron-left" /></button>
+                  <span class="tl-kf">{{ i + 1 }}</span>
+                  <button class="tl-ico" :disabled="i === frames.length - 1" @click="anim.move(f.id, 1)" v-tooltip.bottom="'Move later'"><i class="pi pi-chevron-right" /></button>
+                  <ConfirmDeleteButton title="Delete keyframe" armed-title="Click again to delete" @confirm="deleteKeyframe(f)" />
+                </div>
+                <label class="tl-dur" v-tooltip.bottom="'Seconds this keyframe tweens from the previous'">
+                  <input type="number" min="0.1" step="0.1" :value="f.duration ?? 1"
+                         @change="f.duration = Math.max(0.1, Number(($event.target as HTMLInputElement).value) || 1)" />s
+                </label>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="tl-group"><td :colspan="frames.length + 1">Channels</td></tr>
+            <tr v-for="name in channelRows" :key="'c'+name">
+              <td class="tl-rowhead" :title="name">{{ name }}</td>
+              <td v-for="f in frames" :key="f.id" class="tl-cell">
+                <button v-if="cellState(f, name) !== null" class="tl-dot" :class="{ on: cellState(f, name) }"
+                        @click="toggleCell(f, name)" v-tooltip.bottom="cellState(f, name) ? 'Shown — click to hide' : 'Hidden — click to show'" />
+                <span v-else class="tl-absent">·</span>
+              </td>
+            </tr>
+
+            <template v-if="popRows.length">
+              <tr class="tl-group"><td :colspan="frames.length + 1">Populations &amp; overlays</td></tr>
+              <tr v-for="name in popRows" :key="'p'+name">
+                <td class="tl-rowhead" :title="name">{{ name }}</td>
+                <td v-for="f in frames" :key="f.id" class="tl-cell">
+                  <button v-if="cellState(f, name) !== null" class="tl-dot" :class="{ on: cellState(f, name) }"
+                          @click="toggleCell(f, name)" v-tooltip.bottom="cellState(f, name) ? 'Shown — click to hide' : 'Hidden — click to show'" />
+                  <span v-else class="tl-absent">·</span>
+                </td>
+              </tr>
+            </template>
+
+            <tr class="tl-group"><td :colspan="frames.length + 1">Camera</td></tr>
+            <tr>
+              <td class="tl-rowhead">zoom</td>
+              <td v-for="f in frames" :key="f.id" class="tl-cell tl-cam">{{ cameraZoom(f) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
   </div>
 </template>
 
 <style scoped>
 .anim-page { padding: 1rem 1.25rem; height: 100%; overflow: auto; }
-.anim-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.anim-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 0.8rem; }
 .anim-head h1 { font-size: 1.1rem; margin: 0 0 0.2rem; }
 .anim-sub { font-size: 0.8rem; color: var(--cc-text-dim); max-width: 46rem; margin: 0; }
-.anim-empty { font-size: 0.85rem; color: var(--cc-text-dim); margin-top: 2rem; }
-.anim-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 0.9rem; }
-.anim-card { display: flex; flex-direction: column; gap: 0.35rem; border: 1px solid var(--cc-border);
-  border-radius: 0.5rem; background: var(--cc-surface-1); padding: 0.5rem; }
-.anim-thumb { position: relative; aspect-ratio: 1; background: #000; border-radius: 0.3rem; overflow: hidden; }
-.anim-thumb img { width: 100%; height: 100%; object-fit: contain; }
-.anim-noimg { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--cc-text-dim); font-size: 0.75rem; }
-.anim-legend { position: absolute; bottom: 5px; left: 5px; padding: 3px 5px; border-radius: 3px;
-  background: rgba(0,0,0,0.45); color: #fff; font-size: 10px; font-weight: 600;
-  text-shadow: 0 1px 2px rgba(0,0,0,0.85); pointer-events: none; }
-.anim-title { width: 100%; font-size: 0.78rem; }
-.anim-meta { font-size: 0.68rem; color: var(--cc-text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.anim-actions { display: flex; align-items: center; gap: 0.4rem; }
-.btn-sm { display: inline-flex; align-items: center; gap: 0.3rem; flex: 1; justify-content: center;
-  font-size: 0.7rem; padding: 0.3rem 0.4rem; border: 1px solid var(--cc-border); border-radius: 0.3rem;
-  background: var(--cc-surface-2); color: var(--cc-text); cursor: pointer; }
+.anim-head-ctl { display: flex; align-items: center; gap: 0.6rem; flex-shrink: 0; }
+.anim-fps { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.3rem; }
+.anim-fps input { width: 3rem; font-size: 0.72rem; }
+.anim-empty { font-size: 0.85rem; color: var(--cc-text-dim); margin-top: 1.5rem; }
+.anim-toolbar { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.7rem; }
+.anim-img { font-size: 0.78rem; font-weight: 600; color: var(--cc-text); }
+
+.anim-timeline { overflow-x: auto; }
+.tl { border-collapse: collapse; }
+.tl-rowhead { position: sticky; left: 0; background: var(--cc-bg); text-align: left; font-size: 0.68rem;
+  color: var(--cc-text-dim); padding: 0.2rem 0.6rem 0.2rem 0.2rem; max-width: 9rem; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; z-index: 1; }
+.tl-col { padding: 0 0.15rem 0.3rem; vertical-align: top; }
+.tl-thumb { width: 88px; height: 88px; background: #000; border-radius: 0.3rem; overflow: hidden; }
+.tl-thumb img { width: 100%; height: 100%; object-fit: contain; }
+.tl-colctl { display: flex; align-items: center; justify-content: center; gap: 0.15rem; margin-top: 0.15rem; }
+.tl-kf { font-size: 0.66rem; color: var(--cc-text-dim); min-width: 1rem; text-align: center; }
+.tl-ico { border: none; background: none; color: var(--cc-text-dim); cursor: pointer; padding: 0.1rem; font-size: 0.62rem; }
+.tl-ico:hover:not(:disabled) { color: var(--cc-text); }
+.tl-ico:disabled { opacity: 0.3; cursor: default; }
+.tl-dur { display: flex; align-items: center; justify-content: center; gap: 0.15rem; font-size: 0.62rem; color: var(--cc-text-dim); margin-top: 0.1rem; }
+.tl-dur input { width: 2.6rem; font-size: 0.66rem; }
+.tl-group td { font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--cc-text-dim); padding: 0.5rem 0.2rem 0.15rem; border-bottom: 1px solid var(--cc-border); }
+.tl-cell { text-align: center; padding: 0.18rem 0.15rem; }
+.tl-dot { width: 14px; height: 14px; border-radius: 50%; border: 1px solid var(--cc-border);
+  background: var(--cc-surface-2); cursor: pointer; padding: 0; }
+.tl-dot.on { background: #7c3aed; border-color: #7c3aed; }
+.tl-absent { color: var(--cc-text-dim); opacity: 0.4; }
+.tl-cam { font-size: 0.66rem; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
+
+.btn-sm { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; padding: 0.35rem 0.6rem;
+  border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-2); color: var(--cc-text); cursor: pointer; }
 .btn-sm:hover:not(:disabled) { border-color: #7c3aed; }
 .btn-sm:disabled { opacity: 0.55; cursor: default; }
-.btn-primary { display: inline-flex; align-items: center; gap: 0.4rem; flex-shrink: 0;
-  font-size: 0.78rem; padding: 0.45rem 0.7rem; border: 1px solid #7c3aed; border-radius: 0.35rem;
-  background: #2d1b69; color: #ddd6fe; cursor: pointer; }
+.btn-primary { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.78rem; padding: 0.4rem 0.8rem;
+  border: 1px solid #7c3aed; border-radius: 0.35rem; background: #2d1b69; color: #ddd6fe; cursor: pointer; }
 .btn-primary:hover:not(:disabled) { background: #3b2382; }
 .btn-primary:disabled { opacity: 0.55; cursor: default; }
 </style>

--- a/frontend/src/stores/animation.ts
+++ b/frontend/src/stores/animation.ts
@@ -1,7 +1,8 @@
-// Animation page state: the captured napari "view snapshots" for the current project — each a screenshot
-// (sidecar PNG via assetId, shared with the board strip) + its view state + the image it came from.
-// Debounced autosave → settings/animations.json (mirrors the boards autosave). See AnimationModule.vue
-// and docs/todo/ANIMATION_PLAN.md.
+// Animation page state: captured napari "view snapshots" = the keyframes of the timeline editor. Each
+// is a screenshot (sidecar PNG via assetId, shared with the board strip) + its view state + the image
+// it came from + a duration. A timeline is per-image (keyframes interpolate views of ONE image); the
+// page filters to the open image, in list order. Debounced autosave → settings/animations.json (mirrors
+// the boards autosave). See AnimationModule.vue and docs/todo/ANIMATION_PLAN.md (F2).
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 import { useProjectMetaStore } from './projectMeta'
@@ -9,28 +10,46 @@ import { useProjectMetaStore } from './projectMeta'
 export interface AnimSnapshot {
   id: string
   assetId?: string                      // sidecar PNG id (served via /api/board-assets)
-  snapshot?: Record<string, unknown>    // napari view state (camera + dims + per-layer props)
-  imageUid?: string | null              // the image the view was captured from
+  snapshot?: Record<string, unknown>    // napari view state (camera + dims + per-layer props) — the keyframe
+  imageUid?: string | null              // the image this keyframe belongs to
   imageName?: string
   title?: string
+  duration?: number                     // seconds this keyframe tweens FROM the previous (default 1)
 }
 
 export const useAnimationStore = defineStore('animation', () => {
   const snapshots = ref<AnimSnapshot[]>([])
+  const fps = ref(15)                    // output frame rate (per project)
   const _restoring = ref(false)         // suppress autosave while hydrating from the project load
 
   // hydrate from the project-load response (or clear on a project with none / on switch)
-  function load(data: { snapshots?: AnimSnapshot[] } | null | undefined) {
+  function load(data: { snapshots?: AnimSnapshot[]; fps?: number } | null | undefined) {
     _restoring.value = true
     snapshots.value = data?.snapshots ?? []
+    fps.value = data?.fps ?? 15
     _restoring.value = false
   }
   function add(s: AnimSnapshot) { snapshots.value = [...snapshots.value, s] }
   function remove(id: string) { snapshots.value = snapshots.value.filter(s => s.id !== id) }
 
-  // debounced autosave → /api/projects/animations (dirty on any snapshot add/remove/edit)
+  // move a keyframe one place earlier/later among its OWN image's keyframes (swap with the neighbour of
+  // the same imageUid), so per-image timeline order is what changes.
+  function move(id: string, dir: -1 | 1) {
+    const arr = snapshots.value
+    const i = arr.findIndex(s => s.id === id)
+    if (i < 0) return
+    const uid = arr[i].imageUid
+    let j = i + dir
+    while (j >= 0 && j < arr.length && arr[j].imageUid !== uid) j += dir
+    if (j < 0 || j >= arr.length) return
+    const next = [...arr]; [next[i], next[j]] = [next[j], next[i]]
+    snapshots.value = next
+  }
+
+  // debounced autosave → /api/projects/animations (dirty on any keyframe/fps change, incl. deep edits
+  // to a keyframe's viewState from the row toggles)
   let timer: ReturnType<typeof setTimeout> | null = null
-  watch(snapshots, () => {
+  function _save() {
     if (_restoring.value) return
     const uid = useProjectMetaStore().current?.uid
     if (!uid) return
@@ -38,10 +57,12 @@ export const useAnimationStore = defineStore('animation', () => {
     timer = setTimeout(() => {
       fetch('/api/projects/animations', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ projectUid: uid, animations: { snapshots: snapshots.value } }),
+        body: JSON.stringify({ projectUid: uid, animations: { snapshots: snapshots.value, fps: fps.value } }),
       }).catch(() => { /* autosave is best-effort */ })
     }, 600)
-  }, { deep: true })
+  }
+  watch(snapshots, _save, { deep: true })
+  watch(fps, _save)
 
-  return { snapshots, load, add, remove }
+  return { snapshots, fps, load, add, remove, move }
 })


### PR DESCRIPTION
**Stacked on #144** (the render engine) — base is `feat/animation-keyframes`; the diff here is UI-only. Merge #144 first, then this.

## What

Reworks the Animation page from a snapshot gallery into a **"super-simple OpenShot" timeline** — the row/track matrix we discussed.

A timeline is **per-image** (the image open in napari):
- **Columns = keyframes**: a captured napari view (`viewState` + thumbnail) + a **duration** (seconds it tweens from the previous) + reorder + delete.
- **Rows = channels / populations / camera**, all **inferred from each keyframe's `viewState`** (layers split by name — overlays are parenthesised, channels are plain; camera from `viewState.camera`). A **cell toggle overrides that keyframe's `layer.visible`**.
- **Capture** = grab the current napari view as a base "look"; **Add keyframe** = duplicate the last (a copy to vary via the rows — no re-capture).
- **Render** → `POST /api/napari/record-animation` (keyframes = `viewState`s + `steps = duration × fps`) → interpolated mp4.

The store evolves the S2 snapshots into keyframes (adds `duration` + `fps` + per-image reorder); `animations.json` persists both. Data model stays an **ordered list of `viewState`s**.

## Tests
Typecheck + build green. (Frontend + persistence live on reload.)

## Reservations
- **Not verified live** — the matrix + render need a running backend + napari; verified via typecheck/build only.
- **Thumbnail is the base capture** — toggling a cell changes what *renders* but doesn't regenerate the thumbnail, so the dots are the source of truth (v2: live preview).
- **Camera row is readout-only** (no in-grid camera editing yet).
- Interpolation caveats inherited from #144 (a colormap *name* change steps rather than cross-fades).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
