### PR TITLE
refactor: one way to open images — consolidate napari bridge onto shared zarr/OME readers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,34 @@ labeled DataFrame — one idiom, no guessing.
 
 ---
 
+## Image / OME-ZARR access — always go through `zarr_utils`
+
+**The same rule as H5AD above, for image data. Never hand-roll opening an image or reading its
+geometry — no bare `zarr.open` / `da.from_zarr` / `tifffile.imread` on image or label stores, and
+no reading NGFF `.zattrs` or OME-XML yourself.** There is ONE set of readers in
+`python/cecelia/utils/zarr_utils.py` (+ `ome_xml_utils.py`); use them everywhere — the pipeline
+tasks, the napari bridge, and any external consumer (e.g. coastal).
+
+| Need | Use |
+|---|---|
+| Open an OME-ZARR (image **or** labels) as a level list | `zarr_utils.open_as_zarr(path, as_dask=…)` / `open_zarr(path, multiscales=N, as_dask=…)` |
+| Resolve the series wrapper (bioformats2raw `0/` vs flat root) | `zarr_utils.series_base(path)` — structural (checks the `multiscales` attr, not the `.ome.zarr` suffix), read-only |
+| NGFF axes / per-axis scale | `zarr_utils.read_axes(path)` / `read_scale(path)` — NGFF-first, OME-XML fallback |
+| OME-XML parse / pixel unit / frame interval | `ome_xml_utils.load_ome_xml(path)` / `read_pixel_unit(path)` / `read_scale_from_ome_xml(path, axes)` / `read_time_increment(path)` |
+
+- **Do not** copy these readers into a new module or re-open a store you already opened. The napari
+  bridge did exactly that — a full private zarr/OME reader stack (`_open_zarr_multiscale`,
+  `_read_axes`, `_read_scale`, `_load_ome_xml`, …) that silently **drifted** from the shared ones —
+  and it has been consolidated back. One implementation; the second is the bug (see the divergent
+  re-implementation warning above).
+- **Reads are read-only.** `zarr_data_to_list` only ever mutates a store on a WRITE-mode open —
+  never on `mode='r'`.
+- **One sanctioned exception — file *creation*.** Writing a *new* multiscales store is the
+  producing task's job, via `zarr_utils.create_multiscales` / `save_dask_as_zarr_multiscales` (or
+  the segmentation writer), not a hand-rolled `zarr.open(..., 'w')`.
+
+---
+
 ## Spawning Python — always go through `run_py`
 
 **Never spawn a Python subprocess by hand. There is one launcher — `run_py` in `app/src/py_runner.jl`

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -247,7 +247,9 @@ The full call chain for "eye button clicked":
    - Calls `_do_open!` → sends `set_task_dir` + `open_image` commands to bridge
    - If auto-load is on, sends `load_layer_props` after
    - Sends `configure_autosave {path, enabled}` last → the bridge live-saves this image on change (see *Layer props persistence*)
-3. Bridge `open_image`: loads zarr, reads axes/scale/unit from metadata, calls `viewer.add_image`, sets contrast limits, optionally enters 3D mode
+3. Bridge `open_image`: opens the store and reads axes/scale/unit **through the shared cecelia readers** (`zarr_utils.open_as_zarr` / `read_axes` / `read_scale`, `ome_xml_utils.read_pixel_unit`), calls `viewer.add_image`, sets contrast limits, optionally enters 3D mode
+
+> **The bridge does NOT hand-roll zarr/OME-XML access.** Opening a store and reading its NGFF/OME geometry go through `cecelia.utils.zarr_utils` + `ome_xml_utils` — the same readers the analysis pipeline uses. The bridge previously carried its own private copies (`_open_zarr_multiscale`, `_read_axes`, `_read_scale`, `_load_ome_xml`, …) that drifted from the shared ones; they were consolidated. See CLAUDE.md → *Image / OME-ZARR access — always go through `zarr_utils`*.
 
 ### Pending open
 
@@ -264,7 +266,7 @@ Two zarr layouts coexist and both must work:
 | `bioformats2raw` | Series wrapper: data at `zarr/0/0`, `zarr/0/1`, … | `zarr/0/.zattrs` |
 | `create_multiscales()` | Flat: data at `zarr/0`, `zarr/1`, … | root `.zattrs` |
 
-`_series_base(path)` detects which by checking whether `path/0` is a directory whose `.zattrs` contains `multiscales`. The rest of the bridge always works relative to the resolved base.
+`zarr_utils.series_base(path)` (shared reader) detects which by checking whether `path/0` is a directory whose metadata contains `multiscales` — structural, so it works regardless of the `.ome.zarr` suffix and for both zarr v2 (`.zattrs`) and v3 (`zarr.json`). All the shared readers work relative to the resolved base.
 
 ---
 

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -15,13 +15,20 @@ import sys
 import threading
 import time
 import urllib.request
-from functools import lru_cache
 
 import dask.array as da
 import napari
 import numpy as np
-import zarr
 from qtpy.QtCore import QTimer
+
+# Shared cecelia readers/helpers — the bridge delegates to these instead of hand-rolling its own.
+#   napari_utils : generic viewer.add_* / colormap / view-state / clip-plane / movie builders
+#                  (shared with coastal); only needs numpy, so top-level.
+#   zarr_utils   : the ONE way to open an OME-ZARR + read its NGFF axes/scale (open_as_zarr,
+#                  read_axes, read_scale); light deps, so top-level.
+# ome_xml_utils (read_pixel_unit / read_time_increment) is imported LAZILY where used, so ome-types'
+# pydantic build cost is paid on first image open rather than at bridge startup.
+from cecelia.utils import napari_utils, zarr_utils
 
 HOST = "localhost"
 PORT = 7655
@@ -46,27 +53,15 @@ _CATEGORICAL_RGBA = [
 ]
 
 
-def _hex_to_rgba(hex_str):
-    """'#rrggbb' → (r, g, b, 1.0) floats in 0..1. None/blank → None."""
-    if not hex_str:
-        return None
-    s = hex_str.lstrip('#')
-    if len(s) != 6:
-        return None
-    try:
-        return (int(s[0:2], 16) / 255., int(s[2:4], 16) / 255., int(s[4:6], 16) / 255., 1.0)
-    except ValueError:
-        return None
+# Colour hex↔RGBA conversion lives in the shared toolkit (napari_utils.hex_to_rgba / rgba_to_hex)
+# so every napari colour path parses hex ONE way; the bridge just calls it.
 
