### PR TITLE
Inventory audit: INVENTORY.md + discovery-first rule + duplicate consolidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ Cecelia is an immunological image analysis tool (Nature Communications 2025).
 Stack: **Julia** (backend/WS server) · **Vue 3 + TypeScript** (frontend) · **Python/Napari** (image viewer)
 
 See also:
+- [`INVENTORY.md`](INVENTORY.md) — living index of what already exists and where (canonical readers/helpers, shared Vue components, API handlers, cross-cutting flows). **Check it before building anything** — see *Before implementing anything* below.
 - [`FAQ.md`](FAQ.md) — root-level, reader-facing highlight doc: the *counterintuitive* "why" (AI-written, no Rust, browser-not-Electron, three languages). Punch lines, not prose. Keep it a highlight reel — do NOT expand it into a summary of the `docs/`; add new detail to the relevant `docs/` file and only promote a genuinely surprising one-liner up to the FAQ.
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — layer boundaries, WS protocol, data model contracts, Napari lifecycle
 - [`docs/SCHEDULER.md`](docs/SCHEDULER.md) — chain executor design: per-image threading, resource pools, barriers, resume semantics, event bus, concurrency invariants
@@ -61,6 +62,22 @@ See also:
 > Same reflex for going in circles or losing the thread: if two+ rounds pass on one question without
 > clear progress, or an important aspect keeps being deferred/glossed over, surface it explicitly for
 > the user to decide (or add it to `docs/TODO.md` and move on) rather than pushing through.
+
+## Before implementing anything — mandatory discovery step
+
+Fresh context windows don't know what already exists — which is how we ended up with duplicates
+(two shutdown buttons, hand-rolled zarr access, a private napari reader stack). Before writing any
+code, find the existing implementation of everything the task touches:
+
+1. Check [`INVENTORY.md`](INVENTORY.md) for the canonical component/helper — use it, don't rebuild it.
+2. Grep/find for the specific function, component, or pattern (e.g. a reader, a store, a base component).
+3. Report what you found before writing code.
+4. Build on what exists — only write new if the search genuinely comes up empty.
+5. If in doubt: search, don't build.
+
+Using a hand-rolled solution when a util or component already exists is a bug, not a style choice —
+this is the concrete, do-this-first version of the divergent-re-implementation warning above. When
+you add a significant new shared component, add a line to `INVENTORY.md` in the same change.
 
 ## Previous prompts
 
@@ -166,8 +183,8 @@ tasks, the napari bridge, and any external consumer (e.g. coastal).
 - **Reads are read-only.** `zarr_data_to_list` only ever mutates a store on a WRITE-mode open —
   never on `mode='r'`.
 - **One sanctioned exception — file *creation*.** Writing a *new* multiscales store is the
-  producing task's job, via `zarr_utils.create_multiscales` / `save_dask_as_zarr_multiscales` (or
-  the segmentation writer), not a hand-rolled `zarr.open(..., 'w')`.
+  producing task's job, via `zarr_utils.create_multiscales` (or the segmentation writer), not a
+  hand-rolled `zarr.open(..., 'w')`.
 
 ---
 
@@ -225,14 +242,10 @@ the updated `pixi.toml` + `pixi.lock`.
 | `zarr>=3.0` | lower bound | v3 API: string keys only (`"0"` not `0`), `create_array` not `create_dataset`, `zarr.Array` not `zarr.core.Array`. `zarr_utils.py` is already updated. |
 
 ### GPU detection (cellpose tasks)
-Auto-detected in Python — no user checkbox needed:
+Auto-detected in Python — no user checkbox needed. Use the one helper, don't inline the branch:
 ```python
-if torch.cuda.is_available():
-    use_gpu, gpu_device = True, torch.device('cuda')
-elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-    use_gpu, gpu_device = True, torch.device('mps')
-else:
-    use_gpu, gpu_device = False, None
+from cecelia.utils.gpu_utils import torch_device
+use_gpu, gpu_device = torch_device()   # CUDA → MPS (Apple Silicon) → CPU
 ```
 Do not add a `useGPU` param to task JSON or Julia handlers.
 
@@ -247,11 +260,11 @@ use the named helper, don't re-derive the platform branch inline:
   `Sys.iswindows()`, never hardcode one.
 - **bioformats2raw binary name** — use `bioformats2raw_bin()` in `config.jl`, don't hardcode
   `.bat` vs no-extension.
-- **Process killing** — use `_kill_tree(pid)` in `api/src/sockets.jl`; never write
+- **Process killing** — use `_kill_tree(pid)` in `app/src/tasks/scheduler.jl`; never write
   `kill`/`pgrep`/`taskkill` inline. (`Base.Process` has no `.pid` field — `_kill_tree` already
   handles getting the OS pid via libuv.) Never `taskkill /IM julia.exe` — it kills every Julia
   process on the machine, which is why `stop`/`stop-backend`/`stop-napari` kill by **listening
-  port** instead of process name.
+  port** instead of process name (via `_kill_listeners_on_port`, same file).
 - **`proc.exitcode == 0` doesn't mean success on cancel** — libuv sets it to 0 for signal-killed
   processes too. Always check `proc.termsignal == 0` as well (see *Task system* below).
 - **Directory size** — use `_dir_bytes(path)` in `app/src/utils.jl`, not a hardcoded `du`/`walkdir`.
@@ -431,7 +444,7 @@ OME-ZARR pyramids. Document any fixture you add in `test-data/README.md`.
 - Strings: double quotes only (single quotes = `Char`)
 - Multiple dispatch: separate method per type, not OOP overloading
 - `@infiltrate` = `browser()` from R
