### PR TITLE
fix(lab-log): keep orphaned mutes un-muteable

### DIFF
--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -8,7 +8,7 @@ import { ref, computed, watch, nextTick } from 'vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import {
-  authorKind, correctionPrefill, draftToLines, entryId, decisionPrefill, isRatable,
+  authorKind, correctionPrefill, draftToLines, entryId, decisionPrefill, isRatable, muteChips,
   USER_AUTHOR, CORRECTION_AUTHOR, type LabLogEntry, type Vote,
 } from '../utils/labLog'
 
@@ -29,6 +29,8 @@ const tuning = ref<Record<string, Vote>>({})   // entryId → tuning vote (confi
 const mutes = ref<string[]>([])                // muted digest categories (config, NOT the log)
 const categories = ref<string[]>([])           // all digest categories (task-manager tags), for mute chips
 const mode = computed(() => settings.labLogMode)
+// chips include any orphaned mute (category since renamed/removed) so it can always be un-muted
+const muteableCategories = computed(() => muteChips(categories.value, mutes.value))
 const voteOf = (e: LabLogEntry): Vote | undefined => tuning.value[entryId(e.raw)]
 
 async function load() {
@@ -222,7 +224,7 @@ async function toggleMute(category: string) {
     <!-- mute whole categories from future digests (Tuning mode) -->
     <div v-if="mode === 'tuning' && projectUid" class="ll-mutebar">
       <span class="ll-modelabel">Mute:</span>
-      <button v-for="c in categories" :key="c" class="ll-mutebtn"
+      <button v-for="c in muteableCategories" :key="c" class="ll-mutebtn"
               :class="{ muted: mutes.includes(c) }" @click="toggleMute(c)"
               :title="mutes.includes(c) ? `${c} muted — click to log again` : `Stop logging ${c}`">
         <i :class="['pi', mutes.includes(c) ? 'pi-bell-slash' : 'pi-bell']" /> {{ c }}

--- a/frontend/src/utils/labLog.test.ts
+++ b/frontend/src/utils/labLog.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   authorKind, correctionPrefill, draftToLines, unseenClaudeCount,
-  entryId, decisionPrefill, isRatable,
+  entryId, decisionPrefill, isRatable, muteChips,
   type LabLogEntry,
 } from './labLog'
 
@@ -34,6 +34,21 @@ describe('labLog.draftToLines', () => {
     expect(draftToLines('a\n\n  b  \n')).toEqual(['a', 'b'])
     expect(draftToLines('   ')).toEqual([])
     expect(draftToLines('single')).toEqual(['single'])
+  })
+})
+
+describe('labLog.muteChips', () => {
+  it('keeps canonical order and appends orphaned mutes at the end', () => {
+    expect(muteChips(['Segment', 'Gating', 'Clustering'], ['Gating']))
+      .toEqual(['Segment', 'Gating', 'Clustering'])
+    // a muted category no longer in the canonical list is still shown (so it can be un-muted)
+    expect(muteChips(['Segment', 'Gating'], ['OldName', 'Gating']))
+      .toEqual(['Segment', 'Gating', 'OldName'])
+  })
+  it('handles empty / missing inputs', () => {
+    expect(muteChips([], [])).toEqual([])
+    expect(muteChips(undefined as any, undefined as any)).toEqual([])
+    expect(muteChips([], ['Stuck'])).toEqual(['Stuck'])
   })
 })
 

--- a/frontend/src/utils/labLog.ts
+++ b/frontend/src/utils/labLog.ts
@@ -81,6 +81,16 @@ export function draftToLines(draft: string): string[] {
     .filter(l => l.length > 0)
 }
 
+/** Categories to show as mute chips: the canonical category list (in the backend's order) plus any
+ *  currently-muted category no longer in it (e.g. a task category later renamed/removed), appended
+ *  at the end. Without the union such an orphaned mute would render no chip and could never be
+ *  un-muted. */
+export function muteChips(categories: string[], mutes: string[]): string[] {
+  const cats = categories ?? []
+  const orphans = (mutes ?? []).filter(m => !cats.includes(m))
+  return [...cats, ...orphans]
+}
+
 /** Count entries authored by Claude that are newer than the last one the user has seen (by date +
  *  position). Used to badge unreviewed Claude entries. `seenRaw` is the `raw` of the newest entry
  *  the user has already seen; null/absent means everything is unseen. Entries are newest-first. */


### PR DESCRIPTION
## What

Small follow-up to #164. The lab-log **mute chips** rendered only the canonical category list (task-manager tags). Un-muting a live category already worked — clicking its highlighted chip toggles it back. But if a muted category was later **renamed or removed** from the task JSONs, its mute stayed in the sidecar while **no chip rendered for it** → stuck muted with no way to clear it.

Now the chips render the **union** via a new tested helper `muteChips(categories, mutes)`: canonical order, with any orphaned mute appended at the end. Every active mute always has a clickable chip, so it can always be un-muted.

## Testing
- Frontend: typecheck clean + **156 vitest** (+2 `muteChips` cases: order preserved, orphan appended, empty/undefined inputs).

## Notes
- Verified by typecheck + unit tests only (not clicked in a browser) — the change is a `v-for` source swap + a pure helper.
- Un-muting an orphaned category removes it from the sidecar permanently (intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
