### PR TITLE
PDF/CSV export: wait for plots to render, not a fixed sleep

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -113,6 +113,13 @@ hover toolbar appeared.
 reproduces the layout exactly (spans, plates, gaps), and `plots/pdf.ts` lays out **exact A4** pages
 (per-board orientation) via `pdf-lib`.
 
+- **Wait for plots before capturing** (`utils/plotReady`): the export visits each tab and must capture
+  only once that board's plots have finished fetching + rendering — a fixed sleep captured slow plots
+  blank. Every plot host feeds a board-wide load counter through `useDelayedLoading` (the one spinner
+  composable they all use — no per-plot wiring), and `waitForPlotsIdle()` blocks until the counter has
+  been 0 for a continuous settle window (+2 RAF frames for the final WebGL/canvas paint), capped by a
+  timeout. Both the PDF and CSV export await it after switching tabs.
+
 - **Per-slot title (figure caption)**: each filled slot has an editable title line (`.lc-slot-cap`,
   persisted in the slot's `state.title`), shown above the plot on-screen and drawn above the slot image
   in the PDF (`pdf.ts` reserves `SLOT_TITLE_H` only when a title is set). Empty by default.

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -16,6 +16,7 @@ import { useCanvasPanelsStore } from '../../stores/canvasPanels'
 import { exportTabsToPdf } from '../../plots/pdf'
 import { downloadBlob } from '../../plots/export'
 import { zipTextFiles } from '../../utils/zip'
+import { waitForPlotsIdle } from '../../utils/plotReady'
 import { useLogStore } from '../../stores/log'
 import LayoutCanvas from './LayoutCanvas.vue'
 import ConfirmButton from '../ConfirmButton.vue'
@@ -82,8 +83,9 @@ async function exportPdf() {
     for (const t of tabs.value) {
       tabsStore.setActive(groupKey, t.id)
       await nextTick()
-      await new Promise(r => setTimeout(r, 1400))   // let the board's plots fetch + render before capture
-                                                    // (a mid-render WebGL frame exports sparse/blurry)
+      await waitForPlotsIdle()   // wait for THIS board's plots to finish fetching + rendering — a fixed
+                                 // sleep captured slow plots blank; idle-tracking waits exactly as long
+                                 // as needed (a mid-render WebGL frame exports sparse/blurry)
       const page = await layoutRef.value?.capturePage?.()
       if (page) pages.push({ title: t.name, aspect: page.aspect, slots: page.slots })
     }
@@ -108,7 +110,7 @@ async function exportCsv() {
     for (const t of tabs.value) {
       tabsStore.setActive(groupKey, t.id)
       await nextTick()
-      await new Promise(r => setTimeout(r, 600))   // let the board's plots fetch before reading their data
+      await waitForPlotsIdle()   // wait for the board's plots to finish fetching before reading their data
       for (const { name, csv } of layoutRef.value?.collectCsvs?.() ?? []) {
         if (!csv) continue
         files.push({ name: `${safe(t.name)}_${safe(name)}.csv`, text: csv })

--- a/frontend/src/composables/useDelayedLoading.ts
+++ b/frontend/src/composables/useDelayedLoading.ts
@@ -1,4 +1,5 @@
 import { ref, watch, onUnmounted, type Ref } from 'vue'
+import { beginPlotLoad, endPlotLoad } from '../utils/plotReady'
 
 /**
  * Delayed loading flag for plot spinners (docs/UI.md → "Plot loading state").
@@ -14,12 +15,21 @@ import { ref, watch, onUnmounted, type Ref } from 'vue'
 export function useDelayedLoading(loading: Ref<boolean>, delayMs = 350): Ref<boolean> {
   const show = ref(false)
   let timer: ReturnType<typeof setTimeout> | null = null
+  // also feed the board-wide load counter (utils/plotReady) so the PDF/CSV export can wait for genuine
+  // idle instead of a fixed sleep. `counted` guards against double increments and leaking the count.
+  let counted = false
   const clear = () => { if (timer !== null) { clearTimeout(timer); timer = null } }
+  const uncount = () => { if (counted) { counted = false; endPlotLoad() } }
   watch(loading, (v) => {
     clear()
-    if (v) timer = setTimeout(() => { show.value = true; timer = null }, delayMs)
-    else show.value = false
+    if (v) {
+      if (!counted) { counted = true; beginPlotLoad() }
+      timer = setTimeout(() => { show.value = true; timer = null }, delayMs)
+    } else {
+      show.value = false
+      uncount()
+    }
   }, { immediate: true })
-  onUnmounted(clear)
+  onUnmounted(() => { clear(); uncount() })   // unmounting mid-load must release its count
   return show
 }

--- a/frontend/src/utils/plotReady.test.ts
+++ b/frontend/src/utils/plotReady.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { activePlotLoads, beginPlotLoad, endPlotLoad, waitForPlotsIdle } from './plotReady'
+
+// waitForPlotsIdle ends with requestAnimationFrame; node has none, so stub it.
+;(globalThis as unknown as { requestAnimationFrame: (cb: (t: number) => void) => void })
+  .requestAnimationFrame = (cb) => { setTimeout(() => cb(0), 0) }
+
+beforeEach(() => { activePlotLoads.value = 0 })
+
+describe('plotReady counter', () => {
+  it('increments, decrements, and never goes negative', () => {
+    beginPlotLoad(); beginPlotLoad()
+    expect(activePlotLoads.value).toBe(2)
+    endPlotLoad()
+    expect(activePlotLoads.value).toBe(1)
+    endPlotLoad(); endPlotLoad()          // extra end() is clamped, not negative
+    expect(activePlotLoads.value).toBe(0)
+  })
+})
+
+describe('waitForPlotsIdle', () => {
+  it('resolves after the settle window when already idle', async () => {
+    await expect(waitForPlotsIdle({ settleMs: 60, timeoutMs: 1000, pollMs: 10 })).resolves.toBeUndefined()
+  })
+
+  it('does not resolve while a load is active, then resolves after it ends + settles', async () => {
+    beginPlotLoad()
+    let done = false
+    const p = waitForPlotsIdle({ settleMs: 60, timeoutMs: 3000, pollMs: 10 }).then(() => { done = true })
+    await new Promise(r => setTimeout(r, 80))
+    expect(done).toBe(false)              // still loading → not resolved
+    endPlotLoad()
+    await p
+    expect(done).toBe(true)
+  })
+
+  it('gives up after timeout even if a load never ends', async () => {
+    beginPlotLoad()
+    await expect(waitForPlotsIdle({ settleMs: 60, timeoutMs: 150, pollMs: 10 })).resolves.toBeUndefined()
+    endPlotLoad()
+  })
+})

--- a/frontend/src/utils/plotReady.ts
+++ b/frontend/src/utils/plotReady.ts
@@ -1,0 +1,36 @@
+import { ref, nextTick } from 'vue'
+
+// Board-wide "are any plots still loading?" counter. Every plot host registers its loading state here
+// through `useDelayedLoading` (the one composable they all use for the spinner), so this covers every
+// plot type — summary, cluster heatmap/HMM, UMAP, gating — with no per-plot wiring. The PDF/CSV export
+// waits on `waitForPlotsIdle` so it captures FULLY-RENDERED plots instead of sleeping a fixed guess
+// (a mid-fetch/mid-WebGL-frame plot exports blank/sparse). See TabbedCanvas.exportPdf.
+export const activePlotLoads = ref(0)
+
+export function beginPlotLoad(): void { activePlotLoads.value++ }
+export function endPlotLoad(): void { activePlotLoads.value = Math.max(0, activePlotLoads.value - 1) }
+
+/**
+ * Resolve once no plot has been loading for a continuous `settleMs` window (so a fetch that kicks off a
+ * beat after a tab switch still counts), capped at `timeoutMs` as a hard fallback. Ends with two RAF
+ * frames so the final paint (WebGL/canvas draws after its data arrives) lands before the caller captures.
+ * The `settleMs` floor also means an all-cached board waits ~settleMs, not zero — enough for late fetches
+ * to register. Poll-based (not event-based) so it's robust to loads that start/stop between checks.
+ */
+export async function waitForPlotsIdle({ settleMs = 350, timeoutMs = 10000, pollMs = 50 } = {}): Promise<void> {
+  await nextTick()
+  const deadline = Date.now() + timeoutMs
+  let idleStart: number | null = null
+  while (Date.now() < deadline) {
+    if (activePlotLoads.value > 0) {
+      idleStart = null
+    } else {
+      if (idleStart === null) idleStart = Date.now()
+      else if (Date.now() - idleStart >= settleMs) break
+    }
+    await new Promise(r => setTimeout(r, pollMs))
+  }
+  // two frames for the final paint (a WebGL scatter draws the frame AFTER its data is set)
+  await new Promise(r => requestAnimationFrame(() => r(null)))
+  await new Promise(r => requestAnimationFrame(() => r(null)))
+}


### PR DESCRIPTION
**Sidequest:** plots came out blank/sparse in the exported PDF when they didn't render fast enough.

## Cause
The board export visits each tab, then slept a **fixed** 1400ms (PDF) / 600ms (CSV) before capturing. A plot that fetches + renders (summary, cluster heatmap/UMAP, WebGL scatter) slower than that got captured mid-render → blank.

## Fix
Wait for **genuine idle** instead of a guess. Every plot host already routes its loading state through **`useDelayedLoading`** (the one composable they all use for the spinner), so that hook now also feeds a board-wide load counter (`utils/plotReady`). `waitForPlotsIdle()` blocks until the counter has been 0 for a continuous settle window (+2 RAF frames for the final WebGL/canvas paint), capped by a timeout as a fallback. Both the PDF and CSV export await it after switching tabs.

- **No per-plot wiring** — one hook point (`useDelayedLoading`) covers summary, cluster, UMAP, gating.
- **Not "bump the timeout"** — it waits exactly as long as the plots take, and returns fast for an all-cached board (settle floor only).

## Tests
`utils/plotReady` unit-tested (counter increment/decrement/clamp; idle resolves after settle; stays pending while loading; times out). `typecheck` + `build` green; `test-frontend` 127 pass.

## Reservations
- **Not verified in a live browser** — the idle→capture timing is logic-tested, but I haven't watched an actual export produce a full PDF. If a plot still slips through, the settle window / RAF count are the knobs.
- Relies on plots using `useDelayedLoading` (the documented convention). A plot that fetches without it wouldn't register — none currently do, and the timeout cap + settle floor keep it safe if one appears.
- Independent of the strip-overlays PR (#151); branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
