### PR TITLE
Green accent for the napari viewer controls + floating panel

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -18,8 +18,10 @@ All tokens live in `frontend/src/style.css` under `.cc-dark` (always applied at 
 | `--cc-text-dim` | `#7d8590` | Secondary text, labels |
 | `--cc-border` | `#30363d` | All borders |
 | `--cc-accent` | `#a78bfa` | Active elements, buttons, links |
+| `--cc-selected` | `#ff8c1a` | Amber selection/active highlight for BOXES (panels, cards, timeline keyframes) — distinct from `--cc-accent` (form controls) |
 | `--cc-warn` | `#f59e0b` | Amber warnings (e.g. heavy-load hints) |
 | `--cc-danger` | `#ef4444` | Destructive / error state (delete, invalid) |
+| `--cc-viewer` | `#22c55e` | Green accent for the napari viewer controls button + its floating-panel border (stands apart from purple chrome) |
 | `--cc-mono` | system monospace stack | Log output, code |
 | `--cc-header-h` | `40px` | Fixed header height |
 | `--cc-sidebar-w` | `190px` | Fixed sidebar width |

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -59,7 +59,7 @@ const bare = computed(() => route.meta.bare === true)
     <!-- napari viewer controls: a floating dockable panel (toggled from the sidebar "Viewer" button),
          floating above the content so it's usable on any page while an image is open in napari -->
     <FloatingPanel v-if="settings.viewerPanelOpen" title="Viewer" icon="pi-eye" storage-key="viewer"
-                   @close="settings.viewerPanelOpen = false">
+                   accent="var(--cc-viewer)" @close="settings.viewerPanelOpen = false">
       <ViewerPanel />
     </FloatingPanel>
     <ErrorConsole />

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -305,9 +305,11 @@ function isNavDisabled(item: NavItem): boolean {
   text-align: left;
   transition: background 0.1s, border-color 0.1s, color 0.1s;
 }
-.viewer-cta:hover { border-color: #7c3aed; background: #241a44; }
-.viewer-cta.viewer-on { background: #2d1b69; border-color: #7c3aed; color: #ddd6fe; }
-.viewer-cta-icon { font-size: 0.95rem; color: #a78bfa; flex-shrink: 0; }
+/* GREEN accent (matches the viewer's floating-panel border, --cc-viewer) so the viewer controls read
+   as their own distinct thing, apart from the purple form/accent chrome. */
+.viewer-cta:hover { border-color: #16a34a; background: #14261a; }
+.viewer-cta.viewer-on { background: #0f3d24; border-color: var(--cc-viewer); color: #bbf7d0; }
+.viewer-cta-icon { font-size: 0.95rem; color: var(--cc-viewer); flex-shrink: 0; }
 .viewer-cta-title { flex: 1; min-width: 0; font-size: 0.78rem; font-weight: 700; }
 .viewer-cta-state { font-size: 0.8rem; opacity: 0.75; flex-shrink: 0; }
 

--- a/frontend/src/components/FloatingPanel.vue
+++ b/frontend/src/components/FloatingPanel.vue
@@ -9,11 +9,12 @@ const props = withDefaults(defineProps<{
   title: string
   storageKey: string            // localStorage namespace: cc.floating.<storageKey>
   icon?: string                 // optional PrimeIcons class (e.g. 'pi-eye')
+  accent?: string               // optional highlight colour (border + header icon) so a panel stands out
   defaultX?: number
   defaultY?: number
   defaultW?: number
   defaultH?: number
-}>(), { icon: '', defaultX: 240, defaultY: 84, defaultW: 290, defaultH: 460 })
+}>(), { icon: '', accent: '', defaultX: 240, defaultY: 84, defaultW: 290, defaultH: 460 })
 
 const emit = defineEmits<{ (e: 'close'): void }>()
 
@@ -71,9 +72,10 @@ function endGesture() {
 
 <template>
   <div class="fp" :style="{ left: st.x + 'px', top: st.y + 'px', width: st.w + 'px',
-                            height: st.collapsed ? 'auto' : st.h + 'px' }">
-    <div class="fp-header" @pointerdown="onHeaderDown">
-      <i v-if="icon" :class="['pi', icon, 'fp-icon']" />
+                            height: st.collapsed ? 'auto' : st.h + 'px',
+                            ...(accent ? { borderColor: accent, boxShadow: `0 0 0 1px ${accent}, 0 8px 28px rgba(0,0,0,0.55)` } : {}) }">
+    <div class="fp-header" :style="accent ? { borderBottomColor: accent } : undefined" @pointerdown="onHeaderDown">
+      <i v-if="icon" :class="['pi', icon, 'fp-icon']" :style="accent ? { color: accent } : undefined" />
       <span class="fp-title">{{ title }}</span>
       <button class="fp-btn" @click="st.collapsed = !st.collapsed"
               v-tooltip.bottom="st.collapsed ? 'Expand' : 'Collapse'">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -22,6 +22,9 @@
   /* status colours (amber warning / red danger) — previously only inlined as var() fallbacks */
   --cc-warn:       #f59e0b;
   --cc-danger:     #ef4444;
+  /* viewer accent (green) — the napari viewer controls button + its floating panel border, so the
+     viewer stands out distinctly from the purple form/accent chrome and amber selection boxes. */
+  --cc-viewer:     #22c55e;
 
   /* monospace */
   --cc-mono: ui-monospace, 'Cascadia Code', Consolas, monospace;


### PR DESCRIPTION
Sidequest: the viewer controls (button + floating panel) were purple like the rest of the chrome, so the panel was easy to lose.

## Change
- New **`--cc-viewer`** token (green `#22c55e`).
- The **"Viewer controls"** sidebar button is now green (icon + on-state background/border) instead of purple.
- `FloatingPanel` gains an optional **`accent`** prop — the viewer panel passes `--cc-viewer`, so its **border + header icon are green** (with a subtle 1px glow). The generic `FloatingPanel` is unchanged for any other consumer (accent defaults off).
- Documented `--cc-viewer` + the existing `--cc-selected` in `docs/UI.md` tokens.

Now the viewer reads as its own distinct thing — green button, green-bordered panel — apart from the purple form/accent chrome and amber selection boxes.

`typecheck` + `build` green. Pure CSS/template (no logic → no tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
