### PR TITLE
Clean-capture toggle for publication stills (E1)

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -356,12 +356,13 @@ function api_napari_screenshot(body_bytes::Vector{UInt8})
     data = try JSON3.read(String(body_bytes)) catch; nothing end
     project_uid = data === nothing ? "" : String(get(data, :projectUid, ""))
     isempty(project_uid) && return 400, JSON3.write((; error = "projectUid required"))
+    clean = data === nothing ? false : Bool(get(data, :clean, false))   # E1: hide baked scale bar/timestamp
     path = tempname() * ".png"
     _with_viewer() do
     try
         # fit_data → tight-fit to the data extent at native resolution: no black margins, and the figure
         # matches the viewer (image fills the frame) instead of a tiny image in a big black canvas.
-        reply    = save_screenshot!(v, path; fit_data = true)
+        reply    = save_screenshot!(v, path; fit_data = true, clean = clean)
         # store the PNG as a SIDECAR file (settings/board-assets/<id>.png), not base64 in the board JSON,
         # so analysisBoards.json stays small (autosave-friendly). Return only the id + snapshot.
         asset_id = _save_board_asset_file(project_uid, path)

--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -370,6 +370,7 @@ function api_napari_screenshot(body_bytes::Vector{UInt8})
             assetId   = asset_id,
             viewState = get(reply, "view_state", Dict{String,Any}()),
             imageUid  = _current_image_uid[],
+            extentUm  = get(reply, "extent_um", nothing),   # captured frame physical size → still scale bar (E2)
         ))
     catch e
         return 500, JSON3.write((; error = sprint(showerror, e)))

--- a/app/src/napari.jl
+++ b/app/src/napari.jl
@@ -185,11 +185,12 @@ load_layer_props!(v::NapariViewer, path::String) =
 # (captured atomically with the shot). The caller reads the PNG from `path` and the snapshot from the
 # returned dict's "view_state".
 save_screenshot!(v::NapariViewer, path::String; canvas_only::Bool=true, fit_data::Bool=true,
-                 scale::Union{Real,Nothing}=nothing)::Dict{String,Any} = begin
+                 scale::Union{Real,Nothing}=nothing, clean::Bool=false)::Dict{String,Any} = begin
     cmd = Dict{String,Any}("type"=>"save_screenshot", "path"=>path,
-                           "canvas_only"=>canvas_only, "fit_data"=>fit_data)
+                           "canvas_only"=>canvas_only, "fit_data"=>fit_data, "clean"=>clean)
     # fit_data → tight-fit to the data extent at `scale`× native resolution (no black margins); scale
     # only meaningful with fit_data (plain-screenshot scale would just add margins, so it's not sent).
+    # clean → hide napari's baked scale bar + timestamp for the shot (E1, publication stills).
     scale !== nothing && (cmd["scale"] = scale)
     send(v, cmd)
 end

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -175,6 +175,13 @@ settable scalars stay durable, human-readable and GUI-editable. Commands: `captu
 its provenance are captured atomically (same view). Foundation for zoom-to-source + movies — see
 `docs/todo/ANIMATION_PLAN.md`.
 
+**Clean capture (E1).** `save_screenshot(..., clean=True)` hides napari's baked scale bar + timestamp
+overlay for the shot and restores them after — a clean **publication still** (add a vector scale bar /
+timestamp externally, or Cecelia's own; Decision 7). Threaded `POST /api/napari/screenshot {clean}` →
+`save_screenshot!` → bridge; driven by the persisted **"clean capture"** toggle in the analysis-board
+image-strip ⚙ (`settings.cleanCapture`). Scoped to stills — animation keyframes keep the timestamp (a
+movie wants it). NB: a bridge change → **restart napari** (`pixi run stop-napari`) for it to take effect.
+
 ---
 
 ## Shared layer helpers (`cecelia.utils.napari_utils`)

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -182,6 +182,15 @@ timestamp externally, or Cecelia's own; Decision 7). Threaded `POST /api/napari/
 image-strip ⚙ (`settings.cleanCapture`). Scoped to stills — animation keyframes keep the timestamp (a
 movie wants it). NB: a bridge change → **restart napari** (`pixi run stop-napari`) for it to take effect.
 
+**Vector scale bar + timestamp (E2).** The screenshot reply also carries `extent_um` — the captured
+frame's physical width/height (`_data_extent_um` = data shape × per-axis `_im_scale`; `export_figure`
+tight-fits to the data extent, so it *is* the frame's physical size). The strip draws its own crisp
+scale bar + elapsed-time timestamp on the clean capture via `components/StillOverlay.vue`: an SVG whose
+`viewBox` is the extent (µm) with `preserveAspectRatio="xMidYMid meet"` (matching the frame's
+`object-fit: contain`), so the bar length is correct-by-construction and stays aligned even when the
+frame is letterboxed. Scale-bar length picks a nice round step (`utils/stillOverlay.niceScaleBar`);
+the timestamp reuses `elapsedLabel` (shared with the animation timeline). Toggled per strip in the ⚙.
+
 ---
 
 ## Shared layer helpers (`cecelia.utils.napari_utils`)

--- a/docs/todo/ANIMATION_PLAN.md
+++ b/docs/todo/ANIMATION_PLAN.md
@@ -1,10 +1,10 @@
 # Analysis figures & movies (animation)
 
