### PR TITLE
Align UMAP / heatmap / palette with the R (ggplot) look

### DIFF
--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -291,11 +291,17 @@ docs/TODO.md.)
    governed by the global/local scope (`VisProps`): legend, log scale, gridlines, rotate-X-labels
    (with an **angle slider**, `rotateXAngle`, 0–90°; the bottom margin scales with the angle),
    **facet** (small multiples per series), **dark theme**, Y-range override; jitter type
-   (beeswarm/random/none), colour-data, point size/opacity; **palette** (Okabe-Ito, Tol bright/
+   (beeswarm/random/none), colour-data, point size/opacity; **palette** (**`Cecelia`** house palette, Okabe-Ito, Tol bright/
    muted/light, `distinct`, user list); title, X/Y axis labels, font size. All builder ink is
-   `currentColor` so the dark theme flips with one `style.color`. The **cluster UMAP** (`UmapView`)
-   honours the same `palette` choice for colour-by-cluster (via `paletteRange`; `standard` falls back
-   to its built-in palette).
+   `currentColor` so the dark theme flips with one `style.color`. The `Cecelia` palette
+   (`PALETTES.cecelia` in `plot.ts`) is the old R behaviour-figure `colPal` (yellow / steel-blue /
+   crimson / grey) + accents; it is also offered as clickable swatches in the pop colour picker
+   (`PopulationManager`; the native picker is kept for custom colours). The **cluster UMAP**
+   (`UmapView`, a 2D canvas of **circular** points) honours the picker for the colour-by-cluster
+   **palette** (via `paletteRange`; the built-in fallback is now the Cecelia palette), **point
+   size/opacity**, **dark theme**, **legend** (`vis.legend` — no UMAP-only toggle) and label **font
+   size**. Jitter/log/grid/axis-label knobs are N/A (a fixed embedding, no measured axes); colour &
+   facet have richer UMAP-native controls.
 8. **Track populations in the picker** — a track-granularity plot's picker unions `live` (cell gates
    + derived `/_tracked`) and `track` gates (per-track-measure gates from `{vn}__tracks.json`), each
    tagged with its `popType`; the panel groups series by popType and fetches one `/api/plot_data` per