-
-def _rgba_to_hex(rgba):
-    """(r, g, b, a) floats → '#rrggbb'."""
-    return '#{:02x}{:02x}{:02x}'.format(
-        *(max(0, min(255, int(round(c * 255)))) for c in rgba[:3]))
-
-# The shared label-props reader (cecelia.utils.label_props_utils) resolves via the editable
-# `cecelia` install in the pixi env (python/pyproject.toml + the pixi `cecelia` dep) — no sys.path
-# manipulation needed. Launched via `pixi run napari`.
+# The shared helpers (cecelia.utils.napari_utils generic layer/colour builders, and
+# cecelia.utils.label_props_utils for cell data) resolve via the editable `cecelia` install in the
+# pixi env (python/pyproject.toml + the pixi `cecelia` dep) — no sys.path manipulation needed.
+# napari_utils is imported at module top (it only needs numpy); the heavier cecelia data readers
+# (label_props_utils → anndata) stay lazily imported inside the methods that use them. Launched via
+# `pixi run napari`.
 
 
 # ── State class (mirrors NapariUtils) ─────────────────────────────────────────
@@ -127,11 +122,16 @@ class NapariState:
         self._sel_ctx = None
         self._crop_prev_visible = None   # any in-progress crop draw is void once a new image loads
 
-        self._im_data = _open_zarr_multiscale(path, as_dask=as_dask)
+        # open the store + read its geometry through the shared cecelia readers (the same code the
+        # analysis pipeline uses) — one implementation of "open an OME-ZARR, read its axes/scale".
+        # ome_xml_utils is imported lazily so ome-types' pydantic build cost is paid on first open,
+        # not at bridge startup.
+        from cecelia.utils import ome_xml_utils
+        self._im_data, _ = zarr_utils.open_as_zarr(path, as_dask=as_dask)
 
-        # read axes and scale from .zattrs (series-level, set by bioformats2raw)
-        self._axes = _read_axes(path)
-        full_scale = _read_scale(path)   # one value per axis, e.g. [t, c, z, y, x]
+        # read axes and scale from the NGFF metadata (series-level, set by bioformats2raw)
+        self._axes = zarr_utils.read_axes(path)
+        full_scale = zarr_utils.read_scale(path)   # one value per axis, e.g. [t, c, z, y, x]
 
         # channel axis index and scale without channel dimension
         self._channel_axis = None
@@ -145,14 +145,13 @@ class NapariState:
                 self._im_scale = [s for i, s in enumerate(full_scale)
                                   if i != self._channel_axis]
         if self._im_scale is not None:
-            unit = _read_unit_from_ome_xml(path)
+            unit = ome_xml_utils.read_pixel_unit(path)
             self._im_units = tuple(unit for _ in self._im_scale)
 
         # Delegate the actual layer creation to the SHARED generic helper (cecelia.utils.napari_utils,
         # which coastal mirrors): per-channel colormaps, additive blending, contrast-from-sample and the
         # list-name guard live there so both projects render identically. The bridge keeps all the
         # disk/scale/units logic above. See docs/todo/CECELIA_NAPARI_UPSTREAM_PLAN.md.
-        from cecelia.utils import napari_utils
         napari_utils.add_image(
             self._viewer, self._im_data,
             scale=self._im_scale, units=self._im_units,
@@ -259,7 +258,8 @@ class NapariState:
             ov.visible = False
             return
         t_idx = axes.index("t")
-        interval = _read_time_increment(path)        # seconds per frame, or None
+        from cecelia.utils import ome_xml_utils
+        interval = ome_xml_utils.read_time_increment(path)   # seconds per frame, or None
         def _update(event=None):
             try:
                 step = self._viewer.dims.current_step
@@ -289,7 +289,6 @@ class NapariState:
         if label_files is None:
             label_files = [f"{value_name}.zarr"]
 
-        import os
         for label_filename in label_files:
             # name by the value_name (drop the ".zarr") → "(C) Labels", not "(C.zarr) Labels"
             stem = label_filename[:-5] if label_filename.endswith(".zarr") else label_filename
@@ -302,20 +301,16 @@ class NapariState:
                     print(f"[show_labels] skip: not on disk: {labels_path}", flush=True)
                     continue
 
-                store = zarr.open(labels_path, mode="r")
-                n_levels = len(self._im_data) if self._im_data else 1
-                arrays, lvl = [], 0
-                while lvl < n_levels and str(lvl) in store:
-                    arrays.append(da.from_zarr(store[str(lvl)]))
-                    lvl += 1
-                if not arrays:
-                    arrays = [da.from_zarr(store)]
+                # labels are a flat multiscales store (segmentation_utils writes axes + numeric
+                # `datasets`), same layout as an image — open via the shared reader. Cap to the
+                # image's level count so label pyramid levels line up with the image's.
+                n_levels = len(self._im_data) if self._im_data else None
+                arrays, _ = zarr_utils.open_zarr(labels_path, multiscales=n_levels, as_dask=True)
                 # a present-but-unreadable label set is a real error — surface it, don't no-op.
                 if not arrays:
                     raise RuntimeError(f"no label arrays loaded from {labels_path}")
 
                 _remove_layer(self._viewer, layer_name)
-                from cecelia.utils import napari_utils
                 layer = napari_utils.add_labels(
                     self._viewer, arrays if len(arrays) > 1 else arrays[0],
                     name=layer_name, scale=self._im_scale, units=self._im_units, opacity=0.7,
@@ -340,10 +335,10 @@ class NapariState:
             levels = sorted({int(round(v)) for v in finite})
             lvl_colour = {}
             for i, lvl in enumerate(levels):
-                ov = _hex_to_rgba(overrides.get(str(lvl)))                     # user pop colour, or…
+                ov = napari_utils.hex_to_rgba(overrides.get(str(lvl)))         # user pop colour, or…
                 rgba = ov if ov is not None else _CATEGORICAL_RGBA[i % len(_CATEGORICAL_RGBA)]  # …default
                 lvl_colour[lvl] = rgba
-                legend[str(lvl)] = _rgba_to_hex(rgba)
+                legend[str(lvl)] = napari_utils.rgba_to_hex(rgba)
             for lab, v in zip(labels, vals):
                 color_dict[int(lab)] = (0., 0., 0., 0.) if np.isnan(v) else lvl_colour[int(round(v))]
         elif len(finite):
@@ -577,7 +572,6 @@ class NapariState:
             return self._colcol_cache[key]
         import pandas as pd
         from cecelia.utils.label_props_utils import LabelPropsView
-        from cecelia.utils import napari_utils
         path = os.path.join(self._task_dir, "labelProps", f"{value_name}.h5ad")
         view = LabelPropsView(path)
         df = view.view_cols([column, "track_id"]).as_df()   # label + column (+ track_id) if present
@@ -618,7 +612,6 @@ class NapariState:
         tpath = os.path.join(self._task_dir, "labelProps", f"{value_name}__tracks.h5ad")
         if "track_id" not in cell_df.columns or not os.path.isfile(tpath):
             return None
-        from cecelia.utils import napari_utils
         tview = LabelPropsView(tpath)
         tdf = tview.view_cols([column]).as_df()      # label (= track_id) + column
         tview.close()
@@ -634,7 +627,6 @@ class NapariState:
         (sorted) take a user population's colour where one covers them (`overrides` = {value(str) ->
         '#hex'}), else `_CATEGORICAL_RGBA[i]`; missing (-1) → grey. Returns `(Colormap, legend)` where
         legend is `{value(str) -> '#hex'}`; `(None, {})` if there's nothing to map."""