-Status (updated 2026-07-14): **mostly shipped.** A, B, D, G, F1 (all of F1.1–F1.3) and F2 (MVP +
-render engine + timeline editor) are **merged**. Two partials remain: **C** (channel legend live; the
-populations + colour-by legend sections still to wire into the strip) and **E** (E1 clean-capture toggle
-done; **E2** — Cecelia-drawn vector scale bar + timestamp — still to build). Supersedes the ad-hoc parts
-of the image-strip tasks (#00032 legend, #00036 zoom-to-source) by putting them on a shared foundation.
+Status (updated 2026-07-14): **nearly complete.** A, B, D, E, G, F1 (all of F1.1–F1.3) and F2 (MVP +
+render engine + timeline editor) are **done/merged**. **C is the only remaining partial** — the channel
+legend is live; the populations + colour-by legend sections still need wiring into the strip. Supersedes
+the ad-hoc parts of the image-strip tasks (#00032 legend, #00036 zoom-to-source) by putting them on a
+shared foundation.
 
 ## Goal
 
@@ -119,7 +119,7 @@ first-class, named, portable artifact.
 **A → D → B + C → G → F1 → E → F2.** A/B/C/D land value fast; F1 is the headline user win and
 matches how figures are actually made; F2 is the advanced follow-on.
 
-**Progress:** ~~A~~ · ~~B~~ · C (partial) · ~~D~~ · ~~G~~ · ~~F1~~ · E (E1 done, **E2 left**) · ~~F2~~.
+**Progress:** ~~A~~ · ~~B~~ · **C (partial — only piece left)** · ~~D~~ · ~~G~~ · ~~F1~~ · ~~E~~ · ~~F2~~.
 
 - **~~A. Snapshot atom~~ — DONE** — `capture_view_state()` + `apply_view_state(json)` in the bridge
   (whitelist + sanitise + only-present-layers filter); capture folded into the screenshot reply;
@@ -139,15 +139,18 @@ matches how figures are actually made; F2 is the advanced follow-on.
   the data extent at native resolution → no black margins). D2: the strip went `object-fit: contain`
   (letterbox) so a scale bar / timestamp isn't cropped (E2's own vector scale bar will let frames go
   edge-to-edge again).
-- **E. Scale bar / timestamp for stills** — partial.
+- **~~E. Scale bar / timestamp for stills~~ — DONE.**
   - **~~E1 clean-capture toggle~~ — DONE:** `save_screenshot(clean=True)` hides napari's baked scale bar
     + timestamp for the shot (restored after); threaded `POST /api/napari/screenshot {clean}` → the
     persisted **"clean capture"** toggle in the image-strip ⚙ (`settings.cleanCapture`). Scoped to stills
     (animation keyframes keep the timestamp). See docs/NAPARI.md → *Clean capture*.
