### PR TITLE
Animation timeline polish: edited badge + reset, sliders, colour dots

### DIFF
--- a/frontend/src/components/canvas/CanvasPanel.vue
+++ b/frontend/src/components/canvas/CanvasPanel.vue
@@ -137,7 +137,7 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
   border-radius: 6px; background: var(--cc-surface-1); overflow: hidden; box-shadow: 0 4px 18px rgba(0,0,0,0.35);
   width: 460px; height: 440px; min-width: 340px; min-height: 320px; resize: both; z-index: 5;
   transition: border-color 0.12s, box-shadow 0.12s; }
-.panel.active { border-color: #ff8c1a; box-shadow: 0 0 0 1px #ff8c1a, 0 6px 22px rgba(0,0,0,0.45); z-index: 6; }
+.panel.active { border-color: var(--cc-selected); box-shadow: 0 0 0 1px var(--cc-selected), 0 6px 22px rgba(0,0,0,0.45); z-index: 6; }
 /* docked: fill the grid slot, no float/drag/resize/shadow */
 .panel.docked { position: static; width: 100%; height: 100%; min-width: 0; min-height: 0; resize: none;
   box-shadow: none; z-index: auto; }

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -24,10 +24,64 @@ const openImageUid = computed(() => projectStore.napariImageUid)
 
 const capturing = ref(false)
 const rendering = ref(false)
+const updating = ref(false)
 const dragId = ref<string | null>(null)   // keyframe being dragged (drag-to-reorder)
+const selectedId = ref<string | null>(null)   // the currently-selected keyframe (the highlighted box)
+const syncNapari = ref(false)             // when on, selecting a keyframe applies its view to napari
 function onDrop(targetId: string) {
   if (dragId.value) anim.reorder(dragId.value, targetId)
   dragId.value = null
+}
+
+// apply a keyframe's saved view to the running napari viewer, so you SEE that snapshot (and can then
+// tweak it in napari + Update). No-op if napari isn't running / the image isn't open.
+async function applyToNapari(s: AnimSnapshot) {
+  if (!s.snapshot) return
+  try {
+    await fetch('/api/napari/apply-view-state', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ viewState: s.snapshot }),
+    })
+  } catch { /* napari not running */ }
+}
+// select a keyframe; if Sync is on, push it to napari
+function selectKeyframe(s: AnimSnapshot) {
+  selectedId.value = s.id
+  if (syncNapari.value) applyToNapari(s)
+}
+// toggling Sync on immediately mirrors the selected keyframe into napari
+function onToggleSync(on: boolean) {
+  syncNapari.value = on
+  const sel = frames.value.find(f => f.id === selectedId.value)
+  if (on && sel) applyToNapari(sel)
+}
+
+// Update the selected keyframe FROM the current napari view — re-screenshot and replace its snapshot +
+// thumbnail (and reset its baseline). This is how you "change" a snapshot: sync it, tweak in napari, save.
+async function updateSelected() {
+  const sel = frames.value.find(f => f.id === selectedId.value)
+  if (!sel || !projectUid.value || !openImageUid.value || updating.value) return
+  updating.value = true
+  try {
+    const res = await fetch('/api/napari/screenshot', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid: projectUid.value }),
+    })
+    if (!res.ok) { log.error(`Update failed: ${(await res.json().catch(() => ({}))).error ?? res.status}`, { source: 'napari' }); return }
+    const j = (await res.json()) as { assetId?: string; viewState?: Record<string, unknown> }
+    const oldAsset = sel.assetId
+    sel.snapshot = j.viewState
+    sel.original = JSON.parse(JSON.stringify(j.viewState ?? {}))   // new baseline (no longer "edited")
+    sel.assetId = j.assetId
+    if (oldAsset && oldAsset !== j.assetId && !anim.snapshots.some(o => o.assetId === oldAsset)) {
+      fetch('/api/board-assets/delete', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectUid: projectUid.value, assetId: oldAsset }),
+      }).catch(() => {})
+    }
+  } catch (e) {
+    log.error(`Update failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'napari' })
+  } finally { updating.value = false }
 }
 
 function imageName(uid: string | null | undefined): string {
@@ -42,8 +96,30 @@ function assetUrl(s: AnimSnapshot): string {
   return s.assetId ? `/api/board-assets?projectUid=${projectUid.value}&assetId=${s.assetId}` : ''
 }
 
+const openImage = computed(() => {
+  for (const set of projectStore.sets) {
+    const img = set.images.find(i => i.uid === openImageUid.value)
+    if (img) return img
+  }
+  return null
+})
+
 // a timeline is per-image: the keyframes of whichever image is open in napari, in list order
 const frames = computed(() => anim.snapshots.filter(s => s.imageUid === openImageUid.value))
+
+// where a snapshot sits in the timelapse — its T index + wall-clock (h/min) via the image's
+// TimeIncrement, so you can tell which frame it's from. T is the first dims axis for these stacks.
+function keyframeTime(s: AnimSnapshot): string {
+  const step = (s.snapshot?.dims as { current_step?: number[] } | undefined)?.current_step
+  const t = Array.isArray(step) ? step[0] : undefined
+  if (t === undefined || t === null) return ''
+  const inc = openImage.value?.timeIncrement
+  if (!inc) return `t${t}`
+  const unit = openImage.value?.timeIncrementUnit ?? 'second'
+  const secs = /^min/i.test(unit) ? t * inc * 60 : t * inc
+  const h = Math.floor(secs / 3600), m = Math.round((secs % 3600) / 60)
+  return `t${t} · ${h > 0 ? `${h}h ${m}m` : `${m}m`}`
+}
 
 type Layers = Record<string, { visible?: boolean; colormap?: string }>
 const layersOf = (s: AnimSnapshot) => (s.snapshot?.layers ?? {}) as Layers
@@ -163,7 +239,7 @@ async function render() {
       </div>
       <div class="anim-head-ctl">
         <label class="anim-fps" v-tooltip.bottom="'Output frames per second'">
-          fps <input type="range" min="1" max="60" step="1" v-model.number="anim.fps" class="anim-range" />
+          fps <input type="range" min="1" max="40" step="1" v-model.number="anim.fps" class="anim-range" />
           <span class="anim-num">{{ anim.fps }}</span>
         </label>
         <button class="btn-primary" :disabled="!canRender" @click="render"
@@ -188,6 +264,14 @@ async function render() {
                 v-tooltip.bottom="'Duplicate the last keyframe to vary it via the rows'">
           <i class="pi pi-plus" /> Add keyframe
         </button>
+        <button class="btn-sm" :disabled="!selectedId || updating" @click="updateSelected"
+                v-tooltip.bottom="'Replace the selected keyframe with the current napari view (re-capture)'">
+          <i :class="['pi', updating ? 'pi-spin pi-spinner' : 'pi-refresh']" /> Update selected
+        </button>
+        <label class="anim-sync" v-tooltip.bottom="'Show the selected keyframe in napari when you click it (so you can see / tweak it)'">
+          <input type="checkbox" :checked="syncNapari" @change="onToggleSync(($event.target as HTMLInputElement).checked)" />
+          Sync napari
+        </label>
       </div>
 
       <p v-if="!frames.length" class="anim-empty">No keyframes yet — set up the view in napari and
@@ -200,12 +284,13 @@ async function render() {
               <th class="tl-rowhead tl-corner"></th>
               <th v-for="(f, i) in frames" :key="f.id" class="tl-col" :class="{ dragover: dragId && dragId !== f.id }"
                   @dragover.prevent @drop="onDrop(f.id)">
-                <div class="tl-thumb" :class="{ edited: isEdited(f), dragging: dragId === f.id }"
+                <div class="tl-thumb" :class="{ selected: selectedId === f.id, dragging: dragId === f.id }"
                      draggable="true" @dragstart="dragId = f.id" @dragend="dragId = null"
-                     v-tooltip.bottom="'Drag to reorder'">
+                     @click="selectKeyframe(f)" v-tooltip.bottom="'Click to select (drag to reorder)'">
                   <img v-if="f.assetId" :src="assetUrl(f)" :alt="`keyframe ${i+1}`" />
                   <span v-if="isEdited(f)" class="tl-badge" v-tooltip.bottom="'Edited from the captured view — use ↺ to reset'">edited</span>
                 </div>
+                <div v-if="keyframeTime(f)" class="tl-time">{{ keyframeTime(f) }}</div>
                 <div class="tl-colctl">
                   <button class="tl-ico" :disabled="i === 0" @click="anim.move(f.id, -1)" v-tooltip.bottom="'Move earlier'"><i class="pi pi-chevron-left" /></button>
                   <span class="tl-kf">{{ i + 1 }}</span>
@@ -270,6 +355,7 @@ async function render() {
 .anim-empty { font-size: 0.85rem; color: var(--cc-text-dim); margin-top: 1.5rem; }
 .anim-toolbar { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.9rem; }
 .anim-img { font-size: 0.78rem; font-weight: 600; color: var(--cc-text); margin-right: 0.2rem; }
+.anim-sync { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; color: var(--cc-text-dim); cursor: pointer; }
 
 /* clean matrix (not a bordered table): sticky row labels, colour-coded toggle dots, rounded thumbs */
 .anim-timeline { overflow-x: auto; border: 1px solid var(--cc-border); border-radius: 0.6rem;
@@ -286,11 +372,12 @@ async function render() {
 .tl-thumb { cursor: grab; }
 .tl-thumb.dragging { opacity: 0.4; }
 .tl-col.dragover .tl-thumb { outline: 2px dashed var(--cc-selected); outline-offset: 2px; }
-/* "edited" highlight = the shared selection amber (--cc-selected), matching the plot panels' selected
-   state — one highlight colour for boxes across the app. */
-.tl-thumb.edited { border-color: var(--cc-selected); box-shadow: 0 0 0 2px color-mix(in srgb, var(--cc-selected) 45%, transparent); }
+/* selected keyframe = the highlighted box → amber ring (--cc-selected), matching the plot panels'
+   selected state. "edited" is a separate flag (the badge), not a ring. */
+.tl-thumb.selected { border-color: var(--cc-selected); box-shadow: 0 0 0 2px color-mix(in srgb, var(--cc-selected) 55%, transparent); }
 .tl-badge { position: absolute; top: 4px; right: 4px; font-size: 0.55rem; font-weight: 700; text-transform: uppercase;
-  letter-spacing: 0.04em; color: #1f1400; background: var(--cc-selected); padding: 1px 5px; border-radius: 999px; }
+  letter-spacing: 0.04em; color: #1f1400; background: var(--cc-warn); padding: 1px 5px; border-radius: 999px; }
+.tl-time { font-size: 0.6rem; color: var(--cc-text-dim); text-align: center; margin-top: 0.15rem; font-variant-numeric: tabular-nums; }
 .tl-colctl { display: flex; align-items: center; justify-content: center; gap: 0.1rem; margin-top: 0.3rem; }
 .tl-kf { font-size: 0.66rem; color: var(--cc-text-dim); min-width: 0.9rem; text-align: center; }
 .tl-ico { display: inline-flex; border: none; background: none; color: var(--cc-text-dim); cursor: pointer;

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -24,6 +24,11 @@ const openImageUid = computed(() => projectStore.napariImageUid)
 
 const capturing = ref(false)
 const rendering = ref(false)
+const dragId = ref<string | null>(null)   // keyframe being dragged (drag-to-reorder)
+function onDrop(targetId: string) {
+  if (dragId.value) anim.reorder(dragId.value, targetId)
+  dragId.value = null
+}
 
 function imageName(uid: string | null | undefined): string {
   if (!uid) return '(unknown image)'
@@ -193,8 +198,11 @@ async function render() {
           <thead>
             <tr>
               <th class="tl-rowhead tl-corner"></th>
-              <th v-for="(f, i) in frames" :key="f.id" class="tl-col">
-                <div class="tl-thumb" :class="{ edited: isEdited(f) }">
+              <th v-for="(f, i) in frames" :key="f.id" class="tl-col" :class="{ dragover: dragId && dragId !== f.id }"
+                  @dragover.prevent @drop="onDrop(f.id)">
+                <div class="tl-thumb" :class="{ edited: isEdited(f), dragging: dragId === f.id }"
+                     draggable="true" @dragstart="dragId = f.id" @dragend="dragId = null"
+                     v-tooltip.bottom="'Drag to reorder'">
                   <img v-if="f.assetId" :src="assetUrl(f)" :alt="`keyframe ${i+1}`" />
                   <span v-if="isEdited(f)" class="tl-badge" v-tooltip.bottom="'Edited from the captured view — use ↺ to reset'">edited</span>
                 </div>
@@ -257,7 +265,7 @@ async function render() {
 .anim-sub { font-size: 0.8rem; color: var(--cc-text-dim); max-width: 46rem; margin: 0; }
 .anim-head-ctl { display: flex; align-items: center; gap: 0.9rem; flex-shrink: 0; }
 .anim-fps { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.4rem; }
-.anim-range { width: 5rem; accent-color: #7c3aed; }
+.anim-range { width: 5rem; accent-color: var(--cc-accent); }
 .anim-num { font-size: 0.72rem; color: var(--cc-text); font-variant-numeric: tabular-nums; min-width: 1.2rem; }
 .anim-empty { font-size: 0.85rem; color: var(--cc-text-dim); margin-top: 1.5rem; }
 .anim-toolbar { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.9rem; }
@@ -275,9 +283,14 @@ async function render() {
 .tl-thumb { position: relative; width: 96px; height: 96px; background: #000; border-radius: 0.5rem;
   overflow: hidden; border: 1px solid var(--cc-border); transition: box-shadow 0.12s, border-color 0.12s; }
 .tl-thumb img { width: 100%; height: 100%; object-fit: contain; }
-.tl-thumb.edited { border-color: #7c3aed; box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.45); }
+.tl-thumb { cursor: grab; }
+.tl-thumb.dragging { opacity: 0.4; }
+.tl-col.dragover .tl-thumb { outline: 2px dashed var(--cc-selected); outline-offset: 2px; }
+/* "edited" highlight = the shared selection amber (--cc-selected), matching the plot panels' selected
+   state — one highlight colour for boxes across the app. */
+.tl-thumb.edited { border-color: var(--cc-selected); box-shadow: 0 0 0 2px color-mix(in srgb, var(--cc-selected) 45%, transparent); }
 .tl-badge { position: absolute; top: 4px; right: 4px; font-size: 0.55rem; font-weight: 700; text-transform: uppercase;
-  letter-spacing: 0.04em; color: #ddd6fe; background: rgba(124, 58, 237, 0.85); padding: 1px 5px; border-radius: 999px; }
+  letter-spacing: 0.04em; color: #1f1400; background: var(--cc-selected); padding: 1px 5px; border-radius: 999px; }
 .tl-colctl { display: flex; align-items: center; justify-content: center; gap: 0.1rem; margin-top: 0.3rem; }
 .tl-kf { font-size: 0.66rem; color: var(--cc-text-dim); min-width: 0.9rem; text-align: center; }
 .tl-ico { display: inline-flex; border: none; background: none; color: var(--cc-text-dim); cursor: pointer;
@@ -285,7 +298,7 @@ async function render() {
 .tl-ico:hover:not(:disabled) { color: var(--cc-text); background: var(--cc-surface-2); }
 .tl-ico:disabled { opacity: 0.3; cursor: default; }
 .tl-dur { display: flex; align-items: center; justify-content: center; gap: 0.3rem; margin-top: 0.3rem; }
-.tl-durrange { width: 68px; accent-color: #7c3aed; }
+.tl-durrange { width: 68px; accent-color: var(--cc-accent); }
 .tl-durval { font-size: 0.62rem; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; min-width: 1.8rem; text-align: left; }
 .tl-group .tl-rowhead { font-size: 0.58rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
   color: var(--cc-text-dim); padding-top: 0.7rem; padding-bottom: 0.2rem; }
@@ -300,10 +313,10 @@ async function render() {
 
 .btn-sm { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; padding: 0.35rem 0.6rem;
   border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-2); color: var(--cc-text); cursor: pointer; }
-.btn-sm:hover:not(:disabled) { border-color: #7c3aed; }
+.btn-sm:hover:not(:disabled) { border-color: var(--cc-accent); }
 .btn-sm:disabled { opacity: 0.55; cursor: default; }
 .btn-primary { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.78rem; padding: 0.4rem 0.8rem;
-  border: 1px solid #7c3aed; border-radius: 0.35rem; background: #2d1b69; color: #ddd6fe; cursor: pointer; }
-.btn-primary:hover:not(:disabled) { background: #3b2382; }
+  border: 1px solid var(--cc-accent); border-radius: 0.35rem; background: var(--cc-accent); color: #fff; cursor: pointer; }
+.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
 .btn-primary:disabled { opacity: 0.55; cursor: default; }
 </style>

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -10,6 +10,7 @@ import { useProjectMetaStore } from '../stores/projectMeta'
 import { useProjectStore } from '../stores/project'
 import { useLogStore } from '../stores/log'
 import { useAnimationStore, type AnimSnapshot } from '../stores/animation'
+import { napariColormapHex } from '../utils/napariColormap'
 import ConfirmDeleteButton from '../components/ConfirmDeleteButton.vue'
 
 const projectMeta = useProjectMetaStore()
@@ -67,6 +68,10 @@ const cameraZoom = (s: AnimSnapshot) => {
   const z = (s.snapshot?.camera as { zoom?: number } | undefined)?.zoom
   return typeof z === 'number' ? z.toFixed(1) : '—'
 }
+// the "on" colour of a cell = the layer's real colour (channel colormap tint), else the accent — so a
+// green channel reads green, not a generic dot.
+const layerColour = (s: AnimSnapshot, name: string) =>
+  napariColormapHex(layersOf(s)[name]?.colormap) ?? '#a78bfa'
 
 // capture the CURRENT napari view as a new keyframe (a base "look")
 async function capture() {
@@ -81,6 +86,7 @@ async function capture() {
     const j = (await res.json()) as { assetId?: string; viewState?: Record<string, unknown>; imageUid?: string }
     const uid = j.imageUid ?? openImageUid.value
     anim.add({ id: crypto.randomUUID(), assetId: j.assetId, snapshot: j.viewState,
+               original: JSON.parse(JSON.stringify(j.viewState ?? {})),   // reset target
                imageUid: uid, imageName: imageName(uid), duration: 1 })
   } catch (e) {
     log.error(`Capture failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'napari' })