-        import napari
         overrides = overrides or {}
         pv = sorted({float(v) for v in present_values})
         if not pv:
@@ -643,10 +635,10 @@ class NapariState:
         cmap_of, legend = {}, {}
         for i, v in enumerate(reals):
             key = str(int(v)) if float(v).is_integer() else str(v)     # match Julia _val_key
-            ov = _hex_to_rgba(overrides.get(key))
+            ov = napari_utils.hex_to_rgba(overrides.get(key))
             rgba = ov if ov is not None else _CATEGORICAL_RGBA[i % len(_CATEGORICAL_RGBA)]
             cmap_of[v] = rgba
-            legend[key] = _rgba_to_hex(rgba)
+            legend[key] = napari_utils.rgba_to_hex(rgba)
         for v in pv:
             if v < 0:
                 cmap_of[v] = (0.6, 0.6, 0.6, 1.0)        # missing → grey (≈ labels' transparent)
@@ -765,7 +757,6 @@ class NapariState:
                 _remove_layer(self._viewer, name)
             if len(sub) > 0:
                 props = {"track_id": sub[:, 0].astype(int).tolist()}
-                from cecelia.utils import napari_utils
                 # Three colouring modes (napari Tracks colour ONLY via color_by + a colormap):
                 #   1. colour-by column (whole _tracked only) → categorical Okabe–Ito colormaps_dict /
                 #      continuous viridis, keyed by the column;
@@ -980,7 +971,6 @@ class NapariState:
         mip, mip_scale, mip_units, (h, w) = self._z_mip()   # (t?,y,x) lazy dask + matching scale/units
         mip_layer = self._viewer.add_image(mip, name=CROP_MIP_LAYER, colormap="gray",
                                            blending="translucent", scale=mip_scale, units=mip_units)
-        from cecelia.utils import napari_utils
         napari_utils.set_contrast_from_sample(mip_layer)   # percentile contrast → the MIP isn't washed out
 
         # EMPTY rectangle layer (2-D y,x) in draw mode — the user draws ONE rectangle (like cell
@@ -1142,7 +1132,6 @@ class NapariState:
         self._restore_crop_visibility()
 
     def _apply_clip_planes(self, world_box):
-        from cecelia.utils import napari_utils
         disp = self._display_axes()
         for lyr in self._viewer.layers:
             if lyr.name in (CROP_LAYER, CROP_MIP_LAYER, SELECTION_LAYER):
@@ -1302,13 +1291,11 @@ class NapariState:
         """A durable, JSON-safe snapshot of the current view (camera + dims + per-layer display props),
         for zoom-to-source / animation. Delegates to the shared helper so the schema lives in one place
         (cecelia.utils.napari_utils; coastal can reuse it). See docs/todo/ANIMATION_PLAN.md."""
-        from cecelia.utils import napari_utils
         return napari_utils.capture_view_state(self._viewer)
 
     def apply_view_state(self, snapshot):
         """Re-apply a snapshot from `capture_view_state` to the current viewer (missing layers /
         unsettable attrs are skipped). Delegates to the shared helper."""
-        from cecelia.utils import napari_utils
         return napari_utils.apply_view_state(self._viewer, snapshot)
 
     # ── Screenshot ────────────────────────────────────────────────────────────
@@ -1361,7 +1348,6 @@ class NapariState:
         n_t = self._time_axis_len()
         if not n_t or n_t <= 1:
             raise RuntimeError("this image has a single timepoint — nothing to sweep")
-        from cecelia.utils import napari_utils
         frames = napari_utils.record_timelapse(
             self._viewer, path, t_axis_index=axes.index("t"), n_timepoints=n_t,
             fps=fps, canvas_only=canvas_only, scale=scale, t_start=t_start, t_end=t_end)
