### PR TITLE
fix(napari): track-cluster colours + 3D-crop draw fixes (WIP tag)

### DIFF
--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -427,6 +427,9 @@ if show_3d and (self._z_axis_len() or 0) > 1:
 
 ## 3D crop (Imaris-style slicing → new image)
 
+> **Status: experimental / under construction.** The behaviour and UX are still changing (the Viewer
+> panel shows an "experimental" tag). Treat as a preview feature.
+
 Crop an image to a sub-region. The region is **drawn interactively** in napari; you can either **preview**
 it (view-only clipping planes) or **save** it as a **new image in the set** (a real, persistent crop).
 

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -427,8 +427,8 @@ if show_3d and (self._z_axis_len() or 0) > 1:
 
 ## 3D crop (Imaris-style slicing → new image)
 
-> **Status: experimental / under construction.** The behaviour and UX are still changing (the Viewer
-> panel shows an "experimental" tag). Treat as a preview feature.
+> **Status: work in progress.** It works, but the workflow is still awkward and being improved (the
+> Viewer panel shows a "work in progress" tag).
 
 Crop an image to a sub-region. The region is **drawn interactively** in napari; you can either **preview**
 it (view-only clipping planes) or **save** it as a **new image in the set** (a real, persistent crop).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -222,6 +222,23 @@ path a `TaskRecord` + `chain_run_id` so it's cancellable like the per-image path
 
 ---
 