-- Shell commands: always platform-safe. Use `_kill_tree` (`api/src/sockets.jl`) and `_dir_bytes` (`app/src/utils.jl`); never write `pgrep`/`kill`/`du` inline.
+- Shell commands: always platform-safe. Use `_kill_tree` (`app/src/tasks/scheduler.jl`) and `_dir_bytes` (`app/src/utils.jl`); never write `pgrep`/`kill`/`du` inline.
 - **Don't `export` generic names that collide with common deps or Base.** Exports land in any
   user's namespace; if Cecelia and another `using`'d package both export the same name, Julia
   leaves it *unbound* (ambiguous), breaking unqualified calls. In particular avoid clashing with

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -1,0 +1,106 @@
+# Inventory
+
+Living index of the key existing components — the things a new task should **find and reuse**, not
+rebuild. When you add a significant new component (a shared util, a canonical helper, a reusable
+Vue component, a new API handler file), add a line here. When a task touches something in this list,
+open it and use it.
+
+This is the *what exists and where* companion to `CLAUDE.md` (*how to behave*) and
+`docs/ARCHITECTURE.md` (*how the layers fit together*). It is intentionally not exhaustive — leaf
+task files and one-off components are omitted; shared/cross-cutting things are not.
+
+Last audited: 2026-07-16 (full six-area ground-truth read; against `main` @ c1ce165).
+
+---
+
+## Cross-cutting flows (one canonical path each — do not add a second)
+
+- **App shutdown / quit** — UI: sidebar footer + Settings only → `appControl.quit()` → `POST /api/app/shutdown` → `api_app_shutdown` → `_stop_children_for_exit()`. Two UI entry points, one store action, one endpoint. Do NOT add a third quit button. (Per-service stops — napari `/api/napari/close`, notebooks `/api/notebooks/shutdown` — are separate and legitimate.)
+- **App update** — `appControl.checkUpdate()`/`applyUpdate()` → `/api/update/check` + `/api/update/apply`. Header badge and Settings both read the one store; one handler each.
+- **Napari WebSocket (7655)** — one connector: `app/src/napari.jl` `send(v, msg)`; one bridge server: `napari/napari_bridge.py` `ws_server()`. Port constant `NAPARI_PORT` defined once in `napari.jl`.
+- **Julia ↔ Vue WebSocket (8080 `/ws`)** — one server handler: `api/src/server.jl` `handle_ws` → `sockets.jl` `handle_message`; one Vue client: `frontend/src/stores/ws.ts` (the only `new WebSocket` in the frontend). All outbound goes through `broadcast_ws`.
+- **Task status/progress/log push** — task callbacks → `ws_log`/`ws_progress`/`ws_status`/`ws_result` (`api/src/sockets.jl`) → `broadcast_ws` → `frontend/src/stores/ws.ts`. One emitter family, reused by both the scheduler and the napari batch runner.
+- **Image selection in the UI** — one component: `frontend/src/components/ImageTable.vue`, mounted only via `ModuleLayout.vue`. Every module/analysis page gets its picker by wrapping `ModuleLayout`.
+
+---
+
+## Data access (the canonical readers/writers — never hand-roll)
+
+- **Image / OME-ZARR (Python)**: `python/cecelia/utils/zarr_utils.py` — `open_as_zarr`/`open_zarr` (image AND labels), `series_base` (structural layout detection), `read_axes`/`read_scale`/`read_multiscales_meta`, writers `create_multiscales`/`create_zarr_from_ndarray`, and `multiscales_metadata` (the shared NGFF `.zattrs` builder used by both the image writer and the label writer). All store access routes through here.
+- **OME-XML (Python)**: `python/cecelia/utils/ome_xml_utils.py` — `load_ome_xml` (cached), `read_pixel_unit`/`read_scale_from_ome_xml`/`read_time_increment`, `read_imagej_metadata`; writers `save_meta_in_zarr`/`write_ome_xml`. The one TIFF/ImageJ metadata reader.
+- **Cell data `.h5ad` (Python)**: `python/cecelia/utils/label_props_utils.py` — `LabelPropsView` chain (read `view_cols`/`view_centroid_cols`/`filter_by_label`/`as_df`/`obsm`; write `add_obs`/`add_categorical_obs`/`add_obsm`/`save`). The one Python existing-file h5ad open path. Only NEW-file *creation* uses `anndata` directly (measure/tracking output).
+- **Cell data `.h5ad` (Julia)**: `app/src/label_props.jl` — the sole Julia HDF5 chokepoint: `label_props(...) |> select_cols/filter_rows |> as_df` read chain, `add_obs |> save!` write path, `_with_h5` lock. Categorical/string obs writes delegate to Python via `run_py` (`write_categorical_obs`).
+- **Categorical/string obs (Python)**: `python/cecelia/utils/obs_utils.py` — `write_categorical_obs`, a thin driver over `LabelPropsView.add_categorical_obs` (the categorical-encoding half of the h5ad write contract; Julia writes only numeric obs).
+- **GPU device (Python)**: `python/cecelia/utils/gpu_utils.py` — `torch_device()` → `(use_gpu, device)`, the one CUDA→MPS→CPU detector for torch-backed tasks (cellpose segment + denoise).
+- **Population membership (Python)**: `python/cecelia/cecelia_client.py` — `CeceliaClient` (stdlib HTTP to the Julia gating API); `python/cecelia/utils/pop_utils.py` `PopUtils.pop_df` is the Python population accessor.
+
+## Python utilities (`python/cecelia/utils/`)
+
+- **measure_utils**: `measure_from_zarr` — per-cell morphology + intensity; writes a NEW `labelProps/{vn}.h5ad`.
+- **segmentation_utils**: `SegmentationUtils` base — tiled segmentation loop, seam stitching, post-processing, nuc↔cyto matching, `_write_labels_zarr`.
+- **cellpose_utils**: `CellposeUtils(SegmentationUtils)` — cellpose predict, channel prep, µm→px diameter, auto-GPU.
+- **tracking_utils**: `BayesianTrackingUtils.track_objects` (btrack) + `write_track_props` (new `{vn}__tracks.h5ad`).
+- **clustering_utils**: shared Leiden engine (`find_populations` + `split_back_and_write`); used by both cluster runners.
+- **correction_utils**: AF + drift correction (drift shifts, AF channel correct, denoise/rolling-ball/top-hat).
+- **dim_utils**: `DimUtils` — dimension-order/index/physical-size/slice reasoning off an ome-types OME object. Core dependency of most tasks.
+- **slice_utils**: numpy slice-tuple generators for tiled 2D/3D(+time) processing + downsample strides.
+- **napari_utils**: project-agnostic napari layer builders (`add_image`/`add_labels`/`add_tracks`), hex↔rgba, clip planes, view snapshot, movie recording, colour-by helpers. Imported by the bridge (and coastal).
+- **script_utils**: subprocess plumbing — `StdoutLogger` (`[PROGRESS] n/total`), `script_params`, `get_param`.
+- **math_helpers**: `round_up`/`round_down` to a multiple.
+- **rechunk_zarr**: standalone CLI — rewrites flat stores to per-plane chunks (low-level surgery; reuses `plane_chunks`).
+
+## Python tasks & writers
+
+- **Task runners**: `python/cecelia/tasks/<category>/<name>_run.py` — thin subprocess entry points (segment, cleanupImages, tracking, editImages, importImages, clustPops, clustTracks). Reusable logic lives in `utils/`, not the runners.
+- **Data-layer writers**: `python/cecelia/writers/*_run.py` — e.g. `write_categorical_obs_run` (delegates to `obs_utils`).
+
+## Julia app (`app/src/`)
+
+- **Object model**: `model/image.jl` (`CciaImage` + path accessors `img_filepath`/`img_label_props_path`/`img_physical_sizes`), `model/set.jl` (`CciaSet`, `init_object`), `model/project.jl` (`CciaProject`, `with_transaction`).
+- **Versioned fields**: `helpers.jl` — `versioned_get`/`versioned_set!`/`versioned_keys`/`versioned_active` (the `{value_name => …, "_active" => …}` convention; the one family for both `Dict{String,String}` path dicts and `Any`/JSON3 raw dicts), plus `read_ccid_raw(path)` (the one ccid.json read+Symbol-key normalize).
+- **H5AD chain**: `label_props.jl` (see Data access) + `tracking/track_props.jl` (compute-on-read per-track table, auto categorical/numeric detection).
+- **Python launcher**: `py_runner.jl` — `run_py`, the single Python spawn point (`PYTHONPATH=python/`, `[PROGRESS]` streaming, exit+signal check).
+- **Scheduler**: `tasks/scheduler.jl` — `ResourcePool`, `run_task`/`run_tasks`, `TaskRecord`/`cancel_task!`, per-image logfile, and the kill helpers `_kill_tree`(pid) / `_kill_proc_tree`(proc) / `_kill_listeners_on_port`(port) — the single home for process/port killing.
+- **Task base + registry**: `tasks/task.jl` (`CciaTask`, JSON spec load, `validate_params`, `CompositeTask`), `tasks/task_registry.jl` (`_spec_path` + `_fun_name_map` + composites). Every task = co-located `.jl` + `.json`, same base name.
+- **Chain executor + events**: `tasks/chain.jl` (`ChainTemplate`/`ChainRun`, per-image threads, barriers, resume), `events.jl` (chain event pub/sub; the API WS layer subscribes).
+- **Gating engine**: `gating/population_manager.jl` (`PopulationMap`, `pop_df` unified accessor, sidecar `gating/{vn}.json`), `gating/gating_engine.jl` (`recompute!`, membership, `cells_in_pop`), `gating/gates.jl`, `gating/transforms.jl` (logicle cited), `gating/density.jl`.
+- **Behaviour / plotting**: `behaviour/hmm.jl` (Gaussian HMM), `plotting/plot_data.jl` (`plot_summary_data` server-side aggregation).
+- **Napari client**: `napari.jl` — `NapariViewer` package-level bridge client (WS :7655, `launch!`/`close!`/`restart!`).
+- **Utils / config / logs**: `utils.jl` (`gen_uid`, `_dir_bytes` — the one directory-size helper), `config.jl` (`init_cecelia!`, `.env` reader, `bioformats2raw_bin()`, `python_bin_path()`), `qc.jl`, `run_log.jl`, `lab_log.jl`/`lab_log_context.jl`.
+
+## Julia API (`api/src/`)
+
+- **server.jl**: single `HTTP.listen` entry; `handle_stream` (WS upgrade + static serving), `handle_http` route table, `broadcast_ws` fan-out, `BroadcastLogger`, chain-event→WS bridge, `handle_ws` loop.
+- **sockets.jl**: `handle_message` (the one inbound-WS switch), task telemetry `ws_log`/`ws_status`/`ws_result`/`ws_progress`, `handle_task_run`/`handle_chain_run`/`handle_movie_batch`.
+- **routes.jl**: project/set/image + chain-template CRUD, task-definition serving, fs browser, `api_images_tasklog` (reads the task log file), lab-log routes.
+- **napari_api.jl**: the global `NapariViewer` ref + `_with_viewer` single-flight, all `/api/napari/*` handlers, `run_batch_movies`.
+- **gating_api.jl**: population manager + gating engine routes; **owns the shared helpers** (`_gating_image`/`_resolve_vn`/`_gerr`/`_live_map`) reused by tracking/plotting/napari (include-order coupled — `gating_api.jl` first).
+- **plotting_api.jl**: summary-canvas routes (thin wrappers over `plot_summary_data`).
+- **tracking_api.jl**: `/api/tracking/motion-dims` preflight.
+- **notebooks_api.jl**: Pluto engine lifecycle (:7660) + registry/snapshot CRUD + sysimage build.
+- **app_api.jl**: `_stop_children_for_exit`, `/api/app/shutdown|restart`, dev worktree-switch.
+- **repl_api.jl / update_api.jl / setup_api.jl**: diagnostics + gated REPL; self-update; first-launch wizard.
+- **task_console.jl / dev.jl**: standalone `pixi run console` WS *client*; the `pixi run dev` supervisor. (Both outside the server.)
+
+## Frontend (`frontend/src/`)
+
+- **appControl store** (`stores/appControl.ts`): all app-lifecycle actions — `quit`, `checkUpdate`/`applyUpdate`, dev `restartBackend`/`switchWorktree`, setup state.
+- **ws store** (`stores/ws.ts`): THE WebSocket client (connect/reconnect/`send`/`on`/`off`); dispatches all `task:*`/`chain:*`/`napari:*`/`server:log` events.
+- **Domain stores** (`stores/`): `gating` (pop/gating, pop_type-agnostic), `project`/`projectMeta`, `settings`, `tasks`, `taskDefs`.
+- **ImageTable** (`components/ImageTable.vue`): THE image-selection/listing table. Mounted only via **ModuleLayout** (`components/ModuleLayout.vue`, the standard module-page left column).
+- **Dialog/panel shells**: `BaseModal.vue` (centred dialog), `TeleportPopover.vue` (body-teleported popover, 7 call sites). Two floating-box abstractions that are **deliberately separate** (different coordinate system + event model + features, not a duplicate): `FloatingPanel.vue` = top-level viewport window (fixed, pointer-drag, resize/collapse/persist); `useFloatingPanel.ts` = zoomable-canvas panel behaviour (absolute, mouse-drag+zoom, tile/cascade arrange).
+- **Service control**: `utils/serviceApi.ts` — the one home for napari-bridge + notebooks service endpoints (`napariApi.restart/close`, `notebooksApi.launch/restart/shutdown`); used by both SettingsModule and NotebooksModule. (App lifecycle — quit/update — stays in `appControl`.)
+- **Confirm buttons**: `ConfirmButton.vue` (arm→confirm, replaces `window.confirm`), `ConfirmDeleteButton.vue` (destructive-delete icon).
+- **Canvas / plots**: `canvas/CanvasPanel.vue`, `canvas/SummaryCanvas.vue`, `canvas/SummaryPanel.vue`/`InteractivePanel.vue`, `canvas/TabbedCanvas.vue`, `canvas/PopulationPanelShell.vue`; composables `useCanvasPanels`/`useCanvasWorkspace`/`useCanvasZoom`; the plot layer `plots/{plot,export,pdf,overlays,types}.ts`.
+- **Napari open**: `composables/useNapariOpen.ts` (the one open/reload-in-napari path); overlay utils `utils/{napariOverlays,overlayLayers,napariColormap}.ts`.
+- **View state**: `composables/useViewState.ts` — persisted per-page/per-panel options (mandated by the "persist every user-settable option" rule).
+- **Shared lib**: `lib/{imageMetadataWarnings,qc,valueNames}.ts`; pure helpers in `utils/*.ts` (`imageTable.ts`, `boardAssets.ts`, …).
+
+## Napari bridge (`napari/`)
+
+- **napari_bridge.py**: the whole bridge process — `NapariState` (viewer + per-image state + all command handlers), `execute_command` dispatcher, WS server (`ws_server`, :7655, `_port_available` guard), Qt/asyncio glue. Imports `cecelia.utils.napari_utils`/`zarr_utils` (+ lazy `ome_xml_utils`, `label_props_utils`). No private store readers (consolidated in PR #170).
+
+## MCP observer (`mcp/`)
+
+- **cecelia_mcp/server.py**: FastMCP stdio server `cecelia-observer` — 8 read tools + 1 append tool, each delegating to the client.
+- **cecelia_mcp/client.py**: `CeceliaClient` (stdlib urllib to the Julia API) with `ALLOWED_ROUTES` allow-list — the read-only guarantee. Never opens images/h5ad itself; talks HTTP to :8080 only.

--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -148,7 +148,7 @@ function _execute_pending_open()
         # Re-resolve _active at fire time — a task may have completed between the
         # eye-button click and Napari becoming ready.
         meta_file = joinpath(pending.proj_dir, "1", pending.image_uid, "ccid.json")
-        raw       = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(meta_file, String)))
+        raw       = read_ccid_raw(meta_file)
         filename  = versioned_get_field(raw, "filepath", nothing)   # nothing → _active
         zarr_path = joinpath(pending.proj_dir, "0", pending.image_uid, string(something(filename, "")))
         ch_raw    = versioned_get_field(raw, "imChannelNames", nothing)
