### PR TITLE
fix(board): CSV filename only claims a groupBy split when it happened

### DIFF
--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -16,7 +16,7 @@ import TeleportPopover from '../TeleportPopover.vue'
 import PlotChart from '../plots/PlotChart.vue'
 import PlotSpinner from '../plots/PlotSpinner.vue'
 import { useDelayedLoading } from '../../composables/useDelayedLoading'
-import { plotAxisSuffix } from '../../utils/csvName'
+import { plotAxisSuffix, seriesAreGrouped } from '../../utils/csvName'
 import { backendChart, chartsForMeasure, plotDataToCsv, defaultVis, type VisProps, type BuildOpts } from '../../plots/plot'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import type { PlotSpec, PlotDataResponse, PlotSeries, ChartType, SeriesTarget } from '../../plots/types'
@@ -421,7 +421,14 @@ function getCsv(): string | null { return result.value ? plotDataToCsv(result.va
 // filename so two same-type plots (e.g. two "Track measures" boxplots) are distinguishable by their
 // axis, not just "Board_1_Track_measures". Mirrors the single-panel export stem (`spec.id_measure`):
 // the measure is the plotted axis; a groupBy adds a sub-axis. '' for a measure-less population summary.
-function csvName(): string { return plotAxisSuffix(measure.value, groupBy.value, hasMeasure.value) }
+// gate the by_{groupBy} suffix on whether the split ACTUALLY happened: a cell-level groupBy on a
+// track-level measure is echoed but not applied (series come back group=''), so the plot — and thus
+// the filename — is by population. Heatmaps (matrix) always apply their category, so keep it there.
+function csvName(): string {
+  const r = result.value
+  const applied = !!r && (r.chartType === 'matrix' || seriesAreGrouped(r.series))
+  return plotAxisSuffix(measure.value, applied ? groupBy.value : '', hasMeasure.value)
+}
 // a plot-only, LIGHT-theme PNG for the PDF export (no panel chrome; dark theme is on-screen only)
 async function exportImage(): Promise<string | null> { return (await plotRef.value?.toImageURL('png', true)) ?? null }
 defineExpose({ getCsv, csvName, exportImage })

--- a/frontend/src/utils/csvName.test.ts
+++ b/frontend/src/utils/csvName.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { plotAxisSuffix } from './csvName'
+import { plotAxisSuffix, seriesAreGrouped } from './csvName'
 
 describe('plotAxisSuffix', () => {
   it('uses the measure as the axis descriptor', () => {
@@ -23,5 +23,23 @@ describe('plotAxisSuffix', () => {
   it('drops an empty measure even when hasMeasure is true', () => {
     expect(plotAxisSuffix('', 'track_state', true)).toBe('by_track_state')
     expect(plotAxisSuffix('', '', true)).toBe('')
+  })
+})
+
+describe('seriesAreGrouped', () => {
+  it('is true when any series carries a non-empty group level', () => {
+    expect(seriesAreGrouped([{ group: 'A' }, { group: 'B' }])).toBe(true)
+    expect(seriesAreGrouped([{ group: '' }, { group: 'A' }])).toBe(true)  // one real level is enough
+  })
+
+  it('is false when the groupBy was echoed but not applied (all group empty)', () => {
+    // the track-measure case: groupBy set on the request but every series comes back group=''
+    expect(seriesAreGrouped([{ group: '' }, { group: '' }])).toBe(false)
+    expect(seriesAreGrouped([{}, {}])).toBe(false)                        // group omitted entirely
+  })
+
+  it('is false for no/empty series', () => {
+    expect(seriesAreGrouped([])).toBe(false)
+    expect(seriesAreGrouped(undefined)).toBe(false)
   })
 })

--- a/frontend/src/utils/csvName.ts
+++ b/frontend/src/utils/csvName.ts
@@ -14,3 +14,12 @@ export function plotAxisSuffix(measure: string | undefined, groupBy: string | un
   if (groupBy) parts.push(`by_${groupBy}`)
   return parts.join('_')
 }
+
+// Was the data ACTUALLY split by the groupBy column? A groupBy can be requested but not apply — e.g. a
+// cell-level column (`live.cell.hmm.state.*`) on a track-level measure: the backend echoes the groupBy
+// but returns every series with `group=''`, so the plot renders by population. The CSV filename must
+// reflect what was plotted, not what was merely selected — so gate the `by_{groupBy}` suffix on this.
+// Mirrors the plot renderer's own "does it vary by group" check (see frontend/src/plots/plot.ts).
+export function seriesAreGrouped(series: ReadonlyArray<{ group?: string }> | undefined): boolean {
+  return !!series && series.some(s => (s.group ?? '') !== '')
+}


### PR DESCRIPTION
## The bug

The board CSV export named files by the raw UI `groupBy` selection even when that groupBy **didn't apply**. `live.track.displacement` is a track-level measure; `live.cell.hmm.state.movement` is a cell-level column. The backend can't split a per-track measure by a per-cell state, so it echoes the `groupBy` but returns every series with `group=''` → the plot renders **by population**. Only the filename claimed the split:

`Board_1_Track_measures_live.track.displacement_by_live.cell.hmm.state.movement.csv` → now `Board_1_Track_measures_live.track.displacement.csv`.

## The fix

`csvName()` gates the `by_{groupBy}` suffix on whether the data was **actually** split — a new tested helper `seriesAreGrouped(series)` (any series carries a real group level), mirroring the plot renderer's own "does it vary by group" check (`plots/plot.ts`). Heatmaps (matrix), which always apply their category, keep it.

## Testing
- Frontend: typecheck clean + **159 vitest** (+3 `seriesAreGrouped`: real levels, echoed-but-empty, no series).

## Notes
- Filename honesty only — the plot is unchanged, and a cell-level `groupBy` is still *offered* for a track plot (selectable but no-ops). Filtering `groupByOpts` by granularity would be a separate, larger change.
- Not re-exported from a live board (typecheck + unit tests only); the logic is pure and small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
