### PR TITLE
refactor: read ImageJ tiff metadata via ome_xml_utils (follow-up to #170)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,12 +484,10 @@ Two layouts coexist — the reader handles both:
 | bioformats2raw | Series wrapper: data at `zarr/0/[level]` | `zarr/0/.zattrs` |
 | `create_multiscales()` | Flat: data at `zarr/[level]` | root `.zattrs` |
 
-Detection in `zarr_utils.py` → `open_as_zarr`:
-```python
-if omezarr is True and 'multiscales' not in zgroup.attrs:
-    zgroup = zgroup["0"]   # step into bioformats2raw series wrapper
-```
-Never assume one format — always detect.
+Detection is **structural** in `zarr_utils.py` → `series_base` (checks whether `path/0` carries a
+`multiscales` attr, not the `.ome.zarr` suffix); `zarr_data_to_list` resolves through it, so
+`open_as_zarr`/`open_zarr` handle both layouts. Never assume one format — always go through the
+readers (see *Image / OME-ZARR access — always go through `zarr_utils`* above).
 
 **Exception, and a trap:** `read_ome_metadata` (`app/src/tasks/importImages/omezarr.jl`) does **not**
 do this detection — it hardcodes the bioformats2raw nested layout (`zarr/0/.zattrs`), because it

--- a/python/cecelia/tasks/importImages/read_imagej_physical_size_run.py
+++ b/python/cecelia/tasks/importImages/read_imagej_physical_size_run.py
@@ -18,8 +18,7 @@ usable to correct (not a TIFF, no ImageJ metadata, no `spacing`, or unit already
 
 import json
 
-import tifffile
-
+import cecelia.utils.ome_xml_utils as ome_xml_utils
 import cecelia.utils.script_utils as script_utils
 
 # ImageJ calibration unit → micrometers
@@ -40,8 +39,7 @@ def run(params):
     result = {}
 
     try:
-        with tifffile.TiffFile(im_path) as tif:
-            meta = tif.imagej_metadata
+        meta = ome_xml_utils.read_imagej_metadata(im_path)
     except Exception as e:
         meta = None
         log.log(f'>> not a readable TIFF, skipping ImageJ Z-spacing check: {e}')

--- a/python/cecelia/tests/test_image_readers.py
+++ b/python/cecelia/tests/test_image_readers.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
+import tifffile
 import zarr
 
 import cecelia.utils.zarr_utils as zu
@@ -146,6 +147,33 @@ class OmeXmlReaderTest(unittest.TestCase):
 
     def test_time_increment_seconds(self):
         self.assertEqual(ox.read_time_increment(self.store), 30.0)
+
+
+class ImageJMetadataTest(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.d, ignore_errors=True)
+
+    def test_reads_imagej_calibration(self):
+        p = os.path.join(self.d, "stack.tif")
+        tifffile.imwrite(p, np.zeros((4, 8, 8), dtype=np.uint16), imagej=True,
+                         metadata={"unit": "nm", "spacing": 0.5})
+        meta = ox.read_imagej_metadata(p)
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta.get("unit"), "nm")
+        self.assertAlmostEqual(meta.get("spacing"), 0.5)
+
+    def test_plain_tiff_has_no_imagej_metadata(self):
+        p = os.path.join(self.d, "plain.tif")
+        tifffile.imwrite(p, np.zeros((8, 8), dtype=np.uint16))   # not imagej=True
+        self.assertIsNone(ox.read_imagej_metadata(p))
+
+    def test_non_tiff_raises(self):
+        # a soft skip is the caller's job (it wraps in try/except) — the helper surfaces the error
+        with self.assertRaises(Exception):
+            ox.read_imagej_metadata(os.path.join(self.d, "nope.tif"))
 
 
 if __name__ == "__main__":

--- a/python/cecelia/utils/ome_xml_utils.py
+++ b/python/cecelia/utils/ome_xml_utils.py
@@ -222,6 +222,17 @@ def parse_meta_from_tiff(im_path):
   return from_tiff(im_path)
 
 """
+Read ImageJ's own metadata (the ImageDescription tag) from a tiff
+"""
+def read_imagej_metadata(im_path):
+  """ImageJ's own metadata dict (the ImageDescription tag: `unit`, `spacing`, …) from a TIFF, or
+  None if the file carries no ImageJ metadata. DISTINCT from OME-XML (`parse_meta`) — ImageJ
+  calibration lives in its own tag. The single place a TIFF's ImageJ tags are read; raises if
+  `im_path` isn't a readable TIFF (a caller wanting a soft skip wraps it in try/except)."""
+  with tifffile.TiffFile(im_path) as tif:
+    return tif.imagej_metadata
+
+"""
 Parse metadata from zarr
 """
 def parse_meta_from_zarr(zarr_path):


### PR DESCRIPTION
## Why

Follow-up to #170. Closes the last "opens its own way" spot worth generalising: the importImages ImageJ Z-spacing task read `tifffile.TiffFile` directly. Now all TIFF metadata reads have one home in `ome_xml_utils`.

## What changed

- Add `ome_xml_utils.read_imagej_metadata(path)` — reads ImageJ's `ImageDescription` tag (`unit`/`spacing`), next to `parse_from_tiff`/`parse_meta_from_tiff`. Distinct from OME-XML; raises on a non-TIFF (caller soft-skips).
- `read_imagej_physical_size_run.py` → uses the helper; drops its direct `tifffile` import. Domain logic (unit→micron map, Z correction) stays in the task. **Behavior preserved** — helper raises → the task's existing try/except catches it, as before.
- Fix a **stale CLAUDE.md snippet**: the "OME-ZARR dual-format" section still showed the `omezarr is True` detection that #170 removed; detection is now structural via `zarr_utils.series_base`.
- **`rechunk_zarr.py` left as-is on purpose** — it needs the raw zarr group (`array_keys`, per-level chunks) and must *not* step into `series_base`; the high-level reader is the wrong abstraction there.

## Testing

`pixi run test-py` → **56 pass** (+3: imagej calibration read, plain-tiff → None, non-tiff → raises).

## Not verified here
- The import task isn't run end-to-end (no fixture / can't run the import pipeline), but it's a pure metadata-read wrapper with preserved semantics.
