### PR TITLE
fix(installer): expand a leading ~ in CECELIA_HOME

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -35,8 +35,15 @@ $Scope   = if ($env:CECELIA_INSTALL_SCOPE) { $env:CECELIA_INSTALL_SCOPE } else {
 function Say($m) { Write-Host "[cecelia] $m" -ForegroundColor Cyan }
 
 # ── Install location + scope ────────────────────────────────────────────────────
+# CECELIA_HOME overrides either default. Expand a leading ~ / ~\ / ~/ ourselves — PowerShell doesn't
+# expand a tilde inside a plain string, so without this a literal `~` directory would be created.
 if ($env:CECELIA_HOME) {
-  $InstallDir = $env:CECELIA_HOME
+  $override = $env:CECELIA_HOME
+  if ($override -eq '~' -or $override.StartsWith('~/') -or $override.StartsWith('~\')) {
+    $InstallDir = Join-Path $HOME ($override.Substring(1).TrimStart('/', '\'))
+  } else {
+    $InstallDir = $override
+  }
 } elseif ($Scope -eq 'system') {
   $InstallDir = Join-Path $env:ProgramFiles 'cecelia'
 } else {

--- a/install.sh
+++ b/install.sh
@@ -41,9 +41,15 @@ have curl || err "curl is required."
 have tar  || err "tar is required."
 
 # ── Install location + scope ──────────────────────────────────────────────────
-# CECELIA_HOME overrides either default.
+# CECELIA_HOME overrides either default. Expand a leading ~ / ~/ ourselves: a quoted or
+# assignment-context value (CECELIA_HOME="~/x" / CECELIA_HOME=~/x sh install.sh) skips the shell's
+# tilde expansion, so without this a literal `~` directory would be created instead of $HOME.
 if [ -n "${CECELIA_HOME:-}" ]; then
-  INSTALL_DIR="$CECELIA_HOME"
+  case "$CECELIA_HOME" in
+    "~")   INSTALL_DIR="$HOME" ;;
+    "~/"*) INSTALL_DIR="$HOME/${CECELIA_HOME#\~/}" ;;
+    *)     INSTALL_DIR="$CECELIA_HOME" ;;
+  esac
 elif [ "$SCOPE" = "system" ]; then
   case "$OS" in
     Darwin) INSTALL_DIR="/Applications/cecelia" ;;


### PR DESCRIPTION
## What

`CECELIA_HOME` was used verbatim, but a quoted or assignment-context value skips the shell's tilde expansion:

```sh
CECELIA_HOME="~/cecelia-usertest" sh install.sh   # ~ never expands
```

So the installer created a directory literally named `~` (under the CWD) instead of one under `$HOME`, and the build later failed with `can't cd to ~…/frontend`.

Both `install.sh` and `install.ps1` now expand a leading `~` / `~/` (and `~\` on Windows) themselves in the `CECELIA_HOME` override branch:

| `CECELIA_HOME` | resolves to |
|---|---|
| `~` | `$HOME` |
| `~/cecelia-usertest` | `$HOME/cecelia-usertest` |
| `/opt/cecelia-test` | unchanged |
| `~cecelia-usertest` | unchanged (the `~user` form — left literal on purpose) |

Only the override branch is touched; the default install paths were already `$HOME`/env-based.

## Verification

- `sh -n install.sh` passes; the four `sh` cases above verified locally.
- `install.ps1` mirrors the same logic, **reviewed by hand only** — no PowerShell in the dev env (consistent with the installer being generally unverified on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