-  - **LEFT — E2 (stretch):** Cecelia-drawn **vector** scale bar (N µm + label) + timestamp beneath/on the
-    frame, from `img_physical_sizes` + time interval (crisp + Illustrator-editable, drawn on the clean
-    capture). Needs the captured frame's µm-per-pixel; verify against live napari `export_figure` extent.
-    (Movies may keep baked overlays — this is specifically for publication stills; see Decision 7.)
+  - **~~E2 vector scale bar + timestamp~~ — DONE:** the screenshot reply carries `extent_um` (data shape ×
+    `_im_scale`; `export_figure` tight-fits to the data extent → the frame's physical size). The strip
+    draws its own crisp scale bar + elapsed-time timestamp on the clean capture via `StillOverlay.vue` —
+    an SVG whose `viewBox` is the extent (µm) with `preserveAspectRatio="xMidYMid meet"` (matches the
+    frame's `object-fit: contain`), so geometry is correct even when letterboxed. Toggled per strip in
+    the ⚙. `utils/stillOverlay` (`niceScaleBar`, `elapsedLabel` — shared with the timeline), unit-tested.
+    (Movies keep baked overlays — this is specifically for publication stills; see Decision 7.)
 - **~~G. Split-by-feature colouring~~ — DONE** — colour napari tracks/labels by a categorical measure
   (`/api/napari/colour-labels`, show-tracks `colorBy`); a value a population *filters for* takes that
   pop's colour (`_colour_overrides_for`/`pop_colour_overrides`), else Okabe–Ito; user recolours +

--- a/docs/todo/ANIMATION_PLAN.md
+++ b/docs/todo/ANIMATION_PLAN.md
@@ -1,10 +1,10 @@
 # Analysis figures & movies (animation)
 
 Status (updated 2026-07-14): **mostly shipped.** A, B, D, G, F1 (all of F1.1–F1.3) and F2 (MVP +
-render engine + timeline editor) are **merged**. **C is partial** (channel legend live; the populations
-+ colour-by legend sections still to wire into the strip). **E is the only fully-open phase**
-(scale bar / timestamp for stills). Supersedes the ad-hoc parts of the image-strip tasks
-(#00032 legend, #00036 zoom-to-source) by putting them on a shared foundation.
+render engine + timeline editor) are **merged**. Two partials remain: **C** (channel legend live; the
+populations + colour-by legend sections still to wire into the strip) and **E** (E1 clean-capture toggle
+done; **E2** — Cecelia-drawn vector scale bar + timestamp — still to build). Supersedes the ad-hoc parts
+of the image-strip tasks (#00032 legend, #00036 zoom-to-source) by putting them on a shared foundation.
 
 ## Goal
 
@@ -119,7 +119,7 @@ first-class, named, portable artifact.
 **A → D → B + C → G → F1 → E → F2.** A/B/C/D land value fast; F1 is the headline user win and
 matches how figures are actually made; F2 is the advanced follow-on.
 
-**Progress:** ~~A~~ · ~~B~~ · C (partial) · ~~D~~ · ~~G~~ · ~~F1~~ · **E (open)** · ~~F2~~.
+**Progress:** ~~A~~ · ~~B~~ · C (partial) · ~~D~~ · ~~G~~ · ~~F1~~ · E (E1 done, **E2 left**) · ~~F2~~.
 
 - **~~A. Snapshot atom~~ — DONE** — `capture_view_state()` + `apply_view_state(json)` in the bridge
   (whitelist + sanitise + only-present-layers filter); capture folded into the screenshot reply;
@@ -139,10 +139,15 @@ matches how figures are actually made; F2 is the advanced follow-on.
   the data extent at native resolution → no black margins). D2: the strip went `object-fit: contain`
   (letterbox) so a scale bar / timestamp isn't cropped (E2's own vector scale bar will let frames go
   edge-to-edge again).
-- **E. Scale bar / timestamp for stills** — **the one open phase.** E1 clean-capture toggle (hide the
-  napari scale bar + timestamp for the shot); E2 (stretch) Cecelia-drawn **vector** scale bar (N µm +
-  label) + timestamp beneath the frame, from `img_physical_sizes` + time interval. (Movies may keep
-  baked overlays — this is specifically for publication stills; see Decision 7.)
+- **E. Scale bar / timestamp for stills** — partial.
+  - **~~E1 clean-capture toggle~~ — DONE:** `save_screenshot(clean=True)` hides napari's baked scale bar
+    + timestamp for the shot (restored after); threaded `POST /api/napari/screenshot {clean}` → the
+    persisted **"clean capture"** toggle in the image-strip ⚙ (`settings.cleanCapture`). Scoped to stills
+    (animation keyframes keep the timestamp). See docs/NAPARI.md → *Clean capture*.
+  - **LEFT — E2 (stretch):** Cecelia-drawn **vector** scale bar (N µm + label) + timestamp beneath/on the
+    frame, from `img_physical_sizes` + time interval (crisp + Illustrator-editable, drawn on the clean
+    capture). Needs the captured frame's µm-per-pixel; verify against live napari `export_figure` extent.
+    (Movies may keep baked overlays — this is specifically for publication stills; see Decision 7.)
 - **~~G. Split-by-feature colouring~~ — DONE** — colour napari tracks/labels by a categorical measure
   (`/api/napari/colour-labels`, show-tracks `colorBy`); a value a population *filters for* takes that
   pop's colour (`_colour_overrides_for`/`pop_colour_overrides`), else Okabe–Ito; user recolours +

--- a/frontend/src/components/StillOverlay.vue
+++ b/frontend/src/components/StillOverlay.vue
@@ -1,0 +1,56 @@
+<!--
+  Vector scale bar + timestamp for a captured still (Phase E2). An SVG whose viewBox is the frame's
+  physical extent (µm) with preserveAspectRatio "xMidYMid meet" — the SAME fit as the frame <img>'s
+  object-fit: contain — so annotations stay geometrically correct AND aligned to the image content even
+  when the frame is letterboxed. The scale bar length is drawn in µm (viewBox units), so it's correct by
+  construction; text/bar sizes are fractions of the extent so they scale proportionally with the frame.
+  Drawn on the CLEAN capture (napari's own scale bar/timestamp hidden — see E1). Absolutely fills the
+  parent (which must be position:relative and the frame's box).
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import { niceScaleBar } from '../utils/stillOverlay'
+
+const props = withDefaults(defineProps<{
+  extentUm?: { x?: number; y?: number; unit?: string | null } | null
+  timeLabel?: string        // '' → no timestamp
+  showScaleBar?: boolean
+  showTimestamp?: boolean
+}>(), { showScaleBar: true, showTimestamp: true })
+
+const ex = computed(() => props.extentUm?.x ?? 0)
+const ey = computed(() => props.extentUm?.y ?? 0)
+const ok = computed(() => ex.value > 0 && ey.value > 0)
+const bar = computed(() => niceScaleBar(ex.value, props.extentUm?.unit ?? 'µm'))
+
+// geometry in viewBox (µm) units — margins/sizes as fractions of the extent so they scale with the frame
+const mx = computed(() => ex.value * 0.045)
+const my = computed(() => ey.value * 0.045)
+const barH = computed(() => ey.value * 0.012)
+const font = computed(() => Math.min(ex.value, ey.value) * 0.05)
+const barX1 = computed(() => ex.value - mx.value - (bar.value?.um ?? 0))
+const barX2 = computed(() => ex.value - mx.value)
+const barY = computed(() => ey.value - my.value - barH.value)
+</script>
+
+<template>
+  <svg v-if="ok" class="still-ovl" :viewBox="`0 0 ${ex} ${ey}`" preserveAspectRatio="xMidYMid meet">
+    <!-- timestamp, top-left -->
+    <text v-if="showTimestamp && timeLabel" :x="mx" :y="my + font" :font-size="font"
+          class="ovl-text" text-anchor="start">{{ timeLabel }}</text>
+    <!-- scale bar, bottom-right: bar + label centered above it -->
+    <template v-if="showScaleBar && bar">
+      <rect :x="barX1" :y="barY" :width="bar.um" :height="barH" class="ovl-fill" />
+      <text :x="(barX1 + barX2) / 2" :y="barY - font * 0.35" :font-size="font"
+            class="ovl-text" text-anchor="middle">{{ bar.label }}</text>
+    </template>
+  </svg>
+</template>
+
+<style scoped>
+.still-ovl { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+/* white with a dark outline so it reads on any background (like napari's overlays) */
+.ovl-text { fill: #fff; paint-order: stroke; stroke: rgba(0,0,0,0.85); stroke-width: 0.5;
+  font-weight: 700; font-family: system-ui, sans-serif; }
+.ovl-fill { fill: #fff; stroke: rgba(0,0,0,0.85); stroke-width: 0.3; }
+</style>

--- a/frontend/src/components/ViewLegend.vue
+++ b/frontend/src/components/ViewLegend.vue
@@ -5,14 +5,17 @@
 // Section headings show only when there's more than one section (a lone group needs no title).
 import type { LegendSection } from '../utils/viewLegend'
 
-withDefaults(defineProps<{ sections: LegendSection[]; swatch?: number }>(), { swatch: 10 })
+// `vertical` stacks the items in each section in a column (one per line) instead of a wrapping row —
+// used by the image-strip overlay where the channel names read bottom-left, one under the other.
+withDefaults(defineProps<{ sections: LegendSection[]; swatch?: number; vertical?: boolean }>(),
+  { swatch: 10, vertical: false })
 </script>
 
 <template>
   <div class="view-legend">
     <div v-for="sec in sections" :key="sec.title" class="vl-section">
       <div v-if="sections.length > 1" class="vl-title">{{ sec.title }}</div>
-      <div class="vl-items">
+      <div class="vl-items" :class="{ vertical }">
         <span v-for="it in sec.items" :key="it.label" class="vl-item">
           <span class="vl-swatch" :style="{ background: it.colour, width: swatch + 'px', height: swatch + 'px' }" />
           {{ it.label }}
@@ -27,6 +30,8 @@ withDefaults(defineProps<{ sections: LegendSection[]; swatch?: number }>(), { sw
 .vl-section { display: flex; flex-direction: column; gap: 1px; }
 .vl-title { font-size: 0.82em; font-weight: 700; opacity: 0.65; text-transform: uppercase; letter-spacing: 0.04em; }
 .vl-items { display: flex; flex-wrap: wrap; gap: 1px 8px; }
+/* vertical: one item per line (channel names stacked), left-aligned */
+.vl-items.vertical { flex-direction: column; flex-wrap: nowrap; align-items: flex-start; gap: 1px; }
 .vl-item { display: inline-flex; align-items: center; gap: 4px; font-size: 0.9em; white-space: nowrap; }
 .vl-swatch { border-radius: 2px; flex-shrink: 0; border: 1px solid rgba(128, 128, 128, 0.4); }
 </style>

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -297,7 +297,7 @@ defineExpose({ exportImage })
                       :show-scale-bar="showScaleBar" :show-timestamp="showTimestamp" />
         <!-- optional view legend (channels now; pops + colour-by plug in later), from the frame snapshot -->
         <ViewLegend v-if="showLegend && (c.assetId || c.src) && legendSections(c).length"
-                    :sections="legendSections(c)" :swatch="9" class="is-legend" />
+                    :sections="legendSections(c)" :swatch="9" vertical class="is-legend" />
         <button v-if="!(c.assetId || c.src)" class="is-capture" @click="capture(i)" :disabled="capturing === i"
                 v-tooltip.bottom="'Capture the current napari view'">
           <i class="pi pi-camera" /> {{ capturing === i ? 'capturing…' : 'napari view' }}

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -13,10 +13,12 @@ import { ref, computed, watch, useTemplateRef, nextTick, onMounted, onUnmounted 
 import { elementToImageURL } from '../../plots/export'
 import TeleportPopover from '../TeleportPopover.vue'
 import { useWsStore } from '../../stores/ws'
+import { useSettingsStore } from '../../stores/settings'
 import { channelLegend, viewLegendSections } from '../../utils/viewLegend'
 import ViewLegend from '../ViewLegend.vue'
 
 const ws = useWsStore()
+const settings = useSettingsStore()
 
 // `snapshot` (napari view state) + `imageUid` are the frame's provenance — persisted with the board so
 // zoom-to-source can reopen the image and restore the exact camera/contrast/colours months later
@@ -68,7 +70,7 @@ async function capture(i: number) {
   try {
     const res = await fetch('/api/napari/screenshot', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectUid: props.projectUid }),
+      body: JSON.stringify({ projectUid: props.projectUid, clean: settings.cleanCapture }),
     })
     if (!res.ok) { err.value = ((await res.json().catch(() => ({}))) as { error?: string }).error ?? 'Screenshot failed'; return }
     const data = (await res.json()) as { assetId?: string; png?: string; viewState?: Record<string, unknown>; imageUid?: string | null }
@@ -243,6 +245,9 @@ defineExpose({ exportImage })
           <div class="is-pop">
             <label class="is-check"><input type="checkbox" :checked="showLegend"
               @change="showLegend = ($event.target as HTMLInputElement).checked" /> channel legend</label>
+            <label class="is-check" v-tooltip.bottom="'Hide napari\'s scale bar + timestamp when capturing, for a clean publication still (add your own externally)'">
+              <input type="checkbox" :checked="settings.cleanCapture"
+              @change="settings.cleanCapture = ($event.target as HTMLInputElement).checked" /> clean capture</label>
             <template v-if="separator === 'angled' && orientation === 'h'">
               <label class="is-slider">angle
                 <input type="range" min="0" max="80" :value="skew" @input="skew = +($event.target as HTMLInputElement).value" />

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -14,11 +14,15 @@ import { elementToImageURL } from '../../plots/export'
 import TeleportPopover from '../TeleportPopover.vue'
 import { useWsStore } from '../../stores/ws'
 import { useSettingsStore } from '../../stores/settings'
+import { useProjectStore } from '../../stores/project'
 import { channelLegend, viewLegendSections } from '../../utils/viewLegend'
+import { elapsedLabel } from '../../utils/stillOverlay'
 import ViewLegend from '../ViewLegend.vue'
+import StillOverlay from '../StillOverlay.vue'
 
 const ws = useWsStore()
 const settings = useSettingsStore()
+const project = useProjectStore()
 
 // `snapshot` (napari view state) + `imageUid` are the frame's provenance — persisted with the board so
 // zoom-to-source can reopen the image and restore the exact camera/contrast/colours months later
@@ -27,10 +31,11 @@ const settings = useSettingsStore()
 // inline, so the board JSON stays small (autosave-friendly). `src` is the legacy inline data-URL, kept
 // only for back-compat (migrated to a sidecar on load). `snapshot`+`imageUid` are the view provenance
 // for zoom-to-source. See docs/todo/ANIMATION_PLAN.md.
-interface Cell { assetId?: string; src?: string; snapshot?: Record<string, unknown>; imageUid?: string | null }
+interface ExtentUm { x?: number; y?: number; unit?: string | null }
+interface Cell { assetId?: string; src?: string; snapshot?: Record<string, unknown>; imageUid?: string | null; extentUm?: ExtentUm | null }
 const props = defineProps<{
   projectUid: string; imageUids: string[]; setUid: string | null
-  state: { cells?: Cell[]; orientation?: 'h' | 'v'; separator?: 'straight' | 'angled'; sepAngle?: number; sepThick?: number; showLegend?: boolean }
+  state: { cells?: Cell[]; orientation?: 'h' | 'v'; separator?: 'straight' | 'angled'; sepAngle?: number; sepThick?: number; showLegend?: boolean; showScaleBar?: boolean; showTimestamp?: boolean }
 }>()
 
 // seed defaults into the persisted state bag (the slot starts as {})
@@ -46,6 +51,19 @@ const skew = computed({ get: () => props.state.sepAngle ?? 22, set: v => (props.
 const thick = computed({ get: () => props.state.sepThick ?? 2, set: v => (props.state.sepThick = v) })
 // optional channel-colour legend, read from the frame's snapshot (napari layer colormaps). Off by default.
 const showLegend = computed({ get: () => props.state.showLegend ?? false, set: v => (props.state.showLegend = v) })
+// still overlays (E2): a vector scale bar (from the captured frame's physical extent) + an elapsed-time
+// timestamp — drawn crisp on the clean capture (napari's own hidden via E1). Off by default.
+const showScaleBar  = computed({ get: () => props.state.showScaleBar ?? false,  set: v => (props.state.showScaleBar = v) })
+const showTimestamp = computed({ get: () => props.state.showTimestamp ?? false, set: v => (props.state.showTimestamp = v) })
+// elapsed-time label for a frame: its snapshot T index × the source image's frame interval
+function frameTime(c: Cell): string {
+  const step = (c.snapshot?.dims as { current_step?: number[] } | undefined)?.current_step
+  const t = Array.isArray(step) ? step[0] : undefined
+  if (t === undefined || t === null) return ''
+  const img = project.sets.flatMap(s => s.images).find(im => im.uid === c.imageUid)
+  const lbl = elapsedLabel(t, img?.timeIncrement, img?.timeIncrementUnit)
+  return /^t\d/.test(lbl) ? '' : lbl        // hide the bare "t{N}" fallback (no real time on a still)
+}
 // angled separators are horizontal-only (the clip leans across the row) — snap back to straight if the
 // strip is switched to vertical.
 watch(orientation, o => { if (o === 'v' && separator.value === 'angled') separator.value = 'straight' })
@@ -73,12 +91,13 @@ async function capture(i: number) {
       body: JSON.stringify({ projectUid: props.projectUid, clean: settings.cleanCapture }),
     })
     if (!res.ok) { err.value = ((await res.json().catch(() => ({}))) as { error?: string }).error ?? 'Screenshot failed'; return }
-    const data = (await res.json()) as { assetId?: string; png?: string; viewState?: Record<string, unknown>; imageUid?: string | null }
+    const data = (await res.json()) as { assetId?: string; png?: string; viewState?: Record<string, unknown>; imageUid?: string | null; extentUm?: ExtentUm | null }
     const c = cells.value[i]
     if (data.assetId) { c.assetId = data.assetId; c.src = undefined }         // sidecar PNG (normal path)
     else if (data.png) { c.src = 'data:image/png;base64,' + data.png; c.assetId = undefined }  // inline fallback
     c.snapshot = data.viewState
     c.imageUid = data.imageUid ?? null
+    c.extentUm = data.extentUm ?? null            // physical size → still scale bar (E2)
   } catch (e) { err.value = e instanceof Error ? e.message : String(e) }
   finally { capturing.value = -1 }
 }
@@ -248,6 +267,12 @@ defineExpose({ exportImage })
             <label class="is-check" v-tooltip.bottom="'Hide napari\'s scale bar + timestamp when capturing, for a clean publication still (add your own externally)'">
               <input type="checkbox" :checked="settings.cleanCapture"
               @change="settings.cleanCapture = ($event.target as HTMLInputElement).checked" /> clean capture</label>
+            <label class="is-check" v-tooltip.bottom="'Draw a vector scale bar on each frame (from the image\'s physical pixel size)'">
+              <input type="checkbox" :checked="showScaleBar"
+              @change="showScaleBar = ($event.target as HTMLInputElement).checked" /> scale bar</label>
+            <label class="is-check" v-tooltip.bottom="'Draw the elapsed-time timestamp on each frame'">
+              <input type="checkbox" :checked="showTimestamp"
+              @change="showTimestamp = ($event.target as HTMLInputElement).checked" /> timestamp</label>
             <template v-if="separator === 'angled' && orientation === 'h'">
               <label class="is-slider">angle
                 <input type="range" min="0" max="80" :value="skew" @input="skew = +($event.target as HTMLInputElement).value" />
@@ -266,6 +291,10 @@ defineExpose({ exportImage })
     <div ref="stripRef" class="is-strip" :class="[orientation === 'h' ? 'row' : 'col', separator, { capturing: capturingStrip }]" :style="stripStyle">
       <div v-for="(c, i) in cells" :key="i" class="is-cell" :style="{ clipPath: clipFor(i) }">
         <img v-if="c.assetId || c.src" :src="cellSrc(c)" class="is-img" alt="napari screenshot" />
+        <!-- vector scale bar + timestamp (E2), drawn on the clean capture from the frame's physical extent -->
+        <StillOverlay v-if="(c.assetId || c.src) && (showScaleBar || showTimestamp)"
+                      :extent-um="c.extentUm" :time-label="frameTime(c)"
+                      :show-scale-bar="showScaleBar" :show-timestamp="showTimestamp" />
         <!-- optional view legend (channels now; pops + colour-by plug in later), from the frame snapshot -->
         <ViewLegend v-if="showLegend && (c.assetId || c.src) && legendSections(c).length"
                     :sections="legendSections(c)" :swatch="9" class="is-legend" />

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -11,6 +11,7 @@ import { useProjectStore } from '../stores/project'
 import { useLogStore } from '../stores/log'
 import { useAnimationStore, type AnimSnapshot } from '../stores/animation'
 import { napariColormapHex } from '../utils/napariColormap'
+import { elapsedLabel } from '../utils/stillOverlay'
 import ConfirmDeleteButton from '../components/ConfirmDeleteButton.vue'
 
 const projectMeta = useProjectMetaStore()
@@ -113,12 +114,8 @@ function keyframeTime(s: AnimSnapshot): string {
   const step = (s.snapshot?.dims as { current_step?: number[] } | undefined)?.current_step
   const t = Array.isArray(step) ? step[0] : undefined
   if (t === undefined || t === null) return ''
-  const inc = openImage.value?.timeIncrement
-  if (!inc) return `t${t}`
-  const unit = openImage.value?.timeIncrementUnit ?? 'second'
-  const secs = /^min/i.test(unit) ? t * inc * 60 : t * inc
-  const h = Math.floor(secs / 3600), m = Math.round((secs % 3600) / 60)
-  return `t${t} · ${h > 0 ? `${h}h ${m}m` : `${m}m`}`
+  const e = elapsedLabel(t, openImage.value?.timeIncrement, openImage.value?.timeIncrementUnit)
+  return openImage.value?.timeIncrement ? `t${t} · ${e}` : `t${t}`   // shared formatter (utils/stillOverlay)
 }
 
 type Layers = Record<string, { visible?: boolean; colormap?: string }>

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -17,6 +17,13 @@ export const useSettingsStore = defineStore('settings', () => {
     localStorage.getItem('cc.napariUpdateImage') === 'true'    // default false
   )
 
+  // Clean capture (E1): hide napari's baked scale bar + timestamp when taking a screenshot, for a clean
+  // publication still (add a vector scale bar / timestamp externally). Applies to strip + animation
+  // captures. Default false (keep the on-screen annotations). See docs/todo/ANIMATION_PLAN.md → E.
+  const cleanCapture = ref(
+    localStorage.getItem('cc.cleanCapture') === 'true'         // default false
+  )
+
   // Reload behaviour: reloading a shown image (the eye / a finished task) refreshes DATA only
   // (labels + population/track overlays, re-read from disk) — NOT the image pyramid. Tick "reset" to
   // reopen the image too (needed when a task changed the pixels: drift/denoise). Default false.
@@ -165,6 +172,7 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(taskListAutoFollow,       v => localStorage.setItem('cc.taskListAutoFollow',       String(v)))
   watch(autoRefreshOnTask,        v => localStorage.setItem('cc.autoRefreshOnTask',        String(v)))
   watch(napariUpdateImage,        v => localStorage.setItem('cc.napariUpdateImage',        String(v)))
+  watch(cleanCapture,             v => localStorage.setItem('cc.cleanCapture',             String(v)))
   watch(napariResetOnReload,      v => localStorage.setItem('cc.napariResetOnReload',      String(v)))
   watch(napariAutoSaveLayerProps, v => localStorage.setItem('cc.napariAutoSaveLayerProps', String(v)))
   watch(napariAsDask,             v => localStorage.setItem('cc.napariAsDask',             String(v)))
@@ -173,5 +181,5 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(rightPanelCollapsed,      v => localStorage.setItem('cc.rightPanelCollapsed',      String(v)))
   watch(viewerPanelOpen,          v => localStorage.setItem('cc.viewerPanelOpen',          String(v)))
 
-  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, napariDiscreteGpu, sidebarCollapsed, rightPanelCollapsed, viewerPanelOpen, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible, getColourOverrides, setColourOverride, clearColourOverrides, getMovieConfig, setMovieConfig, getBatchMovieConfig, setBatchMovieConfig }
+  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, cleanCapture, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, napariDiscreteGpu, sidebarCollapsed, rightPanelCollapsed, viewerPanelOpen, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible, getColourOverrides, setColourOverride, clearColourOverrides, getMovieConfig, setMovieConfig, getBatchMovieConfig, setBatchMovieConfig }
 })

--- a/frontend/src/utils/stillOverlay.test.ts
+++ b/frontend/src/utils/stillOverlay.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { elapsedLabel, niceScaleBar } from './stillOverlay'
+
+describe('elapsedLabel', () => {
+  it('formats seconds → m / h m', () => {
+    expect(elapsedLabel(0, 30, 'second')).toBe('0m')
+    expect(elapsedLabel(10, 30, 'second')).toBe('5m')       // 300 s
+    expect(elapsedLabel(240, 30, 'second')).toBe('2h 0m')   // 7200 s
+  })
+  it('respects a minutes interval unit', () => {
+    expect(elapsedLabel(3, 2, 'min')).toBe('6m')            // 3 × 2 min
+    expect(elapsedLabel(90, 1, 'minutes')).toBe('1h 30m')
+  })
+  it('falls back to t{N} when the interval is unknown, and "" with no timepoint', () => {
+    expect(elapsedLabel(4, undefined)).toBe('t4')
+    expect(elapsedLabel(null, 30)).toBe('')
+    expect(elapsedLabel(undefined, 30)).toBe('')
+  })
+})
+
+describe('niceScaleBar', () => {
+  it('picks the largest nice step within maxFraction of the extent', () => {
+    // extent 500 µm, 30% = 150 → largest nice ≤ 150 is 100
+    expect(niceScaleBar(500)).toEqual({ um: 100, label: '100 µm' })
+    // extent 40 µm, 30% = 12 → largest nice ≤ 12 is 10
+    expect(niceScaleBar(40)).toEqual({ um: 10, label: '10 µm' })
+  })
+  it('rolls µm up to mm at/above 1000', () => {
+    // extent 8000 µm, 30% = 2400 → 2000 µm → "2 mm"
+    expect(niceScaleBar(8000)).toEqual({ um: 2000, label: '2 mm' })
+  })
+  it('keeps a non-micron unit as given', () => {
+    expect(niceScaleBar(500, 'nm')).toEqual({ um: 100, label: '100 nm' })
+  })
+  it('returns null for a missing / too-small extent', () => {
+    expect(niceScaleBar(0)).toBeNull()
+    expect(niceScaleBar(null)).toBeNull()
+    expect(niceScaleBar(2)).toBeNull()          // 30% = 0.6, smaller than the smallest step (1)
+  })
+})

--- a/frontend/src/utils/stillOverlay.ts
+++ b/frontend/src/utils/stillOverlay.ts
@@ -1,0 +1,35 @@
+// Pure helpers for still overlays (Phase E2): the elapsed-time timestamp and the vector scale bar drawn
+// on a clean-captured strip frame. Kept out of the SFC so they're unit-testable.
+
+/** Elapsed time for timepoint index `t` as "{h}h {m}m" (or "{m}m" under an hour). `inc` = the frame
+ *  interval, `unit` its unit ('second'/'min…'). Returns '' when there's no timepoint; falls back to
+ *  "t{N}" when the interval is unknown. Shared with the animation timeline (one time formatter). */
+export function elapsedLabel(t: number | null | undefined, inc: number | null | undefined, unit?: string | null): string {
+  if (t === undefined || t === null) return ''
+  if (!inc) return `t${t}`
+  const secs = /^min/i.test(unit ?? 'second') ? t * inc * 60 : t * inc
+  const h = Math.floor(secs / 3600)
+  const m = Math.round((secs % 3600) / 60)
+  return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+
+const NICE_STEPS = [1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 5000]
+
+/** Pick a "nice" round scale-bar length ≤ `maxFraction` of the frame's physical width. `extentUm` is the
+ *  captured frame's physical X-extent (from the bridge). Returns the length (in the same unit as extent,
+ *  rolled up to mm when ≥1000 µm) + a display label, or null when even the smallest step is too big
+ *  (a tiny frame). Correct by construction — the caller draws the bar as `um/extentUm` of the frame. */
+export function niceScaleBar(
+  extentUm: number | null | undefined, unit: string | null | undefined = 'µm', maxFraction = 0.3,
+): { um: number; label: string } | null {
+  if (!extentUm || extentUm <= 0) return null
+  const maxUm = extentUm * maxFraction
+  let pick = 0
+  for (const n of NICE_STEPS) if (n <= maxUm) pick = n
+  if (!pick) return null
+  const u = unit || 'µm'
+  // roll µm up to mm for tidy labels (a 1000 µm bar reads "1 mm")
+  const isMicron = /^(µm|um|micron)/i.test(u)
+  const label = isMicron && pick >= 1000 ? `${pick / 1000} mm` : `${pick} ${isMicron ? 'µm' : u}`
+  return { um: pick, label }
+}

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -1037,7 +1037,8 @@ class NapariState:
 
     # ── Screenshot ────────────────────────────────────────────────────────────
 
-    def save_screenshot(self, path: str, canvas_only: bool = True, scale=1, fit_data: bool = True):
+    def save_screenshot(self, path: str, canvas_only: bool = True, scale=1, fit_data: bool = True,
+                        clean: bool = False):
         """Capture the canvas to `path`.
 
         `fit_data=True` (default) uses napari's `export_figure`: it tightly re-fits the view to the
@@ -1048,11 +1049,29 @@ class NapariState:
         restores the previous camera afterwards, so the view snapshot captured alongside is unaffected.
 
         `fit_data=False` captures the current canvas as-shown (a plain canvas screenshot). Falls back to
-        that if there are no layers to fit."""
-        if fit_data and len(self._viewer.layers) > 0:
-            self._viewer.window.export_figure(path=path, scale=float(scale or 1), flash=False)
-        else:
-            self._viewer.window.screenshot(path, canvas_only=canvas_only, flash=False)
+        that if there are no layers to fit.
+
+        `clean=True` (Phase E1) hides napari's baked scale bar + timestamp overlay for the shot and
+        restores them after — a clean still for publication (add a vector scale bar / timestamp in
+        Illustrator, or Cecelia's own; see ANIMATION_PLAN.md Decision 7)."""
+        sb_was = ts_was = None
+        if clean:
+            try: sb_was = self._viewer.scale_bar.visible;    self._viewer.scale_bar.visible = False
+            except Exception: sb_was = None
+            try: ts_was = self._viewer.text_overlay.visible; self._viewer.text_overlay.visible = False
+            except Exception: ts_was = None
+        try:
+            if fit_data and len(self._viewer.layers) > 0:
+                self._viewer.window.export_figure(path=path, scale=float(scale or 1), flash=False)
+            else:
+                self._viewer.window.screenshot(path, canvas_only=canvas_only, flash=False)
+        finally:
+            if sb_was is not None:
+                try: self._viewer.scale_bar.visible = sb_was
+                except Exception: pass
+            if ts_was is not None:
+                try: self._viewer.text_overlay.visible = ts_was
+                except Exception: pass
 
     def record_timelapse(self, path: str, fps: int = 15, canvas_only: bool = True,
                          scale=1, t_start: int = 0, t_end=None):
@@ -1367,7 +1386,8 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
 
         elif t == "save_screenshot":
             state.save_screenshot(cmd["path"], canvas_only=cmd.get("canvas_only", True),
-                                  scale=cmd.get("scale", 1), fit_data=cmd.get("fit_data", True))
+                                  scale=cmd.get("scale", 1), fit_data=cmd.get("fit_data", True),
+                                  clean=cmd.get("clean", False))
             # fold the view snapshot into the reply so a screenshot and its provenance are captured
             # atomically (same view) — one round trip, no camera-moved-between-calls skew.
             return {"type": "ok", "cmd": t, "view_state": state.capture_view_state()}

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -196,6 +196,32 @@ class NapariState:
         except Exception:
             return None
 
+    def _data_extent_um(self):
+        """Physical (µm) size of the full data extent along x and y, from data shape × per-axis scale.
+        `export_figure` tight-fits the capture to the data extent, so this IS the captured frame's
+        physical width/height — the frontend draws a correct vector scale bar from it (Phase E2). Returns
+        `{"x": w, "y": h, "unit": …}` or None if scale/axes unknown. `_im_scale`/display axes exclude the
+        channel axis and share order, so the same index selects a shape value and its scale."""
+        if not self._axes or not self._im_data or self._im_scale is None:
+            return None
+        try:
+            low   = [a.lower() for a in self._axes]
+            disp  = [a for a in low if a != "c"]                              # matches _im_scale order
+            shape = self._im_data[0].shape
+            shape_noc = [s for i, s in enumerate(shape) if i != self._channel_axis]
+            out = {}
+            for ax in ("x", "y"):
+                if ax in disp:
+                    j = disp.index(ax)
+                    if j < len(shape_noc) and j < len(self._im_scale):
+                        out[ax] = float(shape_noc[j]) * float(self._im_scale[j])
+            if "x" not in out or "y" not in out:
+                return None
+            out["unit"] = self._im_units[0] if self._im_units else None
+            return out
+        except Exception:
+            return None
+
     def _setup_timestamp(self, path: str):
         """For timecourse data (a `t` axis), show an elapsed-time text overlay (top-left) that updates
         as the t slider moves — `t_index × frame_interval`, formatted H:MM:SS. The frame interval is
@@ -1389,8 +1415,10 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
                                   scale=cmd.get("scale", 1), fit_data=cmd.get("fit_data", True),
                                   clean=cmd.get("clean", False))
             # fold the view snapshot into the reply so a screenshot and its provenance are captured
-            # atomically (same view) — one round trip, no camera-moved-between-calls skew.
-            return {"type": "ok", "cmd": t, "view_state": state.capture_view_state()}
+            # atomically (same view) — one round trip, no camera-moved-between-calls skew. `extent_um` =
+            # the captured frame's physical size (for a vector scale bar on the still, Phase E2).
+            return {"type": "ok", "cmd": t, "view_state": state.capture_view_state(),
+                    "extent_um": state._data_extent_um()}
 
         elif t == "capture_view_state":
             return {"type": "ok", "cmd": t, "view_state": state.capture_view_state()}


### PR DESCRIPTION
Phase **E1** of the animation plan (`docs/todo/ANIMATION_PLAN.md` → E): capture a **clean publication still** — no baked napari scale bar / timestamp — so you can add a vector scale bar + timestamp externally (Decision 7).

## What
- **Bridge** `save_screenshot(clean=True)` — hides `viewer.scale_bar.visible` + `viewer.text_overlay.visible` for the shot and restores them after (guarded; try/finally).
- Threaded through: `POST /api/napari/screenshot {clean}` → `save_screenshot!` → bridge command.
- **Frontend** — a persisted **"clean capture"** toggle in the analysis-board image-strip ⚙ (`settings.cleanCapture`); the strip's capture passes it.
- **Scoped to stills** — animation keyframes deliberately keep the timestamp (a movie wants it), so `AnimationModule` is unchanged.

## Verify / notes
- `npm run typecheck` + `build` green; `test-api` loads clean; `napari_bridge.py` parses.
- **Bridge change → restart napari** (`pixi run stop-napari`) for `clean` to take effect.
- **Not run against live napari** — the hide/restore + toggle are wired but the actual clean PNG hasn't been eyeballed in a browser.
- **E2 (Cecelia-drawn vector scale bar + timestamp) is still to build** — noted in the plan; it needs the captured frame's µm-per-pixel and should be verified against `export_figure`'s data extent.

Docs: `docs/NAPARI.md` (Clean capture), `docs/todo/ANIMATION_PLAN.md` (E1 done, E2 left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