+## Napari viewer
+
+**#00079** — **Improve the 3D-crop UX (works but awkward)**
+The 3D crop (draw over a projection → Preview / Save as a new cropped image) works, but the workflow
+is clunky — it's tagged **"work in progress"** in the Viewer panel + `docs/NAPARI.md`. Smooth it out:
+a less fiddly draw/preview/save flow, clearer z/t handling (Preview can't show a t-trim — clipping is
+spatial-only — which is confusing), and fewer forced napari restarts. Code: `napari/napari_bridge.py`
+(`start_crop`/`apply_crop`/`crop_box`/`_z_mip`), `ViewerPanel.vue` 3D-crop section,
+`app/src/tasks/editImages/cropImage.jl`.
+
+**#00080** — **Bridge relaunch-after-`stop-napari` gets stuck**
+After `stop-napari`, clicking an image should relaunch the bridge, but a hung/slow discrete-GPU launch
+leaves `_viewer_starting[]` stuck `true` (only cleared in the async `launch!` `finally`), so
+`_ensure_viewer!` returns `false` forever and every open is blocked until a **full server restart**.
+Fix: time-out the async launch (reset `_viewer_starting[]`/stale `_viewer_ref[]` on failure), and bump
+the discrete-GPU launch timeout. Code: `api/src/napari_api.jl::_ensure_viewer!`, `app/src/napari.jl::launch!`.
+
 ## Figures & movies (animation)
 
 Full design + phased sequence: **`docs/todo/ANIMATION_PLAN.md`**. Build order

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -838,7 +838,12 @@ onUnmounted(() => {
       <!-- ── 3D crop: Imaris-style slicing. Draw an XY rectangle over a Z max-projection, set the
            z-range, apply as clipping planes. Only meaningful when 3D is on. ── -->
       <div v-if="show3D" class="viewer-section">
-        <div class="viewer-section-title">3D crop</div>
+        <div class="viewer-section-title">
+          3D crop
+          <span class="wip-tag" v-tooltip.bottom="'Experimental / under construction — behaviour and UX are still changing.'">
+            <i class="pi pi-wrench" /> experimental
+          </span>
+        </div>
         <div v-if="!cropping" class="viewer-opts">
           <button class="opt-btn" :class="{ active: cropStarting }" :disabled="cropStarting" @click="startCrop"
                   v-tooltip.bottom="cropStarting ? 'Napari is preparing the crop view…' : 'Crop the volume: shows a projection to draw an XY rectangle over, then Save or Preview'">
@@ -996,6 +1001,19 @@ onUnmounted(() => {
   letter-spacing: 0.06em;
   color: var(--cc-text-dim);
 }
+/* experimental / work-in-progress tag on a section header */
+.wip-tag {
+  margin-left: 0.4rem;
+  padding: 0.02rem 0.3rem;
+  border: 1px solid var(--cc-warn);
+  border-radius: 0.6rem;
+  color: var(--cc-warn);
+  font-size: 0.55rem;
+  letter-spacing: 0.03em;
+  vertical-align: middle;
+  cursor: default;
+}
+.wip-tag .pi { font-size: 0.55rem; }
 
 .viewer-hint {
   font-size: 0.72rem;

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -840,8 +840,8 @@ onUnmounted(() => {
       <div v-if="show3D" class="viewer-section">
         <div class="viewer-section-title">
           3D crop
-          <span class="wip-tag" v-tooltip.bottom="'Experimental / under construction — behaviour and UX are still changing.'">
-            <i class="pi pi-wrench" /> experimental
+          <span class="wip-tag" v-tooltip.bottom="'It works, but the workflow is still awkward — we\'re improving it.'">
+            <i class="pi pi-wrench" /> work in progress
           </span>
         </div>
         <div v-if="!cropping" class="viewer-opts">

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -29,6 +29,9 @@ const visibleLabels     = ref<Record<string, boolean>>({})
 const gatedTracksShown  = ref(false)   // master "show gated track populations" toggle (TEST/SDGF)
 const recording         = ref(false)   // a one-click timelapse recording is in progress
 const cropping          = ref(false)   // 3D-crop draw mode active (transient — a drawn region is image-specific)
+const cropStarting      = ref(false)   // crop-start in flight (napari building the projection view)
+const cropSaving        = ref(false)   // the cropImage scheduler task is running (new image being written)
+let   cropTaskId: string | null = null // its task id, to clear cropSaving on completion
 
 // per-pop-type population overlays as centroid POINTS. Only the CELL-grained pop types (flow, clust)
 // belong here: show-populations plots by cell label, whereas track/trackclust are track-grained
@@ -202,15 +205,20 @@ async function recordTimelapse() {
 // crop footprint over the whole structure (not one slice); applyCrop turns that + the z-range into
 // clipping planes and returns to 3D; clearCrop removes the crop. See docs/NAPARI.md → "3D crop".
 async function startCrop() {
+  if (cropStarting.value) return
+  cropStarting.value = true
+  log.info('Napari is preparing the crop view…', { source: 'napari' })
   try {
     const res = await fetch('/api/napari/crop-start', {
       method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
     if (res.ok) {
       cropping.value = true
-      log.info('Resize the yellow rectangle in Napari, set the z-range, then Apply crop.', { source: 'napari' })
+      log.info('Draw a rectangle over the projection in Napari, set the z/t range, then Save or Preview.', { source: 'napari' })
     } else log.error(`Start crop failed: ${await _resError(res)}`, { source: 'napari' })
   } catch (e) {
     log.error(`Start crop failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'napari' })
+  } finally {
+    cropStarting.value = false
   }
 }
 // Preview (view-only): apply the box as clipping planes so you SEE the cropped volume before committing.
@@ -255,7 +263,8 @@ async function saveCrop() {
       type: 'task:run', taskId: t2.id, funName: 'editImages.cropImage', params,
       imageUid: uid, projectUid, setUid, poolName: 'io',
     })
-    log.info('Cropping image → new image in the set… (Napari + IO for a moment)', { source: 'napari' })
+    cropSaving.value = true; cropTaskId = t2.id   // drives the "Cropping…" indicator until the task ends
+    log.info('Cropping image → new image in the set…', { source: 'napari' })
     // clear the draw overlay + leave crop mode; the new image lands on task completion
     await clearCrop()
   } catch (e) {
@@ -519,8 +528,14 @@ async function deleteLabel(valueName: string) {
 }
 
 function onTaskStatus(data: Record<string, unknown>) {
+  const status = String(data.status ?? '')
+  // clear the "Cropping…" indicator when the crop task reaches a terminal state (done/failed)
+  if (cropTaskId && String(data.taskId ?? '') === cropTaskId && (status === 'done' || status === 'failed')) {
+    cropSaving.value = false; cropTaskId = null
+    if (status === 'failed') log.error('Crop failed — see the task log.', { source: 'napari' })
+  }
   if (!settings.napariUpdateImage) return
-  if (String(data.status ?? '') !== 'done') return
+  if (status !== 'done') return
   const napariUid = projectStore.napariImageUid
   if (!napariUid || String(data.imageUid ?? '') !== napariUid) return
   reloadViewer()   // data-only unless the user ticked reset (task changed pixels → reopen)
@@ -581,6 +596,10 @@ function onTaskResult(data: Record<string, unknown>) {
   const imageUid = String(data.imageUid ?? '')
   if (!imageUid || imageUid !== projectStore.napariImageUid) return
   const meta = (data.meta ?? {}) as Record<string, unknown>
+
+  // crop finished → the new image is in the set (added by stores/ws.ts); confirm it in the log
+  const newImageName = meta.newImageName as string | undefined
+  if (newImageName) log.info(`Cropped image ready: "${newImageName}".`, { source: 'napari' })
 
   const addedValueName = meta.valueName as string | undefined
   if (addedValueName) {
@@ -656,6 +675,11 @@ onUnmounted(() => {
       <i class="pi pi-exclamation-triangle" />
       <span class="viewer-stale-txt">Napari running old code</span>
       <button class="viewer-stale-btn" @click="restartNapari">Restart</button>
+    </div>
+    <!-- crop task running (scheduler) → the new cropped image appears when it finishes -->
+    <div v-if="cropSaving" class="viewer-busy">
+      <i class="pi pi-spin pi-spinner" />
+      <span>Cropping image… new image appears when done</span>
     </div>
     <!-- ── View: viewer behaviour toggles (global prefs; apply on next open) ──
          Top of the panel — these are always available, even before an image is open. -->
@@ -816,9 +840,9 @@ onUnmounted(() => {
       <div v-if="show3D" class="viewer-section">
         <div class="viewer-section-title">3D crop</div>
         <div v-if="!cropping" class="viewer-opts">
-          <button class="opt-btn" @click="startCrop"
-                  v-tooltip.bottom="'Crop the volume: shows a Z max-projection to draw an XY rectangle over, then Apply'">
-            <i class="pi pi-clone" />
+          <button class="opt-btn" :class="{ active: cropStarting }" :disabled="cropStarting" @click="startCrop"
+                  v-tooltip.bottom="cropStarting ? 'Napari is preparing the crop view…' : 'Crop the volume: shows a projection to draw an XY rectangle over, then Save or Preview'">
+            <i :class="['pi', cropStarting ? 'pi-spin pi-spinner' : 'pi-clone']" />
           </button>
           <button class="opt-btn" @click="clearCrop"
                   v-tooltip.bottom="'Remove the 3D crop (show the whole volume)'">
@@ -826,7 +850,7 @@ onUnmounted(() => {
           </button>
         </div>
         <template v-else>
-          <span class="viewer-hint">Resize the rectangle in Napari, set the z/t range, then Save (new image) or Preview.</span>
+          <span class="viewer-hint">Draw a rectangle in Napari, set the z/t range, then Save (new image) or Preview.</span>
           <div class="movie-row">
             <span class="movie-lbl" v-tooltip.bottom="'Keep this z-range (%)'">z</span>
             <RangeSlider v-model:lo="cropZLo" v-model:hi="cropZHi" />
@@ -890,6 +914,19 @@ onUnmounted(() => {
   cursor: pointer;
 }
 .viewer-stale-btn:hover { background: color-mix(in srgb, var(--cc-warn) 22%, transparent); }
+
+/* crop-in-progress strip — accent-toned, brief; the new image lands when the scheduler task finishes */
+.viewer-busy {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.28rem 0.4rem;
+  border: 1px solid var(--cc-accent);
+  border-radius: 0.3rem;
+  background: color-mix(in srgb, var(--cc-accent) 12%, transparent);
+  color: var(--cc-accent);
+  font-size: 0.7rem;
+}
 
 .viewer-image {
   display: flex;

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -36,7 +36,6 @@ SELECTION_LAYER = "Cell selection"
 # transient helper layers for the 3D crop (drawn over a Z max-projection, removed once applied)
 CROP_LAYER = "Crop region"        # editable rectangle → the XY crop footprint
 CROP_MIP_LAYER = "Crop MIP"       # Z max-intensity projection you draw the rectangle over
-_MAX_MIP_T = 16                   # cap timepoints sampled for the crop MIP (a footprint needn't read every frame)
 
 # qualitative palette for colouring labels/tracks by a CATEGORICAL obs column (e.g. HMM state).
 # Okabe–Ito (colourblind-safe), as RGBA floats in 0..1 — matches the web canvas 'okabe-ito' palette.
@@ -766,28 +765,38 @@ class NapariState:
                 _remove_layer(self._viewer, name)
             if len(sub) > 0:
                 props = {"track_id": sub[:, 0].astype(int).tolist()}
+                from cecelia.utils import napari_utils
+                # Three colouring modes (napari Tracks colour ONLY via color_by + a colormap):
+                #   1. colour-by column (whole _tracked only) → categorical Okabe–Ito colormaps_dict /
+                #      continuous viridis, keyed by the column;
+                #   2. plain _tracked, no colour-by → napari's per-track turbo (distinguishes tracks);
+                #   3. a NAMED pop (gated track / trackclust) → its FLAT pop colour.
+                # For (3) we must colour by a CONSTANT helper property, NOT track_id: napari keeps its
+                # built-in turbo for `track_id` and ignores a custom colormap attached to it — that's why
+                # the pop colour never showed. A constant property mapped through a solid two-stop
+                # colormap gives one flat colour = the pop's.
                 if use_cby:
                     props[use_cby] = col_vals[mask].tolist()
-                # Delegate to the shared helper (passes scale AND units so napari keeps unit-aware
-                # rendering across layers). Categorical colour-by → the per-level Okabe–Ito
-                # `colormaps_dict` (consistent with labels); otherwise a named colormap (viridis
-                # continuous / turbo by track_id). See docs/todo/CECELIA_NAPARI_UPSTREAM_PLAN.md.
-                from cecelia.utils import napari_utils
-                if use_cby:
-                    layer_cmap, layer_cmaps_dict = (col_cmap or "turbo"), col_cmaps_dict
+                    layer_color_by, layer_cmap, layer_cmaps_dict = use_cby, (col_cmap or "turbo"), col_cmaps_dict
+                elif is_whole:
+                    layer_color_by, layer_cmap, layer_cmaps_dict = "track_id", "turbo", None
                 else:
-                    # solid single-colour colormap from the pop colour (same idiom as the categorical
-                    # step colormap above: two identical stops, zero interpolation → one flat colour)
+                    # NAMED pop → flat pop colour, the old-R way (show_tracks split_tracks): colour a
+                    # NONZERO-constant helper property through a black→colour colormap. Colouring by
+                    # track_id keeps napari's turbo; a helper property + this colormap makes every track
+                    # render in the pop colour (value 1 → the colour end; 0=black is never hit).
                     try:
-                        c = _hex_to_rgba(pop_colour)
-                        layer_cmap = napari.utils.Colormap(colors=[c, c], controls=[0.0, 1.0], interpolation="zero")
+                        props["cc_pop"] = [1.0] * sub.shape[0]
+                        layer_color_by, layer_cmap = "cc_pop", None
+                        layer_cmaps_dict = {"cc_pop": napari_utils.solid_track_colormap(pop_colour)}
                     except Exception:
-                        layer_cmap = "turbo"
-                    layer_cmaps_dict = None
+                        layer_color_by, layer_cmap, layer_cmaps_dict = "track_id", "turbo", None
+                # Delegate to the shared helper (passes scale AND units so napari keeps unit-aware
+                # rendering across layers). See docs/todo/CECELIA_NAPARI_UPSTREAM_PLAN.md.
                 layer = napari_utils.add_tracks(
                     self._viewer, sub, name=name,
                     scale=self._im_scale, units=self._im_units, properties=props,
-                    color_by=(use_cby or "track_id"), tail_width=tail_width, tail_length=tail_length,
+                    color_by=layer_color_by, tail_width=tail_width, tail_length=tail_length,
                     colormap=layer_cmap, colormaps_dict=layer_cmaps_dict,
                 )
                 if prev is not None:                     # carry the user's manual layer tweaks over
@@ -947,11 +956,12 @@ class NapariState:
         self._on_selection_changed()   # re-run point-in-polygon (+ z filter) on the drawn shape
 
     # ── 3D crop (Imaris-style slicing via clipping planes) ─────────────────────
-    # Flow: `start_crop` drops to 2-D, hides the data layers and shows a Z max-projection with an
-    # editable full-extent rectangle — so you draw the XY footprint over the WHOLE structure, not one
-    # slice (napari only edits Shapes in 2-D). `apply_crop` reads the rectangle + a z-range and sets
+    # Flow: `start_crop` drops to 2-D, hides the data layers and shows a Z max-projection with an EMPTY
+    # rectangle layer in draw mode — you draw the XY footprint over the WHOLE structure, not one slice
+    # (napari only edits Shapes in 2-D). `apply_crop` reads the rectangle + a z-range and sets
     # axis-aligned `experimental_clipping_planes` on the image + overlays, then returns to 3-D.
-    # `clear_crop` removes the planes. See docs/NAPARI.md → "3D crop".
+    # `crop_box` resolves it to pixels for the save task. `clear_crop` removes the planes.
+    # See docs/NAPARI.md → "3D crop". The box readers use the LAST-drawn rectangle (a redraw wins).
 
     def start_crop(self):
         """Enter crop-draw mode (see class-level flow note)."""
@@ -967,22 +977,23 @@ class NapariState:
         for lyr in self._viewer.layers:
             lyr.visible = False
 
-        mip, (sy, sx), (h, w) = self._z_mip()
-        yx_unit = (self._im_units[-1], self._im_units[-1]) if self._im_units else None
+        mip, mip_scale, mip_units, (h, w) = self._z_mip()   # (t?,y,x) lazy dask + matching scale/units
         mip_layer = self._viewer.add_image(mip, name=CROP_MIP_LAYER, colormap="gray",
-                                           blending="translucent", scale=(sy, sx), units=yx_unit)
+                                           blending="translucent", scale=mip_scale, units=mip_units)
         from cecelia.utils import napari_utils
         napari_utils.set_contrast_from_sample(mip_layer)   # percentile contrast → the MIP isn't washed out
 
-        # a full-extent rectangle to shrink: grab the corner handles in "select" mode
-        rect = np.array([[0.0, 0.0], [0.0, w], [h, w], [h, 0.0]])
+        # EMPTY rectangle layer (2-D y,x) in draw mode — the user draws ONE rectangle (like cell
+        # selection's add_polygon). Deliberately NOT prefilled full-extent: a prefilled rect the user
+        # draws OVER leaves two shapes, and the box would span their union (= the full image → no crop).
+        sy, sx = mip_scale[-2], mip_scale[-1]
+        yx_unit = (mip_units[-2], mip_units[-1]) if (mip_units and mip_units[-1] is not None) else None
         shp_kwargs = dict(name=CROP_LAYER, edge_color="yellow", face_color="transparent",
                           edge_width=max(1.0, 0.004 * max(h, w)), ndim=2, scale=(sy, sx))
         if yx_unit is not None:
             shp_kwargs["units"] = yx_unit
-        layer = self._viewer.add_shapes([rect], shape_type="rectangle", **shp_kwargs)
-        layer.mode = "select"
-        layer.selected_data = {0}
+        layer = self._viewer.add_shapes(**shp_kwargs)
+        layer.mode = "add_rectangle"
         self._viewer.layers.selection.active = layer
         self._viewer.reset_view()
 
@@ -996,38 +1007,45 @@ class NapariState:
         return len(self._im_data) - 1
 
     def _z_mip(self):
-        """(Y, X) max-projection over z, channels AND time at a coarse pyramid level. Returns
-        ``(mip2d, (scale_y, scale_x) world µm/px, (H, W))``. Projecting over t too means the drawing
-        backdrop shows the whole spatial footprint across the WHOLE timelapse — the crop is spatial
-        (it applies to every timepoint), so there is deliberately no t slider while drawing. Max over
-        channels → one grey image (colour isn't needed to draw a box, and collapsing channels keeps it
-        fast). Ports the parked ``as_mip`` option (docs/NAPARI.md)."""
+        """LAZY projection for the crop backdrop. Max over CHANNELS (dropped) and over Z **with
+        keepdims** — so the layer keeps the SAME display axes as the data (``t, z=1, y, x``) and stays
+        aligned to the viewer's t/z sliders. This is the crux: a z-DROPPED (t,y,x) layer right-aligns
+        its first axis onto the viewer's Z (the hidden 4-D data layers keep the viewer 4-D), so the real
+        T slider wouldn't move it — "the MIP has no time". Keeping z as a singleton fixes the alignment.
+        t is kept so you can scrub timepoints; each frame computes on demand (dask). Returns
+        ``(mip, scale, units, (H, W))`` over the display axes. Coarse pyramid level (XY ~≤ max_px)."""
         axes = [a.lower() for a in self._axes]
         iy, ix = axes.index("y"), axes.index("x")
         iz = axes.index("z") if "z" in axes else None
-        it = axes.index("t") if "t" in axes else None
         ic = self._channel_axis
         level = self._pick_mip_level(iy, ix)
-        arr = self._im_data[level]
-        shapeL = arr.shape
-        shape0 = self._im_data[0].shape
+        arr = self._im_data[level]                      # dask; lazy
+        shape0, shapeL = self._im_data[0].shape, arr.shape
 
-        # subsample t on long movies (a footprint needn't read every frame), then max over t/z/c;
-        # process axes high→low so earlier index removals don't invalidate the still-pending lower ones
-        if it is not None and shapeL[it] > _MAX_MIP_T:
-            idx = np.linspace(0, shapeL[it] - 1, _MAX_MIP_T).astype(int)
-            arr = np.take(arr, idx, axis=it)
         a = arr
-        for ax in sorted([ax for ax in (it, iz, ic) if ax is not None], reverse=True):
-            a = a.max(axis=ax)
-        mip = np.asarray(a)   # small 2-D → compute eagerly (pyramid levels are lazy dask arrays)
+        if ic is not None:
+            a = a.max(axis=ic)                          # drop channel → array axes = the display order
+        if iz is not None:
+            z_disp = self._display_axes().index("z")    # z index within the (channel-dropped) display axes
+            a = a.max(axis=z_disp, keepdims=True)       # collapse z to a singleton, then...
+            # ...broadcast it back across the FULL z extent so the projection shows at ANY z-slider
+            # position. The hidden full-z data layers set the viewer's z range; a size-1 z would be blank
+            # at z>0 (the "blank image"). Lazy view — every z slice references the one projection.
+            tgt = list(a.shape); tgt[z_disp] = int(shape0[iz])
+            a = da.broadcast_to(a, tuple(tgt))
 
-        disp = self._display_axes()
-        sy0 = float(self._im_scale[disp.index("y")]) if self._im_scale else 1.0
-        sx0 = float(self._im_scale[disp.index("x")]) if self._im_scale else 1.0
-        sy = sy0 * (shape0[iy] / shapeL[iy])     # world µm/px at this coarse level
-        sx = sx0 * (shape0[ix] / shapeL[ix])
-        return mip, (sy, sx), (int(mip.shape[0]), int(mip.shape[1]))
+        disp = self._display_axes()                     # e.g. ['t','z','y','x'] — matches `a`'s axes now
+        def sc(al):
+            base = float(self._im_scale[disp.index(al)]) if (self._im_scale and al in disp) else 1.0
+            if al == "y":
+                return base * (shape0[iy] / shapeL[iy])  # coarse-level µm/px
+            if al == "x":
+                return base * (shape0[ix] / shapeL[ix])
+            return base
+        scale = tuple(sc(al) for al in disp)
+        unit  = self._im_units[0] if self._im_units else None
+        units = tuple(unit for _ in disp) if unit is not None else None
+        return a, scale, units, (int(shapeL[iy]), int(shapeL[ix]))
 
     def apply_crop(self, z_lo_frac=0.0, z_hi_frac=1.0):
         """Read the drawn rectangle + z-range → set axis-aligned clipping planes on the data layers,
@@ -1039,7 +1057,7 @@ class NapariState:
         shapes = [np.asarray(s) for s in layer.data if np.asarray(s).shape[0] >= 3]
         if not shapes:
             raise RuntimeError("no crop region drawn")
-        verts = np.concatenate(shapes, axis=0)[:, -2:]   # (…, y, x) data coords of the coarse MIP level
+        verts = shapes[-1][:, -2:]                        # LAST-drawn rectangle, (y, x) coarse-MIP coords
         sy, sx = float(layer.scale[-2]), float(layer.scale[-1])
         y0, x0 = verts.min(axis=0)
         y1, x1 = verts.max(axis=0)
@@ -1077,7 +1095,7 @@ class NapariState:
         shapes = [np.asarray(s) for s in layer.data if np.asarray(s).shape[0] >= 3]
         if not shapes:
             raise RuntimeError("no crop region drawn")
-        verts = np.concatenate(shapes, axis=0)[:, -2:]         # (…, y, x) coarse-level data coords
+        verts = shapes[-1][:, -2:]                              # LAST-drawn rectangle, (y, x) coarse coords
         sy, sx = float(layer.scale[-2]), float(layer.scale[-1])  # coarse µm/px
         disp = self._display_axes()
         axes = [a.lower() for a in self._axes]

--- a/python/cecelia/tests/test_napari_utils.py
+++ b/python/cecelia/tests/test_napari_utils.py
@@ -405,38 +405,46 @@ class TestAxisAlignedClipPlanes(unittest.TestCase):
     # display axes for a t,z,y,x viewer; the crop box only names spatial axes
     DISP = ['t', 'z', 'y', 'x']
 
-    def test_two_planes_per_axis_in_data_coords(self):
-        # image layer (t,z,y,x), scale 1µm/px on t, 2 on z, 0.5 on y/x
+    def test_three_d_vectors_over_displayed_zyx(self):
+        # image layer (t,z,y,x), scale 1µm/px on t, 2 on z, 0.5 on y/x. Clipping planes are 3-D:
+        # position/normal are 3-vectors over the displayed z,y,x (t is dropped), NOT ndim-length.
         layer = _ClipLayer(4, [1.0, 2.0, 0.5, 0.5])
         box = {'z': (4.0, 20.0), 'y': (5.0, 50.0), 'x': (10.0, 100.0)}
         planes = napari_utils.axis_aligned_clip_planes(layer, box, self.DISP)
         self.assertEqual(len(planes), 6)                         # 2 planes × 3 axes
-        # z is layer dim 1: lo 4µm/2 = 2px (normal +), hi 20µm/2 = 10px (normal -)
+        for p in planes:
+            self.assertEqual(len(p['position']), 3)              # 3-D, not 4
+            self.assertEqual(len(p['normal']), 3)
+        # z is the first displayed dim (slot 0): lo 4µm/2 = 2px (normal +), hi 20µm/2 = 10px (normal -)
         z_lo, z_hi = planes[0], planes[1]
-        self.assertEqual(z_lo['position'][1], 2.0)
-        self.assertEqual(z_lo['normal'], (0.0, 1.0, 0.0, 0.0))
-        self.assertEqual(z_hi['position'][1], 10.0)
-        self.assertEqual(z_hi['normal'], (0.0, -1.0, 0.0, 0.0))
+        self.assertEqual(z_lo['position'][0], 2.0)
+        self.assertEqual(z_lo['normal'], (1.0, 0.0, 0.0))
+        self.assertEqual(z_hi['position'][0], 10.0)
+        self.assertEqual(z_hi['normal'], (-1.0, 0.0, 0.0))
+        # x is the third displayed dim (slot 2): lo 10µm/0.5 = 20px
+        self.assertEqual(planes[4]['position'][2], 20.0)
         self.assertTrue(all(p['enabled'] for p in planes))
 
     def test_trailing_alignment_for_fewer_dims(self):
-        # a (z,y,x) layer in a (t,z,y,x) viewer: dims are right-aligned, so 'z' is layer dim 0
+        # a (z,y,x) layer in a (t,z,y,x) viewer: dims are right-aligned, so 'z' is layer dim 0 = slot 0
         layer = _ClipLayer(3, [2.0, 0.5, 0.5])
         planes = napari_utils.axis_aligned_clip_planes(layer, {'z': (4.0, 20.0)}, self.DISP)
         self.assertEqual(len(planes), 2)
-        self.assertEqual(planes[0]['position'][0], 2.0)          # 4µm / 2 = 2px at layer dim 0
+        self.assertEqual(planes[0]['position'][0], 2.0)          # 4µm / 2 = 2px at slot 0
         self.assertEqual(planes[0]['normal'], (1.0, 0.0, 0.0))
 
     def test_translate_offset_applied(self):
-        layer = _ClipLayer(2, [1.0, 1.0], translate=[10.0, 0.0])   # y translated +10µm
-        planes = napari_utils.axis_aligned_clip_planes(layer, {'y': (10.0, 30.0)}, ['y', 'x'])
-        self.assertEqual(planes[0]['position'][0], 0.0)           # (10-10)/1 = 0px
-        self.assertEqual(planes[1]['position'][0], 20.0)          # (30-10)/1 = 20px
+        # (z,y,x) with y translated +10µm; y is displayed slot 1
+        layer = _ClipLayer(3, [1.0, 1.0, 1.0], translate=[0.0, 10.0, 0.0])
+        planes = napari_utils.axis_aligned_clip_planes(layer, {'y': (10.0, 30.0)}, self.DISP)
+        self.assertEqual(len(planes), 2)
+        self.assertEqual(planes[0]['position'][1], 0.0)          # (10-10)/1 = 0px
+        self.assertEqual(planes[1]['position'][1], 20.0)         # (30-10)/1 = 20px
 
-    def test_axis_absent_from_layer_is_skipped(self):
-        # a 2-D (y,x) layer can't be clipped on z → no z planes
+    def test_two_d_layer_returns_empty(self):
+        # clipping planes are a 3-D volume feature — a 2-D (y,x) layer has nothing to clip
         layer = _ClipLayer(2, [0.5, 0.5])
-        planes = napari_utils.axis_aligned_clip_planes(layer, {'z': (0.0, 5.0)}, self.DISP)
+        planes = napari_utils.axis_aligned_clip_planes(layer, {'y': (0.0, 5.0), 'x': (0.0, 5.0)}, self.DISP)
         self.assertEqual(planes, [])
 
 

--- a/python/cecelia/utils/napari_utils.py
+++ b/python/cecelia/utils/napari_utils.py
@@ -146,6 +146,22 @@ def add_tracks(viewer, tracks, *, scale, units=None, color_by='track_id', colorm
   return viewer.add_tracks(tracks, **kw)
 
 
+def solid_track_colormap(hex_colour, name='cc_pop'):
+  """A **black → colour** two-stop colormap for flat-colouring a Tracks layer in a single population
+  colour — the idiom the old R viewer used (``cmap_single(['#000000', colour])`` in
+  ``show_tracks(split_tracks=…)``). A napari Tracks layer colours ONLY via ``color_by`` + a colormap:
+  colouring by ``track_id`` keeps napari's built-in turbo (a custom colormap there is ignored), and a
+  same-colour "solid" map doesn't take either. The working recipe: colour by a helper property whose
+  value is a NONZERO constant, mapped through this black→colour map — the value lands at the colour end
+  (0 = black is never hit), so every track in the pop renders in ``hex_colour``. See old-R
+  ``inst/py/napari_utils.py::show_tracks``."""
+  require_napari()
+  import napari
+  s = str(hex_colour).lstrip('#')
+  rgba = (int(s[0:2], 16) / 255., int(s[2:4], 16) / 255., int(s[4:6], 16) / 255., 1.0)
+  return napari.utils.Colormap([(0.0, 0.0, 0.0, 1.0), rgba], name=name)
+
+
 # ── 3D crop (axis-aligned clipping planes) ────────────────────────────────────
 
 def axis_aligned_clip_planes(layer, world_box, display_axes):
@@ -159,11 +175,20 @@ def axis_aligned_clip_planes(layer, world_box, display_axes):
   ``-axis``); napari intersects all enabled planes, so the kept region is the box. Returns ``[]`` when
   no requested axis lands inside the layer.
 
+  napari clipping planes are **3-D constructs**: ``position``/``normal`` are always 3-vectors over the
+  DISPLAYED spatial dims (the layer's last 3 = z,y,x), regardless of the layer's ndim. Emitting
+  ndim-length vectors for a 4-D (t,z,y,x) layer makes napari reject them silently → nothing clips.
+  Returns ``[]`` for a layer with < 3 dims (clipping is a volume-render feature).
+
   Pure geometry (no napari import): unit-testable with a lightweight stand-in exposing
   ``ndim``/``scale``/``translate``. World→data uses the layer's own ``scale``/``translate`` (each layer
   may differ — image, labels, tracks and points can carry distinct scales), so a single world box clips
   them all consistently."""
   nd = int(layer.ndim)
+  if nd < 3:
+    return []                                # clipping planes are 3-D; a 2-D layer has no volume to clip
+  n_disp = 3                                  # position/normal are 3-vectors over the displayed z,y,x
+  disp_dims = list(range(nd - n_disp, nd))    # the last 3 layer dims = the displayed spatial axes
   scale = np.asarray(layer.scale, dtype=float)
   translate = np.asarray(layer.translate, dtype=float)
   offset = len(display_axes) - nd            # dims are trailing-aligned to the viewer axes
@@ -171,16 +196,17 @@ def axis_aligned_clip_planes(layer, world_box, display_axes):
   for ax, bounds in world_box.items():
     if ax not in display_axes:
       continue
-    ldim = display_axes.index(ax) - offset
-    if ldim < 0 or ldim >= nd:
-      continue
+    ldim = display_axes.index(ax) - offset   # this axis's index in the layer's own dims
+    if ldim not in disp_dims:
+      continue                               # not a displayed spatial dim (e.g. t) → can't clip on it
+    vi = disp_dims.index(ldim)               # its slot in the 3-vector
     s = scale[ldim] if ldim < len(scale) and scale[ldim] else 1.0
     tr = translate[ldim] if ldim < len(translate) else 0.0
     lo_d = (float(bounds[0]) - tr) / s
     hi_d = (float(bounds[1]) - tr) / s
     for coord, sign in ((lo_d, 1.0), (hi_d, -1.0)):
-      pos = [0.0] * nd; pos[ldim] = coord
-      nrm = [0.0] * nd; nrm[ldim] = sign
+      pos = [0.0] * n_disp; pos[vi] = coord
+      nrm = [0.0] * n_disp; nrm[vi] = sign
       planes.append({"position": tuple(pos), "normal": tuple(nrm), "enabled": True})
   return planes
 


### PR DESCRIPTION
## Napari: track-cluster colours + 3D-crop draw fixes (live-testing round)

Fixes from driving the 3D crop + track overlays live. All bridge-side → **needs a napari restart** to take effect.

### Track colours
- Named **track / trackclust** pops now render in their **pop colour**, the old-R way: colour a **nonzero-constant** helper property through a **black→colour** colormap (`napari_utils.solid_track_colormap` = R's `cmap_single(['#000000', colour])`). Colouring by `track_id` kept napari's built-in turbo, and a same-colour "solid" map was ignored — both were why the colour never showed. `_tracked` still gets turbo; colour-by columns unchanged. Also fixes trackclust ribbons not appearing on open (needed a re-toggle). ✅ verified live.

### 3D crop (draw / preview / save)
- **Preview loaded the original** → clipping planes are **3-D**: `axis_aligned_clip_planes` now emits 3-vectors over the displayed z,y,x (was ndim-length → napari silently rejected them).
- **Save "not cropped"** → the draw layer starts **empty** (draw one rectangle) and the readers use the **last-drawn** shape (a prefilled full-extent rect + a drawn one made the box span their union = full image). ✅ save verified live.
- **t slider while cropping** → the MIP maxes z+channels but **keeps t** (lazy dask), with z **broadcast** back across the full extent so it's not blank at z>0 and stays aligned to the viewer's t/z sliders (a z-dropped layer right-aligned onto Z, so the real T slider moved nothing).
- **Progress feedback** → crop-start shows a "preparing…" spinner; Save shows a "Cropping…" strip driven by the `cropImage` scheduler task (cleared on done/failed) + a "Cropped image ready" log.

### Marked work-in-progress
- The crop section now carries a **"work in progress"** tag (Viewer panel + `docs/NAPARI.md`): it works, but the workflow is still awkward and being improved.

### Tests
Clip-plane geometry tests updated for 3-D vectors; `test-py` (39), `typecheck` green.

### ⚠️ Not verified live yet
Crop **preview** clipping, the **t-slider scrub**, the **blank-fix**, and the **progress** strip are reasoned + unit-tested but I couldn't confirm them end-to-end (a separate bridge-relaunch issue kept interrupting). Tracks + crop-save are confirmed.

### Not in this PR (follow-up)
Bridge **relaunch-after-`stop-napari`** robustness — a hung discrete-GPU launch leaves `_viewer_starting[]` stuck true, so opens are blocked until a full server restart. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
