### PR TITLE
Add measure/axis to board CSV export filenames

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -142,7 +142,11 @@ reproduces the layout exactly (spans, plates, gaps), and `plots/pdf.ts` lays out
 - **CSV**: each summary/cluster panel exposes `getCsv()` (the shown aggregated data); the standalone CSV
   button collects them across ALL boards into ONE `analysis_csvs.zip` (one CSV per plot, → Prism) via
   the dependency-free `utils/zip.ts` (STORE method) — a single download instead of dozens of
-  individual "allow multiple downloads" prompts.
+  individual "allow multiple downloads" prompts. Each CSV is named `{board}_{plotLabel}_{axis}.csv`
+  where the axis suffix is the summary panel's `csvName()` (its measure, plus `by_{groupBy}` when a
+  sub-axis is set) — so two same-type plots (e.g. two "Track measures" boxplots on different measures)
+  are distinguishable by filename, not just `Board_1_Track_measures`. `zip.ts` still disambiguates any
+  genuine remaining collision with a ` (2)` suffix.
 
 ## Cross-references
 `docs/UI.md` (generic plot-integration contract, `docked`, canvas shell), `docs/PLOTS.md` (summary-plot

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -292,7 +292,7 @@ function labelFor(c: SlotContent): string {
 }
 // panel instances by slot index, so we can ask each for a PLOT-ONLY, LIGHT-theme image (no chrome) and
 // pull the summary plot's aggregated CSV. Both panel types expose exportImage(); summary also getCsv().
-type SummaryRef = { getCsv(): string | null; exportImage(): Promise<string | null> }
+type SummaryRef = { getCsv(): string | null; csvName?(): string; exportImage(): Promise<string | null> }
 type ExportRef = { exportImage(): Promise<string | null> }
 const summaryRefs = new Map<number, SummaryRef>()
 const interactiveRefs = new Map<number, ExportRef>()
@@ -333,12 +333,17 @@ async function capturePage() {
   } finally { capturing.value = false }
   return { aspect: gr.width / Math.max(1, gr.height), slots }
 }
-// the shown (aggregated) data for every summary slot — for the standalone CSV export (data → Prism)
+// the shown (aggregated) data for every summary slot — for the standalone CSV export (data → Prism).
+// Append the panel's axis descriptor (measure ± groupBy) to the plot label so two same-type plots are
+// distinguishable in the zip — "Track_measures" alone can't tell you WHICH track measure it is.
 function collectCsvs(): { name: string; csv: string | null }[] {
   const out: { name: string; csv: string | null }[] = []
   for (let i = 0; i < entry.value.contents.length; i++) {
     const c = entry.value.contents[i]
-    if (c && (c.kind === 'summary' || isClusterPanel(c.ref))) out.push({ name: labelFor(c), csv: summaryRefs.get(i)?.getCsv() ?? null })
+    if (c && (c.kind === 'summary' || isClusterPanel(c.ref))) {
+      const axis = summaryRefs.get(i)?.csvName?.() ?? ''
+      out.push({ name: axis ? `${labelFor(c)}_${axis}` : labelFor(c), csv: summaryRefs.get(i)?.getCsv() ?? null })
+    }
   }
   return out
 }

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -16,6 +16,7 @@ import TeleportPopover from '../TeleportPopover.vue'
 import PlotChart from '../plots/PlotChart.vue'
 import PlotSpinner from '../plots/PlotSpinner.vue'
 import { useDelayedLoading } from '../../composables/useDelayedLoading'
+import { plotAxisSuffix } from '../../utils/csvName'
 import { backendChart, chartsForMeasure, plotDataToCsv, defaultVis, type VisProps, type BuildOpts } from '../../plots/plot'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import type { PlotSpec, PlotDataResponse, PlotSeries, ChartType, SeriesTarget } from '../../plots/types'
@@ -416,9 +417,14 @@ function exportAs(kind: string) {
 }
 // the shown (aggregated) data as a CSV string — for embedding into the PDF export as an attachment
 function getCsv(): string | null { return result.value ? plotDataToCsv(result.value) : null }
+// a filename hint describing which measure(s)/axes this plot shows — appended to the board CSV export
+// filename so two same-type plots (e.g. two "Track measures" boxplots) are distinguishable by their
+// axis, not just "Board_1_Track_measures". Mirrors the single-panel export stem (`spec.id_measure`):
+// the measure is the plotted axis; a groupBy adds a sub-axis. '' for a measure-less population summary.
+function csvName(): string { return plotAxisSuffix(measure.value, groupBy.value, hasMeasure.value) }
 // a plot-only, LIGHT-theme PNG for the PDF export (no panel chrome; dark theme is on-screen only)
 async function exportImage(): Promise<string | null> { return (await plotRef.value?.toImageURL('png', true)) ?? null }