@@ -91,11 +97,21 @@ async function capture() {
 function addKeyframe() {
   const last = frames.value[frames.value.length - 1]
   if (!last) { capture(); return }   // nothing yet → capture a base
+  const copy = JSON.parse(JSON.stringify(last.snapshot ?? {}))
   anim.add({
     id: crypto.randomUUID(), assetId: last.assetId, imageUid: last.imageUid, imageName: last.imageName,
     duration: last.duration ?? 1,
-    snapshot: JSON.parse(JSON.stringify(last.snapshot ?? {})),   // deep copy of the viewState
+    snapshot: copy,
+    original: JSON.parse(JSON.stringify(copy)),   // baseline = what it starts as; reset returns here
   })
+}
+
+// a keyframe is "edited" once its working viewState diverges from the captured baseline
+function isEdited(s: AnimSnapshot): boolean {
+  return !!s.original && JSON.stringify(s.snapshot) !== JSON.stringify(s.original)
+}
+function resetKeyframe(s: AnimSnapshot) {
+  if (s.original) s.snapshot = JSON.parse(JSON.stringify(s.original))
 }
 
 async function deleteKeyframe(s: AnimSnapshot) {
@@ -142,8 +158,8 @@ async function render() {
       </div>
       <div class="anim-head-ctl">
         <label class="anim-fps" v-tooltip.bottom="'Output frames per second'">
-          fps <input type="number" min="1" max="60" step="1" :value="anim.fps"
-                     @change="anim.fps = Math.min(60, Math.max(1, Number(($event.target as HTMLInputElement).value) || 15))" />
+          fps <input type="range" min="1" max="60" step="1" v-model.number="anim.fps" class="anim-range" />
+          <span class="anim-num">{{ anim.fps }}</span>
         </label>
         <button class="btn-primary" :disabled="!canRender" @click="render"
                 v-tooltip.bottom="canRender ? 'Render the timeline to an mp4'
@@ -176,47 +192,54 @@ async function render() {
         <table class="tl">
           <thead>
             <tr>
-              <th class="tl-rowhead"></th>
+              <th class="tl-rowhead tl-corner"></th>
               <th v-for="(f, i) in frames" :key="f.id" class="tl-col">
-                <div class="tl-thumb"><img v-if="f.assetId" :src="assetUrl(f)" :alt="`keyframe ${i+1}`" /></div>
+                <div class="tl-thumb" :class="{ edited: isEdited(f) }">
+                  <img v-if="f.assetId" :src="assetUrl(f)" :alt="`keyframe ${i+1}`" />
+                  <span v-if="isEdited(f)" class="tl-badge" v-tooltip.bottom="'Edited from the captured view — use ↺ to reset'">edited</span>
+                </div>
                 <div class="tl-colctl">
                   <button class="tl-ico" :disabled="i === 0" @click="anim.move(f.id, -1)" v-tooltip.bottom="'Move earlier'"><i class="pi pi-chevron-left" /></button>
                   <span class="tl-kf">{{ i + 1 }}</span>
                   <button class="tl-ico" :disabled="i === frames.length - 1" @click="anim.move(f.id, 1)" v-tooltip.bottom="'Move later'"><i class="pi pi-chevron-right" /></button>
+                  <button class="tl-ico" :disabled="!isEdited(f)" @click="resetKeyframe(f)" v-tooltip.bottom="'Reset to the captured view'"><i class="pi pi-refresh" /></button>
                   <ConfirmDeleteButton title="Delete keyframe" armed-title="Click again to delete" @confirm="deleteKeyframe(f)" />
                 </div>
-                <label class="tl-dur" v-tooltip.bottom="'Seconds this keyframe tweens from the previous'">
-                  <input type="number" min="0.1" step="0.1" :value="f.duration ?? 1"
-                         @change="f.duration = Math.max(0.1, Number(($event.target as HTMLInputElement).value) || 1)" />s
-                </label>
+                <div class="tl-dur" v-tooltip.bottom="'Seconds this keyframe tweens from the previous'">
+                  <input type="range" min="0.1" max="10" step="0.1" :value="f.duration ?? 1" class="tl-durrange"
+                         @input="f.duration = Number(($event.target as HTMLInputElement).value)" />
+                  <span class="tl-durval">{{ (f.duration ?? 1).toFixed(1) }}s</span>
+                </div>
               </th>
             </tr>
           </thead>
           <tbody>
-            <tr class="tl-group"><td :colspan="frames.length + 1">Channels</td></tr>
-            <tr v-for="name in channelRows" :key="'c'+name">
+            <tr class="tl-group"><td class="tl-rowhead">Channels</td><td v-for="f in frames" :key="f.id" /></tr>
+            <tr v-for="name in channelRows" :key="'c'+name" class="tl-row">
               <td class="tl-rowhead" :title="name">{{ name }}</td>
               <td v-for="f in frames" :key="f.id" class="tl-cell">
                 <button v-if="cellState(f, name) !== null" class="tl-dot" :class="{ on: cellState(f, name) }"
+                        :style="cellState(f, name) ? { background: layerColour(f, name), borderColor: layerColour(f, name) } : undefined"
                         @click="toggleCell(f, name)" v-tooltip.bottom="cellState(f, name) ? 'Shown — click to hide' : 'Hidden — click to show'" />
                 <span v-else class="tl-absent">·</span>
               </td>
             </tr>
 
             <template v-if="popRows.length">
-              <tr class="tl-group"><td :colspan="frames.length + 1">Populations &amp; overlays</td></tr>
-              <tr v-for="name in popRows" :key="'p'+name">
+              <tr class="tl-group"><td class="tl-rowhead">Populations &amp; overlays</td><td v-for="f in frames" :key="f.id" /></tr>
+              <tr v-for="name in popRows" :key="'p'+name" class="tl-row">
                 <td class="tl-rowhead" :title="name">{{ name }}</td>
                 <td v-for="f in frames" :key="f.id" class="tl-cell">
                   <button v-if="cellState(f, name) !== null" class="tl-dot" :class="{ on: cellState(f, name) }"
+                          :style="cellState(f, name) ? { background: layerColour(f, name), borderColor: layerColour(f, name) } : undefined"
                           @click="toggleCell(f, name)" v-tooltip.bottom="cellState(f, name) ? 'Shown — click to hide' : 'Hidden — click to show'" />
                   <span v-else class="tl-absent">·</span>
                 </td>
               </tr>
             </template>
 
-            <tr class="tl-group"><td :colspan="frames.length + 1">Camera</td></tr>
-            <tr>
+            <tr class="tl-group"><td class="tl-rowhead">Camera</td><td v-for="f in frames" :key="f.id" /></tr>
+            <tr class="tl-row">
               <td class="tl-rowhead">zoom</td>
               <td v-for="f in frames" :key="f.id" class="tl-cell tl-cam">{{ cameraZoom(f) }}</td>
             </tr>
@@ -232,36 +255,48 @@ async function render() {
 .anim-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 0.8rem; }
 .anim-head h1 { font-size: 1.1rem; margin: 0 0 0.2rem; }
 .anim-sub { font-size: 0.8rem; color: var(--cc-text-dim); max-width: 46rem; margin: 0; }
-.anim-head-ctl { display: flex; align-items: center; gap: 0.6rem; flex-shrink: 0; }
-.anim-fps { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.3rem; }
-.anim-fps input { width: 3rem; font-size: 0.72rem; }
+.anim-head-ctl { display: flex; align-items: center; gap: 0.9rem; flex-shrink: 0; }
+.anim-fps { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.4rem; }
+.anim-range { width: 5rem; accent-color: #7c3aed; }
+.anim-num { font-size: 0.72rem; color: var(--cc-text); font-variant-numeric: tabular-nums; min-width: 1.2rem; }
 .anim-empty { font-size: 0.85rem; color: var(--cc-text-dim); margin-top: 1.5rem; }
-.anim-toolbar { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.7rem; }
-.anim-img { font-size: 0.78rem; font-weight: 600; color: var(--cc-text); }
+.anim-toolbar { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.9rem; }
+.anim-img { font-size: 0.78rem; font-weight: 600; color: var(--cc-text); margin-right: 0.2rem; }
 
-.anim-timeline { overflow-x: auto; }
-.tl { border-collapse: collapse; }
-.tl-rowhead { position: sticky; left: 0; background: var(--cc-bg); text-align: left; font-size: 0.68rem;
-  color: var(--cc-text-dim); padding: 0.2rem 0.6rem 0.2rem 0.2rem; max-width: 9rem; overflow: hidden;
+/* clean matrix (not a bordered table): sticky row labels, colour-coded toggle dots, rounded thumbs */
+.anim-timeline { overflow-x: auto; border: 1px solid var(--cc-border); border-radius: 0.6rem;
+  background: var(--cc-surface-1); padding: 0.6rem 0.7rem 0.8rem; }
+.tl { border-collapse: separate; border-spacing: 0; }
+.tl-rowhead { position: sticky; left: 0; background: var(--cc-surface-1); text-align: left; font-size: 0.72rem;
+  color: var(--cc-text); padding: 0.25rem 0.9rem 0.25rem 0.1rem; max-width: 11rem; overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap; z-index: 1; }
-.tl-col { padding: 0 0.15rem 0.3rem; vertical-align: top; }
-.tl-thumb { width: 88px; height: 88px; background: #000; border-radius: 0.3rem; overflow: hidden; }
+.tl-corner { min-width: 7rem; }
+.tl-col { padding: 0 0.35rem 0.4rem; vertical-align: top; text-align: center; }
+.tl-thumb { position: relative; width: 96px; height: 96px; background: #000; border-radius: 0.5rem;
+  overflow: hidden; border: 1px solid var(--cc-border); transition: box-shadow 0.12s, border-color 0.12s; }
 .tl-thumb img { width: 100%; height: 100%; object-fit: contain; }
-.tl-colctl { display: flex; align-items: center; justify-content: center; gap: 0.15rem; margin-top: 0.15rem; }
-.tl-kf { font-size: 0.66rem; color: var(--cc-text-dim); min-width: 1rem; text-align: center; }
-.tl-ico { border: none; background: none; color: var(--cc-text-dim); cursor: pointer; padding: 0.1rem; font-size: 0.62rem; }
-.tl-ico:hover:not(:disabled) { color: var(--cc-text); }
+.tl-thumb.edited { border-color: #7c3aed; box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.45); }
+.tl-badge { position: absolute; top: 4px; right: 4px; font-size: 0.55rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.04em; color: #ddd6fe; background: rgba(124, 58, 237, 0.85); padding: 1px 5px; border-radius: 999px; }
+.tl-colctl { display: flex; align-items: center; justify-content: center; gap: 0.1rem; margin-top: 0.3rem; }
+.tl-kf { font-size: 0.66rem; color: var(--cc-text-dim); min-width: 0.9rem; text-align: center; }
+.tl-ico { display: inline-flex; border: none; background: none; color: var(--cc-text-dim); cursor: pointer;
+  padding: 0.15rem; font-size: 0.62rem; border-radius: 0.25rem; }
+.tl-ico:hover:not(:disabled) { color: var(--cc-text); background: var(--cc-surface-2); }
 .tl-ico:disabled { opacity: 0.3; cursor: default; }
-.tl-dur { display: flex; align-items: center; justify-content: center; gap: 0.15rem; font-size: 0.62rem; color: var(--cc-text-dim); margin-top: 0.1rem; }
-.tl-dur input { width: 2.6rem; font-size: 0.66rem; }
-.tl-group td { font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
-  color: var(--cc-text-dim); padding: 0.5rem 0.2rem 0.15rem; border-bottom: 1px solid var(--cc-border); }
-.tl-cell { text-align: center; padding: 0.18rem 0.15rem; }
-.tl-dot { width: 14px; height: 14px; border-radius: 50%; border: 1px solid var(--cc-border);
-  background: var(--cc-surface-2); cursor: pointer; padding: 0; }
-.tl-dot.on { background: #7c3aed; border-color: #7c3aed; }
-.tl-absent { color: var(--cc-text-dim); opacity: 0.4; }
-.tl-cam { font-size: 0.66rem; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
+.tl-dur { display: flex; align-items: center; justify-content: center; gap: 0.3rem; margin-top: 0.3rem; }
+.tl-durrange { width: 68px; accent-color: #7c3aed; }
+.tl-durval { font-size: 0.62rem; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; min-width: 1.8rem; text-align: left; }
+.tl-group .tl-rowhead { font-size: 0.58rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--cc-text-dim); padding-top: 0.7rem; padding-bottom: 0.2rem; }
+.tl-row:hover .tl-cell, .tl-row:hover .tl-rowhead { background: rgba(255, 255, 255, 0.03); }
+.tl-cell { text-align: center; padding: 0.22rem 0.35rem; }
+.tl-dot { width: 15px; height: 15px; border-radius: 50%; border: 1.5px solid var(--cc-border);
+  background: transparent; cursor: pointer; padding: 0; transition: transform 0.1s; }
+.tl-dot:hover { transform: scale(1.18); }
+.tl-dot.on { border-style: solid; }         /* on: filled with the layer colour (set inline) */
+.tl-absent { color: var(--cc-text-dim); opacity: 0.35; }
+.tl-cam { font-size: 0.68rem; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
 
 .btn-sm { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; padding: 0.35rem 0.6rem;
   border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-2); color: var(--cc-text); cursor: pointer; }

--- a/frontend/src/stores/animation.ts
+++ b/frontend/src/stores/animation.ts
@@ -65,5 +65,18 @@ export const useAnimationStore = defineStore('animation', () => {
   watch(snapshots, _save, { deep: true })
   watch(fps, _save)
 
-  return { snapshots, fps, load, add, remove, move }
+  // drag-and-drop: place the dragged keyframe at the target's position (both must be the same image —
+  // the timeline is per-image).
+  function reorder(draggedId: string, targetId: string) {
+    if (draggedId === targetId) return
+    const arr = [...snapshots.value]
+    const from = arr.findIndex(s => s.id === draggedId)
+    const to = arr.findIndex(s => s.id === targetId)
+    if (from < 0 || to < 0 || arr[from].imageUid !== arr[to].imageUid) return
+    const [item] = arr.splice(from, 1)
+    arr.splice(arr.findIndex(s => s.id === targetId), 0, item)
+    snapshots.value = arr
+  }
+
+  return { snapshots, fps, load, add, remove, move, reorder }
 })

--- a/frontend/src/stores/animation.ts
+++ b/frontend/src/stores/animation.ts
@@ -10,7 +10,8 @@ import { useProjectMetaStore } from './projectMeta'
 export interface AnimSnapshot {
   id: string
   assetId?: string                      // sidecar PNG id (served via /api/board-assets)
-  snapshot?: Record<string, unknown>    // napari view state (camera + dims + per-layer props) — the keyframe
+  snapshot?: Record<string, unknown>    // napari view state (camera + dims + per-layer props) — the keyframe (edited)
+  original?: Record<string, unknown>    // the captured baseline viewState — reset target; unchanged by row edits
   imageUid?: string | null              // the image this keyframe belongs to
   imageName?: string
   title?: string

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -15,6 +15,9 @@
   /* borders / accents */
   --cc-border:     #30363d;
   --cc-accent:     #a78bfa;
+  /* selection/active highlight for BOXES (panels, cards, timeline keyframes) — amber, matching the
+     analysis-board plot panels. Distinct from --cc-accent (purple, form controls) and --cc-warn. */
+  --cc-selected:   #ff8c1a;
 
   /* status colours (amber warning / red danger) — previously only inlined as var() fallbacks */
   --cc-warn:       #f59e0b;


### PR DESCRIPTION
Feedback pass on the timeline editor (#145).

## Changes
- **Edited indicator** — each keyframe keeps its captured baseline (`original` viewState); when the working state diverges it shows an **"edited" badge + accent ring**, so it's obvious you changed something.
- **Per-keyframe reset (↺)** — revert a keyframe to its captured view.
- **Sliders, not number inputs** — fps + per-keyframe duration are sliders now (the number spinners rendered badly on **Firefox**; sliders are compact + consistent).
- **Less "PowerPoint 95"** — toggle dots use the layer's **real colour** (channel colormap tint) when on, outline when off; the matrix is softened (no hard table borders, sticky row labels, row hover, rounded thumbnails with the edited ring, cleaner group labels).

## Tests
Frontend-only; **typecheck + build** green. Live behaviour (toggles/reset/render) needs a backend + napari to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
