### PR TITLE
docs(ai-assist): rename phase docs, fix cross-refs, author grounded plans

### DIFF
--- a/docs/ai-assist/LAB-LOG.md
+++ b/docs/ai-assist/LAB-LOG.md
@@ -1,0 +1,216 @@
+# Phase: Lab Log — Shared Project Memory
+
+Design phase for Opus. Read `OBSERVER.md` and `QC-PROCESS.md` alongside this. The lab log is the shared artefact that makes Claude useful across sessions. Without it, every session starts blind. With it, Claude accumulates the non-obvious knowledge that isn't inferable from data or framework alone.
+
+---
+
+## What the lab log is
+
+A per-project, append-only, human-and-AI-writable file that lives in the project directory. It is the persistent memory for AI-assisted analysis sessions.
+
+It is NOT:
+- Documentation (that's `docs/`)
+- A task log (that's the per-image task log the scheduler writes)
+- A results file (that's the analysis output)
+- Image notes (those are per-image, written by the user in Cecelia)
+
+It IS: knowledge that would otherwise be lost between sessions. The methodology. The why. The edge cases. The corrections.
+
+**Filename — decided: `lab-log.md` at the project root** (`{projects_dir}/{proj_uid}/lab-log.md`).
+
+Rationale: it is the working title, and it wins on every axis that matters here. A biologist opening the project directory reads "lab log" instantly — no decoding. Lowercase-hyphen keeps it visually distinct from the uppercase design doc `docs/ai-assist/LAB-LOG.md` (this file), so "the lab log" (per-project data) and "LAB-LOG.md" (the spec) never get confused. Project **root**, not `settings/`, is deliberate: the spec's whole thesis is that this lives *next to the data*, visible, the first thing you see when you return to a project — burying it under `settings/` (where machine-written sidecars like `chains/`, `analysisBoards.json` live, `api/src/routes.jl:7`) would signal "config, not for humans." Rejected alternatives: `NOTES.md`/`README.md` (collide with generic meaning and existing conventions), `METHODS.md` (implies a finished write-up, not an append-only running log), `analysis-log.md` (accurate but less immediately human than "lab log").
+
+---
+
+## Relationship to image notes and task logs
+
+The lab log complements, not duplicates:
+
+- **Image notes** (per-image, user-written in Cecelia UI) — quick observations about a specific image. "This section has a fold." "Channel 2 autofluorescence high."
+- **Task logs** (per-image-per-task, written by the scheduler) — what ran, parameters, output paths, errors. Machine-written.
+- **Lab log** (per-project, human and Claude) — cross-image knowledge, methodology rationale, pattern recognition, corrections. What image notes and task logs don't capture.
+
+Claude reads all three. The lab log is the only one Claude writes to.
+
+---
+
+## What goes in it
+
+**Yes:**
+- Gating decisions not derivable from data ("CD4+ gate runs loose on spleen, channel 2 lower boundary ~0.3 too low for this tissue prep")
+- Image exclusions with quantitative justification
+- Parameter choices that worked for this cohort and why
+- Cross-experiment patterns Claude recognised
+- Corrections to Claude's prior suggestions
+- User's stated rationale when Claude asked "why did you do that"
+- QC flags that were acknowledged and what action was taken
+
+**No — inferable from framework or data:**
+- Task completion status (task manager)
+- Image dimensions, channel names (MCP tools)
+- Population counts (MCP tools)
+- What module functions exist (CLAUDE.md)
+
+---
+
+## Format
+
+Append-only, dated, author-tagged entries. Never edit old entries — add a correction entry instead.
+
+```markdown
+## 2026-07-14 [Claude]
+- Image 7 flagged: gate produced 23 cells (cohort mean 187). User excluded image.
+- Repeat attempt pattern: cellpose on image 12 run 8 times. User confirmed tissue folding 
+  is the issue — cannot be recovered. Excluded.
+
+## 2026-07-14 [User]
+- CD4+ gate: lower boundary channel 2 should be ~0.25 for this tissue prep, not 0.3 default.
+  Spleen samples in this batch have higher background than thymus.
+- Image 3 state 1 dominance is real biology — early-stage infection. Keep, note in analysis.
+
+## 2026-07-14 [User — correction]
+- Corrects 2026-07-12 [Claude]: Image 5 speed distribution is NOT an outlier. This mouse 
+  received a different treatment — the higher motility is expected. Do not flag this pattern
+  for treated cohort.
+```
+
+Author tag `[Claude]` or `[User]` on every entry block. Correction entries reference the original by date and author. Claude reads corrections and adjusts reasoning within the session.
+
+---
+
+## MCP tools
+
+```
+read_lab_log       → full log content, returned newest-first for efficient context loading
+append_lab_log     → append a dated [Claude] entry, never edits, enforces append-only
+```
+
+User writes directly to the file or via the Vue panel. Claude writes only via `append_lab_log`. This keeps Claude entries identifiable and prevents overwrites.
+
+---
+
+## Vue panel
+
+The lab log GUI is what determines whether anyone actually uses it. The file is the backend. The panel is the product. Design for zero friction between "I just made a decision" and "it's recorded."
+
+**Placement**: persistent slide-out panel accessible from any module page without navigation. Not a separate page. The user makes a gating decision, glances right, types one line, continues. If they have to navigate somewhere to log it, they won't.
+
+**Always-visible entry field**: a single text input at the top of the panel, always focused, date and author pre-filled. One sentence minimum. Submit with Enter. No form, no fields, no save button to click.
+
+**Context-aware prefill**: when the user is on a module page and something changes — threshold adjusted, image excluded, task re-run — a "note this" prompt appears inline on that page, pre-filled with the context (image UID, stage, what changed). The user adds the reason and submits. The worst version is an empty box. The best version already knows what happened and just needs the why.
+
+Example prefill from a gating action:
+```
+[2026-07-14] CD4+ gate threshold changed 0.3 → 0.25 on image KDIeEm — [your note here]
+```
+
+**Project open summary**: when a project is opened that has lab log entries, the most recent 3-5 entries surface automatically in a banner or sidebar without the user having to open the panel. If you haven't touched this project in three months, the first thing you see is what you were doing and why.
+
+**Entry display**: chronological, newest first. Clear visual distinction between `[Claude]` and `[User]` entries — different background colour or left border colour, not just a tag. New Claude entries since last session are badged so the user is prompted to review them.
+
+**Correction**: one-click on any entry opens a pre-filled correction: `[correction to YYYY-MM-DD User/Claude]: ` — user completes it and submits. No editing of old entries, only appending corrections.
+
+**Read-only for Claude entries in the UI**: Claude entries cannot be edited from the panel. Append-only enforced both in the UI and in the MCP write tool.
+
+Note: voice input is explicitly out of scope — it solves a problem that doesn't exist for this workflow and adds unnecessary complexity.
+
+---
+
+## Versioning
+
+The lab log is per-project and per-version. On version bump, prior lab log is copied with a version boundary header:
+
+```markdown
+## [Version boundary: v1 → v2, 2026-07-15]
+Entries below are from v1. Context may still be relevant.
+---
+```
+
+Institutional memory does not get lost on version bump.
+
+---
+
+## Claude session behaviour
+
+On session start: Claude reads the full lab log. Weights recent entries more heavily. Explicitly notes correction entries and adjusts reasoning — a corrected pattern should not be flagged again.
+
+Claude appends to the lab log during the session when:
+- A QC flag fires and the user acknowledges it
+- A why question is answered by the user
+- A cross-experiment pattern is recognised
+- A parameter adjustment is accepted or rejected
+
+Claude does NOT append for routine completions, ambient observations that don't reach flag threshold, or anything that duplicates what image notes or task logs already capture.
+
+---
+
+## Implementation plan
+
+> Grounded against the codebase as of 2026-07. The lab log has **standalone value and no hard
+> dependency on the MCP server or observer** — steps 1, 4, 5 can ship first and be written manually
+> via the panel; Claude reads/writes what's already there once the MCP arrives (see the ROADMAP's
+> "start it now").
+
+### 1. File format spec
+
+- Plain markdown, append-only, at `{proj}/lab-log.md`. One `##`-level block per entry: `## YYYY-MM-DD [Author]` where `Author ∈ {Claude, User, User — correction}`, followed by `-` bullet lines. Exactly the format already shown in this doc above — treat that as the normative example.
+- **Required per block**: ISO date, author tag. Correction blocks reference the original by date + author (`## 2026-07-14 [User — correction]` → first bullet begins `Corrects 2026-07-12 [Claude]:`).
+- **Never edit or delete existing entries** — corrections are new appended blocks. This is what makes the file safe for concurrent human + Claude writers and auditable.
+
+### 2. Filename — decided
+
+`lab-log.md` at the project root. Full rationale is under *What the lab log is* above (decided, not deferred).
+
+### 3. MCP read tool — `read_lab_log`
+
+- New thin read-only route `GET /api/lablog?projectUid=…` → reads `{proj}/lab-log.md`, returns `{ content, mtime }`. Add one `elseif` in the GET block of `handle_http` (`api/src/server.jl` ~`:243`) calling a new `api_lablog_read(req)`; response via `JSON3.write((; content, mtime))` (routing convention `docs/API.md:36-47`). Restart required (api/ is not Revise-tracked).
+- **Ordering**: return raw content plus a parsed, **newest-first** list of blocks for efficient context loading (the MCP tool hands Claude newest-first). Parsing is trivial (split on `^## \d{4}-`).
+- **Long-log summarisation**: for the MCP layer, if the file exceeds a token budget, return the full most-recent N entries verbatim + an older-entries digest, and always return **all** `[correction]` blocks verbatim regardless of age (corrections must never be summarised away — they gate future behaviour, step 7).
+
+### 4. MCP write tool — `append_lab_log`
+
+- New route `POST /api/lablog/append` → `api_lablog_append(body)`, body `{ projectUid, author, lines: [...] }`. Server **injects the date and author tag** and formats the block — the caller never supplies the header, which keeps `[Claude]` entries unforgeable and the format uniform.
+- **Append-only + concurrency**: write under the sanctioned project write lock `with_transaction(f, proj)` (`app/src/model/project.jl:150-166`, holds `{proj}/.cecelia.lock`) so a human panel write and a Claude write can't clobber each other. Open the file in append mode; never rewrite existing bytes.
+- **Author enforcement**: the MCP `append_lab_log` tool always passes `author="Claude"`; the panel passes `author="User"`/`"User — correction"`. (When Phase-2 auth exists this can be server-attributed instead of client-declared.)
+- Broadcast `{type:"lab:entry", projectUid, author}` via `broadcast_ws` (`server.jl:52-62`) after a **user** append, so the observer/MCP sees `lab_log_entry_added` (see `QC-PROCESS.md` step 8). Do **not** broadcast Claude's own appends (avoids a feedback loop).
+
+### 5. Vue panel
+
+- **No slide-out/drawer component exists yet** — the reusable "floats above any page" primitive is `frontend/src/components/FloatingPanel.vue` (draggable/resizable, `position:fixed`, persists geometry to `localStorage` under `cc.floating.<key>`; `docs/UI.md:212-232`). Mount the lab-log panel in the app shell `frontend/src/App.vue` **as a sibling to the existing `FloatingPanel`** (App.vue:62-65 already mounts `ViewerPanel` this way), so it is reachable on every module page with zero navigation — the spec's load-bearing requirement.
+- **Open toggle**: add a persisted flag mirroring `viewerPanelOpen` — a `ref` in the `settings` store watched to `localStorage` (`frontend/src/stores/settings.ts:48` + `:160`). Every other user-settable option on the panel goes through `useViewState` over a store-backed bag (`frontend/src/composables/useViewState.ts`), per the hard "persist every user-settable option" rule.
+- **Always-visible entry field** at the top, focused, date/author pre-filled, submit-on-Enter (one input, no form). **Entry display** chronological newest-first, with a distinct left-border/background colour for `[Claude]` vs `[User]` (not just the tag); new Claude entries since last open are badged. **Correction**: one click on any entry opens a pre-filled `[correction to YYYY-MM-DD Author]:` append (never an in-place edit). Claude entries are read-only in the UI (append-only enforced in both the panel and the write route).
+- **Context-aware prefill**: when a module-page action changes something (threshold edited, image excluded, task re-run), show an inline "note this" prompt pre-filled with the context (image UID, stage, what changed) — the user adds only the reason. These actions already have hook points (e.g. the note/inclusion write `POST /api/images/inclusion/set`, `routes.jl:891`).
+- Voice input is explicitly out of scope.
+
+### 6. Version copy behaviour
+
+- **There is no project/set-level version concept today** — the only versioning is the per-field versioned-variable pattern *inside a single image's* ccid.json (`versioned_get_field`/`set_active!`, `app/src/model/image.jl:3-93`); `CciaProject`/`CciaSet` have no `version` field, and there is **no project-level "version bump" event to hook**. So a lab-log version boundary must be defined here, not borrowed.
+- **Recommended trigger**: an explicit, user-invoked "start a new version" action in the panel (and, later, at release/freeze time). On trigger, insert a boundary header into the same append-only file rather than copying to a new file:
+  ```markdown
+  ## [Version boundary: v1 → v2, 2026-07-15]
+  Entries below are from v1. Context may still be relevant.
+  ---
+  ```
+  Keeping it in one file (vs a `lab-log.v1.md` copy) means institutional memory stays in the single document Claude already reads; the boundary is just a parseable marker that lets the reader weight pre-boundary entries as historical. (If the project later gains a real version field — or adopts the notebooks-style snapshot/restore in `docs/NOTEBOOKS.md` — wire the boundary to that instead.)
+
+### 7. Claude weighting
+
+- On session start Claude reads the full log (newest-first, step 3), **weights recent entries more heavily**, and treats entries below a `[Version boundary]` as historical context, not current truth.
+- **Corrections gate future behaviour**: a `[User — correction]` block that says "do not flag pattern X for the treated cohort" must suppress that flag for the rest of the session. Implement as: parse all correction blocks, build a suppression set keyed by (pattern/metric, scope), and check it before the observer surfaces any flag (`QC-PROCESS.md` step 8, speak-vs-silent). This is why corrections are never summarised away (step 3).
+
+### 8. Integration with image notes and task logs
+
+- Claude reads three sources and the lab log is the only one it writes. Avoid duplication by role:
+  - **Image notes** — per-image `note` field on `CciaImage` (ccid.json; read via `_image_payload`/`get_image_notes`, written via `POST /api/images/inclusion/set`, `routes.jl:891`). Quick per-image observations. Claude *cites* them, never copies them into the lab log.
+  - **Task logs** — `{img._dir}/logs/{fun}.log` (`scheduler.jl:321-335`) + the success-only run log `{proj}/1/{uid}/runlog.json` (`app/src/run_log.jl`). Machine-written provenance. Claude reads for the attempt/failure pattern; it does not restate completions in the lab log.
+  - **Lab log** — cross-image methodology, rationale, corrections, acknowledged flags. Only what the other two don't capture.
+- Concretely: Claude appends to the lab log **only** for the events listed under *Lab log entries from QC* in `QC-PROCESS.md` (flag acknowledged, param adjustment accepted, image excluded, cross-experiment pattern, why-answer). Never for routine completions.
+
+### 9. Dependencies and build order
+
+1. **Read/append routes + file format (steps 1, 3, 4)** — pure additions to `api/src` + a lock-guarded writer; no scheduler or model changes. Ships independently.
+2. **Vue panel (step 5)** — depends only on step 1's routes; delivers standalone value with manual entries before any AI integration exists.
+3. **Project-open surfacing** — have `api_projects_load` (`routes.jl:340-411`) return the recent lab-log tail alongside `project/sets/boards/...`, surfaced by the frontend `openProject` after `loadFromApi` (`frontend/src/stores/projectMeta.ts:64-118`).
+4. **MCP `read_lab_log`/`append_lab_log` tools** — thin wrappers over the step-1 routes; depend on the `OBSERVER.md` MCP server.
+5. **QC-triggered appends + correction-gating (steps 7, 8)** — depend on the QC events (`QC-PROCESS.md` steps 2, 8) and the observer being live.
+6. **Version boundary (step 6)** — independent; can land with the panel.

--- a/docs/ai-assist/OBSERVER.md
+++ b/docs/ai-assist/OBSERVER.md
@@ -1,0 +1,157 @@
+# Phase: MCP Server — Claude Integration Infrastructure
+
+This is Phase 1 of a three-phase Claude integration arc. Build the infrastructure here. The behaviour that runs on top of it is defined in `QC-PROCESS.md` and `LAB-LOG.md`. All three documents form one system — read them together.
+
+---
+
+## The arc
+
+**Phase 1 — Observer** (this prompt)
+Claude sits next to the user. Watches what's happening. Reads task logs, image notes, project state. Asks questions. Notices patterns. Stays silent unless something is worth saying. Builds the lab log. No mutations, no autonomy.
+
+**Phase 2 — Designer** (after API and chain scheduler are stable)
+Claude proposes analysis strategies, suggests parameter adjustments, flags before things go wrong rather than after. Write-capable MCP with human confirmation on every action.
+
+**Phase 3 — Analyst** (after Phase 2 is proven)
+The overnight analyst. "I have 20 images, two treatment groups, I need to know if there's a behaviour difference by tomorrow." Claude runs the pipeline, flags edge cases, writes the morning summary. User reviews results, not a blank screen.
+
+---
+
+## Data sources Claude reads
+
+The value of the observer session depends entirely on what Claude can see. Claude must have access to:
+
+- **Project state** — images, processing status per stage, label props available
+- **Task logs** — every task writes a log file per image. Claude reads these. A task that failed 10 times leaves 10 log files. Claude notices.
+- **Image notes** — users can add notes to individual images in Cecelia. These are first-class data for Claude — the user's own words about what they observed.
+- **Lab log** — the accumulated cross-session memory (see `LAB-LOG.md`)
+- **QC metrics** — per-stage quality flags computed after each task (see `QC-PROCESS.md`)
+
+## MCP tools to implement
+
+**Read-only (Phase 1 — implement now):**
+```
+get_project_info          → name, version, image count, current stage
+list_images               → UIDs, names, processing status per stage, any user notes
+get_image_info            → one image: channels, dims, label props, task history
+get_task_log              → log content for a specific task run on a specific image
+get_task_history          → recent tasks across all images: function, status, attempt count, timestamp
+get_image_notes           → user-written notes for a specific image
+read_lab_log              → full lab log content
+get_qc_metrics            → per-image QC flags for a given stage
+```
+
+**Write (Phase 1 — lab log only):**
+```
+append_lab_log            → append a dated [Claude] entry. Append-only, never edits existing content.
+```
+
+**Write (Phase 2 — deferred):**
+```
+submit_task               → propose and submit a task (requires user confirmation)
+adjust_params             → propose parameter adjustment for a flagged image
+acknowledge_flag          → user acknowledges a QC flag, pipeline proceeds
+```
+
+Only expose endpoints that already exist and are stable in the Julia API. Add missing routes as thin read-only endpoints before wiring into MCP.
+
+## Transport
+
+stdio — standard for local MCP servers. Claude Code connects over stdin/stdout. The MCP server starts alongside the Julia API or independently for sessions where the GUI isn't running.
+
+## The observer session (sit next to me mode)
+
+The observer session is a Claude chat window with MCP access to the running Cecelia project. The user opens it and says "just sit next to me" or "watch what I'm doing." Claude doesn't wait to be asked — it monitors and surfaces observations when something is worth saying.
+
+**Event-driven, not continuous.** Claude does not stream logs in real time — that would be prohibitively expensive in tokens. Instead, the MCP server pushes event notifications to Claude when specific things happen:
+
+```
+task_completed            → image UID, function name, outcome, attempt count
+task_failed               → image UID, function name, error summary, attempt count
+image_note_added          → image UID, note content
+qc_flag_fired             → image UID, stage, metric, value, cohort comparison
+lab_log_entry_added       → new entry summary (user-written entries only)
+```
+
+On each event, Claude receives a compact context packet (the event + relevant recent history for that image) and decides: stay silent, or surface an observation. Most events → silence. Claude speaks when the pattern is worth naming.
+
+**The 10-attempts pattern.** If `task_completed` or `task_failed` fires with attempt_count > 3 for the same function on the same image, Claude surfaces it: "You've run cellpose on image 7 ten times. The outcome has been consistent each time. Want to talk through what you're trying to achieve?" This is the core value — pattern recognition across attempts that the user is too close to notice.
+
+**The why question.** When a user does something unexpected — a parameter choice that deviates from prior runs, an image note that suggests an unusual decision — Claude asks why. Not to judge, to record. The answer goes in the lab log. Lab heads want figures. This is how the methodology doesn't get lost.
+
+## Token cost
+
+The event-driven approach keeps costs manageable. Each event triggers one Claude call with a compact context packet — not a full project dump. Estimate: 10-20 events per analysis session, each ~2-3k tokens of context. Comparable to a normal chat session. The observer session does not stream continuously.
+
+**Honest caveat**: this estimate is optimistic for heavy sessions. 20 images with multiple failed tasks, cohort stats, and QC flags could be 10x that. Measure actual token cost in practice and implement a throttle — a configurable max events per session before Claude stops surfacing observations and just logs silently. The user should be able to see running token cost and disable the observer session if it becomes prohibitive.
+
+## Early calibration warning
+
+The observer session becomes more valuable over time, not immediately. Early in a project, before the lab log is rich and before Claude has seen the cohort, its sense of what's "unexpected" is poorly calibrated. It may ask obvious questions or miss genuinely unusual decisions. Set user expectations accordingly — the first few sessions are about building context, not catching errors.
+
+## Implementation plan
+
+> Grounded against the codebase as of 2026-07. **No MCP server exists yet — this is greenfield.**
+> The good news: most read tools map to routes that already exist, so Phase 1 is mostly a thin MCP
+> adapter + a handful of new read-only endpoints + one new event.
+
+### 1. MCP server — separate process, stdio
+
+- Build the MCP server as a **standalone process** (stdio transport, as specified) that talks to the running Julia API over `http://127.0.0.1:8080` (HTTP) and `ws://127.0.0.1:8080/ws` (events). It is **not** in-process Julia — that keeps `api/` Julia-only and matches the stdio-transport decision.
+- **Language — decided: Python**, using the official `mcp` SDK (FastMCP), in a new top-level `mcp/` dir. MCP has two standard, Anthropic-maintained SDKs — TypeScript (the reference implementation) and Python; both are first-class. Python wins here because it is already a first-class, pixi-managed ecosystem in this repo, so the server needs no new toolchain, no second CI lane, and can run from the same env — whereas TypeScript would add a standalone Node project purely for this. Note the `mcp/` dir is **separate infra**, not part of the `cecelia` analysis package (which is unrelated IO), consistent with the one-language-per-top-level-dir rule.
+- The server holds one persistent WS connection for events (§4) and makes on-demand HTTP GETs for the read tools (§2). No Julia dependency is added to `app/`/`api/`.
+
+### 2. Read tools → routes (most already exist)
+
+| MCP tool | Backing route | Status |
+|---|---|---|
+| `get_project_info` | `GET /api/projects` (`routes.jl:313`) + `POST /api/projects/load` (`routes.jl:340-411`, richest state) | **exists** |
+| `list_images` | `sets[].images` from `/api/projects/load` (`_image_payload`, `routes.jl:977-1024`) | **exists** (optional thin `GET /api/images?projectUid` for a lighter call) |
+| `get_image_info` | `GET /api/images/meta?projectUid&imageUid` (`routes.jl:668-684`) — returns channels/dims/physical sizes/labels/`note`, plus `qc=read_all_qc(img)` and `runLog=read_run_log(img)` | **exists** |
+| `get_image_notes` | the `note` field inside `_image_payload` (`routes.jl` note field); no separate call needed | **exists** |
+| `get_qc_metrics` | `GET /api/gating/stats` (`gating_api.jl:364`) for gating; `qc` block in `_image_payload` for per-stage findings; per-set cohort sidecar (`QC-PROCESS.md` step 3) | **partly new** (cohort route) |
+| `get_task_log` | **NEW** `GET /api/images/tasklog?projectUid&imageUid&fun` → reads `{img._dir}/logs/{fun}.log` (`scheduler.jl:321-335`) | **new** |
+| `get_task_history` | `runLog` in `_image_payload` gives per-image history; **NEW** `GET /api/tasks/history?projectUid` to aggregate across images (and, once step 9 of `QC-PROCESS.md` lands, attempt counts) | **partly new** |
+| `read_lab_log` | **NEW** `GET /api/lablog?projectUid` (`LAB-LOG.md` step 3) | **new** |
+| `append_lab_log` (write) | **NEW** `POST /api/lablog/append` (`LAB-LOG.md` step 4), lock-guarded, append-only | **new** |
+
+- Adding each new route = write `api_*(req)` + one `elseif` in `handle_http`'s GET/POST block (`api/src/server.jl:168-391`) + **server restart** (api/ is not Revise-tracked). Response shape: `(status, JSON3.write((; …)))` (`docs/API.md:36-47`).
+- **No-mutation guarantee**: the MCP server only ever calls the read routes above + `POST /api/lablog/append`. It never touches task submission, gate CRUD, or inclusion routes. Enforce by allow-listing the exact routes in the MCP adapter (Phase 1).
+
+### 3. Read-only enforcement
+
+Phase 1 exposes exactly nine tools, eight read + `append_lab_log`. `submit_task`/`adjust_params`/`acknowledge_flag` are Phase 2 and must not be wired now. The append route is the *only* write path and is itself append-only (`LAB-LOG.md` step 4).
+
+### 4. Event push — subscribe-and-rebroadcast
+
+- The backend already bridges the package event bus to WS: `subscribe_chain_events!`/`_fire_chain_event!` (`app/src/events.jl`) → re-broadcast as `chain:node:*` frames in `api/src/server.jl:113-164`, plus task frames `task:status`/`task:log`/`task:result`/`task:progress` (`api/src/sockets.jl:1-21`). The MCP server subscribes to the WS and maps frames to the spec's observer events:
+  - `task_completed`/`task_failed` ← existing `task:status` (`sockets.jl:15`) and chain `node:done`/`node:failed` (`server.jl:139-164`). **Reuse.**
+  - `qc_flag_fired` ← **NEW** backend event (`QC-PROCESS.md` step 8): fire a `node:flagged`/`qc:flag` from `_update_node_state!`, add a bridge subscriber.
+  - `image_note_added` ← **NEW** broadcast added to `api_images_inclusion_set` (`routes.jl:891`).
+  - `lab_log_entry_added` ← **NEW** broadcast from the append route, user entries only (`LAB-LOG.md` step 4).
+- **Event-driven, not streaming**: the MCP server receives frames, assembles a compact context packet (event + recent history for that image via the §2 read tools), and decides speak-vs-silent. Firing stays outside `run._lock` (SCHEDULER.md invariant #2); WS delivery is the existing bounded drop-on-full per-client queue (`server.jl:34-62`).
+
+### 5. The 10-attempts pattern — needs an attempt counter
+
+The core signal (">3 runs of the same fn on the same image") has **no data source today**: the run log records successes only, no retry count (`app/src/run_log.jl`), and `ImageNodeState` has no counter. Add a per-`(uid,node)` attempt counter persisted in `run.json` (`QC-PROCESS.md` step 9) **or** derive it in the MCP server's session memory by counting `node:running`/`node:failed` frames. This is a hard dependency for the pattern — build it with the event push.
+
+### 6. Token cost & throttle
+
+Implement the configurable per-session cap in the MCP server: after N surfaced observations, stop emitting to the chat and only append to the lab log (Silent-equivalent). Report running token cost per session and expose an off switch, per the doc's honest caveat that heavy sessions can be ~10× the estimate.
+
+### 7. Build order
+
+1. New read routes: `get_task_log`, `read_lab_log`/`append_lab_log`, `get_task_history` (thin, no scheduler change).
+2. MCP server skeleton (`mcp/`) + the eight read tools + `append_lab_log`, allow-listed — satisfies "describe project state without being told" and the no-mutation verify.
+3. Attempt counter (§5) + `qc_flag_fired`/`image_note_added`/`lab_log_entry_added` events (§4) — enables the attempt pattern and QC surfacing.
+4. Throttle + token reporting (§6).
+5. Cohort `get_qc_metrics` route once cohort stats land (`QC-PROCESS.md` step 3).
+
+## Verify
+
+- Connect Claude to MCP, open a project — Claude describes project state correctly without being told
+- Run a task that fails 3 times — Claude surfaces the pattern without being asked
+- Add an image note — Claude acknowledges it and incorporates it in context
+- Append to lab log via MCP — entry appears with correct [Claude] tag and date
+- Confirm no mutations possible beyond lab log append
+- Confirm token usage is reported per session and throttle fires correctly

--- a/docs/ai-assist/QC-PROCESS.md
+++ b/docs/ai-assist/QC-PROCESS.md
@@ -1,0 +1,228 @@
+# Phase: Claude QC Integration — Scientific Peer Reviewer
+
+Design phase for Opus. Read `OBSERVER.md` and `LAB-LOG.md` alongside this. The three documents form one system. This document defines what Claude does with the data the MCP server provides.
+
+---
+
+## The distinction that matters
+
+**Convenience** (not the goal): Claude tells you what's in your project, summarises what ran, produces plots. The whiteboard, task manager, and analysis canvas already do this.
+
+**Value** (the goal): Claude functions as the person who used to sit at the image analysis computer and notice things. "You've tried this 10 times with the same outcome. Maybe try X." "From my reasoning I wouldn't have done it that way — but the outcome looks great. Why did you do that?" The answer to that second question is exactly what gets lost in every lab and exactly what the lab log captures.
+
+---
+
+## Three operating modes
+
+Stored in project config, not the lab log. User switches at any time.
+
+**Silent**: Claude observes, writes to lab log, never interrupts. For routine runs the user is confident in. Claude is building context for future sessions.
+
+**Advisory**: Claude surfaces observations in the chat window when the pattern is worth naming. Never pauses the pipeline. "Image 7 gated to 23 cells — 8x below cohort mean. Continuing." User acts or ignores.
+
+**Collaborative**: Claude pauses at configurable checkpoints and requires acknowledgement. "3 images flagged at segmentation. Review before tracking?" For overnight runs — user sets checkpoints before leaving, reviews flags in the morning.
+
+---
+
+## What Claude flags
+
+Flags are statistical, not interpretive. Claude says "this gate produced 23 cells, 8x below the cohort mean of 187." Not "this gate is wrong." Interpretation is the user's job.
+
+**Per-stage QC metrics:**
+
+*Segmentation*:
+- Cell count per image vs. cohort mean
+- Mean Cellpose confidence (if available)
+- Fraction of Z-slices with low cell count (Z-drift indicator)
+- Label size distribution — flag bimodal when unimodal expected
+
+*Gating*:
+- Cells per population as fraction of parent — flag <5% or >95%
+- Absolute count <50 cells
+- Count >3 SD from cohort mean for same population
+
+*Tracking*:
+- Track length distribution — flag bimodal when unimodal expected
+- Fraction of cells tracked vs. segmented — flag <30%
+
+*HMM/behaviour*:
+- State frequency per image vs. cohort — flag >2 SD deviation
+- Single state >95% dominant in one image but not others
+
+**Cohort statistics**: computed after all images complete a stage. Per-image flags that depend on cohort context are deferred until the cohort is complete — Claude needs the full set to know what's an outlier.
+
+**Cross-experiment memory**: if the lab log contains prior experiment records, Claude cross-references. "This pattern (low cell count + bimodal track lengths) appeared in experiment X on 2026-03-12 — root cause was Z-drift. Check Z-stack integrity."
+
+**Repeat attempt pattern**: if the same function has been run >3 times on the same image — regardless of outcome — Claude surfaces it. This is the most reliable signal that something is wrong that the user hasn't named yet.
+
+---
+
+## The hold state
+
+A task can currently run, fail, or complete. There is no "completed but flagged, awaiting decision." This is the most important missing piece.
+
+Design a `flagged` task state:
+- Task completed successfully — output is valid
+- QC check produced a flag above threshold
+- In Collaborative mode: downstream stages for this image pause pending acknowledgement
+- In Advisory mode: downstream stages proceed, flag surfaced but not blocking
+- Hold is per-image, not per-chain — image 7 held does not block images 1-6
+
+User actions on a flagged image:
+- Acknowledge and proceed
+- Acknowledge and exclude (logged to lab log)
+- Acknowledge and re-run with adjusted params
+
+---
+
+## Parameter adjustment proposals
+
+When an image is flagged, Claude proposes a specific concrete alternative — not a general suggestion:
+
+"Standard threshold 0.3 → 23 cells. Proposed: threshold 0.2 → estimated ~180 cells (based on cohort distribution). Run alternative?"
+
+If accepted: branch run with adjusted params, results presented side by side. User accepts one branch, other discarded. Accepted params and rationale logged.
+
+Parameter search space is bounded — only within the range defined in the module JSON spec.
+
+---
+
+## The why question
+
+When a user does something unexpected — parameter deviation from prior runs, an unusual image note, a decision that contradicts lab log entries — Claude asks why in the chat window. Not to judge. To capture methodology.
+
+"You set the HMM to 4 states here but the lab log notes that 3 states worked well for this cohort. What are you trying to capture with the additional state?"
+
+The user's answer goes in the lab log as a `[User]` entry. This is how domain knowledge stops getting lost.
+
+---
+
+## Morning summary format
+
+For Collaborative/overnight mode. Objective state, no conclusions:
+
+```
+COMPLETED CLEANLY (n images)
+  → ready for next stage
+
+COMPLETED WITH FLAGS (n images)
+  Image 7: gate produced 23 cells (cohort mean 187) — awaiting acknowledgement
+  Image 12: track fraction 18% (cohort mean 67%) — awaiting acknowledgement
+
+PAUSED — REQUIRES DECISION (n images)
+  Image 3: segmentation attempt 8, consistent low confidence — recommend parameter review
+
+FAILED (n images)
+  Image 15: btrack OOM error — see task log
+```
+
+No biological conclusions. No "there is a significant difference." The biologist reads the summary and draws the conclusion.
+
+---
+
+## What Claude must NOT do
+
+- Draw biological conclusions
+- Recommend exclusion without quantitative justification
+- Adjust parameters without user approval in any mode
+- Write speculative entries to the lab log
+- Flag things inferable from a single image without cohort context
+- Surface observations in Silent mode
+
+## Honest reservations
+
+**The why question will misfire early.** The why-question trigger requires Claude to have a model of what's expected — built from the lab log and prior runs. Early in a project, before the lab log is rich, Claude's sense of "unexpected" is poorly calibrated. It may ask obvious questions or miss genuinely unusual decisions. Document this for users: the observer becomes more useful over time, not immediately.
+
+**"Cohort complete" needs a definition.** Per-image flags that depend on cohort statistics are deferred until the cohort is complete — but images get added, excluded, and re-processed. Define what "cohort complete" means: all images that have passed a given stage, or an explicit user declaration. Ambiguity here means cohort flags either fire too early (incomplete cohort) or never fire (waiting for a declaration that never comes). Recommend: cohort stats computed automatically once all currently-included images reach a stage, recomputed when images are added or excluded.
+
+**Overnight calibration.** Before running unsupervised overnight, the user should run a supervised session on a subset of images to calibrate flag thresholds. If too many images hit the hold state overnight, the morning summary becomes a wall of decisions rather than a result — worse than no overnight run. Recommend a "dry run" mode: run the pipeline with all QC checks active but hold states advisory only, so the user can tune thresholds before committing to an unattended run.
+
+---
+
+## Lab log entries from QC
+
+Claude appends when:
+- A flag fires and user acknowledges — what was flagged, what action taken
+- A parameter adjustment is accepted — original, adjusted, outcome
+- An image is excluded — which image, metric, who decided
+- A cross-experiment pattern recognised — what matched, prior root cause
+- A why question is answered — the user's stated rationale
+
+Claude does NOT append for routine completions with no flags.
+
+---
+
+## Implementation plan
+
+> Grounded against the codebase as of 2026-07. File:line anchors point at what each step builds on.
+> **Cecelia already has a QC framework** — `app/src/qc.jl` + `docs/todo/QC_PLAN.md` (Phase 1 landed) —
+> that writes advisory per-image *findings* sidecars. This plan **extends** it; it does not add a
+> second QC mechanism. Every metric below is written through `write_qc`, and every read through
+> `read_qc`/`read_all_qc`. See the ⚠️ locked-decision conflict in step 1 — read it before building.
+
+### 1. The `flagged` task state
+
+- Per-image chain state today is `ImageNodeState.status::Symbol` ∈ `:pending|:running|:done|:failed|:cancelled|:skipped` (`app/src/tasks/chain.jl:73-80`), held in `ChainRun.image_states` and persisted to `<project>/settings/chains/runs/<run_id>/run.json` by `_save_run!` (`chain.jl:241-266`). Every transition passes through one choke point, `_update_node_state!` (`chain.jl:268-328`), which saves under `run._lock` and fires the event bus outside it.
+- **Add `:flagged` as a new status symbol.** It round-trips `_save_run!`/`load_chain_run` for free (status stored as `Symbol(string(...))`, `chain.jl:246-250`, `:900-906`).
+- **Set it where final status is computed** — after `run_task` returns in `_execute_image_chain!` (`chain.jl:518-525`): read the just-written QC (`read_qc`, step 2); if the worst finding ≥ the mode's threshold, transition to `:flagged` instead of `:done`.
+- **Hold (per-image downstream pause).** Add a clause at the top of the per-node loop, beside the fault-isolation gate (`chain.jl:456-463`): if an upstream node *for this uid* is `:flagged` **and** the mode is Collaborative, park this image's thread instead of `:skip`. Because each image is its own thread walking nodes sequentially (`chain.jl:400-527`), a hold is simply "do not advance past the flagged node" — images 1-6 keep running (per-image, not per-chain, exactly as the spec requires).
+- Handle `:flagged` in `_reset_stale_nodes!` (`chain.jl:842-878`): on resume treat a `:flagged` node as decision-pending (like `:done` for re-run purposes) until the user acts (acknowledge → `:done`; exclude → image dropped; re-run → `_force_restart_from!`, `chain.jl:823-837`).
+- ⚠️ **Locked-decision conflict — ratify before building.** `docs/todo/QC_PLAN.md` decision #4 and `app/src/qc.jl:8` lock QC as **advisory: it never blocks or gates a task** (the `"error"` level is reserved and unused). The hold state is the deliberate opposite. Amend `QC_PLAN.md` first: scope the advisory-only guarantee to Silent/Advisory mode and make Collaborative mode the explicit, opt-in exception. **Barrier caveat:** a held image must still `_barrier_arrive!` at set-scope nodes or it deadlocks the cohort (`chain.jl:365-389`, SCHEDULER.md invariant #4) — the hold must park *after* barrier arrival, not before.
+
+### 2. Per-stage QC metric computation
+
+- **Reuse the existing producer pattern**: a task computes findings in its `_run_task` after the subprocess returns and calls `write_qc(img, fun_name, value_name, findings; source, output)` → sidecar `{proj}/1/{uid}/qc/{funName}/{valueName}.json` (`app/src/qc.jl:32-43`; reference impl `app/src/tasks/segment/drift_correct.jl:95-108`, findings builder `_drift_qc_findings` `:9-31`). Build each finding with `qc_finding(level, code, short, long; detail)` (`qc.jl:20-28`), `level ∈ info|warn`. Keep finding text brief-and-actionable (short = problem, long = the imperative action, numbers in `detail`).
+- **Add per-stage metric functions** (Julia, in `app/src/`), computed off the canonical accessors so nothing new touches HDF5:
+  - *Segmentation*: cell count = `nrow(label_props(img; value_name) |> as_df)`; label-size distribution off the `area` var column (`app/src/label_props.jl`, `select_cols(["area"])`); bimodality via `_hist_counts` (`app/src/plotting/plot_data.jl:27`).
+  - *Gating*: `pop_stats(m, path)` already returns `(count, parent_count, pct_parent)` (`app/src/gating/gating_engine.jl:87`) — flag `pct_parent < 5% || > 95%`, `count < 50`.
+  - *Tracking*: fraction tracked = tracked-cell count (obs `track_id > 0` / `is_tracked`, `population_manager.jl:774`) ÷ segmented rows; track-length distribution from `track_props(img).num_cells` (`app/src/tracking/track_props.jl:69-88`) or `live.track.trackLength` in `__tracks.h5ad`.
+  - *HMM/behaviour*: state frequency per image from obs `live.cell.hmm.state.<name>` (`app/src/tasks/behaviour/hmm_states.jl:96`) via `_summary_agg(chart_type="frequency", by_image=true)` (`plot_data.jl:262-285`).
+- Single-image flags (bimodality, absolute counts, single-state dominance) write immediately. Cohort-relative flags (vs mean/SD) are deferred to step 3 — Claude "needs the full set to know what's an outlier."
+
+### 3. Cohort statistics computation
+
+- **Cohort = the images in a `CciaSet`** — iterate `images(s::CciaSet)` (`app/src/model/set.jl:84`). The per-image → cohort aggregation already exists at the plotting layer: `_population_metric_frame` counts per `(value_name, pop, uID)` with genuine-zero completion (`plot_data.jl:153-190`) and `_summary_agg` reduces to one point per image (`plot_data.jl:197`). Reuse these for mean/SD across the `uID` axis rather than hand-rolling.
+- **Timing — the "cohort complete" definition** (an honest reservation in this doc): compute cohort stats automatically once **all currently-included images** have reached a given stage, and **recompute** when an image is added, excluded, or re-processed. Inclusion is the `included` flag on `CciaImage` (ccid.json; surfaced in `_image_payload`, `api/src/routes.jl:1019` region) — "cohort complete for stage S" = every `included` image has a `:done` node for S in the active `ChainRun`. No user declaration required (avoids the "waits forever" failure mode).
+- **Storage**: write cohort-relative findings back through `write_qc` per image (so they surface identically to single-image flags), plus a per-set summary sidecar `{proj}/1/{set_uid}/qc/cohort/{stage}.json` for the morning summary and MCP `get_qc_metrics`.
+
+### 4. Operating mode storage and enforcement
+
+- **Store the mode in per-project config, not the lab log** (the doc's explicit requirement). The established home for per-project non-object settings is `{proj}/settings/` (`api/src/routes.jl:7`, alongside `chains/`, `analysisBoards.json`, `animations.json`) — add `settings/ai-assist.json` = `{ "mode": "silent|advisory|collaborative", "checkpoints": [...], "thresholds": {...} }`.
+- **Enforcement is layered:** (a) the `:flagged` hold in step 1 is gated on `mode == collaborative` inside `_execute_image_chain!`; (b) whether Claude *surfaces* an observation vs only logs is enforced in the observer/MCP layer (Silent → append to lab log only, never emit to the chat; Advisory/Collaborative → emit). Mode is read at flag-time and at event-emit time — a mid-run switch takes effect on the next event.
+
+### 5. Parameter adjustment branch run
+
+- **Deferred to Phase 2** (write-capable MCP). Design: when an image is flagged, Claude proposes a concrete alternative bounded by the module JSON spec's declared range (task JSON is the single source of truth, served via `GET /api/tasks/definitions`). On accept, run the alternative as a **new value_name variant** using the existing versioned-variable pattern (`versioned_set_field!`; correction tasks already do this — e.g. `cpCorrected`/`afCorrected`, `app/src/model/image.jl:3-93`), so the original output is preserved and the two are directly comparable. Present side by side via the existing summary/QC plot path; on user accept, `set_active!` the chosen variant, discard the other, and log the accepted params + rationale to the lab log (see `LAB-LOG.md`).
+- No new storage mechanism — a branch run is just a second versioned output, which the object model already supports.
+
+### 6. The why-question trigger
+
+- **"Unexpected" = a measurable deviation from an established baseline**, not a heuristic guess: (a) a task param differs from the value used on prior images in the same set/cohort (compare against `runLog`/completed-node params); (b) an image `note` was added that pairs with an unusual decision (`image_note_added` event, step 8); (c) a decision contradicts a lab-log entry (e.g. HMM state count differs from a `[User]` entry recording what worked). Claude asks *why* in the chat; the answer is appended as a `[User]` lab-log entry.
+- **Honest reservation (carried from this doc):** the trigger needs a baseline to deviate from, so it misfires early — before the lab log is rich and the cohort is seen. Ship with expectations set: the first few sessions build context, they don't catch errors.
+
+### 7. Morning summary generation
+
+- **Trigger**: fires when a Collaborative-mode run reaches a configured checkpoint or completes overnight. Content is exactly the four-bucket format specified above (COMPLETED CLEANLY / WITH FLAGS / PAUSED / FAILED) — **objective state, no biological conclusions**.
+- **Sources**: per-image `:done`/`:flagged`/`:failed` from the `ChainRun`; flag detail from the QC sidecars (steps 2–3); FAILED detail from the task log (`{img._dir}/logs/{fun}.log`, `scheduler.jl:321-335`).
+- **Surfaced in two places**: appended once to the lab log (`append_lab_log`, a `[Claude]` entry) and pushed to the frontend as a WS notification (a new `ai:summary` frame via `broadcast_ws`, `server.jl:52-62`) so the user sees it on arrival without opening the panel.
+
+### 8. Event notification design
+
+- The observer is **event-driven, not streaming** (token cost). The MCP server subscribes to the WS feed and translates frames into MCP notifications; the backend already re-broadcasts chain events via the subscribe-and-rebroadcast bridge (`api/src/server.jl:113-164`) built on `subscribe_chain_events!`/`_fire_chain_event!` (`app/src/events.jl`). Extend that surface:
+  - `task_completed` / `task_failed` → already exist as `task:status` frames (`api/src/sockets.jl:15`) and chain `node:done`/`node:failed` (`server.jl:139-164`). **Reuse — do not add duplicates.**
+  - `qc_flag_fired` → **NEW**. Fire a `node:flagged` (or dedicated `qc:flag`) event from `_update_node_state!` at the `:flagged` branch (step 1), payload `(run_id, project_uid, image_uid, node_id, fn, stage, metric, value, cohort_mean)`; add a bridge subscriber in `server.jl`. Must fire outside `run._lock` (SCHEDULER.md invariant #2).
+  - `image_note_added` → **NEW**. `api_images_inclusion_set` (`api/src/routes.jl:891-909`) currently writes the note with **no broadcast** — add `broadcast_ws({type:"image:note", projectUid, imageUid, note})` after the mutate.
+  - `lab_log_entry_added` (user-written only) → **NEW**, broadcast from the lab-log append route (`LAB-LOG.md` step 4).
+- **Speak-vs-silent** is decided in the MCP/observer layer per event + mode: most events → silence; surface on the ">3 attempts same image" pattern (see the attempt-count gap in step 9), cohort outliers, and unexpected-decision triggers. The doc's token throttle (configurable max events/session) lives here.
+
+### 9. Dependencies on framework components not yet built — and build order
+
+- **Attempt counter is missing.** The run log (`app/src/run_log.jl`, `{proj}/1/{uid}/runlog.json`) records only *successful* runs — no failures, no retry count; `ImageNodeState` has no counter either. The ">3 attempts on the same image" signal — called the *most reliable* value signal in this doc and `OBSERVER.md` — therefore needs a **new per-(uid,node) attempt counter**, persisted on `ImageNodeState` in `run.json` (or derived by counting `node:failed`/`node:running` events in the MCP server's session memory). Build this early; it gates the core observer behaviour.
+- **Build order:**
+  1. `OBSERVER.md` infra (read-only MCP + read endpoints + event bridge) — no scheduler changes, unblocks everything.
+  2. Per-stage QC metric functions (step 2) — pure additions on existing accessors, advisory-only, safe under the current locked decision.
+  3. Attempt counter (step 9) + `qc_flag_fired`/`image_note_added` events (step 8) — enables the observer's real signals.
+  4. Cohort stats (step 3) — needs the "cohort complete" definition settled.
+  5. `:flagged` state + hold (step 1) — **requires the QC_PLAN.md amendment ratified first**; this is Phase 2, gated on the ROADMAP check-in.
+  6. Mode storage/enforcement (step 4), morning summary (step 7) — Phase 2/3.
+  7. Parameter branch runs (step 5) — Phase 2, write-capable MCP.

--- a/docs/ai-assist/ROADMAP.md
+++ b/docs/ai-assist/ROADMAP.md
@@ -1,0 +1,133 @@
+# AI Assistant Integration Roadmap
+
+This document tracks the phased rollout of Claude as a scientific peer reviewer in Cecelia. It is a living document — updated at each check-in. Read `OBSERVER.md`, `QC-PROCESS.md`, and `LAB-LOG.md` in this folder for the design detail behind each phase.
+
+The goal is not convenience. It is a collaborator that catches what the user would miss — the person who used to sit at the image analysis computer and notice things.
+
+---
+
+## Phase 1 — Observer (current phase)
+
+**Goal**: Claude sits next to the user. Watches what's happening. Builds context. Stays silent unless something is worth saying.
+
+**What gets built:**
+- Read-only MCP server exposing project state, task logs, image notes, QC metrics
+- Lab log: per-project append-only file, written by human and Claude
+- Observer session: event-driven chat window in Cecelia Vue frontend
+- Lab log Vue panel: new Claude entries visually prominent, user input field, correction template
+
+**Definition of done:**
+- [ ] MCP server connects, Claude describes project state without being told
+- [ ] Task failure pattern (>3 attempts same image) surfaces in observer session without being asked
+- [ ] User adds image note → Claude incorporates in session context
+- [ ] Lab log appends correctly with `[Claude]` / `[User]` tags and dates
+- [ ] Token cost measured across 3 real analysis sessions and within acceptable range
+- [ ] Vue lab log panel shows new Claude entries prominently
+
+**Check-in criteria before Phase 2:**
+- Lab log has accumulated entries from at least 10 real analysis sessions
+- Claude's observations are more signal than noise — user finds them useful, not annoying
+- Token cost per session is known and acceptable
+- At least one instance where Claude caught something the user would have missed
+- At least one instance where Claude's observation was wrong and the correction was recorded
+
+**Do not start Phase 2 until all check-in criteria are met.**
+
+---
+
+## Phase 2 — Designer (deferred)
+
+**Goal**: Claude proposes analysis strategies, suggests parameter adjustments, flags before things go wrong rather than after.
+
+**Depends on:**
+- Phase 1 check-in criteria met
+- Chain scheduler and population manager stable (API not changing)
+- Lab log rich enough that Claude's sense of "normal" is calibrated for at least one cohort
+
+**What gets built:**
+- Write-capable MCP: task submission, parameter adjustment, flag acknowledgement — all with human confirmation
+- Hold state in task scheduler: `flagged` state, per-image pause, downstream blocking in Collaborative mode
+- Cohort statistics: computed after all images complete a stage, accessible via MCP
+- Parameter adjustment branch runs: proposed alternative, side-by-side results, user accepts one
+
+**Check-in criteria before Phase 3:**
+- Hold state working correctly: flagged images pause, others continue
+- Parameter adjustment proposals are concrete and within spec bounds
+- Cohort statistics compute at the right time (cohort-complete definition settled)
+- At least one full experiment run in Advisory mode with useful flag output
+- Morning summary format validated: objective state, no conclusions, actionable
+- "Dry run" mode validated: thresholds tuned on subset before overnight run
+
+**Do not start Phase 3 until all check-in criteria are met.**
+
+---
+
+## Phase 3 — Analyst (deferred)
+
+**Goal**: The overnight analyst. User describes the experiment and goes home. Claude runs the pipeline, flags edge cases, writes the morning summary. User arrives to results, not a blank screen.
+
+**Depends on:**
+- Phase 2 check-in criteria met
+- Hold state proven reliable across multiple experiments
+- Lab log has cross-experiment history for at least 2-3 cohort types
+- Token cost at Phase 2 scale measured and acceptable
+
+**What gets built:**
+- Collaborative mode fully operational with configurable checkpoints
+- Cross-experiment pattern recognition: lab log cross-reference at flag time
+- Morning summary: structured evidence only, no biological conclusions
+- The why question: triggers on unexpected decisions, captures user rationale in lab log
+
+**Honest reservation built into this phase:**
+The overnight analyst will occasionally produce a result that looks clean in the morning summary but has a subtle flaw a 30-second human glance would have caught. This is not a bug to fix — it is a fundamental limitation of autonomous analysis. The hold state and morning summary exist to minimise this risk, not eliminate it. Scientific validation remains the user's responsibility.
+
+---
+
+## Check-in schedule
+
+Aligned with the existing release schedule. At each scheduled GitHub release check-in, also review this roadmap:
+
+- **Is Phase 1 done?** → review check-in criteria, decide whether to begin Phase 2
+- **Is Phase 2 done?** → review check-in criteria, decide whether to begin Phase 3
+- **Is the lab log accumulating useful entries?** → review recent entries, adjust observer sensitivity if needed
+- **Is token cost acceptable?** → review session costs, adjust throttle if needed
+
+The roadmap is updated at each check-in. If a phase is taking longer than expected, document why — don't silently extend without acknowledging the delay.
+
+---
+
+## Files in this folder
+
+```
+docs/ai-assist/
+  ROADMAP.md          ← this file
+  OBSERVER.md         ← MCP server and observer session design
+  QC-PROCESS.md       ← QC flags, hold state, parameter proposals, morning summary
+  LAB-LOG.md          ← lab log format, MCP tools, Vue panel, versioning
+```
+
+---
+
+## What this is not
+
+- A feature list to ship as fast as possible
+- A replacement for scientific judgment
+- A system that draws conclusions — that is always the user's job
+
+The value compounds over time. Phase 1 is not impressive on day one. It becomes impressive when the lab log has six months of entries and Claude cross-references a current deviation against something it saw in March. Build slowly. Measure. Don't skip phases.
+
+---
+
+## The lab log has standalone value — start it now
+
+The lab log does not require the MCP server, the observer session, or any AI integration to be useful. It solves a problem that predates AI: image analysis methodology gets lost.
+
+Most analytical decisions live in the analyst's head and disappear when they leave the lab. The person who figured out that the CD4 gate runs loose on spleen tissue, that mouse 7 had Z-drift in the late timepoints, that HMM with 3 states fits this cohort better than 2 — that knowledge either gets passed down informally or gets rediscovered by the next person who spends two days confused.
+
+Nobody keeps an image analysis notebook because you try many things and take the one that seems to work. The lab log is not a notebook — it is append-only, low friction, and lives next to the data. One line after a decision is enough.
+
+**Start using the lab log before Phase 1 is built.** The file format is plain markdown. Nothing prevents creating `lab-log.md` in the project directory today and writing to it manually. When the MCP server arrives, Claude reads what's already there. When the Vue panel arrives, it surfaces what's already there. The AI integration makes the lab log more useful — it does not make the lab log possible.
+
+**The Vue panel is load-bearing for adoption.** Nobody will persistently edit a file on the side. The panel must be a persistent slide-out accessible from any module page, with a pre-filled context-aware entry field that just needs the reason. Zero navigation, zero friction. If opening the lab log requires leaving the current page, people will stop using it within a week. The GUI design is specified in `LAB-LOG.md` — treat it as a first-class feature, not an afterthought.
+
+When handing off a project, returning to it after six months, or trying to reproduce a result, the lab log is the thing that makes it possible to understand not just what was done but why. That value exists regardless of whether Claude ever reads it.


### PR DESCRIPTION
## What

Clean-start pass on the `docs/ai-assist/` design set (the phased "Claude as scientific peer reviewer" plan). No code — docs only.

- **Renamed** the four docs to the names `ROADMAP.md` already expected (via `git mv`, history preserved):
  `ai-assist-ROADMAP.md → ROADMAP.md`, `mcp-readonly-prompt.md → OBSERVER.md`, `qc-process-prompt.md → QC-PROCESS.md`, `lab-log-prompt.md → LAB-LOG.md`.
- **Fixed every stale cross-reference** between the docs (they pointed at the old `*-prompt.md` names).
- **Decided the lab-log filename**: `lab-log.md` at the project root (rationale in LAB-LOG.md).
- **Locked the MCP server language**: Python (official `mcp`/FastMCP SDK) in a new `mcp/` dir — Python is already pixi-managed here, so no new toolchain/CI lane.
- **Authored the two requested implementation plans** (replacing the "Opus: produce a plan" prompts) in OBSERVER / QC-PROCESS / LAB-LOG, each anchored to real `file:line` from the codebase.

## Key findings surfaced (need a decision, not blockers to merging the docs)

1. **The hold-state contradicts a locked decision.** Cecelia already has a QC framework (`app/src/qc.jl` + `docs/todo/QC_PLAN.md`) where QC is *advisory and never blocks a task* (decision #4). The AI-assist `:flagged`/hold is the deliberate opposite — `QC_PLAN.md` must be amended (scope advisory-only to Silent/Advisory; Collaborative = explicit exception) before any code lands. Documented in QC-PROCESS.md step 1.
2. **Missing attempt counter.** The ">3 attempts on the same image" signal (the core observer value) has no data source today — the run log records successes only. A per-`(uid,node)` counter is needed. Documented in QC-PROCESS.md step 9 / OBSERVER.md step 5.

## Notes

- These are design docs, unverified against a running system; the `file:line` anchors are point-in-time.
- The ai-assist folder is not yet linked from `CLAUDE.md`/`docs/ROADMAP.md` — deliberate, to avoid colliding with an in-flight branch; easy follow-up.
- The same docs were removed from `feat/strip-overlays` (they were committed there by accident) so they land only once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