@@ -1372,7 +1358,6 @@ class NapariState:
         applied + captured with `steps` tween frames from the previous one (camera/contrast/colour/T
         interpolation). The "connect animation steps" render — see docs/todo/ANIMATION_PLAN.md (F2).
         Delegates to the shared `napari_utils.record_keyframes`. Needs ≥2 keyframes."""
-        from cecelia.utils import napari_utils
         frames = napari_utils.record_keyframes(self._viewer, path, keyframes, fps=fps, canvas_only=canvas_only)
         return {"frames": frames, "path": path, "keyframes": len(keyframes)}
 
@@ -1382,165 +1367,10 @@ class NapariState:
         self._task_dir = path
 
 
-# ── OME-ZARR helpers ──────────────────────────────────────────────────────────
-
-def _series_base(path: str) -> str:
-    """Return the path containing resolution-level directories.
-    bioformats2raw: multiscales lives in path/0  → return path/0
-    flat OME-ZARR:  multiscales lives in path    → return path
-    Uses zarr API so it works for both zarr v2 (.zattrs) and zarr v3 (zarr.json).
-    """
-    import os
-    series = os.path.join(path, "0")
-    if not os.path.isdir(series):
-        return path
-    try:
-        g = zarr.open_group(series, mode='r')
-        if g.attrs.get("multiscales"):
-            return series
-    except Exception:
-        pass
-    return path
-
-
-# contrast-from-sample moved to the shared cecelia.utils.napari_utils.set_contrast_from_sample
-# (open_image delegates via napari_utils.add_image(contrast=True)); coastal mirrors it.
-
-
-def _open_zarr_multiscale(path: str, as_dask: bool = True) -> list:
-    """Return list of arrays, one per resolution level.
-    as_dask=True (default): lazy dask arrays — chunked, computed on demand.
-    as_dask=False: raw zarr arrays — direct chunk access, no dask overhead.
-    """
-    import os
-    base = _series_base(path)
-    store = zarr.open_group(base, mode='r')
-    arrays, level = [], 0
-    while str(level) in store:
-        arr = store[str(level)]
-        if as_dask:
-            arr = da.from_array(arr, chunks=arr.chunks)
-        arrays.append(arr)
-        level += 1
-    if not arrays:
-        root = zarr.open_group(path, mode='r')
-        arr = root[next(iter(root))] if len(root) else zarr.open(path, mode='r')
-        if as_dask:
-            arr = da.from_array(arr, chunks=arr.chunks)
-        arrays.append(arr)
-    return arrays
-
-
-def _read_multiscales_meta(path: str) -> dict:
-    """Return the first multiscales entry, checking series dir first.
-    Uses zarr API to handle both zarr v2 (.zattrs) and zarr v3 (zarr.json).
-    """
-    import os
-    for candidate in [os.path.join(path, "0"), path]:
-        if not os.path.isdir(candidate):
-            continue
-        try:
-            g = zarr.open_group(candidate, mode='r')
-            ms = g.attrs.get("multiscales")
-            if ms:
-                return ms[0] if isinstance(ms, list) else {}
-        except Exception:
-            continue
-    return {}
-
-
-def _read_axes(path: str):
-    ms = _read_multiscales_meta(path)
-    axes = ms.get("axes", [])
-    return [ax["name"] for ax in axes] if axes else None
-
-
-@lru_cache(maxsize=64)
-def _parse_ome_xml(xml_path: str, _mtime: float):
-    """Parse one OME-XML file. Cached on (path, mtime) — a long-lived bridge parses each store's
-    metadata at most once (mtime in the key invalidates it if the file is rewritten). `ome_types`
-    is imported lazily here so its pydantic model-build cost is paid on first use, not at import."""
-    from ome_types import from_xml
-    with open(xml_path) as f:
-        return from_xml(f.read())
-
-
-def _load_ome_xml(path: str):
-    """Locate and parse a store's OME-XML (OME/METADATA.ome.xml or METADATA.ome.xml), or None.
-    Shared by the readers below so a single open parses the file once instead of two or three times."""
-    import os
-    for candidate in (
-        os.path.join(path, "OME", "METADATA.ome.xml"),
-        os.path.join(path, "METADATA.ome.xml"),
-    ):
-        if os.path.isfile(candidate):
-            try:
-                return _parse_ome_xml(candidate, os.path.getmtime(candidate))
-            except Exception:
-                return None
-    return None
-
-
-def _read_unit_from_ome_xml(path: str) -> str:
-    """Read physical pixel unit from OME-XML metadata. Returns 'µm' as default."""
-    omexml = _load_ome_xml(path)
-    if omexml is not None:
-        try:
-            unit = omexml.images[0].pixels.physical_size_x_unit
-            if unit is not None:
-                return unit.value  # e.g. 'µm', 'nm', 'mm'
-        except Exception:
-            pass
-    return 'µm'
-
-
-def _read_scale_from_ome_xml(path: str, axes):
-    """Read physical pixel scale from OME-XML metadata, returning values in axis order."""
-    omexml = _load_ome_xml(path)
-    if omexml is None:
-        return None
-    try:
-        pixels = omexml.images[0].pixels
-        sizes = {
-            'x': pixels.physical_size_x,
-            'y': pixels.physical_size_y,
-            'z': pixels.physical_size_z,
-        }
-        return [float(sizes.get(ax.lower()) or 1.0) for ax in axes]
-    except Exception:
-        return None
-
-
-def _read_scale(path: str):
-    """Return scale list (one value per axis, physical units) or None."""
-    ms = _read_multiscales_meta(path)
-    for dataset in ms.get("datasets", [])[:1]:
-        for t in dataset.get("coordinateTransformations", []):
-            if t.get("type") == "scale":
-                return t["scale"]
-    # Fallback: read from OME-XML when zarr metadata has no coordinateTransformations.
-    axes = _read_axes(path)
-    if axes:
-        return _read_scale_from_ome_xml(path, axes)
-    return None
-
-
-def _read_time_increment(path: str):
-    """Seconds between timepoints from OME-XML `pixels.time_increment` (with its unit), or None.
-    Used for the timecourse timestamp overlay. Converts ms/min/h to seconds where the unit says so."""
-    omexml = _load_ome_xml(path)
-    if omexml is None:
-        return None
-    try:
-        pixels = omexml.images[0].pixels
-        inc = pixels.time_increment
-        if inc is None:
-            return None
-        secs = float(inc)
-        unit = getattr(getattr(pixels, "time_increment_unit", None), "value", None)
-        return {"ms": secs / 1000.0, "min": secs * 60.0, "h": secs * 3600.0}.get(unit, secs)
-    except Exception:
-        return None
+# OME-ZARR store opening + NGFF/OME-XML geometry reading now live in the shared cecelia readers
+# (cecelia.utils.zarr_utils: open_as_zarr/open_zarr, series_base, read_axes, read_scale;
+# cecelia.utils.ome_xml_utils: read_pixel_unit, read_time_increment). The bridge used to carry
+# its own copies — they were consolidated so images are opened ONE way. See docs/NAPARI.md.
 
 
 def _remove_layer(viewer: napari.Viewer, name: str):

--- a/python/cecelia/tasks/segment/measure_labels_run.py
+++ b/python/cecelia/tasks/segment/measure_labels_run.py
@@ -25,7 +25,6 @@ import sys
 import os
 # `cecelia.*` resolves via PYTHONPATH=python/, set by the Julia launcher (app/src/py_runner.jl::run_py).
 
-import zarr
 import cecelia.utils.zarr_utils as zarr_utils
 import cecelia.utils.ome_xml_utils as ome_xml_utils
 import cecelia.utils.script_utils as script_utils
@@ -75,7 +74,9 @@ def run(params: dict):
             continue
         ltype = _label_type_from_filename(fname, out_vn)
         try:
-            label_zarrs[ltype] = zarr.open(fpath, mode='r')
+            # open labels through the shared reader (same as the image above) — a list of
+            # multiscale levels; measure_from_zarr takes level 0 (full-res). NOT hand-rolled zarr.
+            label_zarrs[ltype], _ = zarr_utils.open_as_zarr(fpath, as_dask=use_dask)
             log.log(f'>> opened label "{ltype}": {fpath}')
         except Exception as e:
             log.log(f'[WARN] Could not open {fpath}: {e}')

--- a/python/cecelia/tests/test_image_readers.py
+++ b/python/cecelia/tests/test_image_readers.py
@@ -1,0 +1,152 @@
+"""Unit tests for the shared OME-ZARR / OME-XML readers (cecelia.utils.zarr_utils +
+cecelia.utils.ome_xml_utils).
+
+These readers used to live as private copies inside the napari bridge (napari/napari_bridge.py);
+they were consolidated here so images are opened and their geometry read ONE way across the bridge,
+the analysis pipeline and coastal. This is their first unit coverage — it pins:
+  - series_base: structural bioformats2raw-series-wrapper detection (nested `0/` vs flat root),
+  - read_axes / read_scale: NGFF axes + coordinateTransformations, with the OME-XML scale fallback,
+  - open_as_zarr: a read-only multiscale open on both layouts,
+  - ome_xml_utils.load_ome_xml + read_pixel_unit / read_scale_from_ome_xml / read_time_increment.
+
+Part of the Python (analysis-env) suite — run with `pixi run test-py`.
+"""
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+import zarr
+
+import cecelia.utils.zarr_utils as zu
+import cecelia.utils.ome_xml_utils as ox
+
+AXES = ("t", "c", "z", "y", "x")
+SHAPE = (1, 1, 4, 8, 8)
+SCALE = [1.0, 1.0, 2.0, 0.5, 0.5]
+
+
+def _multiscales(scale=SCALE, with_scale=True):
+    ds = {"path": "0"}
+    if with_scale:
+        ds["coordinateTransformations"] = [{"type": "scale", "scale": list(scale)}]
+    return [{"axes": [{"name": a} for a in AXES], "datasets": [ds]}]
+
+
+def _make_flat_store(path, with_scale=True):
+    """Flat store (create_multiscales / segmentation_utils layout): multiscales + numeric arrays at root."""
+    g = zarr.open_group(path, mode="w", zarr_format=2)
+    g.attrs["multiscales"] = _multiscales(with_scale=with_scale)
+    g.create_array("0", data=np.zeros(SHAPE, dtype=np.uint16), chunks=SHAPE)
+    return path
+
+
+def _make_nested_store(path):
+    """bioformats2raw layout: a series group at `0/` holds the multiscales; arrays at `0/0`."""
+    root = zarr.open_group(path, mode="w", zarr_format=2)
+    series = root.create_group("0")
+    series.attrs["multiscales"] = _multiscales()
+    series.create_array("0", data=np.zeros(SHAPE, dtype=np.uint16), chunks=SHAPE)
+    return path
+
+
+_OME_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06">
+  <Image ID="Image:0" Name="test">
+    <Pixels ID="Pixels:0" DimensionOrder="XYZCT" Type="uint16"
+            SizeX="8" SizeY="8" SizeZ="4" SizeC="1" SizeT="1"
+            PhysicalSizeX="0.5" PhysicalSizeXUnit="µm"
+            PhysicalSizeY="0.5" PhysicalSizeYUnit="µm"
+            PhysicalSizeZ="2.0" PhysicalSizeZUnit="µm"
+            TimeIncrement="30.0" TimeIncrementUnit="s">
+      <Channel ID="Channel:0" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </Pixels>
+  </Image>
+</OME>
+"""
+
+
+def _write_ome_xml(store):
+    ome_dir = os.path.join(store, "OME")
+    os.makedirs(ome_dir, exist_ok=True)
+    with open(os.path.join(ome_dir, "METADATA.ome.xml"), "w") as f:
+        f.write(_OME_XML)
+
+
+class SeriesBaseTest(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.d, ignore_errors=True)
+
+    def test_flat_returns_root(self):
+        p = _make_flat_store(os.path.join(self.d, "flat.ome.zarr"))
+        # a flat store also has a `0/` dir (its level-0 array) but it carries NO multiscales attr,
+        # so series_base must NOT step into it
+        self.assertEqual(zu.series_base(p), p)
+
+    def test_nested_steps_into_series(self):
+        p = _make_nested_store(os.path.join(self.d, "nested.ome.zarr"))
+        self.assertEqual(zu.series_base(p), os.path.join(p, "0"))
+
+
+class NgffGeometryTest(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.d, ignore_errors=True)
+
+    def test_axes_and_scale_flat(self):
+        p = _make_flat_store(os.path.join(self.d, "flat.ome.zarr"))
+        self.assertEqual(zu.read_axes(p), list(AXES))
+        self.assertEqual(zu.read_scale(p), SCALE)
+
+    def test_axes_and_scale_nested(self):
+        p = _make_nested_store(os.path.join(self.d, "nested.ome.zarr"))
+        self.assertEqual(zu.read_axes(p), list(AXES))
+        self.assertEqual(zu.read_scale(p), SCALE)
+
+    def test_scale_falls_back_to_ome_xml(self):
+        # no coordinateTransformations in the NGFF metadata → read_scale reads OME-XML physical sizes
+        p = _make_flat_store(os.path.join(self.d, "noscale.ome.zarr"), with_scale=False)
+        _write_ome_xml(p)
+        self.assertEqual(zu.read_scale(p), SCALE)   # t,c → 1.0; z,y,x from OME-XML
+
+    def test_open_as_zarr_readonly_both_layouts(self):
+        for maker, name in ((_make_flat_store, "flat"), (_make_nested_store, "nested")):
+            p = maker(os.path.join(self.d, f"{name}.ome.zarr"))
+            data, _ = zu.open_as_zarr(p, as_dask=True)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(tuple(data[0].shape), SHAPE)
+
+
+class OmeXmlReaderTest(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.store = _make_flat_store(os.path.join(self.d, "img.ome.zarr"))
+        _write_ome_xml(self.store)
+
+    def tearDown(self):
+        shutil.rmtree(self.d, ignore_errors=True)
+
+    def test_load_ome_xml_found_and_missing(self):
+        self.assertIsNotNone(ox.load_ome_xml(self.store))
+        self.assertIsNone(ox.load_ome_xml(os.path.join(self.d, "does-not-exist")))
+
+    def test_pixel_unit_preserves_micron(self):
+        self.assertEqual(ox.read_pixel_unit(self.store), "µm")   # NOT normalised to 'um'
+        self.assertEqual(ox.read_pixel_unit(os.path.join(self.d, "nope")), "µm")  # default
+
+    def test_scale_from_ome_xml_in_axis_order(self):
+        self.assertEqual(ox.read_scale_from_ome_xml(self.store, AXES), SCALE)
+
+    def test_time_increment_seconds(self):
+        self.assertEqual(ox.read_time_increment(self.store), 30.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/cecelia/tests/test_napari_utils.py
+++ b/python/cecelia/tests/test_napari_utils.py
@@ -290,6 +290,31 @@ class TestIsCategoricalColumn(unittest.TestCase):
         self.assertFalse(napari_utils.is_categorical_column('area', np.arange(0., 100., 2.0)))
 
 
+class TestHexRgbaConversion(unittest.TestCase):
+    """Colour hex↔RGBA float — the ONE parse shared across every napari colour path (labels/tracks
+    colormaps, points face_color, the solid track colormap); the bridge delegates here."""
+
+    def test_hex_to_rgba_parses(self):
+        self.assertEqual(napari_utils.hex_to_rgba('#ffffff'), (1.0, 1.0, 1.0, 1.0))
+        self.assertEqual(napari_utils.hex_to_rgba('#000000'), (0.0, 0.0, 0.0, 1.0))
+        r, g, b, a = napari_utils.hex_to_rgba('#ff8000')      # tolerates a missing leading '#' too
+        self.assertAlmostEqual(r, 1.0); self.assertAlmostEqual(b, 0.0); self.assertEqual(a, 1.0)
+        self.assertEqual(napari_utils.hex_to_rgba('ff8000'), napari_utils.hex_to_rgba('#ff8000'))
+
+    def test_hex_to_rgba_malformed_is_none(self):
+        for bad in (None, '', '#fff', '#gggggg', 'not-a-colour'):
+            self.assertIsNone(napari_utils.hex_to_rgba(bad))
+
+    def test_rgba_to_hex_clamps_and_drops_alpha(self):
+        self.assertEqual(napari_utils.rgba_to_hex((1.0, 1.0, 1.0, 1.0)), '#ffffff')
+        self.assertEqual(napari_utils.rgba_to_hex((0.0, 0.0, 0.0)), '#000000')
+        self.assertEqual(napari_utils.rgba_to_hex((2.0, -1.0, 0.5, 0.3)), '#ff0080')  # clamped to 0..255
+
+    def test_round_trip(self):
+        for hx in ('#123456', '#abcdef', '#00ff88'):
+            self.assertEqual(napari_utils.rgba_to_hex(napari_utils.hex_to_rgba(hx)), hx)
+
+
 class TestBroadcastTrackToCells(unittest.TestCase):
     """Colour cells by their TRACK's value (clusters.* broadcast) — the track↔cell join behind
     'colour tracks by their cluster/population' (ports R split_tracks)."""

--- a/python/cecelia/utils/measure_utils.py
+++ b/python/cecelia/utils/measure_utils.py
@@ -68,8 +68,9 @@ class MeasureUtils:
 
     def measure_from_zarr(self, label_zarrs: dict, im_dat, log):
         """
-        label_zarrs : {'base': zarr.Group, 'nuc': zarr.Group, …}  – multiscale groups
-        im_dat      : multiscale zarr group for the intensity image
+        label_zarrs : {'base': [level0, level1, …], 'nuc': […], …}  – multiscale level lists
+                      (as returned by zarr_utils.open_as_zarr; level 0 is full-res)
+        im_dat      : multiscale level list for the intensity image (im_dat[0] = full-res)
         log         : script_utils logfile helper (has .log(str))
 
         All label types are measured together and written to a single .h5ad file.
@@ -91,7 +92,7 @@ class MeasureUtils:
         label_dim_order = [ax for ax in dim_order if ax != 'C']
         l_la_t = label_dim_order.index('T') if 'T' in label_dim_order else None
 
-        base_arr = label_zarrs['base']['0']   # full-res array
+        base_arr = label_zarrs['base'][0]   # full-res array (level 0)
         im_arr   = im_dat[0]
 
         if is_3d and self.extended_measures and not _HAS_TRIMESH:
@@ -130,7 +131,7 @@ class MeasureUtils:
             for ltype, lzarr in label_zarrs.items():
                 if ltype == 'base':
                     continue
-                sec_vol = self._extract_t(lzarr['0'], l_la_t, t_idx)
+                sec_vol = self._extract_t(lzarr[0], l_la_t, t_idx)
                 morph_df = self._measure_secondary_intensities(
                     morph_df, sec_vol, im_vol, la_c, la_t, n_c, ltype)
 

--- a/python/cecelia/utils/napari_utils.py
+++ b/python/cecelia/utils/napari_utils.py
@@ -146,6 +146,29 @@ def add_tracks(viewer, tracks, *, scale, units=None, color_by='track_id', colorm
   return viewer.add_tracks(tracks, **kw)
 
 
+# ── Colour conversion (hex ↔ RGBA float) ──────────────────────────────────────
+# Shared so every napari colour path parses hex ONE way — labels/tracks colormaps, points
+# face_color, and the solid track colormap below. cecelia's bridge imports these; coastal can too.
+
+def hex_to_rgba(hex_colour):
+  """``'#rrggbb'`` → ``(r, g, b, 1.0)`` floats in 0..1. None / blank / malformed → None."""
+  if not hex_colour:
+    return None
+  s = str(hex_colour).lstrip('#')
+  if len(s) != 6:
+    return None
+  try:
+    return (int(s[0:2], 16) / 255., int(s[2:4], 16) / 255., int(s[4:6], 16) / 255., 1.0)
+  except ValueError:
+    return None
+
+
+def rgba_to_hex(rgba):
+  """``(r, g, b, a)`` floats in 0..1 → ``'#rrggbb'`` (alpha dropped, channels clamped to 0..255)."""
+  return '#{:02x}{:02x}{:02x}'.format(
+    *(max(0, min(255, int(round(c * 255)))) for c in rgba[:3]))
+
+
 def solid_track_colormap(hex_colour, name='cc_pop'):
   """A **black → colour** two-stop colormap for flat-colouring a Tracks layer in a single population
   colour — the idiom the old R viewer used (``cmap_single(['#000000', colour])`` in
@@ -155,10 +178,8 @@ def solid_track_colormap(hex_colour, name='cc_pop'):
   value is a NONZERO constant, mapped through this black→colour map — the value lands at the colour end
   (0 = black is never hit), so every track in the pop renders in ``hex_colour``. See old-R
   ``inst/py/napari_utils.py::show_tracks``."""
-  require_napari()
-  import napari
-  s = str(hex_colour).lstrip('#')
-  rgba = (int(s[0:2], 16) / 255., int(s[2:4], 16) / 255., int(s[4:6], 16) / 255., 1.0)
+  napari = require_napari()
+  rgba = hex_to_rgba(hex_colour) or (1.0, 1.0, 1.0, 1.0)   # malformed colour → white (never crash a render)
   return napari.utils.Colormap([(0.0, 0.0, 0.0, 1.0), rgba], name=name)
 
 

--- a/python/cecelia/utils/ome_xml_utils.py
+++ b/python/cecelia/utils/ome_xml_utils.py
@@ -7,6 +7,8 @@ or TIFF files.  The canonical on-disk location for OME-ZARR is:
 """
 
 import os
+from functools import lru_cache
+
 import tifffile
 from ome_types import from_xml, from_tiff, to_xml
 
@@ -223,23 +225,87 @@ def parse_meta_from_tiff(im_path):
 Parse metadata from zarr
 """
 def parse_meta_from_zarr(zarr_path):
-  # open XML file
-  # (I) at the moment, the XML is in the Zarr directory
-  # https://github.com/zarr-developers/zarr-specs/issues/112
-  # https://github.com/ome/ngff/issues/27
-  xml_path = os.path.join(zarr_path, "METADATA.ome.xml")
-  
-  if os.path.isfile(xml_path) is False:
-    xml_path = os.path.join(zarr_path, "OME", "METADATA.ome.xml")
-  
-  # https://codecap.org/typeerror-a-bytes-like-object-is-required-not-str/
-  with open(xml_path, "rb") as f:
-    xml_lines = f.readlines()
-    
-  # decode bytes
-  xml_lines = [x.decode() for x in xml_lines]
-  
-  return from_xml(xml_path)
+  # the canonical OME-XML location for an OME-ZARR store is {store}/OME/METADATA.ome.xml (older
+  # stores kept it at the root); load_ome_xml checks both. Raise if neither exists so callers that
+  # rely on metadata fail loudly rather than on a None dereference downstream.
+  omexml = load_ome_xml(zarr_path)
+  if omexml is None:
+    raise FileNotFoundError(f"no OME-XML metadata under {zarr_path}")
+  return omexml
+
+
+@lru_cache(maxsize=64)
+def _parse_ome_xml_cached(xml_path, _mtime):
+  """Parse one OME-XML file, cached on (path, mtime) so a long-lived reader (e.g. the napari
+  bridge) parses each store's metadata at most once; a rewrite (new mtime) invalidates the entry.
+  ome-types is already imported at module top, so the pydantic model-build cost is paid on the
+  first parse regardless."""
+  with open(xml_path) as f:
+    return from_xml(f.read())
+
+
+def load_ome_xml(path):
+  """Locate + parse a store's OME-XML (OME/METADATA.ome.xml, else the legacy root METADATA.ome.xml),
+  or None if absent/unparseable. The ONE OME-XML reader — the napari bridge and the pipeline both
+  go through here instead of re-opening the file themselves."""
+  for candidate in (
+      os.path.join(path, "OME", "METADATA.ome.xml"),
+      os.path.join(path, "METADATA.ome.xml"),
+  ):
+    if os.path.isfile(candidate):
+      try:
+        return _parse_ome_xml_cached(candidate, os.path.getmtime(candidate))
+      except Exception:
+        return None
+  return None
+
+
+def read_pixel_unit(path, default="µm"):
+  """Physical pixel unit from a store's OME-XML (physical_size_x_unit), e.g. 'µm'/'nm'/'mm'. The
+  RAW unit string is preserved (NOT normalised to 'um') so napari's unit-aware rendering matches
+  the image. Returns `default` when the metadata is absent."""
+  omexml = load_ome_xml(path)
+  if omexml is not None:
+    try:
+      unit = omexml.images[0].pixels.physical_size_x_unit
+      if unit is not None:
+        return unit.value
+    except Exception:
+      pass
+  return default
+
+
+def read_scale_from_ome_xml(path, axes):
+  """Per-axis physical pixel scale from OME-XML, in the given `axes` order (an axis with no size →
+  1.0), or None if there's no metadata. The fallback for stores whose NGFF metadata carries no
+  `coordinateTransformations` (see zarr_utils.read_scale)."""
+  omexml = load_ome_xml(path)
+  if omexml is None:
+    return None
+  try:
+    pixels = omexml.images[0].pixels
+    sizes = {"x": pixels.physical_size_x, "y": pixels.physical_size_y, "z": pixels.physical_size_z}
+    return [float(sizes.get(ax.lower()) or 1.0) for ax in axes]
+  except Exception:
+    return None
+
+
+def read_time_increment(path):
+  """Seconds between timepoints from a store's OME-XML `pixels.time_increment` (converting a
+  ms/min/h unit to seconds), or None. Used for the timecourse timestamp overlay."""
+  omexml = load_ome_xml(path)
+  if omexml is None:
+    return None
+  try:
+    pixels = omexml.images[0].pixels
+    inc = pixels.time_increment
+    if inc is None:
+      return None
+    secs = float(inc)
+    unit = getattr(getattr(pixels, "time_increment_unit", None), "value", None)
+    return {"ms": secs / 1000.0, "min": secs * 60.0, "h": secs * 3600.0}.get(unit, secs)
+  except Exception:
+    return None
 
 """
 Parse metadata from zarr file

--- a/python/cecelia/utils/zarr_utils.py
+++ b/python/cecelia/utils/zarr_utils.py
@@ -33,8 +33,7 @@ def open_as_zarr(im_path, multiscales=None, as_dask=False, mode='r'):
 
 
 def open_zarr(zarr_path, mode='r', multiscales=None, as_dask=False):
-    zarr_data, zarr_group_info = zarr_data_to_list(
-        zarr_path, multiscales=multiscales, mode=mode, omezarr=zarr_path.endswith('.ome.zarr'))
+    zarr_data, zarr_group_info = zarr_data_to_list(zarr_path, multiscales=multiscales, mode=mode)
     if as_dask is True:
         zarr_data = zarr_data_to_dask(zarr_data)
     return zarr_data, zarr_group_info
@@ -88,50 +87,110 @@ def plane_chunks(shape, dim_utils=None, xy_tile=512):
     return tuple(min(int(s), xy_tile) if i in spatial else 1 for i, s in enumerate(shape))
 
 
-def open_labels_as_dask(filepath, multiscales=None):
-    zarr_data, zarr_group_info = open_labels_as_zarr(filepath, multiscales=multiscales)
-    return zarr_data_to_dask(zarr_data), zarr_group_info
-
-
-def open_labels_as_zarr(filepath, multiscales=None):
-    return zarr_data_to_list(filepath, multiscales=multiscales, data_group='labels')
+# NOTE: labels are opened the SAME way as images — open_as_zarr / open_zarr (a flat multiscales
+# store with numeric `datasets`; see segmentation_utils). The old `open_labels_as_zarr/_as_dask`
+# (data_group='labels') were a verbatim port from the R version, had NO callers here, and would
+# KeyError on current stores (which key multiscales under 'datasets', not 'labels') — removed.
 
 
 def zarr_data_to_dask(zarr_data):
     return [da.from_zarr(arr) for arr in zarr_data]
 
 
-def zarr_data_to_list(zarr_store, multiscales=None, data_group='datasets', mode='r', omezarr=False):
+def zarr_data_to_list(zarr_store, multiscales=None, mode='r'):
     if type(zarr_store) == str:
-        if os.path.exists(os.path.join(zarr_store, '.zarray')) and os.path.exists(os.path.join(zarr_store, '.group')):
+        # only mutate on a WRITE open — a stray leaf .zarray shadowing a group dir breaks a write.
+        # NEVER touch the store on a read (the napari bridge opens images strictly read-only).
+        if mode != 'r' and os.path.exists(os.path.join(zarr_store, '.zarray')) \
+                and os.path.exists(os.path.join(zarr_store, '.group')):
             os.unlink(os.path.join(zarr_store, '.zarray'))
+        # step into the bioformats2raw series wrapper (path/0) when that's where `multiscales`
+        # lives — detected by STRUCTURE (the attr), not the `.ome.zarr` suffix. Flat
+        # create_multiscales stores keep multiscales at the root; series_base returns them as-is.
+        zarr_store = series_base(zarr_store, mode=mode)
 
     zgroup = zarr.open(zarr_store, mode=mode)
-
-    if omezarr is True and 'multiscales' not in zgroup.attrs:
-        # bioformats2raw wraps arrays in a series group at "0/".
-        # Flat OME-ZARRs (written by create_multiscales) have multiscales at root.
-        zgroup = zgroup["0"]
 
     if 'multiscales' in zgroup.attrs and not isinstance(zgroup, zarr.Array):
         zarr_group_info = None
 
+        datasets = zgroup.attrs['multiscales'][0]['datasets']
         if multiscales is None:
             multiscale_slices = slice(None)
         else:
-            if multiscales > len(zgroup.attrs['multiscales'][0][data_group]):
-                multiscales = len(zgroup.attrs['multiscales'][0][data_group])
+            multiscales = min(multiscales, len(datasets))
             multiscale_slices = slice(0, multiscales, 1)
 
-        zarr_data = [
-            zgroup[dataset['path']]
-            for dataset in zgroup.attrs['multiscales'][0][data_group][multiscale_slices]
-        ]
+        zarr_data = [zgroup[dataset['path']] for dataset in datasets[multiscale_slices]]
     else:
         zarr_group_info = [dict(zgroup.info.obj.info_items())]
         zarr_data = [zgroup]
 
     return zarr_data, zarr_group_info
+
+
+# ── OME-ZARR structure + NGFF geometry (read-only; shared with the napari bridge) ──────────────
+# The single home for "where does this store keep its multiscales / axes / scale". The napari
+# bridge used to carry its own copies of all of these (napari/napari_bridge.py) — they now live
+# here so the bridge, the pipeline and any consumer (e.g. coastal) read OME-ZARR geometry ONE way.
+
+def series_base(path, mode='r'):
+    """The store path that holds the `multiscales` metadata: the bioformats2raw series wrapper
+    (``path/0``) when that's where multiscales lives, else ``path`` (a flat create_multiscales
+    store). STRUCTURE-based (checks the attr, not the ``.ome.zarr`` suffix) and read-only, so it
+    tells a nested series group at ``0/`` apart from a flat store's level-0 array also at ``0/``
+    (the latter has no ``multiscales`` attr). Works for zarr v2 (.zattrs) and v3 (zarr.json)."""
+    series = os.path.join(path, "0")
+    if not os.path.isdir(series):
+        return path
+    try:
+        g = zarr.open_group(series, mode=mode)
+        if g.attrs.get("multiscales"):
+            return series
+    except Exception:
+        pass
+    return path
+
+
+def read_multiscales_meta(path):
+    """First NGFF ``multiscales`` entry (dict) for a store, checking the series dir then the flat
+    root; ``{}`` if there is none."""
+    for candidate in (os.path.join(path, "0"), path):
+        if not os.path.isdir(candidate):
+            continue
+        try:
+            g = zarr.open_group(candidate, mode='r')
+            ms = g.attrs.get("multiscales")
+            if ms:
+                return ms[0] if isinstance(ms, list) else {}
+        except Exception:
+            continue
+    return {}
+
+
+def read_axes(path):
+    """NGFF axis names for a store (e.g. ``['t','c','z','y','x']``), or None."""
+    ms = read_multiscales_meta(path)
+    axes = ms.get("axes", [])
+    return [ax["name"] for ax in axes] if axes else None
+
+
+def read_scale(path):
+    """Per-axis physical scale (one value per axis) for a store: NGFF ``coordinateTransformations``
+    first, falling back to OME-XML physical sizes when the NGFF metadata carries no scale (e.g.
+    processed variants that omit it). None if neither is available."""
+    ms = read_multiscales_meta(path)
+    for dataset in ms.get("datasets", [])[:1]:
+        for t in dataset.get("coordinateTransformations", []):
+            if t.get("type") == "scale":
+                return t["scale"]
+    axes = read_axes(path)
+    if axes:
+        # lazy import: keeps `import zarr_utils` free of ome-types' pydantic build cost until a
+        # store actually needs the OME-XML fallback (no cycle — ome_xml_utils has no cecelia deps).
+        import cecelia.utils.ome_xml_utils as ome_xml_utils
+        return ome_xml_utils.read_scale_from_ome_xml(path, axes)
+    return None
 
 
 def save_dask_as_zarr_multiscales(image_array, im_path, nscales=1):


### PR DESCRIPTION
## Why

The napari bridge had quietly grown its **own private zarr/OME-XML reader stack** that drifted from `cecelia.utils`. This consolidates onto the shared readers so images, labels, and their geometry are read **one way** across the bridge, the analysis pipeline, and coastal — and adds a documented rule so it can't drift again.

## What changed

**`napari_utils` / `napari_bridge` cleanup**
- Fix redundant `import napari` in `solid_track_colormap` (use `require_napari`).
- Promote `hex_to_rgba`/`rgba_to_hex` into the shared toolkit — the bridge no longer hand-rolls hex parsing.
- Collapse 11 scattered `napari_utils` imports → one top-level; drop redundant `import napari`/`os`.

**Bridge → shared readers** (`napari_bridge.py` sheds ~250 lines)
- `_open_zarr_multiscale`/`_series_base` → `zarr_utils.open_as_zarr`/`series_base`
- `_read_axes`/`_read_scale`/`_read_multiscales_meta` → `zarr_utils` equivalents
- `_load_ome_xml`/`_parse_ome_xml`/`_read_unit_from_ome_xml`/`_read_scale_from_ome_xml`/`_read_time_increment` → `ome_xml_utils.load_ome_xml`/`read_pixel_unit`/`read_scale_from_ome_xml`/`read_time_increment`
- `show_labels` inline label-open → `zarr_utils.open_zarr`

**Shared readers** (`zarr_utils.py`, `ome_xml_utils.py`)
- Add `series_base` (structural, read-only), `read_multiscales_meta`, `read_axes`, `read_scale` (NGFF-first, OME-XML fallback).
- Add `load_ome_xml` (cached, graceful, **µm preserved**), `read_pixel_unit`, `read_scale_from_ome_xml`, `read_time_increment`; `parse_meta_from_zarr` delegates to `load_ome_xml`.
- `zarr_data_to_list`: **guard the destructive `os.unlink` to WRITE mode only** (reads never mutate the store); series detection is now structural (drop the `.ome.zarr`-suffix `omezarr` hint).
- Remove dead **and** broken `open_labels_as_zarr`/`_as_dask` (no callers; would `KeyError` on current `datasets`-keyed label stores — a verbatim R-port artifact) and the now-vestigial `data_group` param.

**`measure_labels_run` bypass fixed**
- Open label zarrs via `zarr_utils.open_as_zarr` (was a bare `zarr.open`); `measure_from_zarr` indexes the level list `[0]` instead of a group `['0']` — type-identical on the default (`as_dask=False`) path.

**Docs + tests**
- `CLAUDE.md`: new rule **"Image / OME-ZARR access — always go through `zarr_utils`"** (sibling to the H5AD rule); `docs/NAPARI.md` cross-references it.
- `test_image_readers.py`: first unit coverage for the moved readers (structural series detection, NGFF axes/scale, OME-XML fallback, read-only open on both layouts) + hex-helper tests.

## Testing

`pixi run test-py` → **53 pass** (+10 new). All touched files compile.

## Reservations / not verified here

- **`measure_labels_run` not runtime-verified** — no fixture/unit test for the measure task and I can't run the real pipeline in this env. Change is type-preserving on the default path but touches a task I couldn't exercise end-to-end. **Please run a measure-labels task before merge.**
- **Bridge not driven in a live napari session** — verified via the shared readers' unit tests + compile, not by actually opening an image in the viewer. **Please click the eye button on an image (ideally a timelapse + a segmentation) before merge.**
- `zarr_data_to_list` behavior change touches 6 pipeline tasks (suffix→structural series detection, `omezarr` param removed) — behavior-preserving for well-formed `.ome.zarr` stores (all current callers), now covered by the new tests.

## Left deliberately (follow-ups)
- `rechunk_zarr.py` (low-level raw plumbing) and `read_imagej_physical_size_run.py` (niche TIFF-tag read) still open directly — borderline/legit, untouched.