@@ -245,7 +245,7 @@ function api_napari_open(body_bytes::Vector{UInt8})
     isdir(proj_dir)   || return 404, JSON3.write((; error = "Project not found: $project_uid"))
     isfile(meta_file) || return 404, JSON3.write((; error = "Image metadata not found: $image_uid"))
 
-    raw = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(meta_file, String)))
+    raw = read_ccid_raw(meta_file)
 
     filename = versioned_get_field(raw, "filepath", value_name)
     if isnothing(filename)
@@ -439,10 +439,7 @@ function api_napari_record_timelapse(body_bytes::Vector{UInt8})
     # segmentation — the recording captures the whole current view (which can show several segmentations'
     # tracks/labels at once), so tagging it with one value_name would be misleading. Fall back to the uid
     # if the name is blank / unsafe. (F1.3 will switch to attr-based names for batch runs.)
-    movies_dir = joinpath(dirname(dirname(img._dir)), "movies")
-    mkpath(movies_dir)
-    safe = replace(strip(img.name), r"[^A-Za-z0-9._-]+" => "_")
-    path = joinpath(movies_dir, (isempty(safe) ? image_uid : safe) * ".mp4")
+    path = _movie_named_path(img, image_uid)
 
     _with_viewer() do
         try
@@ -474,10 +471,7 @@ function api_napari_record_animation(body_bytes::Vector{UInt8})
     v = _viewer()
     (isnothing(v) || !_viewer_alive()) && return 400, JSON3.write((; error = "Napari not running"))
 
-    movies_dir = joinpath(dirname(dirname(img._dir)), "movies")
-    mkpath(movies_dir)
-    safe = replace(strip(img.name), r"[^A-Za-z0-9._-]+" => "_")
-    path = joinpath(movies_dir, (isempty(safe) ? image_uid : safe) * "_animation.mp4")
+    path = _movie_named_path(img, image_uid; suffix = "_animation")
 
     _with_viewer() do
         try
@@ -507,6 +501,22 @@ function _call_napari_api(f::Function, payload)::Tuple{Bool,Any}
     (status == 200, parsed)
 end
 
+# {proj}/movies/ for an image (img._dir = {proj}/1/{uid}); created if missing. One place the movies
+# dir is derived — the single-image recorders and the batch path all go through here.
+function _movies_dir(img)::String
+    d = joinpath(dirname(dirname(img._dir)), "movies")
+    mkpath(d)
+    d
+end
+
+# Movie output path named by the IMAGE (not attrs) — used by the single-image recorders. Sanitises
+# img.name, falls back to the uid when blank/unsafe. `suffix` distinguishes timelapse ("") from
+# animation ("_animation").
+function _movie_named_path(img, uid::AbstractString; suffix::AbstractString = "")::String
+    safe = replace(strip(img.name), r"[^A-Za-z0-9._-]+" => "_")
+    joinpath(_movies_dir(img), (isempty(safe) ? String(uid) : safe) * suffix * ".mp4")
+end
+
 # Attr-named output filename: <attr1>_<attr2>_..._<uid>.mp4 (mirrors the R `paste(fileAttrs...) _ uid`).
 # Blank/missing attrs are dropped; the uid always terminates the name so batch outputs never collide.
 # Falls back to just the uid when no fileAttrs are given. Pure (attr dict + uid) → testable.
@@ -520,11 +530,9 @@ function _movie_basename(attr::AbstractDict, uid::AbstractString, file_attrs::Ve
     replace(join(parts, "_"), r"[^A-Za-z0-9._-]+" => "_") * ".mp4"
 end
 
-# Full attr-named output path under {proj}/movies/ (img._dir = {proj}/1/{uid}).
+# Full attr-named output path under {proj}/movies/.
 function _movie_out_path(img, file_attrs::Vector{String})::String
-    movies_dir = joinpath(dirname(dirname(img._dir)), "movies")
-    mkpath(movies_dir)
-    joinpath(movies_dir, _movie_basename(img.attr, img.uid, file_attrs))
+    joinpath(_movies_dir(img), _movie_basename(img.attr, img.uid, file_attrs))
 end
 
 # Apply an authored movie config to ONE image already resolvable by uid (F1.2). Opens the image (contrast

--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -354,7 +354,7 @@ function api_projects_load(body_bytes::Vector{UInt8})
     # Update lastOpenedAt
     meta_file = joinpath(proj_dir, "project.json")
     try
-        raw = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(meta_file, String)))
+        raw = read_ccid_raw(meta_file)
         raw["lastOpenedAt"] = string(now())
         open(meta_file, "w") do io; JSON3.write(io, raw); end
         project["lastOpenedAt"] = raw["lastOpenedAt"]
@@ -562,7 +562,7 @@ function api_projects_rename(body_bytes::Vector{UInt8})
 
     meta_file = joinpath(proj_dir, "project.json")
     try
-        raw = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(meta_file, String)))
+        raw = read_ccid_raw(meta_file)
         raw["name"] = name
         open(meta_file, "w") do io; JSON3.write(io, raw); end
     catch
@@ -874,7 +874,7 @@ function api_images_delete_labels(body_bytes::Vector{UInt8})
     isdir(proj_dir) || return 404, JSON3.write((; error="Project not found"))
     isfile(ccid)    || return 404, JSON3.write((; error="Image not found"))
 
-    raw = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(ccid, String)))
+    raw = read_ccid_raw(ccid)
 
     # Delete zarr files registered under labels[valueName]
     labels_dict = get(raw, "labels", Dict{String,Any}())
@@ -1171,7 +1171,7 @@ function _image_payload(img::CciaImage)
         fps["default"] = "ccidImage.ome.zarr"
     end
     active_vn = versioned_active(img.filepath)
-    active_fn = something(active(img.filepath), get(fps, VERSIONED_DEFAULT_VAL, ""))
+    active_fn = something(versioned_get(img.filepath), get(fps, VERSIONED_DEFAULT_VAL, ""))
     ch        = channel_names(img)
     (;
         uid             = img.uid,

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -494,3 +494,18 @@ end
     # unsafe characters in an attr value are sanitised to underscores
     @test _movie_basename(Dict("T" => "a/b c:d"), "u1", ["T"]) == "a_b_c_d_u1.mp4"
 end
+
+# The single-image recorders (timelapse / animation) name by IMAGE via the shared _movies_dir +
+# _movie_named_path (img._dir = {proj}/1/{uid} → {proj}/movies/). Mock img with a NamedTuple.
+@testset "API: single-image movie naming" begin
+    mktempdir() do tmp
+        img = (; _dir = joinpath(tmp, "proj", "1", "uid7"), name = "My Image")
+        @test _movie_named_path(img, "uid7") == joinpath(tmp, "proj", "movies", "My_Image.mp4")
+        @test _movie_named_path(img, "uid7"; suffix = "_animation") ==
+              joinpath(tmp, "proj", "movies", "My_Image_animation.mp4")
+        @test isdir(joinpath(tmp, "proj", "movies"))   # _movies_dir created it
+        # blank / unsafe name falls back to the uid
+        blank = (; _dir = joinpath(tmp, "proj", "1", "uid7"), name = "   ")
+        @test _movie_named_path(blank, "uid7") == joinpath(tmp, "proj", "movies", "uid7.mp4")
+    end
+end

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -11,7 +11,7 @@ export gen_uid, UID_LENGTH
 # ── Versioned-variable helpers ────────────────────────────────────────────────
 export VERSIONED_ACTIVE_KEY, VERSIONED_DEFAULT_VAL
 export versioned_active, versioned_get, versioned_set!
-export versioned_get_field, versioned_set_field!, versioned_keys
+export versioned_get_field, versioned_set_field!, versioned_keys, read_ccid_raw
 
 # ── Data model ────────────────────────────────────────────────────────────────
 export CciaImage, CciaSet, CciaProject
@@ -19,7 +19,7 @@ export save!
 export load_project, init_object
 export create_project!, add_image!, add_set!, images, sets
 export delete_image!, delete_set!
-export active, set_active!, value_names, img_filepath, img_zero_dir, img_physical_sizes, image_included
+export img_filepath, img_zero_dir, img_physical_sizes, image_included
 export img_label_props_dir, img_label_props_path, img_track_props_path, img_value_names, img_has_value_name
 export read_module_fun_params, write_module_fun_params!
 export TRACK_PROPS_SUFFIX, is_reserved_value_name

--- a/app/src/helpers.jl
+++ b/app/src/helpers.jl
@@ -84,3 +84,11 @@ end
 function versioned_keys(d::AbstractDict)::Vector{String}
     [string(k) for k in keys(d) if string(k) != VERSIONED_ACTIVE_KEY]
 end
+
+# Read a ccid.json / project.json into a String-keyed Dict{String,Any} ready for the versioned_*
+# helpers. JSON3 yields Symbol keys that make `get(d, "field", …)` silently miss (see the JSON3
+# gotcha in CLAUDE.md); this is the one place that normalizes them. Use it instead of hand-rolling
+# `Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(path, String)))`.
+function read_ccid_raw(path::AbstractString)::Dict{String,Any}
+    Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(path, String)))
+end