@@ -325,9 +331,15 @@ Observable Plot covers both natively.
 whole `pop_df` frame (every selected population/segmentation/image) into ONE grid — a composition view,
 not a per-series overlay. Two **modes** (generic, reusable for any data):
 - **profile** — rows = `measures` (the spec's `measureOptions`), columns = the levels of a categorical
-  `category` column; each cell = the **mean** of that measure for cells in that level. `zscore`
-  standardises each row across the levels (→ diverging RdBu pivoted at 0) so differently-scaled
-  measures are comparable: the **"state signature"** (what properties do cells in each HMM state have).
+  `category` column; each cell = the **mean** of that measure for cells in that level: the **"state
+  signature"** (what properties do cells in each HMM state have). Each row is normalised so
+  differently-scaled measures are comparable — two **scale** modes, chosen in the panel:
+  - **0–1** (default, `heatmapScale: 'minmax'`) — per-feature min-max to `[0,1]` on a **sequential
+    viridis** scale with a fixed 0–1 colourbar. Ports the old R heat plots (`normalit()` +
+    `scale_fill_viridis(limits=c(0,1))`). The rescale is `rescaleRows01` in `utils/heatmapScale.ts`
+    (pure + unit-tested); it is invariant under z-score, so it works whatever the fetch's `zscore` flag.
+  - **z-score** (`heatmapScale: 'zscore'`) — server-standardised rows on a **diverging RdBu** pivoted
+    at 0 (above/below the row mean).
 - **crosstab** — a single categorical `category` whose values encode a pair `"from<sep>to"` (HMM
   transitions `"1_2"`, or the cross-model hybrid `"1.2_3.4"` — the hybrid joins state columns with
   `.`, so the FIRST `sep` splits prev|cur). Cell = count, or a rate (`row` = P(to|from), `col` =
@@ -337,12 +349,14 @@ Backend: `_matrix_agg(df; mode, measures, category, separator, zscore, normalize
 `plot_data.jl`, dispatched from `_summary_agg` when `chart_type == "matrix"` (and threaded through all
 four `plot_summary_data` methods + `/api/plot_data` as `matrixMode`/`measures`/`category`/`separator`/
 `zscore`/`matrixNormalize`). Returns a flat `cells` `[{x,y,value,n|count}]` + ordered `xLabels`/
-`yLabels` + `valueLabel`. Frontend: `buildHeatmap` in `plot.ts` (`Plot.cell` + viridis/diverging
-scale + per-cell value text; continuous legend stashed in `_colorLegend` for `PlotChart` to draw as an
-overlay). The panel offers `heatmap` independent of the measure type (it's a grid, not a measure
-distribution); its options popover picks **Mode**, **Category** (from the discovered categorical obs
-columns — crosstab defaults to a `*transitions*` column, profile to a `*state*` column), and
-**z-score** (profile) / **Normalize** (crosstab). Plot defs: `state_signature.json` (profile) and
+`yLabels` + `valueLabel`. Frontend: `buildHeatmap` in `plot.ts` (`Plot.cell`, the colour scale per the
+mode above, **white** tile borders + a **black `theme_classic` L-axis**, tight margins; continuous
+legend stashed in `_colorLegend` for `PlotChart` to draw as an overlay). In-cell value text is a
+`heatmapValues` toggle — **off** by default for profile (matches R), on for crosstab. The panel offers
+`heatmap` independent of the measure type (it's a grid, not a measure distribution); its options
+popover picks **Mode**, **Category** (from the discovered categorical obs columns — crosstab defaults
+to a `*transitions*` column, profile to a `*state*` column), **Scale** (0–1 / z-score, profile) /
+**Normalize** (crosstab), and **Cell values**. Plot defs: `state_signature.json` (profile) and
 `transition_matrix.json` (crosstab).
 
 **Tiled / spatial map** (binned positions over the image field) — roadmap → `Plot.raster` /

--- a/frontend/src/components/canvas/PlotOptions.vue
+++ b/frontend/src/components/canvas/PlotOptions.vue
@@ -90,6 +90,7 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <label class="po-row"><span>Palette</span>
           <select class="po-sel" :value="vis.palette" @change="set({ palette: ($event.target as HTMLSelectElement).value as VisProps['palette'] })">
             <option value="standard">standard (population)</option><option value="distinct">distinct</option>
+            <option value="cecelia">Cecelia</option>
             <option value="okabe-ito">Okabe-Ito</option>
             <option value="tol-bright">Tol bright</option><option value="tol-muted">Tol muted</option>
             <option value="tol-light">Tol light</option><option value="user">user</option>

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -21,7 +21,8 @@ import { useProjectStore } from '../../stores/project'
 import { useSettingsStore } from '../../stores/settings'
 import PopulationPanelShell from './PopulationPanelShell.vue'
 import ConfirmDeleteButton from '../ConfirmDeleteButton.vue'
-import type { VisProps } from '../../plots/plot'
+import TeleportPopover from '../TeleportPopover.vue'
+import { PALETTES, type VisProps } from '../../plots/plot'
 
 const props = withDefaults(defineProps<{
   selected: string
@@ -66,6 +67,25 @@ const napariPointSize = computed<number>({
 const optionsOpen = ref(false)     // gate / viewer options box (host-specific, in the shell #options slot)
 const editing = ref<string | null>(null)
 const editName = ref('')
+
+// pop colour picker: clicking a pop's swatch opens a small popover offering the Cecelia palette
+// (click a chip) plus the native picker for anything custom. A native <input type="color"> can't
+// carry preset swatches, so we anchor our own popover to the clicked swatch instead.
+const CECELIA_PALETTE = PALETTES.cecelia
+const colourPop = ref<string | null>(null)          // path of the pop whose picker is open
+const colourAnchor = ref<HTMLElement | null>(null)  // the clicked swatch (drives popover placement)
+const colourOpen = computed<boolean>({ get: () => colourPop.value !== null, set: v => { if (!v) colourPop.value = null } })
+const colourPopColour = computed(() => g.flat.find(p => p.path === colourPop.value)?.colour ?? '#ffffff')
+const eqColour = (a: string, b: string) => a.toLowerCase() === b.toLowerCase()
+function openColour(p: FlatPop, e: MouseEvent) {
+  if (props.readonly || p.transient) return
+  colourAnchor.value = e.currentTarget as HTMLElement
+  colourPop.value = p.path
+}
+function setColour(c: string, close = true) {
+  if (colourPop.value) g.updatePop(colourPop.value, { colour: c })
+  if (close) colourPop.value = null
+}
 
 function pick(p: FlatPop) { emit('update:selected', p.path) }
 function beginRename(p: FlatPop) { editing.value = p.path; editName.value = p.name }
@@ -144,9 +164,9 @@ async function addClusterPopulation() {
              @click="pick(p)">
           <i v-if="p.transient" class="pi pi-map-marker pm-napari"
              v-tooltip.left="'Cells selected in napari (temporary)'" :style="{ color: p.colour }" />
-          <input v-else type="color" class="pm-swatch" :value="p.colour" :disabled="readonly"
-                 v-tooltip.left="readonly ? '' : 'Colour'"
-                 @click.stop @change="g.updatePop(p.path, { colour: ($event.target as HTMLInputElement).value })" />
+          <button v-else type="button" class="pm-swatch" :style="{ background: p.colour }" :disabled="readonly"
+                  v-tooltip.left="readonly ? '' : 'Colour'"
+                  @click.stop="openColour(p, $event)" />
 
           <span v-if="editing !== p.path" class="pm-name"
                 @dblclick.stop="!readonly && !p.transient && beginRename(p)">{{ p.name }}</span>
@@ -195,6 +215,22 @@ async function addClusterPopulation() {
           <span v-if="!props.clusterIds.length" class="pm-chip-empty">no clusters at this suffix</span>
         </div>
       </template>
+
+      <!-- pop colour picker popover: Cecelia palette chips + a native picker for custom colours -->
+      <TeleportPopover v-model="colourOpen" :anchor="colourAnchor" placement="bottom-start">
+        <div class="pm-colours">
+          <div class="pm-colours-grid">
+            <button v-for="c in CECELIA_PALETTE" :key="c" type="button" class="pm-colour-chip"
+                    :class="{ on: eqColour(c, colourPopColour) }" :style="{ background: c }"
+                    v-tooltip.top="c" @click="setColour(c)" />
+          </div>
+          <label class="pm-colour-custom">
+            <span>custom</span>
+            <input type="color" :value="colourPopColour"
+                   @change="setColour(($event.target as HTMLInputElement).value, false)" />
+          </label>
+        </div>
+      </TeleportPopover>
 
     <!-- ── gate / viewer options (host-specific, #options slot). In cluster mode there are no gates
          (the plot group); trackclust has no viewer control either, so the whole block is hidden. ── -->
@@ -263,7 +299,17 @@ async function addClusterPopulation() {
 .pm-row.active { background: color-mix(in srgb, var(--cc-accent) 22%, transparent); }
 .pm-row.transient { font-style: italic; background: color-mix(in srgb, #22d3ee 8%, transparent); }
 .pm-napari { width: 16px; text-align: center; font-size: 13px; }
-.pm-swatch { width: 16px; height: 16px; padding: 0; border: none; background: none; cursor: pointer; }
+.pm-swatch { width: 16px; height: 16px; padding: 0; border: 1px solid var(--cc-border); border-radius: 3px; cursor: pointer; flex-shrink: 0; }
+.pm-swatch:disabled { cursor: default; opacity: 0.7; }
+/* colour picker popover (Cecelia palette + native custom) — TeleportPopover gives surface/border */
+.pm-colours { display: flex; flex-direction: column; gap: 8px; padding: 8px; }
+.pm-colours-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 5px; }
+.pm-colour-chip { width: 22px; height: 22px; border: 1px solid var(--cc-border); border-radius: 4px; cursor: pointer; padding: 0; }
+.pm-colour-chip:hover { transform: scale(1.08); }
+.pm-colour-chip.on { outline: 2px solid var(--cc-text); outline-offset: 1px; }
+.pm-colour-custom { display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  font-size: 12px; color: var(--cc-text-dim); border-top: 1px solid var(--cc-border); padding-top: 6px; }
+.pm-colour-custom input { width: 28px; height: 20px; padding: 0; border: none; background: none; cursor: pointer; }
 .pm-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .pm-rename { flex: 1; background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-accent); border-radius: 3px; padding: 1px 4px; }
 .pm-stat { color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -49,7 +49,7 @@ interface PanelState {
   specId: string; sel: string[]; vis: VisProps
   chartType?: ChartType; measure?: string; bins?: number; normalize?: boolean; errorMetric?: 'sd' | 'sem' | 'ci95'
   groupBy?: string; smooth?: number; interval?: boolean
-  matrixMode?: 'profile' | 'crosstab'; zscore?: boolean; matrixNormalize?: 'none' | 'row' | 'col' | 'total'
+  matrixMode?: 'profile' | 'crosstab'; zscore?: boolean; heatmapValues?: boolean; matrixNormalize?: 'none' | 'row' | 'col' | 'total'
 }
 const canvasRef = useTemplateRef<HTMLElement>('canvasRef')   // the visible viewport (zoom + fit measure it)
 const zoomRef = useTemplateRef<HTMLElement>('zoomRef')       // the scaled workspace (panels' offsetParent)

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -34,7 +34,7 @@ const props = defineProps<{
   // per-panel chart options, PERSISTED in the host's panel state (so chart type/measure/bins survive
   // navigation). Seeded lazily from the spec's defaults; written back on user change.
   ui: { chartType?: ChartType; measure?: string; bins?: number; normalize?: boolean; errorMetric?: 'sd' | 'sem' | 'ci95'; groupBy?: string;
-        matrixMode?: 'profile' | 'crosstab'; zscore?: boolean; matrixNormalize?: 'none' | 'row' | 'col' | 'total'; smooth?: number; interval?: boolean }
+        matrixMode?: 'profile' | 'crosstab'; zscore?: boolean; heatmapValues?: boolean; matrixNormalize?: 'none' | 'row' | 'col' | 'total'; smooth?: number; interval?: boolean }
   collapseSeries?: boolean             // pool across pops & images → series by the groupBy level only
   reloadToken?: number                 // bumped by the host to force a refetch (live gate updates)
   persistKey?: string                  // CanvasPanel geometry persistence key
@@ -182,7 +182,11 @@ const specPinnedMode = computed(() => !!props.spec.dataSource.matrix?.mode)
 const matrixMode = computed<'profile' | 'crosstab'>({
   get: () => (specPinnedMode.value ? props.spec.dataSource.matrix!.mode! : (props.ui.matrixMode ?? 'profile')),
   set: v => (props.ui.matrixMode = v) })
-const zscore = computed<boolean>({ get: () => props.ui.zscore ?? true, set: v => (props.ui.zscore = v) })
+// z-score OFF by default → per-feature 0–1 viridis (the old R heat-plot look); ON → diverging RdBu.
+const zscore = computed<boolean>({ get: () => props.ui.zscore ?? false, set: v => (props.ui.zscore = v) })
+// cell numbers: off by default for a profile signature (matches R), on for a crosstab (counts/probs).
+const heatmapValues = computed<boolean>({
+  get: () => props.ui.heatmapValues ?? (matrixMode.value === 'crosstab'), set: v => (props.ui.heatmapValues = v) })
 const matrixNormalize = computed<'none' | 'row' | 'col' | 'total'>({
   get: () => props.ui.matrixNormalize ?? 'row', set: v => (props.ui.matrixNormalize = v) })
 // effective category: the user's chosen column, else the spec's pinned hint (if available), else a
@@ -390,6 +394,7 @@ const buildOpts = computed<BuildOpts>(() => ({
   nonNegative: true,               // the measures plotted here are non-negative
   trend: timeSeries.value, smooth: smooth.value, interval: interval.value,
   ...vis.value,                    // logScale, legend, pointSize, pointOpacity
+  heatmapScale: zscore.value ? 'zscore' : 'minmax', heatmapValues: heatmapValues.value,
 }))
 
 // ── export: the shown DATA as CSV, or the rendered chart as PNG / SVG (like the R version) ──
@@ -468,7 +473,7 @@ defineExpose({ getCsv, exportImage })
               </select>
             </label>
             <label v-if="matrixMode === 'profile'" class="sp-pop-row"
-                   v-tooltip.left="'Standardise each measure row across categories (comparable signature)'">
+                   v-tooltip.left="'Off: rescale each feature to 0–1 (viridis). On: z-score rows → diverging above/below-mean (RdBu).'">
               <span>Z-score rows</span>
               <input type="checkbox" v-model="zscore" />
             </label>
@@ -480,6 +485,10 @@ defineExpose({ getCsv, exportImage })
                 <option value="total">total</option>
                 <option value="none">counts</option>
               </select>
+            </label>
+            <label class="sp-pop-row" v-tooltip.left="'Print the value in each cell'">
+              <span>Cell values</span>
+              <input type="checkbox" v-model="heatmapValues" />
             </label>
           </template>
           <label v-if="chartType === 'histogram'" class="sp-pop-row">

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -21,7 +21,7 @@ import { useLogStore } from '../../stores/log'
 import { useProjectStore } from '../../stores/project'
 import { useDataRefresh } from '../../composables/useDataRefresh'
 import { plotHostToImageURL, rasterPlotToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
-import { paletteRange, type VisProps } from '../../plots/plot'
+import { paletteRange, PALETTES, type VisProps } from '../../plots/plot'
 import { tkey, parseTkey } from '../../plots/series'
 import type { SegmentationPops } from '../../plots/types'
 import TeleportPopover from '../TeleportPopover.vue'
@@ -38,7 +38,7 @@ const props = defineProps<{
   // populations — colourPops tkeys), or 'attribute' (each point's image attribute — colourAttr).
   // facetBy: split into small multiples — 'none' (default), 'attribute' (facetAttr) or 'population'.
   // See docs/todo/UMAP_COLOUR_FACET_PLAN.md.
-  state: { labels?: boolean; legend?: boolean
+  state: { labels?: boolean
            colourBy?: 'cluster' | 'population' | 'attribute'
            colourPops?: string[]; colourAttr?: string
            facetBy?: 'none' | 'attribute' | 'population'; facetAttr?: string }
@@ -53,9 +53,9 @@ const facetAttr = computed({ get: () => props.state.facetAttr ?? '', set: v => (
 // the population dimension (popIdx) is needed whenever EITHER colour OR facet is by population
 const usePopIdx = computed(() => colourBy.value === 'population' || facetBy.value === 'population')
 const labels = computed({ get: () => props.state.labels !== false, set: v => (props.state.labels = v) })
-// show/hide the population legend — persisted per panel (default on). On the Analysis canvas it can
-// eat ~half the plot, so let the user reclaim that space.
-const showLegend = computed({ get: () => props.state.legend !== false, set: v => (props.state.legend = v) })
+// show/hide the population legend — follows the picker's Legend option (vis.legend), like the other
+// plots, rather than a UMAP-only toggle. Default on when no vis is supplied.
+const showLegend = computed(() => props.vis?.legend !== false)
 const unit = computed(() => (props.popType === 'trackclust' ? 'tracks' : 'cells'))
 
 // `forceLight` flips to a light render for the board's PDF export (dark theme is on-screen only) —
@@ -72,20 +72,23 @@ const scatterGround = computed(() => (screenDark.value ? '#0d0b1a' : '#ffffff'))
 // the PNG background (points are drawn transparent, so this fill IS the exported ground).
 const dark = computed(() => !forceLight.value && screenDark.value)
 const ground = computed(() => (dark.value ? '#0d0b1a' : '#ffffff'))
-// label chip + legend ink follow the theme so they stay legible on the exported ground (a light
-// ground with the app's light legend ink was invisible — #00061 follow-up).
-const labelStyle = computed(() => dark.value
-  ? { color: '#111', background: 'rgba(255,255,255,0.85)', borderColor: 'rgba(0,0,0,0.35)' }
-  : { color: '#f5f5f5', background: 'rgba(20,20,28,0.82)', borderColor: 'rgba(255,255,255,0.35)' })
+// cluster label chip: the ggplot `geom_label` look (white box, thin black border, black text) in BOTH
+// themes — it reads on the dark on-screen ground AND the white PDF export (the old light-export chip
+// was a dark box with white text, which didn't match the R figures). See geom_label_repel in
+// plotClustersUMAPServer.R.
+const labelStyle = computed(() => ({ color: '#111', background: 'rgba(255,255,255,0.9)', borderColor: 'rgba(0,0,0,0.55)' }))
 const legendInk = computed(() => (dark.value ? '#e6e6e6' : '#111'))
 // legend box background follows the theme too — in light mode the dark ink sat on the app's dark
 // panel surface (unreadable on the canvas); give it a light box so the pop names are legible.
 const legendBg = computed(() => (dark.value ? 'transparent' : '#ffffff'))
 
+// default cluster colours = the Cecelia house palette (the R behaviour-figure colours: yellow /
+// steel-blue / crimson / grey lead), so the UMAP matches the published look out of the box. Extra
+// hues follow for runs with >8 clusters. The pop-manager palette knob still overrides via paletteRange.
 const PALETTE = [
-  '#ef4444', '#f59e0b', '#10b981', '#3b82f6', '#a78bfa', '#ec4899', '#14b8a6', '#eab308',
-  '#f97316', '#22d3ee', '#84cc16', '#8b5cf6', '#f43f5e', '#06b6d4', '#a3e635', '#d946ef',
-  '#fb7185', '#2dd4bf', '#fbbf24', '#60a5fa',
+  ...PALETTES.cecelia,
+  '#ef4444', '#10b981', '#a78bfa', '#f97316', '#84cc16', '#8b5cf6', '#f43f5e', '#06b6d4',
+  '#a3e635', '#d946ef', '#fb7185', '#2dd4bf',
 ]
 const UNCLUSTERED = '#555a6e'
 // faint whole-cloud backdrop behind each facet — dark grey on the dark ground, light grey on the light
@@ -181,24 +184,33 @@ const dotsEl = useTemplateRef<HTMLCanvasElement>('dotsEl')
 const plotBoxEl = useTemplateRef<HTMLElement>('plotBoxEl')
 let dctx: CanvasRenderingContext2D | null = null
 let dro: ResizeObserver | null = null
-const DOT_R = 2
+// point radius + opacity follow the pop-manager knobs (vis.pointSize / vis.pointOpacity); the redraw
+// watch below fires when they change so the canvas repaints without a refetch.
+const dotR = computed(() => Math.max(0.5, props.vis?.pointSize ?? 2))
+const dotAlpha = computed(() => Math.min(1, Math.max(0.05, props.vis?.pointOpacity ?? 0.9)))
+const TAU = Math.PI * 2
+// draw one filled circle (fillStyle is set by the caller, once per colour bucket)
+function dot(c: CanvasRenderingContext2D, px: number, py: number, r: number) {
+  c.beginPath(); c.arc(px, py, r, 0, TAU); c.fill()
+}
 // centroid labels + facet titles scale with the pop-manager font-size slider (vis.fontSize)
 const labelFont = computed(() => props.vis?.fontSize ?? 11)
 // paint a set of point indices via `toPx`, bucketed by category so fillStyle is set once per colour
 function paintInto(c: CanvasRenderingContext2D, idx: number[], toPx: (i: number) => [number, number]) {
-  const cats = categories.value!, pal = palette.value, s = DOT_R * 2
+  const cats = categories.value!, pal = palette.value
   const groups: number[][] = pal.map(() => [])
   for (const i of idx) { const g = groups[cats[i]]; if (g) g.push(i) }
   for (let gi = 0; gi < pal.length; gi++) {
     const g = groups[gi]; if (!g.length) continue
     c.fillStyle = pal[gi]
-    for (const i of g) { const [px, py] = toPx(i); c.fillRect(px - DOT_R, py - DOT_R, s, s) }
+    for (const i of g) { const [px, py] = toPx(i); dot(c, px, py, dotR.value) }
   }
 }
 function paintDots(c: CanvasRenderingContext2D, w: number, h: number) {
   const pts = points.value, cats = categories.value, pal = palette.value
   if (!pts || !cats || !pal.length) return
-  c.globalAlpha = 0.9
+  const alpha = dotAlpha.value
+  c.globalAlpha = alpha
   const fs = facets.value
   if (facetBy.value === 'none' || fs.length <= 1) {
     const n = pts.length / 2, groups: number[][] = pal.map(() => [])
@@ -206,7 +218,7 @@ function paintDots(c: CanvasRenderingContext2D, w: number, h: number) {
     for (let gi = 0; gi < pal.length; gi++) {
       const g = groups[gi]; if (!g.length) continue
       c.fillStyle = pal[gi]
-      for (const i of g) { const [px, py] = mapPx(pts[2 * i], pts[2 * i + 1], w, h); c.fillRect(px - DOT_R, py - DOT_R, DOT_R * 2, DOT_R * 2) }
+      for (const i of g) { const [px, py] = mapPx(pts[2 * i], pts[2 * i + 1], w, h); dot(c, px, py, dotR.value) }
     }
   } else {
     const n = pts.length / 2
@@ -215,8 +227,8 @@ function paintDots(c: CanvasRenderingContext2D, w: number, h: number) {
       // GHOST: the whole cloud in faint grey behind each facet, so the UMAP shape stays legible and
       // facets are comparable (you see where this facet's points sit within the full embedding).
       c.globalAlpha = 0.6; c.fillStyle = ghostColour()
-      for (let i = 0; i < n; i++) { const [px, py] = mapRect(pts[2 * i], pts[2 * i + 1], cell); c.fillRect(px - 1, py - 1, 2, 2) }
-      c.globalAlpha = 0.9
+      for (let i = 0; i < n; i++) { const [px, py] = mapRect(pts[2 * i], pts[2 * i + 1], cell); dot(c, px, py, 1) }
+      c.globalAlpha = alpha
       paintInto(c, fs[fi].idx, i => mapRect(pts[2 * i], pts[2 * i + 1], cell))
     }
   }
@@ -465,6 +477,8 @@ watch(usePopIdx, v => { if (v && !popGroups.value.length) loadPopGroups() }, { i
 // backdrop is theme-coloured — dark grey on dark, light grey on light/export)
 watch([points, categories, palette, extents], () => nextTick(redraw), { deep: true })
 watch(dark, () => nextTick(redraw))
+// styling knobs that only affect the canvas paint (no refetch): point size + opacity
+watch([() => props.vis?.pointSize, () => props.vis?.pointOpacity], () => nextTick(redraw))
 onMounted(() => {
   load()
   // observe the STABLE square box (present from mount) so a panel resize always repaints + repositions
@@ -508,8 +522,7 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
     <div class="uv-ctrl cc-panel-controls">
       <button class="cc-btn cc-btn-ghost" :class="{ on: labels }" @click="labels = !labels"
               v-tooltip.bottom="'Toggle centroid labels'"><i class="pi pi-tag" /> #</button>
-      <button class="cc-btn cc-btn-ghost" :class="{ on: showLegend }" @click="showLegend = !showLegend"
-              v-tooltip.bottom="'Toggle the legend'"><i class="pi pi-list" /></button>
+      <!-- legend visibility follows the picker's Legend option (vis.legend) — no separate toggle here -->
       <!-- colour + facet controls live in a single options popover to keep the (often docked) bar tidy -->
       <button ref="optsBtn" class="cc-btn cc-btn-ghost" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
               v-tooltip.bottom="'Colour & facet options'"><i class="pi pi-palette" /> options</button>
@@ -628,7 +641,7 @@ defineExpose({ exportFormats: ['png', 'csv'], exportAs, exportImage })
 .uv-plot { position: absolute; inset: 0; background: #0d0b1a; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
 .uv-canvas { position: absolute; inset: 0; width: 100%; height: 100%; }
 .uv-label { position: absolute; transform: translate(-50%, -50%); pointer-events: none; font-weight: 700;
-  color: #111; background: rgba(255,255,255,0.85); border: 1px solid rgba(0,0,0,0.35); border-radius: 3px; padding: 0 4px; line-height: 1.4; z-index: 2; }
+  color: #111; background: rgba(255,255,255,0.9); border: 1px solid rgba(0,0,0,0.55); border-radius: 3px; padding: 0 4px; line-height: 1.4; z-index: 2; }
 /* small-multiples facet title: centred at the top of each cell (positioned in CSS px from facetTitles) */
 .uv-facet-title { position: absolute; transform: translateX(-50%); pointer-events: none; z-index: 2;
   font-size: 10px; font-weight: 700; white-space: nowrap; }

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
   // the reload watch fires when the cluster→pop assignment changes (membership changes, same path).
   shownPops?: { path: string; name: string; colour: string; clusterIds: number[] }[]
   vis?: VisProps                 // canvas plot styling (dark-theme etc.) — see ClusterPlots panelVis
-  state: { features?: string[] }
+  state: { features?: string[]; heatmapScale?: 'minmax' | 'zscore'; heatmapValues?: boolean }
   docked?: boolean               // fill a grid slot (Analysis board) instead of free-floating
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
@@ -50,8 +50,15 @@ const loading = ref(false)
 const err = ref('')
 // merge the canvas vis (dark-theme, font size, legend, …) over the defaults so the pop-manager
 // styling knobs drive the heatmap too; the matrix-specific fields below stay fixed regardless.
+// scale/annotation controls (persisted in panel state) — default to the R look: per-feature 0–1
+// viridis, no in-cell numbers. `zscore` flips to the diverging above/below-mean view.
+const heatmapScale = computed<'minmax' | 'zscore'>({
+  get: () => props.state.heatmapScale ?? 'minmax', set: v => (props.state.heatmapScale = v) })
+const heatmapValues = computed<boolean>({
+  get: () => props.state.heatmapValues ?? false, set: v => (props.state.heatmapValues = v) })
 const opts = computed<BuildOpts>(() => ({
   ...defaultVis(), ...(props.vis ?? {}), chartType: 'heatmap', byImage: false, normalize: false, errorMetric: 'sd', colorOf: () => '#8888aa',
+  heatmapScale: heatmapScale.value, heatmapValues: heatmapValues.value,
 }))
 const label = (raw: string) => props.nameMap[raw] ?? raw
 
@@ -130,6 +137,14 @@ defineExpose({ exportImage, getCsv })
           <p v-if="!featureOptions.length" class="feat-empty">No recorded features — re-run clustering, or this run predates feature tracking.</p>
         </div>
       </details>
+      <select v-model="heatmapScale" class="hm-sel"
+              v-tooltip.bottom="'Colour scale: 0–1 rescales each feature to its min→max (viridis); z-score shows above/below the feature mean (diverging)'">
+        <option value="minmax">0–1</option>
+        <option value="zscore">z-score</option>
+      </select>
+      <label class="hm-chk" v-tooltip.bottom="'Print the value in each cell'">
+        <input type="checkbox" v-model="heatmapValues" /> values
+      </label>
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel / the HMM panels -->
     <template #footer>
@@ -162,6 +177,8 @@ defineExpose({ exportImage, getCsv })
   background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 5px; padding: 5px; box-shadow: 0 4px 14px rgba(0,0,0,0.4); }
 .feat-row { display: flex; align-items: center; gap: 5px; padding: 2px 3px; color: var(--cc-text); white-space: nowrap; }
 .feat-empty { color: var(--cc-text-dim); font-size: 11px; margin: 4px; }
+.hm-sel { font-size: 12px; margin-left: 6px; }
+.hm-chk { display: inline-flex; align-items: center; gap: 3px; font-size: 12px; color: var(--cc-text-dim); margin-left: 6px; cursor: pointer; }
 .hm-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
   border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-1);
   color: var(--cc-text-dim); cursor: pointer; font-size: 0.7rem; }

--- a/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
@@ -88,7 +88,7 @@ async function load() {
     const out: { group: string; state: string; freq: number }[] = []
     for (const s of r.series ?? []) {
       const g = labelOf(s)
-      cats.value.forEach((c, i) => out.push({ group: g, state: `state ${c}`, freq: (s.values ?? [])[i] ?? 0 }))
+      cats.value.forEach((c, i) => out.push({ group: g, state: `${c}`, freq: (s.values ?? [])[i] ?? 0 }))
     }
     rows.value = out
     render()
@@ -112,7 +112,7 @@ async function render() {
   const fg = effDark.value ? '#e6e6e6' : '#111'
   const bg = effDark.value ? '#1f2226' : 'white'
   // palette knob → explicit colours for the state levels; 'standard' (null) keeps a categorical scheme
-  const domain = cats.value.map(c => `state ${c}`)
+  const domain = cats.value.map(c => `${c}`)
   const range = paletteRange(o, domain.length)
   const colorScale = range ? { domain, range } : { scheme: 'Tableau10', domain }
   // NB: no inline `legend` — that wraps the chart in a <figure> whose swatch legend sits on a white

--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -15,7 +15,8 @@
 //
 // buildPlotOptions takes the Plot module as a parameter so this module carries no eager dependency
 // on @observablehq/plot (PlotChart.vue lazy-imports it and passes it in).
-import type { PlotDataResponse, PlotSeries, ChartType } from './types'
+import type { PlotDataResponse, PlotSeries, ChartType, MatrixCell } from './types'
+import { rescaleRows01 } from '../utils/heatmapScale'
 
 // charts valid for each measure type (panel intersects with the spec's allowed `chartTypes`)
 export const NUMERIC_CHARTS: ChartType[] = ['histogram', 'boxplot', 'violin', 'bar', 'strip']
@@ -401,20 +402,11 @@ function buildHeatmap(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts): Reco
   const useMinmax = profile && (o.heatmapScale ?? 'minmax') === 'minmax'
   const diverging = profile && !useMinmax   // z-score display → diverging RdBu
   const valLabel = r.valueLabel ?? 'value'
-  // per-feature (row) min-max → [0,1]; store as `norm` so the fill uses it while the tooltip/label
-  // still read the original value. Flat rows (max == min) sit mid-scale.
-  if (useMinmax) {
-    const rng = new Map<string, [number, number]>()
-    for (const c of cells) {
-      const e = rng.get(c.y)
-      if (!e) rng.set(c.y, [c.value, c.value])
-      else { if (c.value < e[0]) e[0] = c.value; if (c.value > e[1]) e[1] = c.value }
-    }
-    for (const c of cells as { y: string; value: number; norm?: number }[]) {
-      const [lo, hi] = rng.get(c.y)!
-      c.norm = hi > lo ? (c.value - lo) / (hi - lo) : 0.5
-    }
-  }
+  // per-feature (row) min-max → [0,1] (rescaleRows01, tested in utils); attach as `norm` on a COPY so
+  // the fill uses it while the tooltip/label still read the original value, and r.cells is untouched.
+  const drawCells: (MatrixCell & { norm?: number })[] = useMinmax
+    ? rescaleRows01(cells).map((norm, i) => ({ ...cells[i], norm }))
+    : cells
   const fillCh = useMinmax ? 'norm' : 'value'
   // colour scale: minmax → viridis over a fixed [0,1] (no legend title, like the R heat plots);
   // z-score → diverging RdBu pivoted at 0; crosstab → sequential viridis over the data range.
@@ -456,10 +448,10 @@ function buildHeatmap(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts): Reco
     y: { domain: [...(r.yLabels ?? [])].reverse(), label: o.labY || yLab },   // first row at the top
     color: colorScale,
     marks: [
-      Plot.cell(cells, { x: 'x', y: 'y', fill: fillCh, inset: 0.5, stroke: tileStroke, strokeWidth: 0.5,
+      Plot.cell(drawCells, { x: 'x', y: 'y', fill: fillCh, inset: 0.5, stroke: tileStroke, strokeWidth: 0.5,
                          title: tip, tip: true }),
       ...(showValues
-        ? [Plot.text(cells, { x: 'x', y: 'y', text: valFmt, fill: textInk, fontSize: Math.max(8, (o.fontSize || 11) - 2) })]
+        ? [Plot.text(drawCells, { x: 'x', y: 'y', text: valFmt, fill: textInk, fontSize: Math.max(8, (o.fontSize || 11) - 2) })]
         : []),
       // theme_classic L-shaped axis: a black (theme-ink) line on the left + bottom, matching the other
       // charts (Observable Plot draws ticks/labels but no domain line for band scales).

--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -39,12 +39,15 @@ export function backendChart(c: ChartType): { chartType: string; rawPoints?: boo
 // colourblind-safe) and Paul Tol's qualitative schemes. 'standard' = the population manager colours
 // (per-pop `colorOf`); the others assign by series order; 'user' = a comma-separated custom list.
 export const PALETTES: Record<string, string[]> = {
+  // the house palette ported from the old R behaviour figures (behaviourDTx.Rmd colPal + accents) — the
+  // cluster colours lead (yellow / steel-blue / crimson / grey, matching the published UMAPs).
+  'cecelia': ['#EBD441', '#4682B4', '#AA1F5E', '#B3BCC2', '#009FE3', '#E71D73', '#00C5FF', '#616161'],
   'okabe-ito': ['#E69F00', '#56B4E9', '#009E73', '#F0E442', '#0072B2', '#D55E00', '#CC79A7', '#000000'],
   'tol-bright': ['#4477AA', '#EE6677', '#228833', '#CCBB44', '#66CCEE', '#AA3377', '#BBBBBB'],
   'tol-muted': ['#88CCEE', '#44AA99', '#117733', '#332288', '#DDCC77', '#999933', '#CC6677', '#882255', '#AA4499'],
   'tol-light': ['#77AADD', '#EE8866', '#EEDD88', '#FFAABB', '#99DDFF', '#44BB99', '#BBCC33', '#AAAA00'],
 }
-export type PaletteName = 'standard' | 'distinct' | 'okabe-ito' | 'tol-bright' | 'tol-muted' | 'tol-light' | 'user'
+export type PaletteName = 'standard' | 'distinct' | 'cecelia' | 'okabe-ito' | 'tol-bright' | 'tol-muted' | 'tol-light' | 'user'
 
 // N visually-distinct colours by even HCL-ish hue spacing (port of R randomcoloR::distinctColorPalette
 // intent — deterministic here so it's stable across renders). Golden-angle hue rotation, fixed S/L.
@@ -86,6 +89,9 @@ export interface VisProps {
   labX: string                               // x-axis label override (R labX)
   labY: string                               // y-axis label override (R labY)
   fontSize: number                           // base font size px (R adjFontSize; one knob, see note)
+  // heatmap (profile) look — ports the old R heat plots (behaviourDTx.Rmd / plotHeatmaps.R)
+  heatmapScale?: 'minmax' | 'zscore'         // per-feature min-max→[0,1] (viridis, R default) vs z-score (diverging)
+  heatmapValues?: boolean                    // print the value in each cell (default off for profile, matches R)
 }
 // Colour range for a categorical axis of `n` levels from the chosen palette (R adjustColors). Returns
 // an explicit colour list, or `null` for 'standard' — meaning "no palette override, use your default
@@ -111,6 +117,7 @@ export const defaultVis = (): VisProps => ({
   jitter: 'beeswarm', pointSize: 2, pointOpacity: 0.5, colorData: true,
   legend: true, logScale: false, grid: false, rotateXLabel: false, rotateXAngle: 45, rotate: false, darkTheme: true, facet: false,
   yMin: '', yMax: '', palette: 'standard', userColors: '', title: '', labX: '', labY: '', fontSize: 11,
+  heatmapScale: 'minmax', heatmapValues: false,
 })
 
 export interface BuildOpts extends VisProps {
@@ -375,56 +382,92 @@ export function buildPlotOptions(Plot: PlotModule, r: PlotDataResponse, o: Build
 }
 
 // ── matrix / heatmap (Plot.cell) ──────────────────────────────────────────────────
-// One pooled grid: xLabels × yLabels, fill = cell value. PROFILE (measures × category) uses a
-// sequential viridis scale, or a diverging RdBu pivoted at 0 when z-scored (rows standardised, so 0 =
-// the row mean — diverging reads "above/below average"). CROSSTAB (transition matrix) uses viridis.
-// Value text is overlaid per cell (white/black chosen for contrast). The continuous colour legend is
-// stashed in `_colorLegend` for PlotChart to draw as an overlay (like the discrete legend).
+// One pooled grid: xLabels × yLabels. PROFILE (measures × category) ports the old R heat plots
+// (behaviourDTx.Rmd / plotHeatmaps.R): each FEATURE (row) is min-max rescaled to [0,1] and shown on a
+// sequential viridis scale (`heatmapScale='minmax'`, the default) — a clean per-feature "low→high
+// across clusters" readout with a 0–1 colourbar. `heatmapScale='zscore'` instead keeps the raw
+// (server-standardised) values on a diverging RdBu pivoted at 0 ("above/below the row mean"). NB the
+// two agree on ordering — z-score is a positive affine per-row transform, so rescaling z-scores per
+// row gives the same [0,1] as rescaling the raw means; minmax works regardless of the fetch's zscore
+// flag. CROSSTAB (transition matrix) keeps viridis over the data range.
+// In-cell value text is off by default for profile (matches R) and on for crosstab; `heatmapValues`
+// overrides. The continuous colour legend is stashed in `_colorLegend` for PlotChart to draw.
 function buildHeatmap(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts): Record<string, unknown> | null {
   const cells = (r.cells ?? []).filter(c => Number.isFinite(c.value))
   if (!cells.length) return null
   const fg = o.darkTheme ? '#e6e6e6' : '#111'
   const bg = o.darkTheme ? '#1f2226' : 'white'
-  const diverging = r.matrixMode === 'profile' && !!r.zscore
+  const profile = r.matrixMode !== 'crosstab'
+  const useMinmax = profile && (o.heatmapScale ?? 'minmax') === 'minmax'
+  const diverging = profile && !useMinmax   // z-score display → diverging RdBu
   const valLabel = r.valueLabel ?? 'value'
-  // colour scale: diverging pivots at 0 (z-score); else sequential viridis from the data range.
+  // per-feature (row) min-max → [0,1]; store as `norm` so the fill uses it while the tooltip/label
+  // still read the original value. Flat rows (max == min) sit mid-scale.
+  if (useMinmax) {
+    const rng = new Map<string, [number, number]>()
+    for (const c of cells) {
+      const e = rng.get(c.y)
+      if (!e) rng.set(c.y, [c.value, c.value])
+      else { if (c.value < e[0]) e[0] = c.value; if (c.value > e[1]) e[1] = c.value }
+    }
+    for (const c of cells as { y: string; value: number; norm?: number }[]) {
+      const [lo, hi] = rng.get(c.y)!
+      c.norm = hi > lo ? (c.value - lo) / (hi - lo) : 0.5
+    }
+  }
+  const fillCh = useMinmax ? 'norm' : 'value'
+  // colour scale: minmax → viridis over a fixed [0,1] (no legend title, like the R heat plots);
+  // z-score → diverging RdBu pivoted at 0; crosstab → sequential viridis over the data range.
   const vals = cells.map(c => c.value)
-  const colorScale: Record<string, unknown> = diverging
-    ? { scheme: 'rdbu', pivot: 0, reverse: true, label: valLabel }
-    : { scheme: 'viridis', label: valLabel,
-        domain: [Math.min(...vals), Math.max(...vals)] }
+  const colorScale: Record<string, unknown> = useMinmax
+    ? { scheme: 'viridis', domain: [0, 1] }
+    : diverging
+      ? { scheme: 'rdbu', pivot: 0, reverse: true, label: valLabel }
+      : { scheme: 'viridis', label: valLabel, domain: [Math.min(...vals), Math.max(...vals)] }
   // contrast ink for the value text: for viridis, light cells (high end) get dark text. Cheap split
   // at the scale midpoint (good enough — the labels are a readout, not a precise encoding).
   const lo = Math.min(...vals), hi = Math.max(...vals), mid = (lo + hi) / 2
-  const textInk = (c: { value: number }) =>
-    diverging ? '#111' : (c.value > mid ? '#111' : '#eee')
-  const xLab = r.matrixMode === 'crosstab' ? 'to' : (r.category ?? null)
+  const textInk = (c: { value: number; norm?: number }) =>
+    diverging ? '#111' : useMinmax ? ((c.norm ?? 0) > 0.5 ? '#111' : '#eee') : (c.value > mid ? '#111' : '#eee')
+  // profile heatmaps blank the category axis title (R uses xlab("")/ylab("")); crosstab keeps to/from.
+  const xLab = r.matrixMode === 'crosstab' ? 'to' : null
   const yLab = r.matrixMode === 'crosstab' ? 'from' : null
+  const showValues = o.heatmapValues ?? (r.matrixMode === 'crosstab')
+  // tile border: white (R's geom_tile colour="white") — a thin gap that reads on both the dark ground
+  // and the white export; never black (that framed every cell too heavily).
+  const tileStroke = '#ffffff'
   const valFmt = (c: { value: number }) => fmt(c.value)
   const tip = (c: { x: string; y: string; value: number; n?: number; count?: number }) =>
     `${r.matrixMode === 'crosstab' ? `${c.y} → ${c.x}` : `${c.y} · ${c.x}`}\n${valLabel}: ${fmt(c.value)}` +
     (c.count != null ? `\nn ${c.count}` : c.n != null ? `\nn ${c.n}` : '')
   // reserve a top band for the colour-ramp legend (drawn top-right as an overlay) so it never covers
   // the top row of cells — and a touch more when a title (top-left) shares the band.
-  const topPad = o.legend ? (o.title ? 52 : 46) : (o.title ? 34 : 12)
+  const topPad = o.legend ? (o.title ? 44 : 38) : (o.title ? 28 : 8)
   // left margin fits the longest y tick label (feature names like "live.track.meanTurningAngle" were
   // clipped at a fixed 120). MEASURE the rendered width so it fits exactly (a char-count estimate
-  // over-reserved → a big left gap); +14 for the tick mark + gap, clamped so it never eats the plot.
+  // over-reserved → a big left gap); +12 for the tick mark + gap, clamped so it never eats the plot.
   const longestYW = (r.yLabels ?? []).reduce((m, s) => Math.max(m, textWidth(String(s), o.fontSize || 11)), 0)
-  const marginLeft = Math.round(Math.min(260, Math.max(48, longestYW + 14)))
+  const marginLeft = Math.round(Math.min(240, Math.max(40, longestYW + 12)))
   const opts: Record<string, unknown> = {
-    ...THEME, marginLeft, marginBottom: 64, marginTop: topPad, marginRight: 16,
+    // tight margins (R heat plots are compact — fig.height 2 × width 4)
+    ...THEME, marginLeft, marginBottom: 48, marginTop: topPad, marginRight: 8,
     style: { background: bg, color: fg, fontFamily: FONT, fontSize: `${o.fontSize || 11}px` },
     x: { domain: r.xLabels ?? [], label: o.labX || xLab, tickRotate: o.rotateXLabel ? xTickRotate(o) : 0 },
     y: { domain: [...(r.yLabels ?? [])].reverse(), label: o.labY || yLab },   // first row at the top
     color: colorScale,
     marks: [
-      Plot.cell(cells, { x: 'x', y: 'y', fill: 'value', inset: 0.5, stroke: bg, strokeWidth: 0.5,
+      Plot.cell(cells, { x: 'x', y: 'y', fill: fillCh, inset: 0.5, stroke: tileStroke, strokeWidth: 0.5,
                          title: tip, tip: true }),
-      Plot.text(cells, { x: 'x', y: 'y', text: valFmt, fill: textInk, fontSize: Math.max(8, (o.fontSize || 11) - 2) }),
+      ...(showValues
+        ? [Plot.text(cells, { x: 'x', y: 'y', text: valFmt, fill: textInk, fontSize: Math.max(8, (o.fontSize || 11) - 2) })]
+        : []),
+      // theme_classic L-shaped axis: a black (theme-ink) line on the left + bottom, matching the other
+      // charts (Observable Plot draws ticks/labels but no domain line for band scales).
+      Plot.frame({ anchor: 'bottom', stroke: 'currentColor', strokeWidth: 1 }),
+      Plot.frame({ anchor: 'left', stroke: 'currentColor', strokeWidth: 1 }),
     ],
   }
-  if (o.rotateXLabel) opts.marginBottom = xRotMargin(84, o)
+  if (o.rotateXLabel) opts.marginBottom = xRotMargin(72, o)
   // continuous legend (PlotChart draws it as an overlay, reading `_colorLegend`)
   ;(opts as Record<string, unknown>)._colorLegend = { color: colorScale }
   return opts

--- a/frontend/src/utils/heatmapScale.test.ts
+++ b/frontend/src/utils/heatmapScale.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { rescaleRows01 } from './heatmapScale'
+
+describe('rescaleRows01', () => {
+  it('rescales each row independently to [0,1]', () => {
+    const cells = [
+      { y: 'a', value: 10 }, { y: 'a', value: 20 }, { y: 'a', value: 30 },  // → 0, .5, 1
+      { y: 'b', value: 5 },  { y: 'b', value: 7 },  { y: 'b', value: 9 },   // → 0, .5, 1
+    ]
+    expect(rescaleRows01(cells)).toEqual([0, 0.5, 1, 0, 0.5, 1])
+  })
+
+  it('maps a flat row (max == min) to 0.5', () => {
+    expect(rescaleRows01([{ y: 'a', value: 3 }, { y: 'a', value: 3 }])).toEqual([0.5, 0.5])
+  })
+
+  it('handles negative values', () => {
+    expect(rescaleRows01([{ y: 'a', value: -2 }, { y: 'a', value: 0 }, { y: 'a', value: 2 }]))
+      .toEqual([0, 0.5, 1])
+  })
+
+  it('is invariant under a positive affine per-row transform (z-score ≡ raw)', () => {
+    // z-score is z = (x - mean) / sd, a positive affine map per row, so rescaling z-scores must
+    // give the same [0,1] as rescaling the raw means — the property the heatmap relies on.
+    const raw = [{ y: 'a', value: 4 }, { y: 'a', value: 8 }, { y: 'a', value: 10 }]
+    const mean = 22 / 3, sd = 2.494438   // arbitrary a>0, b — any positive affine works
+    const zscored = raw.map(c => ({ y: c.y, value: (c.value - mean) / sd }))
+    const rawNorm = rescaleRows01(raw)
+    const zNorm = rescaleRows01(zscored)
+    rawNorm.forEach((v, i) => expect(zNorm[i]).toBeCloseTo(v, 10))
+  })
+
+  it('returns an empty array for no cells', () => {
+    expect(rescaleRows01([])).toEqual([])
+  })
+})

--- a/frontend/src/utils/heatmapScale.ts
+++ b/frontend/src/utils/heatmapScale.ts
@@ -1,0 +1,24 @@
+// Per-feature (row) min-max rescale of matrix-heatmap cells to [0,1] — the profile-heatmap viridis
+// look that ports the old R behaviour heat plots (`normalit()` + `scale_fill_viridis(limits=c(0,1))`
+// in behaviourDTx.Rmd; see plots/plot.ts `buildHeatmap`). Each ROW (the cell's `y` / feature) is
+// scaled independently by its own [min,max] across the columns; a flat row (max == min) maps to 0.5.
+//
+// NB min-max is invariant under a positive affine per-row transform: rescale01(a·x + b) == rescale01(x)
+// for a > 0. So rescaling z-scored values gives the same result as rescaling the raw means — the
+// heatmap does not need to know which the server sent. (Asserted in heatmapScale.test.ts.)
+
+export interface RowCell { y: string; value: number }
+
+/** Norm in [0,1] for each cell, parallel to `cells`, from a per-row (per-`y`) min-max rescale. Pure. */
+export function rescaleRows01(cells: readonly RowCell[]): number[] {
+  const range = new Map<string, [number, number]>()
+  for (const c of cells) {
+    const e = range.get(c.y)
+    if (!e) range.set(c.y, [c.value, c.value])
+    else { if (c.value < e[0]) e[0] = c.value; if (c.value > e[1]) e[1] = c.value }
+  }
+  return cells.map(c => {
+    const [lo, hi] = range.get(c.y)!
+    return hi > lo ? (c.value - lo) / (hi - lo) : 0.5
+  })
+}


### PR DESCRIPTION
Aligns the cluster/behaviour plot output with the previous R (ggplot) version.

## Heatmap (cluster + summary profile heatmaps)
- Default to **per-feature 0–1 viridis** with a 0–1 colourbar (ports `behaviourDTx.Rmd`'s `normalit()` + `scale_fill_viridis(limits=c(0,1))`). **Z-score** (diverging RdBu, above/below row mean) is a toggle. Min-max is invariant under z-score, so no refetch is needed to switch.
- In-cell **values off by default** for profile (matches R), on for crosstab — toggle either way.
- **White** tile borders (was black), **black `theme_classic` L-axis**, tighter margins.
- Rescale logic extracted to `utils/heatmapScale.ts` (pure `rescaleRows01`) + vitest, including the z-score-invariance property; `buildHeatmap` no longer mutates `r.cells`.

## UMAP
- **Circular** points instead of squares.
- **Point size, opacity and legend now follow the picker** (`vis.*`) — no UMAP-only toggles left (except the centroid-label toggle, which has no picker equivalent).
- Default cluster palette = the Cecelia house colours.

## Palette
- New **`Cecelia`** preset (`behaviourDTx.Rmd` `colPal` — yellow/steel-blue/crimson/grey — + accents) in the plot palette dropdown **and** as clickable swatches in the pop colour picker (native picker kept for custom colours).

## HMM states by cluster
- Bare numeric legend (`1..4`).

## Notes for review
- Verified: full frontend build + typecheck green, 104 unit tests pass. The **UMAP** was eyeballed in-app; the **heatmap** and **pop-picker popover** were built/typechecked but not yet visually verified — worth a look.
- Behaviour change: existing summary heatmaps default flips from z-score → 0–1 viridis (toggle restores z-score). UMAP default opacity is now the picker's `pointOpacity` (0.5) rather than a hardcoded 0.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
