### PR TITLE
Track pops keep their own colour under colour-by

### DIFF
--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -201,12 +201,14 @@ after reopening: it parses which tracks/pops were shown from the snapshot's over
 (`utils/overlayLayers`) + the captured colour-by and re-requests them (`utils/napariOverlays` → the
 same show-tracks/show-populations/colour-labels endpoints) — otherwise reopening only restored channels.
 
-**Track pops render in their OWN colour.** `show_tracks` colours each track ribbon by the track
-population's colour (a solid single-colour colormap, the same `Colormap([c,c], interpolation="zero")`
-idiom as the categorical step map) when there's **no** colour-by column — exactly like point pops use
-`face_color`. A track pop defined in the pop manager (e.g. a Leiden track cluster) shows in the colour
-you gave it, not turbo-by-track_id; turbo/viridis only apply when a colour-by column IS set (categorical
-→ per-level pop colours, continuous → viridis). So the strip's populations legend matches the ribbons.
+**Track pops render in their OWN colour.** `show_tracks` colours each **named** track pop (a gated
+`track` / `trackclust` population defined in the pop manager, e.g. a Leiden track cluster) by that
+population's colour — a solid single-colour colormap (the `Colormap([c,c], interpolation="zero")` idiom),
+exactly like point pops use `face_color`. **Colour-by does NOT override a named pop's colour** — a pop's
+defined colour always wins. Colour-by applies **only to the whole-segmentation `_tracked` overlay** (all
+tracks, no per-pop colour): categorical → per-level pop colours, continuous → viridis, none → turbo. So
+a track cluster shows the colour you gave it even while the plain `_tracked` layer is shaded by a measure,
+and the strip's populations legend matches the ribbons. (Distinguished by `pop.path` ending `_tracked`.)
 
 **One overlay request-builder.** `utils/napariOverlays` (`pushTracks`/`pushPopulations`/`pushColourLabels`)
 is the single place that builds those three requests; the interactive ViewerPanel and the non-interactive

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -728,13 +728,16 @@ class NapariState:
                 continue
             ids     = set(int(t) for t in pop.get("track_ids", []))
             visible = pop.get("show", True)
-            use_cby = cby if col_vals is not None else ""
-            # No colour-by → colour the ribbons by the track POPULATION's own colour (solid), exactly
-            # like point pops use face_color: a track pop defined in the pop manager (e.g. a Leiden
-            # track cluster) renders in the colour you gave it, NOT turbo-by-track_id. Ports the R
-            # splitTracks behaviour. pop_colour is in the sig so a recolour re-renders.
+            # A NAMED track pop (gated `track` / `trackclust`, defined in the pop manager) always renders
+            # in ITS OWN colour — like point pops (face_color) — even when a colour-by column is active:
+            # colour-by must NOT override a population's defined colour. Colour-by applies ONLY to the
+            # whole-segmentation "_tracked" overlay (all tracks, no per-pop colour). So a Leiden track
+            # cluster shows the colour you gave it; the plain _tracked layer can be shaded by a measure.
+            is_whole = str(pop.get("path", "")).endswith("_tracked")
+            use_cby  = cby if (col_vals is not None and is_whole) else ""
+            # Not colour-by → solid pop colour (turbo only for an un-coloured _tracked with no colour-by).
             pop_colour = pop.get("colour") or "#9ca3af"
-            sig = (vn, hash(tuple(sorted(ids))), tail_width, tail_length, visible, use_cby, ov_sig, pop_colour)
+            sig = (vn, hash(tuple(sorted(ids))), tail_width, tail_length, visible, use_cby, ov_sig, pop_colour, is_whole)
             existing = name in self._viewer.layers
             if existing and self._track_sigs.get(name) == sig:
                 continue


### PR DESCRIPTION
Follow-up to #151: you were right — **colour-by was overriding the track pops' colours.**

## Cause
`show_tracks` applies `colorBy` as a single viewer-level column across **all** track layers. So when a colour-by column is set, even a named track pop (a gated `track` / `trackclust` population you defined in the pop manager, with its own colour) got coloured by that column instead of its pop colour — the per-pop-solid path from #151 only ran when colour-by was *off*.

## Fix
A **named** track pop always renders in **its own colour** — colour-by can't override a population's defined colour (same as point pops). Colour-by now applies **only to the whole-segmentation `_tracked` overlay** (all tracks, no per-pop colour): categorical → per-level pop colours, continuous → viridis, none → turbo. Distinguished by `pop.path` ending in `_tracked`.

So a Leiden track cluster shows the colour you gave it in the pop manager, even with a colour-by active — and it matches the strip legend.

## Verify
`napari_bridge.py` parses. **Bridge change → restart napari** (`pixi run stop-napari`) to test.

## Reservations
- **Not verified live** (bridge change; needs a restart + your eyes). The change is a one-line predicate (`is_whole = path.endswith("_tracked")`) gating `use_cby`, plus it in the layer signature so a recolour re-renders.
- If you *want* to colour a specific track pop's ribbons by a measure (not its pop colour), that's no longer possible per-pop — colour-by is now whole-segmentation only. Say so if you need per-pop colour-by back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