--- a/app/src/label_props.jl
+++ b/app/src/label_props.jl
@@ -61,7 +61,7 @@ Construct a lazy `LabelProps` view. The image form resolves the `.h5ad` under
 tests / REPL use.
 """
 function label_props(img::CciaImage; value_name=nothing)
-    filename = isnothing(value_name) ? active(img.label_props) :
+    filename = isnothing(value_name) ? versioned_get(img.label_props) :
                get(img.label_props, string(value_name), nothing)
     isnothing(filename) && error("No labelProps for value_name=$(value_name) on image $(img.uid)")
     path = joinpath(img_label_props_dir(img), filename)

--- a/app/src/model/image.jl
+++ b/app/src/model/image.jl
@@ -1,21 +1,8 @@
 using JSON3
 
-# ── Versioned path dict helpers ────────────────────────────────────────────────
-
-function active(d::Dict{String,String})::Union{String,Nothing}
-    key = get(d, "_active", "default")
-    get(d, key, nothing)
-end
-
-function set_active!(d::Dict{String,String}, filename::String, name::String="default")
-    d[name]      = filename
-    d["_active"] = name
-    d
-end
-
-function value_names(d::Dict{String,String})::Vector{String}
-    filter(k -> k != "_active", collect(keys(d)))
-end
+# Versioned path-dict access (active entry, list value names, …) goes through the shared
+# `versioned_*` helpers in helpers.jl — one family for both the String→String path dicts here and
+# the Any/JSON3 raw ccid.json dicts. Don't add a second variant.
 
 # ── CciaImage ──────────────────────────────────────────────────────────────────
 
@@ -61,7 +48,7 @@ end
 
 """Absolute path to the active (or named) filepath version. Resolves into the 0 (image) dir."""
 function img_filepath(img::CciaImage, name::Union{String,Nothing}=nothing)::Union{String,Nothing}
-    filename = isnothing(name) ? active(img.filepath) : get(img.filepath, name, nothing)
+    filename = isnothing(name) ? versioned_get(img.filepath) : get(img.filepath, name, nothing)
     isnothing(filename) ? nothing : joinpath(img_zero_dir(img), filename)
 end
 

--- a/app/src/napari.jl
+++ b/app/src/napari.jl
@@ -99,7 +99,8 @@ function _log_gl_info(v::NapariViewer)
 end
 
 function close!(v::NapariViewer)
-    v.proc !== nothing && kill(v.proc)
+    # Kill the whole tree — napari/Qt spawns children a bare `kill(v.proc)` would orphan.
+    v.proc !== nothing && try; _kill_proc_tree(v.proc); catch; end
     v.proc = nothing
 end
 

--- a/app/src/tasks/scheduler.jl
+++ b/app/src/tasks/scheduler.jl
@@ -189,6 +189,16 @@ function _kill_tree(pid::Int)
     end
 end
 
+# Kill a live process AND its child tree, given the Julia Process handle. `Base.Process` has no
+# `.pid` field, so get the OS pid via libuv, kill the tree (subprocesses — napari/Qt, bioformats —
+# spawn children), then SIGKILL the handle itself. Best-effort; callers wrap in try/catch where a
+# dead/reused handle is possible. One place for the `uv_process_get_pid` + `_kill_tree` + `kill` dance.
+function _kill_proc_tree(proc::Base.Process)
+    pid = Int(ccall(:uv_process_get_pid, Cint, (Ptr{Cvoid},), proc.handle))
+    _kill_tree(pid)
+    kill(proc, Base.SIGKILL)
+end
+
 # Kill whatever process is LISTENING on a TCP port (+ its tree). Cross-platform, best-effort. Used to
 # guarantee a clean app shutdown even for a child we only ADOPTED or that outlived a crash (no process
 # handle to `kill`) — napari :7655, notebooks :7660 — mirroring `pixi run stop`. There is no libuv API
@@ -225,9 +235,7 @@ function cancel_task!(task_id::String)
     proc = @atomic rec.proc
     isnothing(proc) && return
     try
-        pid = Int(ccall(:uv_process_get_pid, Cint, (Ptr{Cvoid},), proc.handle))
-        _kill_tree(pid)
-        kill(proc, Base.SIGKILL)
+        _kill_proc_tree(proc)
     catch e
         @warn "Error killing task $task_id" exception = e
     end
@@ -271,11 +279,7 @@ function _execute_job!(job::TaskJob)
                       # was nothing when cancel_task! ran, so the kill was skipped. Kill
                       # here now that we hold the process handle.
                       if is_cancelled(job.id)
-                          try
-                              pid = Int(ccall(:uv_process_get_pid, Cint, (Ptr{Cvoid},), proc.handle))
-                              _kill_tree(pid)
-                              kill(proc, Base.SIGKILL)
-                          catch; end
+                          try; _kill_proc_tree(proc); catch; end
                       end
                       Base.invokelatest(job.on_process, proc)
                   end)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -612,6 +612,26 @@ end
         rm(proj.root; recursive=true)
     end
 
+    # read_ccid_raw is the one ccid.json read+Symbol-key-normalize helper (used by the api layer).
+    # versioned_get is the single active-value accessor for both String→String path dicts and the
+    # Any/JSON3 raw dicts (replaced the removed image.jl `active`).
+    @testset "read_ccid_raw + versioned_get on path dicts" begin
+        mktempdir() do d
+            p = joinpath(d, "ccid.json")
+            write(p, """{"filepath":{"default":"x.ome.zarr","_active":"default"},"class":"CciaImage"}""")
+            raw = read_ccid_raw(p)
+            @test raw isa Dict{String,Any}
+            @test all(k -> k isa String, keys(raw))
+            @test raw["class"] == "CciaImage"
+            # readable via the exact helper the api/tasks use (nothing → active entry)
+            @test versioned_get_field(raw, "filepath") == "x.ome.zarr"
+        end
+        # versioned_get on a concrete String→String versioned dict (the img.filepath / img.label_props shape)
+        d = Dict{String,String}("default" => "a.zarr", "v2" => "b.zarr", "_active" => "v2")
+        @test versioned_get(d) == "b.zarr"                 # active entry
+        @test sort(versioned_keys(d)) == ["default", "v2"] # excludes _active
+    end
+
     # ── Destructive ops ──────────────────────────────────────────────────────────
     @testset "delete_image! / delete_set!" begin
         proj = create_project!(name="del-test-$(rand(1000:9999))", kind="static")

--- a/frontend/src/components/FloatingPanel.vue
+++ b/frontend/src/components/FloatingPanel.vue
@@ -3,6 +3,12 @@
 // (position: fixed). Position/size/collapsed persist per `storageKey` so it reopens where you left it.
 // The parent owns visibility (v-if) and handles @close; the panel owns everything else. Reusable —
 // not viewer-specific — so any tool that wants a floating box uses this one component.
+//
+// NOT the same as `composables/useFloatingPanel.ts` — that drives the *canvas* panels (position:
+// absolute inside a zoomable offsetParent, mouse-drag with zoom compensation + tile/cascade arrange,
+// size owned by CSS `resize`, no persistence). This is a top-level viewport window (position: fixed,
+// pointer-drag + resize handle + collapse + localStorage). Different coordinate system, event model,
+// and feature set — a deliberate split, not duplication to merge (see INVENTORY.md).
 import { reactive, onMounted, onUnmounted, watch } from 'vue'
 
 const props = withDefaults(defineProps<{

--- a/frontend/src/composables/useFloatingPanel.ts
+++ b/frontend/src/composables/useFloatingPanel.ts
@@ -13,6 +13,12 @@ export interface ArrangeCmd { x: number; y: number; w: number; h: number; seq: n
  *
  * Extracted verbatim from the duplicated logic in GatePlotPanel + PopulationManager so every
  * floating panel behaves identically and there is one place to fix the clamp maths.
+ *
+ * NOT the same as the `components/FloatingPanel.vue` component — that is a top-level viewport window
+ * (position: fixed, pointer-drag + resize handle + collapse + localStorage persistence). This drives
+ * the zoomable-canvas panels (position: absolute, mouse-drag with zoom compensation + tile/cascade
+ * arrange, size via CSS `resize`). Different coordinate system, event model, and feature set — a
+ * deliberate split, not duplication to merge (see INVENTORY.md).
  */
 export function useFloatingPanel(
   el: Ref<HTMLElement | null>,

--- a/frontend/src/modules/NotebooksModule.vue
+++ b/frontend/src/modules/NotebooksModule.vue
@@ -6,6 +6,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import NotebookTable from '../components/NotebookTable.vue'
+import { notebooksApi } from '../utils/serviceApi'
 
 const projectMeta = useProjectMetaStore()
 
@@ -88,13 +89,7 @@ async function launch() {
   errorMsg.value = ''
   server.value = 'starting'
   try {
-    const res = await fetch('/api/notebooks/launch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectUid: projectUid.value }),
-    })
-    const d = await res.json().catch(() => ({}))
-    if (!res.ok) throw new Error(d.error ?? `HTTP ${res.status}`)
+    const d = await notebooksApi.launch(projectUid.value)
     url.value = d.url ?? url.value
     secret.value = d.secret ?? ''
     if (!d.starting) { server.value = 'running'; return }
@@ -110,13 +105,7 @@ async function restart() {
   errorMsg.value = ''
   server.value = 'starting'
   try {
-    const res = await fetch('/api/notebooks/restart', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectUid: projectUid.value }),
-    })
-    const d = await res.json().catch(() => ({}))
-    if (!res.ok) throw new Error(d.error ?? `HTTP ${res.status}`)
+    const d = await notebooksApi.restart(projectUid.value)
     url.value = d.url ?? url.value
     secret.value = d.secret ?? ''
     if (!d.starting) { server.value = 'running'; return }
@@ -130,11 +119,7 @@ async function restart() {
 async function shutdown() {
   stopPoll()
   try {
-    const res = await fetch('/api/notebooks/shutdown', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
-    })
-    const d = await res.json().catch(() => ({}))
-    if (!res.ok) errorMsg.value = d.error ?? `HTTP ${res.status}`
+    await notebooksApi.shutdown()
   } catch (e) {
     errorMsg.value = e instanceof Error ? e.message : String(e)
   }

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -5,6 +5,7 @@ import { useSettingsStore } from '../stores/settings'
 import PackagesDialog from '../components/PackagesDialog.vue'
 import ConfirmButton from '../components/ConfirmButton.vue'
 import { napariState, notebooksState, stateInfo, formatUptime, type ServiceState } from '../utils/serviceStatus'
+import { notebooksApi, napariApi } from '../utils/serviceApi'
 import { useAppControlStore } from '../stores/appControl'
 
 const showPackages = ref(false)
@@ -136,7 +137,7 @@ async function toggleGpu() {
     })
     const d = await res.json()
     if (d.needsRestart) {
-      await svcPost('/api/napari/restart')
+      await napariApi.restart()
       svcMsg.value = `Napari restarting on the ${which} GPU — reopen the image to reload its layers.`
     } else {
       svcMsg.value = `Napari will use the ${which} GPU next time it starts.`
@@ -155,13 +156,10 @@ let svcTimer: number | undefined
 onMounted(() => { pollServices(); svcTimer = window.setInterval(pollServices, 4000) })
 onUnmounted(() => { if (svcTimer) window.clearInterval(svcTimer) })
 
-const svcPost = (url: string, body?: object) =>
-  fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body ?? {}) })
-
 async function napariAction(kind: 'restart' | 'stop') {
   svcBusy.value = 'napari'; svcMsg.value = ''
   try {
-    await svcPost(kind === 'restart' ? '/api/napari/restart' : '/api/napari/close')
+    await (kind === 'restart' ? napariApi.restart() : napariApi.close())
     svcMsg.value = kind === 'restart' ? 'Napari restarting — reopen the image to reload its layers.' : 'Napari stopped.'
   } catch { svcMsg.value = 'Napari action failed.' }
   finally { svcBusy.value = ''; setTimeout(pollServices, 500) }
@@ -169,8 +167,9 @@ async function napariAction(kind: 'restart' | 'stop') {
 async function notebooksAction(kind: 'start' | 'stop' | 'restart') {
   svcBusy.value = 'notebooks'; svcMsg.value = ''
   try {
-    if (kind === 'stop') await svcPost('/api/notebooks/shutdown')
-    else await svcPost(kind === 'start' ? '/api/notebooks/launch' : '/api/notebooks/restart', { projectUid: projectUid.value })
+    if (kind === 'stop') await notebooksApi.shutdown()
+    else if (kind === 'start') await notebooksApi.launch(projectUid.value)
+    else await notebooksApi.restart(projectUid.value)
     svcMsg.value = kind === 'stop' ? 'Notebooks stopped.' : kind === 'start' ? 'Notebooks starting…' : 'Notebooks restarting…'
   } catch { svcMsg.value = 'Notebooks action failed.' }
   finally { svcBusy.value = ''; setTimeout(pollServices, 500) }

--- a/frontend/src/utils/serviceApi.test.ts
+++ b/frontend/src/utils/serviceApi.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { svcPost, notebooksApi } from './serviceApi'
+
+function mockFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  })
+}
+
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('svcPost', () => {
+  it('returns the parsed body on success', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { starting: true, url: 'u' }))
+    expect(await svcPost('/api/notebooks/launch', { projectUid: 'p' }))
+      .toEqual({ starting: true, url: 'u' })
+  })
+
+  it('throws the server error message on a non-2xx response', async () => {
+    vi.stubGlobal('fetch', mockFetch(500, { error: 'boom' }))
+    await expect(svcPost('/x')).rejects.toThrow('boom')
+  })
+
+  it('throws HTTP <status> when the body has no error field', async () => {
+    vi.stubGlobal('fetch', mockFetch(404, {}))
+    await expect(svcPost('/x')).rejects.toThrow('HTTP 404')
+  })
+
+  it('POSTs JSON with the content-type header', async () => {
+    const f = mockFetch(200, {})
+    vi.stubGlobal('fetch', f)
+    await svcPost('/api/x', { a: 1 })
+    expect(f).toHaveBeenCalledWith('/api/x', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ a: 1 }),
+    }))
+  })
+
+  it('notebooksApi.shutdown hits the one shutdown endpoint', async () => {
+    const f = mockFetch(200, {})
+    vi.stubGlobal('fetch', f)
+    await notebooksApi.shutdown()
+    expect(f.mock.calls[0][0]).toBe('/api/notebooks/shutdown')
+  })
+})

--- a/frontend/src/utils/serviceApi.ts
+++ b/frontend/src/utils/serviceApi.ts
@@ -1,0 +1,31 @@
+// One home for the backend service-control endpoints — the Pluto notebooks server and the napari
+// bridge. Both the Settings service panel (SettingsModule) and the Notebooks page (NotebooksModule)
+// drive these; route through here so an endpoint string / request shape lives in exactly ONE place
+// (the same reason app quit goes through the appControl store). App-level lifecycle (quit / update /
+// dev restart) stays in appControl — this is only the per-service start/stop/restart controls.
+
+/** POST JSON to a service endpoint. Returns the parsed body; throws Error(server message | HTTP n)
+ *  on a non-2xx response so callers can surface failures in their own UI state. */
+export async function svcPost(url: string, body?: object): Promise<any> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error((data as any)?.error ?? `HTTP ${res.status}`)
+  return data
+}
+
+/** Pluto notebooks server (port 7660). */
+export const notebooksApi = {
+  launch: (projectUid: string) => svcPost('/api/notebooks/launch', { projectUid }),
+  restart: (projectUid: string) => svcPost('/api/notebooks/restart', { projectUid }),
+  shutdown: () => svcPost('/api/notebooks/shutdown'),
+}
+
+/** Napari bridge (port 7655). */
+export const napariApi = {
+  restart: () => svcPost('/api/napari/restart'),
+  close: () => svcPost('/api/napari/close'),
+}

--- a/notebooks/example_object_model.jl
+++ b/notebooks/example_object_model.jl
@@ -75,7 +75,7 @@ img = (proj === nothing || isempty(img_uid)) ? nothing : init_object(proj_uid, i
 img === nothing ? md"_(no image resolved)_" :
     md"""
     **$(img.name)** (`$(img_uid)`)
