### PR TITLE
feat(diagnostics): backend uptime + commit + napari bridge uptime

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -1213,6 +1213,26 @@ end
 
 # ── REST: GET /api/napari/status ──────────────────────────────────────────────
 
+# Newest mtime among the sources the napari bridge loads at startup — its own file plus the cecelia
+# Python helpers it imports (napari/zarr/ome/dim/label-props utils). The bridge is a SEPARATE process,
+# NOT Revise-tracked, so ANY edit to these after it started means it's running old code — the "stale
+# bridge" that silently breaks new viewer features until you restart napari + reopen. mtime (not git)
+# so it also catches UNCOMMITTED edits (the common dev case: edit napari code, restart the backend but
+# not the bridge). Same machine → mtime and the bridge start time share a clock.
+function _napari_src_mtime()
+    root = dirname(dirname(@__DIR__))   # api/src → api → repo root
+    newest = 0.0
+    for d in (joinpath(root, "napari"), joinpath(root, "python", "cecelia", "utils"))
+        isdir(d) || continue
+        for (r, _, fs) in walkdir(d), f in fs
+            endswith(f, ".py") || continue
+            m = try; mtime(joinpath(r, f)); catch; 0.0; end
+            m > newest && (newest = m)
+        end
+    end
+    newest
+end
+
 function api_napari_status(req::HTTP.Request)
     # ping once (unlocked, like _viewer_alive — never blocks on a long op) and read the bridge's start
     # time from the reply, so the Settings panel can show bridge uptime and spot a STALE bridge (it
@@ -1229,8 +1249,12 @@ function api_napari_status(req::HTTP.Request)
         end
     end
     bridge_uptime = bridge_started === nothing ? nothing : round(Int, time() - Float64(bridge_started))
+    # stale = a napari source was edited AFTER the bridge started (1s guard against same-second noise)
+    bridge_stale = bridge_started !== nothing &&
+                   (try; _napari_src_mtime() > Float64(bridge_started) + 1.0; catch; false; end)
     200, JSON3.write((; alive = alive, starting = _viewer_starting[],
-                        bridgeStartedAt = bridge_started, bridgeUptimeSeconds = bridge_uptime))
+                        bridgeStartedAt = bridge_started, bridgeUptimeSeconds = bridge_uptime,
+                        bridgeStale = bridge_stale))
 end
 
 # ── REST: discrete-GPU toggle ─────────────────────────────────────────────────

--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -1214,7 +1214,23 @@ end
 # ── REST: GET /api/napari/status ──────────────────────────────────────────────
 
 function api_napari_status(req::HTTP.Request)
-    200, JSON3.write((; alive = _viewer_alive(), starting = _viewer_starting[]))
+    # ping once (unlocked, like _viewer_alive — never blocks on a long op) and read the bridge's start
+    # time from the reply, so the Settings panel can show bridge uptime and spot a STALE bridge (it
+    # survives a backend restart). Same machine → same clock, so uptime is computed server-side.
+    v = _viewer()
+    alive = false
+    bridge_started = nothing
+    if v !== nothing
+        try
+            resp = send(v, Dict("type" => "ping"))
+            alive = true
+            bridge_started = get(resp, "started_at", nothing)
+        catch
+        end
+    end
+    bridge_uptime = bridge_started === nothing ? nothing : round(Int, time() - Float64(bridge_started))
+    200, JSON3.write((; alive = alive, starting = _viewer_starting[],
+                        bridgeStartedAt = bridge_started, bridgeUptimeSeconds = bridge_uptime))
 end
 
 # ── REST: discrete-GPU toggle ─────────────────────────────────────────────────

--- a/api/src/repl_api.jl
+++ b/api/src/repl_api.jl
@@ -29,15 +29,13 @@ _repl_available() = _repl_on[] && _host_is_loopback()
 # Process start time + short git commit — so the Diagnostics panel can tell a FRESHLY-restarted backend
 # from a STALE one still holding the port. A failed `pixi run dev` (port already bound) silently leaves
 # the old process serving old code; the panel otherwise looks identical either way (same port, same