-defineExpose({ getCsv, exportImage })
+defineExpose({ getCsv, csvName, exportImage })
 </script>
 
 <template>

--- a/frontend/src/utils/csvName.test.ts
+++ b/frontend/src/utils/csvName.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { plotAxisSuffix } from './csvName'
+
+describe('plotAxisSuffix', () => {
+  it('uses the measure as the axis descriptor', () => {
+    expect(plotAxisSuffix('live.cell.speed', '', true)).toBe('live.cell.speed')
+  })
+
+  it('appends a by_{groupBy} sub-axis when set', () => {
+    expect(plotAxisSuffix('live.cell.speed', 'live.cell.hmm.state', true))
+      .toBe('live.cell.speed_by_live.cell.hmm.state')
+  })
+
+  it('is empty for a measure-less population summary', () => {
+    expect(plotAxisSuffix(undefined, '', false)).toBe('')
+    expect(plotAxisSuffix('live.cell.speed', '', false)).toBe('')  // hasMeasure gates the measure
+  })
+
+  it('emits only the groupBy sub-axis when there is no measure', () => {
+    expect(plotAxisSuffix(undefined, 'track_generation', false)).toBe('by_track_generation')
+  })
+
+  it('drops an empty measure even when hasMeasure is true', () => {
+    expect(plotAxisSuffix('', 'track_state', true)).toBe('by_track_state')
+    expect(plotAxisSuffix('', '', true)).toBe('')
+  })
+})

--- a/frontend/src/utils/csvName.ts
+++ b/frontend/src/utils/csvName.ts
@@ -1,0 +1,16 @@
+// Filename helpers for the analysis-board CSV export.
+//
+// The board zips one CSV per plot. Naming a file only by its plot-type label ("Track measures")
+// can't tell you WHICH measure it holds — two same-type plots on different measures then collide
+// and the zip falls back to a bare ` (2)` suffix. `plotAxisSuffix` builds the disambiguating axis
+// descriptor (the measure, plus `by_{groupBy}` when a sub-axis is set) that gets appended to the
+// label. Kept out of the .vue SFC so it's unit-testable in isolation.
+
+// The axis descriptor for a summary plot: its measure, plus a `by_{groupBy}` sub-axis when set.
+// Returns '' for a measure-less population summary (count/proportion) — nothing to disambiguate.
+export function plotAxisSuffix(measure: string | undefined, groupBy: string | undefined, hasMeasure: boolean): string {
+  const parts: string[] = []
+  if (hasMeasure && measure) parts.push(measure)
+  if (groupBy) parts.push(`by_${groupBy}`)
+  return parts.join('_')
+}


### PR DESCRIPTION
## Problem

The Analysis board's **Export CSV** zips one CSV per plot, named `{board}_{plotLabel}.csv`. The plot-type label alone can't say *which measure* a plot holds — so two "Track measures" plots on different measures collide, and the zip disambiguates them into `Board_1_Track_measures.csv` and `Board_1_Track_measures (2).csv`. You can't tell them apart from the filename.

The single-panel Export dropdown already includes the measure (`spec.id_measure`); only the board-level zip didn't.

## Fix

Append each summary panel's **axis descriptor** to the filename: the measure, plus `by_{groupBy}` when a sub-axis is set (`''` for a measure-less population summary). `Board_1_Track_measures (2).csv` becomes e.g. `Board_1_Track_measures_live.cell.speed.csv`.

- `SummaryPanel.vue` — expose `csvName()`, delegating to a new util.
- `LayoutCanvas.vue` — `collectCsvs()` appends the descriptor to the label.
- `utils/csvName.ts` + `.test.ts` — extracted `plotAxisSuffix()` with unit tests (5 cases).
- `docs/ANALYSIS.md` — document the naming scheme.

Genuine same-measure-and-type collisions still fall back to `zip.ts`'s ` (2)` suffix, unchanged.

## Testing

- `npm run typecheck` — passes.
- `npx vitest run src/utils/csvName.test.ts` — 5/5 pass.
- Not exercised in a live browser: the wiring is verified by types + unit tests, not by clicking Export CSV. Low risk (pure string composition off already-settled reactive state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