-    - segmentations: **$(join([v for v in value_names(img.label_props) if v != "_active"], ", "))**
+    - segmentations: **$(join(versioned_keys(img.label_props), ", "))**
     - active: **$(get(img.label_props, "_active", "—"))**
     """
 

--- a/notebooks/example_pop_df.jl
+++ b/notebooks/example_pop_df.jl
@@ -41,7 +41,7 @@ img = (isempty(proj_uid) || isempty(uid)) ? nothing : init_object(proj_uid, uid)
 
 # ╔═╡ b4000000-0000-0000-0000-000000000000
 # `label_props` keys are the segmentations (value_names); `_active` is the default one.
-segs = img === nothing ? String[] : [v for v in value_names(img.label_props) if v != "_active"]
+segs = img === nothing ? String[] : versioned_keys(img.label_props)
 
 # ╔═╡ b5000000-0000-0000-0000-000000000000
 img === nothing ? md"➡️ set `proj_uid` + `uid` above (or `CECELIA_EXAMPLE_PROJ`/`_UID`)." :

--- a/notebooks/populations.ipynb
+++ b/notebooks/populations.ipynb
@@ -57,15 +57,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "pID    = \"NRUBxU\"\n",
-    "imgUID = \"KDIeEm\"\n",
-    "\n",
-    "img = init_object(pID, imgUID)\n",
-    "@show img.name\n",
-    "@show value_names(img.label_props)   # the segmentations: [\"A\", \"B\", \"C\"]\n",
-    "img.label_props"
-   ]
+   "source": "pID    = \"NRUBxU\"\nimgUID = \"KDIeEm\"\n\nimg = init_object(pID, imgUID)\n@show img.name\n@show versioned_keys(img.label_props)   # the segmentations: [\"A\", \"B\", \"C\"]\nimg.label_props"
   },
   {
    "cell_type": "markdown",
@@ -82,12 +74,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "for vn in value_names(img.label_props)\n",
-    "    m = load_pop_map(img; value_name=vn, pop_type=\"flow\")\n",
-    "    println(\"$vn  pop_type=$(m.pop_type)  pops=$(pop_paths(m))\")\n",
-    "end"
-   ]
+   "source": "for vn in versioned_keys(img.label_props)\n    m = load_pop_map(img; value_name=vn, pop_type=\"flow\")\n    println(\"$vn  pop_type=$(m.pop_type)  pops=$(pop_paths(m))\")\nend"
   },
   {
    "cell_type": "markdown",
@@ -233,14 +220,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# active segmentation (no value_name) + drop cells with NaN track_id\n",
-    "active = pop_df(img, \"flow\", [\"/qc\"]; pop_cols=[\"track_id\"], drop_na=true)\n",
-    "@show value_names(img.label_props)\n",
-    "@show img.label_props[\"_active\"]\n",
-    "@show nrow(active)\n",
-    "first(active, 5)"
-   ]
+   "source": "# active segmentation (no value_name) + drop cells with NaN track_id\nactive = pop_df(img, \"flow\", [\"/qc\"]; pop_cols=[\"track_id\"], drop_na=true)\n@show versioned_keys(img.label_props)\n@show img.label_props[\"_active\"]\n@show nrow(active)\nfirst(active, 5)"
   }
  ],
  "metadata": {

--- a/python/cecelia/tasks/cleanupImages/cellpose_correct_run.py
+++ b/python/cecelia/tasks/cleanupImages/cellpose_correct_run.py
@@ -22,10 +22,9 @@ import cecelia.utils.zarr_utils as zarr_utils
 import cecelia.utils.ome_xml_utils as ome_xml_utils
 from cecelia.utils.dim_utils import DimUtils
 import cecelia.utils.script_utils as script_utils
+from cecelia.utils.gpu_utils import torch_device
 
 from cellpose import denoise
-import torch
-import ome_types
 import numpy as np
 
 
@@ -48,15 +47,7 @@ def run(params):
     log.log(f'>> models: {models}')
 
     # Auto-detect GPU: prefer CUDA, fall back to MPS (Apple Silicon), then CPU.
-    if torch.cuda.is_available():
-        use_gpu    = True
-        gpu_device = torch.device('cuda')
-    elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-        use_gpu    = True
-        gpu_device = torch.device('mps')
-    else:
-        use_gpu    = False
-        gpu_device = None
+    use_gpu, gpu_device = torch_device()
     log.log(f'>> GPU: {gpu_device if gpu_device else "none (CPU)"}')
 
     # Load the full resolution level into RAM (or keep as Dask for large images).
@@ -66,8 +57,9 @@ def run(params):
         output_image = zarr_utils.fortify(im_dat[0])
 
     # Physical pixel size (µm/px); divides the user-supplied µm diameter to get pixels.
+    # Normalise to µm — DimUtils reports the stored unit ('um' after µ→u, 'mm', …).
     scaling_factor = dim_utils.im_physical_size('x')
-    if dim_utils.omexml.images[0].pixels.physical_size_x_unit == ome_types.model.UnitsLength.MILLIMETER:
+    if dim_utils.im_physical_unit('x') == 'mm':
         scaling_factor *= 1000
 
     # Rescale factor to convert the normalised cellpose output back to the

--- a/python/cecelia/tests/test_gpu_utils.py
+++ b/python/cecelia/tests/test_gpu_utils.py
@@ -1,0 +1,34 @@
+"""Tests for the shared torch GPU-detection helper."""
+
+import unittest
+from unittest import mock
+
+import torch
+
+from cecelia.utils.gpu_utils import torch_device
+
+
+class TorchDeviceTest(unittest.TestCase):
+    def test_cuda_preferred(self):
+        with mock.patch.object(torch.cuda, 'is_available', return_value=True):
+            use_gpu, device = torch_device()
+        self.assertTrue(use_gpu)
+        self.assertEqual(device.type, 'cuda')
+
+    def test_mps_fallback_when_no_cuda(self):
+        with mock.patch.object(torch.cuda, 'is_available', return_value=False), \
+             mock.patch.object(torch.backends.mps, 'is_available', return_value=True):
+            use_gpu, device = torch_device()
+        self.assertTrue(use_gpu)
+        self.assertEqual(device.type, 'mps')
+
+    def test_cpu_fallback(self):
+        with mock.patch.object(torch.cuda, 'is_available', return_value=False), \
+             mock.patch.object(torch.backends.mps, 'is_available', return_value=False):
+            use_gpu, device = torch_device()
+        self.assertFalse(use_gpu)
+        self.assertIsNone(device)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/cecelia/tests/test_label_props_utils.py
+++ b/python/cecelia/tests/test_label_props_utils.py
@@ -1,0 +1,70 @@
+"""Tests for the LabelPropsView write path — focus on the categorical obs encoding
+(the half of the h5ad write contract Julia can't produce)."""
+
+import os
+import tempfile
+import unittest
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+from cecelia.utils.label_props_utils import LabelPropsView
+from cecelia.utils import obs_utils
+
+
+def _make_h5ad(path, labels):
+    """A minimal label-props .h5ad: X + integer-string obs index."""
+    n = len(labels)
+    adata = ad.AnnData(
+        X=np.zeros((n, 2), dtype=np.float64),
+        obs=pd.DataFrame(index=[str(l) for l in labels]),
+    )
+    adata.var_names = ["f0", "f1"]
+    adata.write_h5ad(path)
+
+
+class AddCategoricalObsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.path = os.path.join(self.tmp, "x.h5ad")
+        _make_h5ad(self.path, [10, 20, 30])
+
+    def test_categorical_roundtrip_and_unset_is_code_minus_one(self):
+        # label 20 is deliberately omitted -> should remain unset (code -1)
+        LabelPropsView(self.path).add_categorical_obs(
+            "state", labels=[10, 30], values=["A", "B"]).save()
+
+        back = ad.read_h5ad(self.path)
+        col = back.obs["state"]
+        self.assertIsInstance(col.dtype, pd.CategoricalDtype)
+        self.assertEqual(sorted(col.cat.categories.tolist()), ["A", "B"])
+        codes = dict(zip(back.obs.index, col.cat.codes))
+        self.assertEqual(back.obs.loc["10", "state"], "A")
+        self.assertEqual(back.obs.loc["30", "state"], "B")
+        self.assertEqual(codes["20"], -1)   # unset label -> missing category
+
+    def test_values_stringified(self):
+        # integer transition codes come through as string categories
+        LabelPropsView(self.path).add_categorical_obs(
+            "hmm", labels=[10, 20, 30], values=[1, 2, 1]).save()
+        back = ad.read_h5ad(self.path)
+        self.assertEqual(sorted(back.obs["hmm"].cat.categories.tolist()), ["1", "2"])
+
+    def test_driver_drops_then_writes(self):
+        # seed a column, then the obs_utils driver drops + rewrites it
+        LabelPropsView(self.path).add_categorical_obs(
+            "state", labels=[10], values=["OLD"]).save()
+        obs_utils.write_categorical_obs({
+            "filepath": self.path,
+            "drop": ["state"],
+            "columns": [{"name": "state", "labels": [20, 30], "values": ["X", "Y"]}],
+        })
+        back = ad.read_h5ad(self.path)
+        self.assertEqual(sorted(back.obs["state"].cat.categories.tolist()), ["X", "Y"])
+        self.assertEqual(back.obs.loc["20", "state"], "X")
+        self.assertEqual(back.obs["state"].cat.codes[back.obs.index.get_loc("10")], -1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/cecelia/tests/test_zarr_store.py
+++ b/python/cecelia/tests/test_zarr_store.py
@@ -43,5 +43,80 @@ class CreateMultiscalesStoreTest(unittest.TestCase):
             shutil.rmtree(d, ignore_errors=True)
 
 
+_OME_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06">
+  <Image ID="Image:0" Name="t">
+    <Pixels ID="Pixels:0" DimensionOrder="XYZCT" Type="uint16"
+            SizeT="1" SizeZ="1" SizeC="2" SizeY="4" SizeX="3"
+            PhysicalSizeX="0.5" PhysicalSizeXUnit="µm"
+            PhysicalSizeY="0.5" PhysicalSizeYUnit="µm"
+            PhysicalSizeZ="2.0" PhysicalSizeZUnit="µm">
+      <Channel ID="Channel:0:0" SamplesPerPixel="1"/>
+      <Channel ID="Channel:0:1" SamplesPerPixel="1"/>
+    </Pixels>
+  </Image>
+</OME>
+"""
+
+
+class CreateMultiscalesOnDiskTest(unittest.TestCase):
+    """End-to-end: create_multiscales derives axes + scale from a real DimUtils and writes them into
+    the on-disk .zattrs (the wiring around the shared multiscales_metadata builder)."""
+
+    def test_writes_axes_and_scale_from_dim_utils(self):
+        import ome_types
+        from cecelia.utils.dim_utils import DimUtils
+
+        omexml = ome_types.from_xml(_OME_XML)
+        du = DimUtils(omexml, use_channel_axis=True)
+        du.calc_image_dimensions((2, 4, 3))   # C,Y,X (size-1 T,Z dropped)
+
+        arr = da.from_array(np.zeros((2, 4, 3), dtype=np.uint16), chunks=(1, 4, 3))
+        d = tempfile.mkdtemp()
+        try:
+            path = os.path.join(d, "img.ome.zarr")
+            zu.create_multiscales(arr, path, dim_utils=du, nscales=1)
+            g = zarr.open_group(path, mode="r")
+            ms = g.attrs["multiscales"][0]
+            self.assertEqual([a["name"] for a in ms["axes"]], ["c", "y", "x"])
+            # C has no physical size → 1.0; Y/X → 0.5, in dim order
+            self.assertEqual(ms["datasets"][0]["coordinateTransformations"][0]["scale"],
+                             [1.0, 0.5, 0.5])
+            self.assertEqual(tuple(g["0"].shape), (2, 4, 3))
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+
+class MultiscalesMetadataTest(unittest.TestCase):
+    """The shared NGFF metadata builder used by both the image writer (create_multiscales) and
+    the label writer (segmentation_utils._write_labels_zarr)."""
+
+    def test_image_shape_xy_downsampled_per_level(self):
+        axes = ['T', 'C', 'Y', 'X']
+        scale = {'T': 1.0, 'C': 1.0, 'Y': 0.5, 'X': 0.5}
+        ms = zu.multiscales_metadata(axes, 2, scale_for_axis=scale)
+        self.assertEqual(len(ms), 1)
+        self.assertEqual([a['name'] for a in ms[0]['axes']], ['t', 'c', 'y', 'x'])
+        ds = ms[0]['datasets']
+        self.assertEqual([d['path'] for d in ds], ['0', '1'])
+        # level 0 = base; level 1 = XY *2, other axes unchanged
+        self.assertEqual(ds[0]['coordinateTransformations'][0]['scale'], [1.0, 1.0, 0.5, 0.5])
+        self.assertEqual(ds[1]['coordinateTransformations'][0]['scale'], [1.0, 1.0, 1.0, 1.0])
+
+    def test_label_axes_drop_channel_and_missing_axis_defaults_to_one(self):
+        # label array has no C axis; the scale map still carries C (ignored). Z missing → 1.0
+        label_axes = ['T', 'Y', 'X']
+        ax_to_scale = {'T': 1.0, 'C': 1.0, 'Y': 0.25, 'X': 0.25}   # note: no Z
+        ms = zu.multiscales_metadata(label_axes, 1, scale_for_axis=ax_to_scale)
+        self.assertEqual([a['name'] for a in ms[0]['axes']], ['t', 'y', 'x'])
+        self.assertEqual(ms[0]['datasets'][0]['coordinateTransformations'][0]['scale'],
+                         [1.0, 0.25, 0.25])
+
+    def test_no_axes_writes_paths_only(self):
+        ms = zu.multiscales_metadata([], 2)
+        self.assertNotIn('axes', ms[0])
+        self.assertEqual(ms[0]['datasets'], [{'path': '0'}, {'path': '1'}])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/cecelia/utils/cellpose_utils.py
+++ b/python/cecelia/utils/cellpose_utils.py
@@ -5,11 +5,11 @@ Implements predict_slice() using the cellpose CellposeModel API.
 """
 
 import numpy as np
-import torch
 from scipy import ndimage
 from skimage import filters
 
 from cecelia.utils.segmentation_utils import SegmentationUtils
+from cecelia.utils.gpu_utils import torch_device
 
 
 class CellposeUtils(SegmentationUtils):
@@ -17,15 +17,7 @@ class CellposeUtils(SegmentationUtils):
     def __init__(self, params, dim_utils):
         super().__init__(params, dim_utils)
 
-        if torch.cuda.is_available():
-            self.use_gpu    = True
-            self.gpu_device = torch.device('cuda')
-        elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-            self.use_gpu    = True
-            self.gpu_device = torch.device('mps')
-        else:
-            self.use_gpu    = False
-            self.gpu_device = None
+        self.use_gpu, self.gpu_device = torch_device()
 
         # Physical pixel size for µm → pixel diameter conversion
         self.phys_size_x = dim_utils.im_physical_size('x', default=1.0)

--- a/python/cecelia/utils/correction_utils.py
+++ b/python/cecelia/utils/correction_utils.py
@@ -12,7 +12,6 @@ import numpy as np
 import shutil
 
 import dask.array as da
-import zarr
 import scipy.ndimage
 import skimage.restoration
 import skimage.morphology

--- a/python/cecelia/utils/gpu_utils.py
+++ b/python/cecelia/utils/gpu_utils.py
@@ -1,0 +1,20 @@
+"""GPU device detection for torch-backed tasks (cellpose segment + denoise).
+
+One canonical detector so the CUDA → MPS → CPU fallback isn't duplicated per task.
+"""
+
+import torch
+
+
+def torch_device():
+    """Auto-detect the compute device: prefer CUDA, fall back to MPS (Apple
+    Silicon), then CPU.
+
+    Returns:
+        (use_gpu: bool, device: torch.device | None)
+    """
+    if torch.cuda.is_available():
+        return True, torch.device('cuda')
+    if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        return True, torch.device('mps')
+    return False, None

--- a/python/cecelia/utils/label_props_utils.py
+++ b/python/cecelia/utils/label_props_utils.py
@@ -33,6 +33,7 @@ class LabelPropsView:
         self._pending_obs = None     # staged obs columns to write; flushed by save()
         self._pending_drop = None    # staged obs column names to delete; flushed by save()
         self._pending_obsm = None    # staged obsm matrices to write; flushed by save()
+        self._pending_cat = None     # staged categorical/string obs columns; flushed by save()
 
     # ── metadata ────────────────────────────────────────────────────────────────
     def labels(self) -> np.ndarray:
@@ -141,6 +142,28 @@ class LabelPropsView:
                 self._pending_obs[k] = np.asarray(v)
         return self
 
+    def add_categorical_obs(self, name, labels, values):
+        """Stage a categorical / string obs column (HMM states, HMM transitions like ``"1_2"``,
+        cluster ids), aligned by label like ``add_obs``. Encoded as a pandas ``Categorical``
+        (anndata's categories + integer codes) rather than a float array — this is the encoding
+        Julia's ``LabelProps`` writer can't produce (it writes float64 obs only), so categorical
+        writes come through here. ``values`` is aligned to ``labels``; labels absent from the file,
+        or with a null value, are left unset (category code -1). Repeated calls accumulate.
+        Terminal verb is ``save()``."""
+        if self._pending_cat is None:
+            self._pending_cat = {}
+        row_labels = self.adata.obs.index.astype(np.int64).to_numpy()
+        rowof = {int(l): i for i, l in enumerate(row_labels)}
+        arr = np.full(len(row_labels), None, dtype=object)
+        for lab, v in zip(labels, values):
+            if v is None:
+                continue
+            r = rowof.get(int(lab))
+            if r is not None:
+                arr[r] = str(v)
+        self._pending_cat[name] = pd.Categorical(arr)
+        return self
+
     def drop_obs(self, names):
         """Stage obs columns to delete (by name). Names absent from the file are ignored
         (idempotent). Mirror of the Julia `drop_obs`. Use to invalidate derived columns whose
@@ -170,13 +193,16 @@ class LabelPropsView:
         """Terminal write: flush staged obs adds/drops + obsm matrices into the .h5ad via anndata.
         No-op if nothing is staged. Drops are applied before adds (so a column can be dropped and
         re-added in one chain)."""
-        if not self._pending_obs and not self._pending_drop and not self._pending_obsm:
+        if (not self._pending_obs and not self._pending_drop
+                and not self._pending_obsm and not self._pending_cat):
             return self
         labels = self.adata.obs.index.astype(np.int64).to_numpy()
         for c in (self._pending_drop or []):
             if c in self.adata.obs.columns:
                 del self.adata.obs[c]
         for k, v in (self._pending_obs or {}).items():
+            self.adata.obs[k] = v
+        for k, v in (self._pending_cat or {}).items():
             self.adata.obs[k] = v
         for key, (lab, vals) in (self._pending_obsm or {}).items():
             rowof = {int(l): i for i, l in enumerate(labels)}
@@ -190,6 +216,7 @@ class LabelPropsView:
         self._pending_obs = None
         self._pending_drop = None
         self._pending_obsm = None
+        self._pending_cat = None
         return self
 
     def close(self):

--- a/python/cecelia/utils/measure_utils.py
+++ b/python/cecelia/utils/measure_utils.py
@@ -19,7 +19,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import zarr
 import skimage.measure as skmeas
 import skimage.filters as skfilt
 import anndata as ad

--- a/python/cecelia/utils/obs_utils.py
+++ b/python/cecelia/utils/obs_utils.py
@@ -10,13 +10,15 @@ docs/ARCHITECTURE.md). The Julia reader already decodes categoricals on read.
 Invoked as a subprocess by a Julia task (see ``write_categorical_obs`` in label_props.jl).
 """
 
-import anndata as ad
-import numpy as np
-import pandas as pd
+from cecelia.utils.label_props_utils import LabelPropsView
 
 
 def write_categorical_obs(params, log=None):
     """Write/replace categorical obs columns in an existing ``.h5ad``, aligned by label.
+
+    Thin driver over ``LabelPropsView.add_categorical_obs`` — the one Python h5ad-open path
+    (docs/DATAMODEL.md). This module owns the param contract + logging; the view owns the
+    encoding and file I/O.
 
     params:
       - ``filepath``: target ``.h5ad`` (must exist).
@@ -32,30 +34,19 @@ def write_categorical_obs(params, log=None):
     columns = params.get("columns", []) or []
     drop = params.get("drop", []) or []
 
-    adata = ad.read_h5ad(filepath)
-    obs_labels = adata.obs.index.astype(np.int64).to_numpy()
-    rowof = {int(l): i for i, l in enumerate(obs_labels)}
-
-    for c in drop:
-        if c in adata.obs.columns:
-            del adata.obs[c]
-            _log(f"[INFO] dropped obs column {c}")
+    view = LabelPropsView(filepath)
+    if drop:
+        view.drop_obs(drop)
+        _log(f"[INFO] dropping obs columns: {', '.join(drop)}")
 
     for col in columns:
         name = col["name"]
         labels = col.get("labels", [])
         values = col.get("values", [])
-        arr = np.full(len(obs_labels), None, dtype=object)
-        for lab, v in zip(labels, values):
-            if v is None:
-                continue
-            r = rowof.get(int(lab))
-            if r is not None:
-                arr[r] = str(v)
-        adata.obs[name] = pd.Categorical(arr)
-        n_set = int(np.sum(arr != np.array(None)))
-        n_cat = len(adata.obs[name].cat.categories)
-        _log(f"[INFO] wrote categorical obs '{name}': {n_set}/{len(arr)} labelled, {n_cat} categories")
+        view.add_categorical_obs(name, labels, values)
+        n_set = sum(1 for v in values if v is not None)
+        n_cat = len({str(v) for v in values if v is not None})
+        _log(f"[INFO] wrote categorical obs '{name}': {n_set} labelled, {n_cat} categories")
 
-    adata.write_h5ad(filepath)
+    view.save()
     _log(f"[INFO] saved {filepath}")

--- a/python/cecelia/utils/segmentation_utils.py
+++ b/python/cecelia/utils/segmentation_utils.py
@@ -13,6 +13,8 @@ import shutil
 import numpy as np
 import zarr
 
+import cecelia.utils.zarr_utils as zarr_utils
+
 from skimage import morphology, segmentation
 from scipy import ndimage
 
@@ -425,26 +427,14 @@ class SegmentationUtils:
 
         dim_utils = self.dim_utils
         full_scale = dim_utils.im_scale()  # one value per image axis (including C)
+        # Map base scale by axis NAME so it survives the label array dropping the channel axis.
         ax_to_scale = {ax: full_scale[i] for i, ax in enumerate(dim_utils.im_dim_order)}
 
-        def level_scale(lvl):
-            return [
-                ax_to_scale.get(ax, 1.0) * (2 ** lvl if ax in ('Y', 'X') else 1.0)
-                for ax in label_axes
-            ]
-
         g = zarr.open_group(out_path, mode='w', zarr_format=2)
-        datasets = [
-            {
-                'path': str(lvl),
-                'coordinateTransformations': [{'type': 'scale', 'scale': level_scale(lvl)}],
-            }
-            for lvl in range(nscales)
-        ]
-        g.attrs['multiscales'] = [{
-            'axes': [{'name': ax.lower()} for ax in label_axes],
-            'datasets': datasets,
-        }]
+        # Shared multiscales builder (see zarr_utils.multiscales_metadata) — one layout for
+        # image and label stores. label_axes already excludes C.
+        g.attrs['multiscales'] = zarr_utils.multiscales_metadata(
+            label_axes, nscales, scale_for_axis=ax_to_scale)
 
         chunks = self._label_chunks(arr.shape, label_axes)
         g.create_array('0', data=arr.astype(self.LABEL_DTYPE), chunks=chunks)

--- a/python/cecelia/utils/zarr_utils.py
+++ b/python/cecelia/utils/zarr_utils.py
@@ -193,17 +193,6 @@ def read_scale(path):
     return None
 
 
-def save_dask_as_zarr_multiscales(image_array, im_path, nscales=1):
-    shutil.rmtree(im_path)
-    multiscales_zarr = zarr.open(im_path, mode='w')
-    multiscales_zarr.attrs['multiscales'] = [{'datasets': [
-        {'path': f'{x}'} for x in range(0, nscales)
-    ]}]
-    for i in range(nscales):
-        new_scale = image_array[::(2**i), ::(2**i)]
-        new_scale.to_zarr(os.path.join(im_path, str(i)), overwrite=True)
-
-
 def create_zarr_from_ndarray(im_array, dim_utils, reference_zarr=None, im_chunks=None,
                              store_path=None, ignore_channel=False, ignore_time=False,
                              copy_values=True, remove_previous=False):
@@ -243,6 +232,34 @@ def create_zarr_from_ndarray(im_array, dim_utils, reference_zarr=None, im_chunks
     return new_zarr, im_chunks
 
 
+def multiscales_metadata(axes, nscales, scale_for_axis=None, keyword='datasets'):
+    """Build the NGFF ``multiscales`` attr value (a 1-element list) shared by every multiscale
+    writer — the image writer (`create_multiscales`) and the label writer
+    (`segmentation_utils._write_labels_zarr`). One place that decides the datasets/axes/scale
+    shape, so the layout can't drift between the two.
+
+    ``axes``: ordered axis letters for the stored array (e.g. ``['T','C','Y','X']``, or the
+    channel-dropped label axes). Empty → no ``axes`` key and no scale (legacy no-metadata store).
+    ``scale_for_axis``: maps an axis letter → base physical scale (missing → 1.0). None → omit
+    ``coordinateTransformations``. XY axes are downsampled by ``2**level``; all other axes keep
+    the base scale.
+    ``keyword``: the datasets key (``'datasets'``)."""
+    axes = list(axes or [])
+    datasets = []
+    for lvl in range(nscales):
+        entry = {'path': str(lvl)}
+        if axes and scale_for_axis is not None:
+            entry['coordinateTransformations'] = [{'type': 'scale', 'scale': [
+                float(scale_for_axis.get(ax, 1.0)) * (2 ** lvl if ax in ('X', 'Y') else 1.0)
+                for ax in axes
+            ]}]
+        datasets.append(entry)
+    ms_entry = {keyword: datasets}
+    if axes:
+        ms_entry['axes'] = [{'name': ax.lower()} for ax in axes]
+    return [ms_entry]
+
+
 def create_multiscales(im_array, filepath, dim_utils=None, im_chunks=None,
                        x_idx=None, y_idx=None, nscales=1, keyword='datasets',
                        ignore_channel=False, reference_zarr=None, mode='w',
@@ -250,28 +267,17 @@ def create_multiscales(im_array, filepath, dim_utils=None, im_chunks=None,
     # Write zarr v2 format so napari and zarr_data_to_list can read .zattrs directly.
     multiscales_zarr = zarr.open_group(filepath, mode=mode, zarr_format=2)
 
-    # Build datasets entries; include physical scale in coordinateTransformations when available.
-    scale_base = None
-    if dim_utils is not None and dim_utils.im_dim_order:
-        raw = dim_utils.im_scale()
-        scale_base = [float(s) if s is not None else 1.0 for s in raw]
-
-    datasets = []
-    for lvl in range(nscales):
-        entry = {'path': str(lvl)}
-        if scale_base is not None:
-            # XY axes are downsampled by 2^level; all other axes keep base scale.
-            level_scale = [
-                s * (2 ** lvl) if dim_utils.im_dim_order[i] in ('X', 'Y') else s
-                for i, s in enumerate(scale_base)
-            ]
-            entry['coordinateTransformations'] = [{'type': 'scale', 'scale': level_scale}]
-        datasets.append(entry)
-
-    ms_entry = {keyword: datasets}
-    if dim_utils is not None and dim_utils.im_dim_order:
-        ms_entry['axes'] = [{'name': ax.lower()} for ax in dim_utils.im_dim_order]
-    multiscales_zarr.attrs['multiscales'] = [ms_entry]
+    # Build the multiscales metadata (shared builder — see multiscales_metadata). Axes and the
+    # per-axis base scale come from dim_utils, mapped by axis NAME (letters are unique).
+    axes = list(dim_utils.im_dim_order) if (dim_utils is not None and dim_utils.im_dim_order) else []
+    scale_for_axis = None
+    if axes:
+        scale_for_axis = {
+            ax: (float(s) if s is not None else 1.0)
+            for ax, s in zip(axes, dim_utils.im_scale())
+        }
+    multiscales_zarr.attrs['multiscales'] = multiscales_metadata(
+        axes, nscales, scale_for_axis=scale_for_axis, keyword=keyword)
 
     if isinstance(im_array, dask.array.core.Array):
         # Write into the group so the sub-array inherits zarr v2 format. Chunk PER PLANE — NOT with the


### PR DESCRIPTION
## What & why

A full-codebase **inventory audit** so fresh context windows stop re-implementing things that already exist (two shutdown buttons, hand-rolled zarr, the drifted napari reader stack). Adds `INVENTORY.md` (the living index of what exists + the single-path cross-cutting flows) and a mandatory **discovery-first rule** in `CLAUDE.md`, then consolidates every *real* duplicate the audit surfaced.

The big cross-cutting flows were already clean (WS, task telemetry, shutdown, update, image table, h5ad, `run_py`, image/zarr access). The fixes here are the localised duplicates.

## Changes

**Docs**
- `INVENTORY.md` (new) — ground-truth index; cross-cutting flows, canonical readers/helpers, Vue components, API handlers, bridge, MCP.
- `CLAUDE.md` — "Before implementing anything — mandatory discovery step"; fixed a stale `_kill_tree` pointer (`scheduler.jl`, not `sockets.jl`); GPU-detection snippet → `gpu_utils.torch_device()`; dropped the deleted `save_dask_as_zarr_multiscales` reference.

**Python**
- `gpu_utils.torch_device()` — one CUDA→MPS→CPU detector (was copied in `cellpose_utils` + `cellpose_correct_run`).
- `zarr_utils.multiscales_metadata()` — shared NGFF `.zattrs` builder for the image writer (`create_multiscales`) and label writer (`segmentation_utils._write_labels_zarr`).
- `LabelPropsView.add_categorical_obs()` — `obs_utils` folded onto the one Python h5ad-open path.
- `cellpose_correct` mm-unit via `dim_utils.im_physical_unit` (no raw `ome_types`).
- Dead code removed: 2× unused `import zarr`, `save_dask_as_zarr_multiscales`.

**Julia**
- `_kill_proc_tree(proc)` — one process-tree kill (removed the `uv_process_get_pid` ccall dup ×3; `napari.jl` `close!` no longer orphans Qt children).
- Collapsed `image.jl` `active`/`set_active!` onto the `versioned_*` family (both removed; `value_names` too — example notebooks migrated to `versioned_keys`).
- `read_ccid_raw()` — one ccid.json read + Symbol-key normalize (replaced ×5).
- `napari_api` movies dir — `_movies_dir` + `_movie_named_path` (was built 3 ways).

**Frontend**
- `utils/serviceApi.ts` — one home for napari/notebooks service endpoints, used by SettingsModule + NotebooksModule.
- `FloatingPanel.vue` vs `useFloatingPanel.ts` — documented as a deliberate split (different coordinate system / event model / features), **not** merged.

## Tests

All green: Python **66**, package **976** (+1 pre-existing broken), API (batch + single-image movie naming), frontend **164** + typecheck. New: `gpu_utils`, label-props categorical, `multiscales_metadata` + on-disk `create_multiscales`, `read_ccid_raw`/`versioned_get`, single-image movie naming, `serviceApi`.

## ⚠️ Behaviour changes + needs live verification (couldn't run the app)

- **napari stop/restart is now SIGKILL + process-tree** (was bare SIGTERM) — on the live path (Settings stop/restart, `restart!`, app-quit). Verify Settings napari stop→restart + a full Quit.
- **`svcPost` now throws on non-2xx** → Settings napari/notebooks actions surface backend failures in `svcMsg` (was silent).
- **api/ changes need a full backend restart** (not Revise) — `routes.jl`/`napari_api.jl` aren't Revise-tracked and the `Cecelia.jl` export list changed.
- Worth one live run each: cellpose-correct + segmentation/measure-labels (then open in napari — exercises the shared multiscales writer), a categorical-obs task (HMM/clustering), and a timelapse/animation recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