-# fields). Captured once at load; git is best-effort (absent/empty in a packaged build without .git).
+# fields). `_GIT_COMMIT` is captured once at load (the code the process is RUNNING); diagnostics also
+# reads the live HEAD each request, and flags `stale` when they differ — i.e. the tree moved
+# (commit/merge/pull) but the backend wasn't restarted. git is best-effort ("" in a packaged build).
+const _REPO_ROOT = dirname(dirname(@__DIR__))
+_git_short(root) = try; String(strip(read(`git -C $root rev-parse --short HEAD`, String))); catch; ""; end
 const _STARTED_AT = time()
-const _GIT_COMMIT = let root = dirname(dirname(@__DIR__))
-    try
-        strip(read(`git -C $root rev-parse --short HEAD`, String))
-    catch
-        ""
-    end
-end
+const _GIT_COMMIT = _git_short(_REPO_ROOT)
 
 # POST /api/repl/config {enabled} — flip the runtime toggle. Not a security boundary (eval still needs a
 # loopback bind), so it's safe to accept from the UI; returns the resulting state.
@@ -99,11 +97,15 @@ end
 
 function api_diagnostics(::HTTP.Request)
     gb(x) = round(x / 2^30; digits = 2)
+    commit_now = _git_short(_REPO_ROOT)                  # live HEAD (this request) vs the running commit
+    stale = !isempty(_GIT_COMMIT) && !isempty(commit_now) && _GIT_COMMIT != commit_now
     200, JSON3.write((;
         threads     = Threads.nthreads(),
         julia       = string(VERSION),
         version     = _installed_version(),
-        commit      = _GIT_COMMIT,                       # short git SHA the backend is running (dev)
+        commit      = _GIT_COMMIT,                       # short git SHA the backend is RUNNING (dev)
+        commitCurrent = commit_now,                       # live HEAD on disk
+        stale       = stale,                              # running commit ≠ HEAD → restart to load latest
         startedAt   = _STARTED_AT,                        # epoch seconds — spot a stale/failed-restart backend
         uptimeSeconds = round(Int, time() - _STARTED_AT),
         projectsDir = projects_dir(),

--- a/api/src/repl_api.jl
+++ b/api/src/repl_api.jl
@@ -26,6 +26,19 @@ _host_is_loopback() = _BOUND_HOST[] in ("127.0.0.1", "::1", "localhost", "[::1]"
 # network control (a 0.0.0.0 server never serves the REPL, toggle or not); the UI reads `replAvailable`.
 _repl_available() = _repl_on[] && _host_is_loopback()
 
+# Process start time + short git commit — so the Diagnostics panel can tell a FRESHLY-restarted backend
+# from a STALE one still holding the port. A failed `pixi run dev` (port already bound) silently leaves
+# the old process serving old code; the panel otherwise looks identical either way (same port, same
+# fields). Captured once at load; git is best-effort (absent/empty in a packaged build without .git).
+const _STARTED_AT = time()
+const _GIT_COMMIT = let root = dirname(dirname(@__DIR__))
+    try
+        strip(read(`git -C $root rev-parse --short HEAD`, String))
+    catch
+        ""
+    end
+end
+
 # POST /api/repl/config {enabled} — flip the runtime toggle. Not a security boundary (eval still needs a
 # loopback bind), so it's safe to accept from the UI; returns the resulting state.
 function api_repl_config(body_bytes::Vector{UInt8})
@@ -90,6 +103,9 @@ function api_diagnostics(::HTTP.Request)
         threads     = Threads.nthreads(),
         julia       = string(VERSION),
         version     = _installed_version(),
+        commit      = _GIT_COMMIT,                       # short git SHA the backend is running (dev)
+        startedAt   = _STARTED_AT,                        # epoch seconds — spot a stale/failed-restart backend
+        uptimeSeconds = round(Int, time() - _STARTED_AT),
         projectsDir = projects_dir(),
         memFreeGB   = gb(Sys.free_memory()),
         memTotalGB  = gb(Sys.total_memory()),

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -608,13 +608,38 @@ function onTaskResult(data: Record<string, unknown>) {
 // the image-table eye, clicked on the ALREADY-open image, asks us to reload it (data-only unless reset)
 watch(() => projectStore.napariReloadTick, () => reloadViewer())
 
+// Stale-bridge flag: napari is a separate process that survives a backend restart, so after editing
+// napari code you can be looking at old behaviour without knowing. Poll the backend (which compares the
+// bridge's start time to the napari source mtimes) and warn right here, where you'd act on it.
+const bridgeStale = ref(false)
+let bridgeTimer: number | undefined
+async function pollBridge() {
+  try {
+    const s = await (await fetch('/api/napari/status')).json() as { bridgeStale?: boolean }
+    bridgeStale.value = !!s.bridgeStale
+  } catch { bridgeStale.value = false }
+}
+async function restartNapari() {
+  try {
+    const res = await fetch('/api/napari/restart', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+    if (res.ok) log.info('Napari restarting — reopen the image to reload it.', { source: 'napari' })
+    else log.error(`Napari restart failed: ${await _resError(res)}`, { source: 'napari' })
+  } catch (e) {
+    log.error(`Napari restart failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'napari' })
+  }
+  setTimeout(pollBridge, 1500)
+}
+
 onMounted(() => {
+  pollBridge(); bridgeTimer = window.setInterval(pollBridge, 5000)
   ws.on('napari:opened', onNapariOpened)
   ws.on('task:status', onTaskStatus)
   ws.on('task:result', onTaskResult)
   ws.on('gating:popmap', onGatingChange)
 })
 onUnmounted(() => {
+  if (bridgeTimer) clearInterval(bridgeTimer)
   ws.off('napari:opened', onNapariOpened)
   ws.off('task:status', onTaskStatus)
   ws.off('task:result', onTaskResult)
@@ -624,6 +649,14 @@ onUnmounted(() => {
 
 <template>
   <div class="viewer-panel">
+    <!-- stale-bridge warning: napari started before the latest napari-code changes (it survives a
+         backend restart). Brief here; the action is the Restart button + the tooltip. -->
+    <div v-if="bridgeStale" class="viewer-stale"
+         v-tooltip.bottom="'Napari started before your latest changes — restart it, then reopen the image.'">
+      <i class="pi pi-exclamation-triangle" />
+      <span class="viewer-stale-txt">Napari running old code</span>
+      <button class="viewer-stale-btn" @click="restartNapari">Restart</button>
+    </div>
     <!-- ── View: viewer behaviour toggles (global prefs; apply on next open) ──
          Top of the panel — these are always available, even before an image is open. -->
     <!-- Convention: append new toggles at the END of the row. -->
@@ -831,6 +864,32 @@ onUnmounted(() => {
   flex-direction: column;
   gap: 0.35rem;
 }
+
+/* stale-bridge warning strip — amber, brief; the Restart button is the action */
+.viewer-stale {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.28rem 0.4rem;
+  border: 1px solid var(--cc-warn);
+  border-radius: 0.3rem;
+  background: color-mix(in srgb, var(--cc-warn) 14%, transparent);
+  color: var(--cc-warn);
+  font-size: 0.7rem;
+}
+.viewer-stale-txt { flex: 1; min-width: 0; }
+.viewer-stale-btn {
+  flex-shrink: 0;
+  font-size: 0.66rem;
+  font-weight: 600;
+  padding: 0.15rem 0.45rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--cc-warn);
+  background: none;
+  color: var(--cc-warn);
+  cursor: pointer;
+}
+.viewer-stale-btn:hover { background: color-mix(in srgb, var(--cc-warn) 22%, transparent); }
 
 .viewer-image {
   display: flex;

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -86,7 +86,7 @@ onMounted(checkUpdates)
 
 // ── Diagnostics + debug console ──────────────────────────────────────────────
 interface Diag {
-  threads: number; julia: string; version: string; commit?: string; projectsDir: string
+  threads: number; julia: string; version: string; commit?: string; commitCurrent?: string; stale?: boolean; projectsDir: string
   startedAt?: number; uptimeSeconds?: number
   memFreeGB: number; memTotalGB: number; gcLiveMB: number
   host: string; port: number; loopback: boolean
@@ -145,7 +145,7 @@ onMounted(loadDiag)
 // Live status of the backend's child processes + per-component and global controls. Status is
 // ephemeral UI state (polled) → plain refs, not persisted view state. Pure status→state mapping
 // lives in utils/serviceStatus.ts (unit-tested); here we only poll, act, and pick which buttons show.
-const napariRaw = ref<{ alive?: boolean; starting?: boolean; bridgeUptimeSeconds?: number | null } | null>(null)
+const napariRaw = ref<{ alive?: boolean; starting?: boolean; bridgeUptimeSeconds?: number | null; bridgeStale?: boolean } | null>(null)
 const notebooksRaw = ref<{ running?: boolean; starting?: boolean } | null>(null)
 const napariSt = computed<ServiceState>(() => napariState(napariRaw.value))
 const notebooksSt = computed<ServiceState>(() => notebooksState(notebooksRaw.value))
@@ -464,13 +464,28 @@ async function switchWt(path: string) {
 
       <div v-if="diag" class="diag-grid">
         <span>Version</span><span class="mono">{{ diag.version }}</span>
-        <span v-if="diag.commit">Commit</span><span v-if="diag.commit" class="mono">{{ diag.commit }}</span>
+        <span v-if="diag.commit">Commit</span>
+        <span v-if="diag.commit" class="mono" :class="{ 'diag-stale': diag.stale }">
+          {{ diag.commit }}
+          <span v-if="diag.stale" class="diag-stale-note"
+                v-tooltip.bottom="`Backend runs an older commit than your files (HEAD ${diag.commitCurrent}) — restart it to load the latest.`">
+            <i class="pi pi-exclamation-triangle" /> stale
+          </span>
+        </span>
         <span>Backend up</span><span class="mono">{{ formatUptime(diag.uptimeSeconds) }}</span>
+        <span>Napari bridge</span>
+        <span class="mono" :class="{ 'diag-stale': napariRaw?.bridgeStale }">
+          <template v-if="napariSt === 'running'">up {{ formatUptime(napariRaw?.bridgeUptimeSeconds) }}</template>
+          <template v-else>{{ stateInfo(napariSt).label }}</template>
+          <span v-if="napariRaw?.bridgeStale" class="diag-stale-note"
+                v-tooltip.bottom="'Napari is running old code — restart it (System panel above) and reopen the image.'">
+            <i class="pi pi-exclamation-triangle" /> stale
+          </span>
+        </span>
         <span>Server threads</span><span class="mono">{{ diag.threads }}</span>
         <span>Julia</span><span class="mono">{{ diag.julia }}</span>
         <span>Memory</span><span class="mono">{{ diag.memFreeGB }} / {{ diag.memTotalGB }} GB free · GC live {{ diag.gcLiveMB }} MB</span>
         <span>Host</span><span class="mono">{{ diag.host }}:{{ diag.port }}</span>
-        <span>Napari bridge</span><span class="mono">{{ napariSt === 'running' ? `up ${formatUptime(napariRaw?.bridgeUptimeSeconds)}` : stateInfo(napariSt).label }}</span>
         <span>Projects dir</span><span class="mono">{{ diag.projectsDir }}</span>
       </div>
 
@@ -692,6 +707,10 @@ async function switchWt(path: string) {
 .diag-grid > span:nth-child(odd) { color: var(--cc-text-dim); }
 .mono { font-family: var(--cc-mono); font-size: 0.74rem; word-break: break-all; }
 .field-hint code, .diag-grid code { font-family: var(--cc-mono); font-size: 0.72rem; }
+/* stale-process flag: amber value + a small chip (problem short; the action is in the tooltip) */
+.diag-stale { color: var(--cc-warn); }
+.diag-stale-note { margin-left: 0.4rem; font-size: 0.68rem; color: var(--cc-warn); white-space: nowrap; cursor: default; }
+.diag-stale-note .pi { font-size: 0.66rem; }
 
 /* debug console */
 .repl-log {

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -4,7 +4,7 @@ import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import PackagesDialog from '../components/PackagesDialog.vue'
 import ConfirmButton from '../components/ConfirmButton.vue'
-import { napariState, notebooksState, stateInfo, type ServiceState } from '../utils/serviceStatus'
+import { napariState, notebooksState, stateInfo, formatUptime, type ServiceState } from '../utils/serviceStatus'
 import { useAppControlStore } from '../stores/appControl'
 
 const showPackages = ref(false)
@@ -86,7 +86,8 @@ onMounted(checkUpdates)
 
 // ── Diagnostics + debug console ──────────────────────────────────────────────
 interface Diag {
-  threads: number; julia: string; version: string; projectsDir: string
+  threads: number; julia: string; version: string; commit?: string; projectsDir: string
+  startedAt?: number; uptimeSeconds?: number
   memFreeGB: number; memTotalGB: number; gcLiveMB: number
   host: string; port: number; loopback: boolean
   replEnabled: boolean; replAvailable: boolean; dev: boolean
@@ -144,7 +145,7 @@ onMounted(loadDiag)
 // Live status of the backend's child processes + per-component and global controls. Status is
 // ephemeral UI state (polled) → plain refs, not persisted view state. Pure status→state mapping
 // lives in utils/serviceStatus.ts (unit-tested); here we only poll, act, and pick which buttons show.
-const napariRaw = ref<{ alive?: boolean; starting?: boolean } | null>(null)
+const napariRaw = ref<{ alive?: boolean; starting?: boolean; bridgeUptimeSeconds?: number | null } | null>(null)
 const notebooksRaw = ref<{ running?: boolean; starting?: boolean } | null>(null)
 const napariSt = computed<ServiceState>(() => napariState(napariRaw.value))
 const notebooksSt = computed<ServiceState>(() => notebooksState(notebooksRaw.value))
@@ -463,10 +464,13 @@ async function switchWt(path: string) {
 
       <div v-if="diag" class="diag-grid">
         <span>Version</span><span class="mono">{{ diag.version }}</span>
+        <span v-if="diag.commit">Commit</span><span v-if="diag.commit" class="mono">{{ diag.commit }}</span>
+        <span>Backend up</span><span class="mono">{{ formatUptime(diag.uptimeSeconds) }}</span>
         <span>Server threads</span><span class="mono">{{ diag.threads }}</span>
         <span>Julia</span><span class="mono">{{ diag.julia }}</span>
         <span>Memory</span><span class="mono">{{ diag.memFreeGB }} / {{ diag.memTotalGB }} GB free · GC live {{ diag.gcLiveMB }} MB</span>
         <span>Host</span><span class="mono">{{ diag.host }}:{{ diag.port }}</span>
+        <span>Napari bridge</span><span class="mono">{{ napariSt === 'running' ? `up ${formatUptime(napariRaw?.bridgeUptimeSeconds)}` : stateInfo(napariSt).label }}</span>
         <span>Projects dir</span><span class="mono">{{ diag.projectsDir }}</span>
       </div>
 

--- a/frontend/src/utils/serviceStatus.test.ts
+++ b/frontend/src/utils/serviceStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { napariState, notebooksState, stateInfo } from './serviceStatus'
+import { napariState, notebooksState, stateInfo, formatUptime } from './serviceStatus'
 
 describe('napariState', () => {
   it('maps the /api/napari/status payload', () => {
@@ -22,6 +22,22 @@ describe('notebooksState', () => {
     expect(notebooksState({ running: false, starting: true })).toBe('starting')
     expect(notebooksState({ running: false, starting: false })).toBe('stopped')
     expect(notebooksState(null)).toBe('stopped')
+  })
+})
+
+describe('formatUptime', () => {
+  it('formats seconds / minutes / hours', () => {
+    expect(formatUptime(45)).toBe('45s')
+    expect(formatUptime(59)).toBe('59s')
+    expect(formatUptime(60)).toBe('1m')
+    expect(formatUptime(12 * 60)).toBe('12m')
+    expect(formatUptime(3 * 3600 + 4 * 60)).toBe('3h 4m')
+  })
+  it('returns — for missing/invalid', () => {
+    expect(formatUptime(null)).toBe('—')
+    expect(formatUptime(undefined)).toBe('—')
+    expect(formatUptime(-5)).toBe('—')
+    expect(formatUptime(NaN)).toBe('—')
   })
 })
 

--- a/frontend/src/utils/serviceStatus.ts
+++ b/frontend/src/utils/serviceStatus.ts
@@ -19,6 +19,18 @@ export function notebooksState(s: { running?: boolean; starting?: boolean } | nu
   return s.running ? 'running' : 'stopped'
 }
 
+/** Human uptime from a whole-second count: "45s", "12m", "3h 4m". "—" for missing/invalid. Used to show
+ *  how long the backend / napari bridge has been up (spotting a stale process that didn't restart). */
+export function formatUptime(seconds: number | null | undefined): string {
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return '—'
+  const s = Math.floor(seconds)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
+
 /** Display label + colour tone for a state pill. */
 export function stateInfo(state: ServiceState): { label: string; tone: Tone } {
   switch (state) {

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -13,6 +13,7 @@ import pickle
 import queue
 import sys
 import threading
+import time
 import urllib.request
 from functools import lru_cache
 
@@ -24,6 +25,10 @@ from qtpy.QtCore import QTimer
 
 HOST = "localhost"
 PORT = 7655
+
+# bridge process start time — reported in the ping reply so the backend/Settings panel can show the
+# bridge's uptime and spot a STALE bridge (it survives a backend restart; see docs/NAPARI.md restart rules)
+_STARTED_AT = time.time()
 
 # name of the Shapes layer used for spatial cell selection (linked brushing → flow plots)
 SELECTION_LAYER = "Cell selection"
@@ -1531,7 +1536,7 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
     t = cmd.get("type")
     try:
         if t == "ping":
-            return {"type": "pong"}
+            return {"type": "pong", "started_at": _STARTED_AT}
 
         elif t == "gl_info":
             return {"type": "gl_info", **_gl_info()}


### PR DESCRIPTION
## Diagnostics: backend uptime + commit, and napari bridge uptime

Makes a **stale / failed-restart backend** visible in Settings → Diagnostics. A failed `pixi run dev` (port 8080 already bound) silently leaves the *old* process serving old code — and the panel, served over that same port, otherwise looks identical either way (same fields, same port). Now you can tell which process you're actually talking to.

### Changes
- **`/api/diagnostics`** → adds `commit` (short git SHA, best-effort — empty on a packaged build with no `.git`), `startedAt`, `uptimeSeconds` (captured once at server load).
- **napari bridge** reports `started_at` in its `ping` reply; **`/api/napari/status`** surfaces `bridgeStartedAt` + `bridgeUptimeSeconds` (computed server-side — same machine/clock), so a stale bridge (which survives a backend restart) is visible too.
- **Settings → Diagnostics** shows three new rows: `Commit`, `Backend up`, `Napari bridge` (`up 12m` / `Stopped` / `Starting…`). Uptime formatting via a unit-tested `formatUptime` in `serviceStatus.ts`.

### Why
The diagnostics panel can't catch a port clash *as it happens* (the failed process never serves anything), but it makes the resulting **stale state** obvious — which is the part that actually trips you up (routes 404 even though "the app works").

### Tests
`serviceStatus` `formatUptime` unit tests; `test-frontend` (151), `typecheck`, `test-api` all green.

### ⚠️ Not verified live
Endpoint changes need a **backend restart** to appear (`api/src` isn't Revise-tracked), and `bridgeStartedAt` only populates once the **napari bridge is restarted** (a stale bridge's old `ping` has no `started_at` → the panel shows `up —`, itself a mild "bridge is stale" tell). `commit` reflects the *running* process's code by design (won't update without a restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
