### PR TITLE
feat(mcp): observer 10-attempts pattern + note/lab-log events (Slice B)

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -102,5 +102,7 @@ Last audited: 2026-07-16 (full six-area ground-truth read; against `main` @ c1ce
 
 ## MCP observer (`mcp/`)
 
-- **cecelia_mcp/server.py**: FastMCP stdio server `cecelia-observer` — 8 read tools + 1 append tool, each delegating to the client.
+- **cecelia_mcp/server.py**: FastMCP stdio server `cecelia-observer` — 8 read tools + `poll_observations` + 1 append tool, each delegating to the client/monitor.
 - **cecelia_mcp/client.py**: `CeceliaClient` (stdlib urllib to the Julia API) with `ALLOWED_ROUTES` allow-list — the read-only guarantee. Never opens images/h5ad itself; talks HTTP to :8080 only.
+- **cecelia_mcp/monitor.py**: `SessionMonitor` + `normalize_frame` — pure, thread-safe session-state for the 10-attempts pattern (counts terminal task outcomes per `(image_uid, fn)` off the WS stream) + note/lab-log events. No I/O; unit-tested. `poll` drains observations.
+- **cecelia_mcp/wsclient.py**: thin WS listener (`observe`/`start_listener`) feeding the monitor from `ws://…/ws`; best-effort, reconnects, receive-only. Backend events it consumes: `chain:node:*`, `task:status` (now carries `fun`), `image_note_added`, `lab_log_entry_added`.

--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -1079,6 +1079,12 @@ function api_images_inclusion_set(body_bytes::Vector{UInt8})
             haskey(fields, "included") && (img.included = Bool(fields["included"]))
             haskey(fields, "note")     && (img.note     = string(fields["note"]))
         end
+        # Notify observers (mcp/) that a note was set — first-class user context (OBSERVER.md §4).
+        if haskey(fields, "note")
+            broadcast_ws(Dict{String,Any}(
+                "type" => "image_note_added", "projectUid" => project_uid,
+                "imageUid" => String(image_uid), "note" => string(fields["note"])))
+        end
     end
     200, JSON3.write((; ok=true))
 end
@@ -1169,6 +1175,15 @@ function api_lablog_append(body_bytes::Vector{UInt8})
         append_lab_log!(proj, author, lines)
     catch e
         return 400, JSON3.write((; error=sprint(showerror, e)))
+    end
+    # Notify observers (mcp/) of USER-written entries only — not the observer's own [Claude] writes
+    # (would loop) nor [Cecelia] auto-digests (not a user decision). See OBSERVER.md §4.
+    let a = lowercase(strip(author))
+        if !startswith(a, "claude") && !startswith(a, "cecelia")
+            broadcast_ws(Dict{String,Any}(
+                "type" => "lab_log_entry_added", "projectUid" => project_uid,
+                "summary" => join(lines, " ")))
+        end
     end
     200, JSON3.write((; ok=true, block, entries=parse_lab_log(read_lab_log(proj))))
 end

--- a/api/src/sockets.jl
+++ b/api/src/sockets.jl
@@ -12,7 +12,10 @@ ws_log(_ws, task_id, line)             = _broadcast_task((; type="task:log",    
 # representative (first) member, so the frontend needs the full list to invalidate every member's plots
 # (task-refresh; see docs/todo/TASK_DATA_REFRESH_PLAN.md). Defaults empty → single-image tasks fall back
 # to `imageUid` on the frontend.
-ws_status(_ws, task_id, status, uid=""; image_uids=String[]) = _broadcast_task((; type="task:status", taskId=task_id, status=status, imageUid=uid, imageUids=image_uids))
+# `fun` carries the task fun_name so a WS observer (mcp/) can attribute a module-page run to a
+# function for the 10-attempts pattern (chain nodes already carry `fn`; module tasks didn't). Empty
+# for non-task status frames (batch movies). The frontend ignores the extra field.
+ws_status(_ws, task_id, status, uid=""; image_uids=String[], fun="") = _broadcast_task((; type="task:status", taskId=task_id, status=status, imageUid=uid, imageUids=image_uids, fun=fun))
 ws_result(_ws, task_id, uid, meta)     = _broadcast_task((; type="task:result",    taskId=task_id, imageUid=uid, meta=meta))
 
 ws_progress(_ws, task_id, fraction::Float64) =
@@ -206,7 +209,7 @@ function handle_task_run(ws, data)
     proj_root = joinpath(projects_dir(), project_uid)
     if !isdir(proj_root)
         ws_log(ws, task_id, "[ERROR] Project not found: $project_uid")
-        ws_status(ws, task_id, "failed")
+        ws_status(ws, task_id, "failed"; fun=fun_name)
         return
     end
 
@@ -218,7 +221,7 @@ function handle_task_run(ws, data)
     end
     if isempty(image_uids) && isempty(image_uid)
         ws_log(ws, task_id, "[ERROR] No images to run (all selected images are excluded).")
-        ws_status(ws, task_id, "failed")
+        ws_status(ws, task_id, "failed"; fun=fun_name)
         return
     end
 
@@ -233,7 +236,7 @@ function handle_task_run(ws, data)
             _task_from_fun_name(fun_name)
         catch
             ws_log(ws, task_id, "[ERROR] Unknown task: $fun_name")
-            ws_status(ws, task_id, "failed", image_uid)
+            ws_status(ws, task_id, "failed", image_uid; fun=fun_name)
             return
         end
 
@@ -253,7 +256,7 @@ function handle_task_run(ws, data)
             end
             if isempty(imgs)
                 ws_log(ws, task_id, "[ERROR] Set task '$fun_name' has no images")
-                ws_status(ws, task_id, "failed", image_uid)
+                ws_status(ws, task_id, "failed", image_uid; fun=fun_name)
                 return
             end
             rep = first(imgs).uid
@@ -269,14 +272,14 @@ function handle_task_run(ws, data)
                                   # still-QUEUED one — reflects immediately, not only when a worker later
                                   # dequeues and skips it. :done/:failed still wait for the final send.
                                   if rec.status in (:queued, :running, :cancelled)
-                                      ws_status(ws, task_id, string(rec.status), rep)
+                                      ws_status(ws, task_id, string(rec.status), rep; fun=fun_name)
                                   end
                                   final_status[] = rec.status
                               end)
             isnothing(result) || ws_result(ws, task_id, rep, result)
             # a set task touched EVERY member — send the full list so the frontend invalidates all of
             # their plots, not just the representative's (closes the non-rep-member gap).
-            ws_status(ws, task_id, string(final_status[]), rep; image_uids=[i.uid for i in imgs])
+            ws_status(ws, task_id, string(final_status[]), rep; image_uids=[i.uid for i in imgs], fun=fun_name)
             return
         end
 
@@ -287,7 +290,7 @@ function handle_task_run(ws, data)
             obj
         catch ex
             ws_log(ws, task_id, "[ERROR] Could not load image: $ex")
-            ws_status(ws, task_id, "failed", image_uid)
+            ws_status(ws, task_id, "failed", image_uid; fun=fun_name)
             return
         end
 
@@ -304,13 +307,13 @@ function handle_task_run(ws, data)
                               # order before it) so a cancelled — especially still-QUEUED — task
                               # reflects at once. Hold :done/:failed until after the result is sent.
                               if rec.status in (:queued, :running, :cancelled)
-                                  ws_status(ws, task_id, string(rec.status), image_uid)
+                                  ws_status(ws, task_id, string(rec.status), image_uid; fun=fun_name)
                               end
                               final_status[] = rec.status
                           end)
 
         isnothing(result) || ws_result(ws, task_id, image_uid, result)
-        ws_status(ws, task_id, string(final_status[]), image_uid)
+        ws_status(ws, task_id, string(final_status[]), image_uid; fun=fun_name)
     end
 end
 

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -509,3 +509,69 @@ end
         @test _movie_named_path(blank, "uid7") == joinpath(tmp, "proj", "movies", "uid7.mp4")
     end
 end
+
+# Observer (mcp/) event broadcasts — Slice B. Capture WS frames by registering a private queue in
+# `_ws_clients` (broadcast_ws puts a serialised frame per client). These frames drive the observer's
+# 10-attempts pattern + note/lab-log surfacing (docs/ai-assist/OBSERVER.md §4-5).
+@testset "API: observer event broadcasts" begin
+    # register a capture client; drain returns the parsed frames seen since the last drain
+    cap = Channel{String}(64)
+    key = gensym("test-observer")
+    lock(_ws_clients_lock) do; _ws_clients[key] = cap; end
+    drain() = (frames = []; while isready(cap); push!(frames, JSON3.read(take!(cap))); end; frames)
+
+    conf = cecelia_conf()
+    dirs = get!(conf, "dirs", Dict{String,Any}())
+    had  = haskey(dirs, "projects"); old = get(dirs, "projects", nothing)
+    tmp  = mktempdir()
+    dirs["projects"] = tmp
+    try
+        proj = create_project!(name="api-observer", kind="static")
+        uid  = proj.uid
+        s    = add_set!(proj; name="set-A")
+        img  = add_image!(s; name="img-1", meta=Dict{String,Any}("ori_path"=>"/tmp/a.tif"))
+
+        # ── ws_status carries `fun` so a module-page run is attributable to a function ──
+        drain()
+        ws_status(nothing, "task-1", "done", img.uid; fun="segment.cellpose")
+        let f = drain()
+            @test length(f) == 1
+            @test f[1].type == "task:status" && f[1].fun == "segment.cellpose"
+            @test f[1].status == "done" && f[1].imageUid == img.uid
+        end
+
+        # ── image_note_added fires when a note is set ──
+        drain()
+        @test _post(api_images_inclusion_set,
+                    Dict("projectUid"=>uid, "values"=>Dict(img.uid=>Dict("note"=>"odd cells"))))[1] == 200
+        let f = drain()
+            note = filter(x -> x.type == "image_note_added", f)
+            @test length(note) == 1
+            @test note[1].imageUid == img.uid && note[1].note == "odd cells" && note[1].projectUid == uid
+        end
+        # setting only `included` (no note) does NOT broadcast a note event
+        drain()
+        @test _post(api_images_inclusion_set,
+                    Dict("projectUid"=>uid, "values"=>Dict(img.uid=>Dict("included"=>false))))[1] == 200
+        @test isempty(filter(x -> x.type == "image_note_added", drain()))
+
+        # ── lab_log_entry_added fires for USER entries only (not [Claude]/[Cecelia]) ──
+        drain()
+        @test _post(api_lablog_append, Dict("projectUid"=>uid, "author"=>"User", "lines"=>["switched to diam 30"]))[1] == 200
+        let f = filter(x -> x.type == "lab_log_entry_added", drain())
+            @test length(f) == 1 && occursin("diam 30", f[1].summary) && f[1].projectUid == uid
+        end
+        # the observer's own [Claude] append must NOT re-broadcast (would loop)
+        drain()
+        @test _post(api_lablog_append, Dict("projectUid"=>uid, "author"=>"Claude", "lines"=>["noted"]))[1] == 200
+        @test isempty(filter(x -> x.type == "lab_log_entry_added", drain()))
+        # [Cecelia] auto-digests are not user decisions → no broadcast
+        drain()
+        @test _post(api_lablog_append, Dict("projectUid"=>uid, "author"=>"Cecelia", "lines"=>["digest"]))[1] == 200
+        @test isempty(filter(x -> x.type == "lab_log_entry_added", drain()))
+    finally
+        lock(_ws_clients_lock) do; delete!(_ws_clients, key); end
+        had ? (dirs["projects"] = old) : delete!(dirs, "projects")
+        rm(tmp; recursive=true, force=true)
+    end
+end

--- a/docs/ai-assist/OBSERVER.md
+++ b/docs/ai-assist/OBSERVER.md
@@ -143,13 +143,24 @@ Implement the configurable per-session cap in the MCP server: after N surfaced o
 
 1. ✅ **DONE** — New read routes: `get_task_log` (`GET /api/images/tasklog`), `get_task_history` (`GET /api/tasks/history`), plus a read-only `GET /api/images` project listing (so `list_images`/`get_project_info` avoid `/projects/load`'s `lastOpenedAt` write). `read_lab_log`/`append_lab_log` already existed. Thin, no scheduler change.
 2. ✅ **DONE** — MCP server skeleton (`mcp/`, Python + FastMCP, stdio) + the eight read tools + `append_lab_log`, allow-listed in `cecelia_mcp/client.py` (the no-mutation guarantee; append is the sole write). `pixi run mcp` / `pixi run test-mcp`. See `mcp/README.md`.
-3. Attempt counter (§5) + `qc_flag_fired`/`image_note_added`/`lab_log_entry_added` events (§4) — enables the attempt pattern and QC surfacing. **← next slice**
-4. Throttle + token reporting (§6).
+3. ✅ **DONE (Slice B)** — Attempt counter (§5) + `image_note_added`/`lab_log_entry_added` events (§4).
+   Counter lives in the **MCP server's session memory** (the doc's "OR" option), fed by the WS stream
+   via `mcp/cecelia_mcp/monitor.py` (pure, unit-tested) + `wsclient.py` (thin listener), surfaced by
+   the `poll_observations` pull tool. Backend: `fun` added to the `task:status` frame (so module-page
+   runs are attributable, `sockets.jl`); `image_note_added` broadcast from `api_images_inclusion_set`
+   and `lab_log_entry_added` (user entries only) from `api_lablog_append` (`routes.jl`). **Deferred:**
+   `qc_flag_fired` — needs the `:flagged` node state that doesn't exist yet (`QC-PROCESS.md` step 1/8);
+   ships with the QC work. Also deferred: server→client *push* (MCP is client-pull; `poll_observations`
+   is the reliable Phase-1 surface — validate live push before building the continuous version).
+4. Throttle + token reporting (§6). **← next slice**
 5. Cohort `get_qc_metrics` route once cohort stats land (`QC-PROCESS.md` step 3).
 
-> **Status (Slice A):** steps 1–2 landed. The observer can describe project state, read task logs +
-> history, read the lab log, and append `[Claude]` entries — and can do nothing else (allow-list
-> enforced + tested). Events / the 10-attempts pattern (step 3) and throttling (step 4) are the next slices.
+> **Status (Slice B):** steps 1–3 landed (minus `qc_flag_fired`, which waits on QC flag state). The
+> observer can describe project state, read task logs + history + the lab log, append `[Claude]`
+> entries, and now **detect the 10-attempts pattern live** (chain + module-page runs, session-scoped)
+> plus surface user notes / lab-log entries via `poll_observations` — and can do nothing else
+> (allow-list enforced + tested; the WS connection is receive-only). Throttling/token reporting
+> (step 4) is next.
 
 ## Verify
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -16,9 +16,12 @@ that talks to the Julia API over HTTP. It is separate infra, not part of the `ce
 mcp/
   cecelia_mcp/
     client.py    # read-only HTTP client + the ALLOW-LIST (stdlib only; the no-mutation guarantee)
-    server.py    # FastMCP server — wires the client into 8 read tools + append_lab_log
+    monitor.py   # pure session monitor: 10-attempts pattern + WS frame → observation (no I/O)
+    wsclient.py  # thin WS listener that feeds the monitor from ws://…/ws
+    server.py    # FastMCP server — wires the client into 8 read tools + poll_observations + append_lab_log
   tests/
-    test_client.py   # stdlib unittest, HTTP mocked
+    test_client.py    # stdlib unittest, HTTP mocked
+    test_monitor.py   # the 10-attempts pattern + frame normalization (pure, no socket)
 ```
 
 ## Tools
@@ -33,7 +36,26 @@ mcp/
 | `get_task_log(project_uid, image_uid, fun)` | `GET /api/images/tasklog` | raw log text for one task fn on one image |
 | `get_task_history(project_uid, limit=100)` | `GET /api/tasks/history` | recent runs across all images, newest first |
 | `read_lab_log(project_uid)` | `GET /api/lablog` | the full lab-log markdown |
+| `poll_observations(project_uid)` | *(in-process, WS-fed)* | pending observations since the last poll — the "sit next to me" signal (see below) |
 | `append_lab_log(project_uid, lines)` | `POST /api/lablog/append` | **the only write** — appends a dated `[Claude]` entry, append-only |
+
+## Live observation — the 10-attempts pattern (Slice B)
+
+Beyond the on-demand reads, the server keeps a **session monitor** fed by the API's WebSocket event
+stream (`ws://…/ws`, best-effort — reconnects on its own, never blocks the read tools). It watches for
+patterns the user is too close to notice and exposes them through **`poll_observations`** — a *pull*
+tool Claude calls periodically while watching a project (MCP is client-pull; unsolicited server→client
+push is a later slice). Each poll drains and returns a (usually empty) list:
+
+- **`repeat_attempts`** — the same function has run **>3 times on one image this session**
+  (`imageUid`, `fn`, `attempts`, `completed`/`failed` tallies, `lastOutcome`). The core signal.
+  Counting is session-scoped and **launch-path-agnostic**: whiteboard chain nodes and module-page
+  single tasks land in the same tally (both terminal outcomes are counted once each).
+- **`image_note_added`** — the user added a note to an image (`imageUid`, `note`).
+- **`lab_log_entry_added`** — a user (non-`[Claude]`/`[Cecelia]`) lab-log entry appeared (`summary`).
+
+The monitor is pure and unit-tested (`tests/test_monitor.py`); the WS listener only decodes frames and
+feeds it. The connection is receive-only — no mutation path is added.
 
 ## The no-mutation guarantee
 

--- a/mcp/cecelia_mcp/monitor.py
+++ b/mcp/cecelia_mcp/monitor.py
@@ -1,0 +1,168 @@
+"""Session monitor — the observer's live pattern detection, driven off the Julia API's WS stream.
+
+The MCP server holds one ``SessionMonitor`` for the life of the process. A background task feeds it
+normalized events (see ``normalize_frame``) as they arrive on the WebSocket; the ``poll_observations``
+tool drains the observations it has accumulated. This is the "sit next to me" signal, but pull-based:
+Claude asks what's worth surfacing rather than the server pushing unsolicited (MCP is client-pull;
+server→client push for the continuous version is a later slice — see docs/ai-assist/OBSERVER.md §7).
+
+Everything here is pure and thread-safe (a single lock): no network, no MCP SDK. That keeps the core
+signal — the 10-attempts pattern — unit-testable without a live backend or Claude Code.
+
+The 10-attempts pattern (OBSERVER.md §"The 10-attempts pattern"): counting is **session-scoped and
+launch-path-agnostic**. A user iterating on cellpose params re-runs the same function on the same
+image many times — sometimes as whiteboard chain nodes, sometimes as module-page single tasks, each
+a fresh submission. We count terminal outcomes per (image_uid, fn) off the event stream, so every
+launch path lands in the same tally, and "you've run this N times *this session*" is exactly what the
+pattern means (a persisted counter would resurface stale weeks-old counts as noise).
+"""
+from __future__ import annotations
+
+import threading
+
+# Surface the repeat-attempts pattern once the count EXCEEDS this (so >3 ⇒ fires on the 4th run),
+# matching OBSERVER.md / QC-PROCESS.md ("same function run >3 times on the same image").
+DEFAULT_ATTEMPT_THRESHOLD = 3
+
+# Terminal chain node states that are NOT a real attempt at the task (see chain.jl: node:failed is
+# fired for :failed, :skipped AND :cancelled). Only genuine failures count toward the pattern.
+_NON_ATTEMPT_NODE_STATES = frozenset({"skipped", "cancelled"})
+# task:status values that are not a terminal outcome — ignored for counting.
+_NON_TERMINAL_TASK_STATUS = frozenset({"queued", "cancelled"})
+
+
+def normalize_frame(frame: dict) -> dict | None:
+    """Map one raw WS frame to a normalized observer event, or None if it isn't one we track.
+
+    Handles both launch paths: whiteboard chain nodes (``chain:node:*`` — carry ``fn``) and
+    module-page single tasks (``task:status`` — carry ``fun``, added backend-side for the observer).
+    Also the two new backend broadcasts wired in this slice: ``image_note_added`` / ``lab_log_entry_added``.
+    """
+    t = frame.get("type")
+
+    if t == "chain:node:running":
+        return {"kind": "task_running", "image_uid": frame.get("imageUid", ""),
+                "fn": frame.get("fn", ""), "project_uid": frame.get("projectUid", "")}
+    if t == "chain:node:done":
+        return {"kind": "task_completed", "image_uid": frame.get("imageUid", ""),
+                "fn": frame.get("fn", ""), "project_uid": frame.get("projectUid", "")}
+    if t == "chain:node:failed":
+        # node:failed doubles as skipped/cancelled — only a real failure is an attempt.
+        if str(frame.get("status", "failed")) in _NON_ATTEMPT_NODE_STATES:
+            return None
+        return {"kind": "task_failed", "image_uid": frame.get("imageUid", ""),
+                "fn": frame.get("fn", ""), "project_uid": frame.get("projectUid", "")}
+
+    if t == "task:status":
+        status = str(frame.get("status", ""))
+        if status in _NON_TERMINAL_TASK_STATUS or status == "running":
+            # running isn't a terminal outcome; queued/cancelled aren't attempts.
+            return None if status != "running" else {
+                "kind": "task_running", "image_uid": frame.get("imageUid", ""),
+                "fn": frame.get("fun") or frame.get("funName") or "", "project_uid": ""}
+        kind = "task_completed" if status == "done" else ("task_failed" if status == "failed" else None)
+        if kind is None:
+            return None
+        return {"kind": kind, "image_uid": frame.get("imageUid", ""),
+                "fn": frame.get("fun") or frame.get("funName") or "", "project_uid": ""}
+
+    if t == "image_note_added":
+        return {"kind": "image_note_added", "image_uid": frame.get("imageUid", ""),
+                "note": frame.get("note", ""), "project_uid": frame.get("projectUid", "")}
+    if t == "lab_log_entry_added":
+        return {"kind": "lab_log_entry_added", "summary": frame.get("summary", ""),
+                "project_uid": frame.get("projectUid", "")}
+
+    return None
+
+
+class SessionMonitor:
+    """Accumulates observations from normalized events; ``poll`` drains them.
+
+    Thread-safe: ``record`` runs on the WS listener thread, ``poll`` on the MCP tool thread.
+    """
+
+    def __init__(self, threshold: int = DEFAULT_ATTEMPT_THRESHOLD):
+        self._threshold = threshold
+        self._lock = threading.Lock()
+        # (image_uid, fn) → {"completed": int, "failed": int}
+        self._outcomes: dict[tuple[str, str], dict[str, int]] = {}
+        # (image_uid, fn) → latest repeat-attempts observation (coalesced: one per key, updated in place)
+        self._pending_attempts: dict[tuple[str, str], dict] = {}
+        # note / lab-log events — each distinct, kept as an ordered list
+        self._pending_events: list[dict] = []
+
+    def record(self, event: dict) -> None:
+        """Fold one normalized event into session state. Unknown/None-ish events are ignored."""
+        if not event:
+            return
+        kind = event.get("kind")
+        if kind in ("task_completed", "task_failed"):
+            self._record_attempt(event)
+        elif kind == "image_note_added":
+            with self._lock:
+                self._pending_events.append({
+                    "type": "image_note_added",
+                    "imageUid": event.get("image_uid", ""),
+                    "note": event.get("note", ""),
+                    "projectUid": event.get("project_uid", ""),
+                })
+        elif kind == "lab_log_entry_added":
+            with self._lock:
+                self._pending_events.append({
+                    "type": "lab_log_entry_added",
+                    "summary": event.get("summary", ""),
+                    "projectUid": event.get("project_uid", ""),
+                })
+        # task_running is tracked implicitly (we count terminal outcomes only) — ignored here.
+
+    def _record_attempt(self, event: dict) -> None:
+        uid = event.get("image_uid") or ""
+        fn = event.get("fn") or ""
+        if not uid or not fn:
+            # Can't attribute (e.g. a module-page task frame from a backend without `fun`) — don't
+            # count it against a phantom key. Better to under-count than misattribute.
+            return
+        key = (uid, fn)
+        outcome = "failed" if event["kind"] == "task_failed" else "completed"
+        with self._lock:
+            tally = self._outcomes.setdefault(key, {"completed": 0, "failed": 0})
+            tally[outcome] += 1
+            total = tally["completed"] + tally["failed"]
+            if total > self._threshold:
+                self._pending_attempts[key] = {
+                    "type": "repeat_attempts",
+                    "imageUid": uid,
+                    "fn": fn,
+                    "attempts": total,
+                    "completed": tally["completed"],
+                    "failed": tally["failed"],
+                    "lastOutcome": outcome,
+                    "projectUid": event.get("project_uid", ""),
+                }
+
+    def poll(self, project_uid: str = "") -> list[dict]:
+        """Return and clear pending observations. If ``project_uid`` is given, only observations for
+        that project (or of unknown project — module-page task frames don't carry one) are returned;
+        others are left pending for a poll that names their project."""
+        with self._lock:
+            keep_attempts: dict[tuple[str, str], dict] = {}
+            out: list[dict] = []
+            for key, obs in self._pending_attempts.items():
+                if _matches_project(obs, project_uid):
+                    out.append(obs)
+                else:
+                    keep_attempts[key] = obs
+            keep_events: list[dict] = []
+            for obs in self._pending_events:
+                (out if _matches_project(obs, project_uid) else keep_events).append(obs)
+            self._pending_attempts = keep_attempts
+            self._pending_events = keep_events
+            return out
+
+
+def _matches_project(obs: dict, project_uid: str) -> bool:
+    if not project_uid:
+        return True
+    op = obs.get("projectUid", "")
+    return op == "" or op == project_uid

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -18,11 +18,15 @@ import os
 from mcp.server.fastmcp import FastMCP
 
 from cecelia_mcp.client import CeceliaClient
+from cecelia_mcp.monitor import SessionMonitor
+from cecelia_mcp.wsclient import api_url_to_ws, start_listener
 
 # Lab-log author tag for observer-written entries. Matches the frontend's authorKind() 'claude'.
 CLAUDE_AUTHOR = "Claude"
 
-_client = CeceliaClient(base_url=os.environ.get("CECELIA_API_URL", "http://127.0.0.1:8080"))
+_API_URL = os.environ.get("CECELIA_API_URL", "http://127.0.0.1:8080")
+_client = CeceliaClient(base_url=_API_URL)
+_monitor = SessionMonitor()
 mcp = FastMCP("cecelia-observer")
 
 
@@ -98,7 +102,29 @@ def append_lab_log(project_uid: str, lines: list[str]) -> dict:
     return _client.append_lab_log(project_uid, CLAUDE_AUTHOR, lines)
 
 
+@mcp.tool()
+def poll_observations(project_uid: str) -> list:
+    """Drain the observer's pending observations since the last poll — the "sit next to me" signal.
+
+    Call this periodically while watching a project. Returns a list (often empty — most of the time
+    nothing is worth surfacing) of observations detected from the live task stream:
+
+    - `repeat_attempts`: the same function has run >3 times on one image this session
+      (`imageUid`, `fn`, `attempts`, `completed`/`failed` tallies, `lastOutcome`). This is the core
+      signal — surface it: "you've run cellpose on this image N times; want to talk through the goal?"
+    - `image_note_added`: the user added a note to an image (`imageUid`, `note`) — ask *why* if the
+      decision looks unusual; the answer belongs in the lab log.
+    - `lab_log_entry_added`: a user (non-[Claude]) lab-log entry appeared (`summary`).
+
+    Observations are cleared once returned. Empty list ⇒ stay silent.
+    """
+    return _monitor.poll(project_uid)
+
+
 def main():
+    # Best-effort: subscribe to the API's WS event stream so the monitor can detect patterns. If the
+    # backend isn't up yet the listener reconnects on its own; the read tools work regardless.
+    start_listener(_monitor, api_url_to_ws(_API_URL))
     mcp.run()  # stdio transport
 
 

--- a/mcp/cecelia_mcp/wsclient.py
+++ b/mcp/cecelia_mcp/wsclient.py
@@ -1,0 +1,75 @@
+"""WebSocket listener that feeds the SessionMonitor from the Julia API's event stream.
+
+Deliberately thin: all it does is connect to ``ws://…/ws``, JSON-decode each frame, run it through
+``normalize_frame``, and hand the result to the monitor. The signal logic lives in ``monitor.py``
+(pure, tested there); the parse step is testable via ``feed_raw`` without opening a socket.
+
+The MCP server (stdio) runs FastMCP's own loop; this runs on a background daemon thread with its own
+asyncio loop (see ``start_listener``). ``websockets`` is already a repo dependency (the napari bridge),
+so no new dep. If the backend is down or drops, ``websockets.connect``'s async-iterator form
+reconnects automatically — the observer is best-effort and never blocks the read tools.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import websockets
+
+from cecelia_mcp.monitor import SessionMonitor, normalize_frame
+
+
+def feed_raw(monitor: SessionMonitor, raw: str) -> dict | None:
+    """Decode one raw WS message and fold it into the monitor. Returns the normalized event (or None
+    if not tracked / not decodable). Pulled out so it can be unit-tested without a live socket."""
+    try:
+        frame = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(frame, dict):
+        return None
+    event = normalize_frame(frame)
+    if event:
+        monitor.record(event)
+    return event
+
+
+def api_url_to_ws(api_url: str) -> str:
+    """http://host:port → ws://host:port/ws  (https → wss)."""
+    base = api_url.rstrip("/")
+    if base.startswith("https://"):
+        base = "wss://" + base[len("https://"):]
+    elif base.startswith("http://"):
+        base = "ws://" + base[len("http://"):]
+    return base + "/ws"
+
+
+async def observe(monitor: SessionMonitor, ws_url: str, *, stop: asyncio.Event | None = None) -> None:
+    """Connect and stream frames into the monitor forever, reconnecting on drop. Best-effort."""
+    async for ws in websockets.connect(ws_url, ping_interval=20, open_timeout=5):
+        try:
+            async for raw in ws:
+                feed_raw(monitor, raw)
+                if stop is not None and stop.is_set():
+                    return
+        except websockets.ConnectionClosed:
+            continue  # reconnect
+        if stop is not None and stop.is_set():
+            return
+
+
+def start_listener(monitor: SessionMonitor, ws_url: str) -> threading.Thread:
+    """Run ``observe`` on a background daemon thread with its own event loop. Returns the thread.
+
+    Daemon so it never keeps the process alive past FastMCP's stdio loop. Failures are swallowed —
+    the observer is an add-on; the read tools must work even if the event stream never connects."""
+    def _run():
+        try:
+            asyncio.run(observe(monitor, ws_url))
+        except Exception:  # noqa: BLE001 — best-effort background listener, never crash the server
+            pass
+
+    thread = threading.Thread(target=_run, name="cecelia-observer-ws", daemon=True)
+    thread.start()
+    return thread

--- a/mcp/tests/test_monitor.py
+++ b/mcp/tests/test_monitor.py
@@ -1,0 +1,174 @@
+"""Tests for the session monitor — the 10-attempts pattern + frame normalization.
+
+Pure logic, no socket, no MCP SDK. This is the core observer signal, so it's tested hard here rather
+than left to a live Claude Code session.
+"""
+import unittest
+
+from cecelia_mcp.monitor import SessionMonitor, normalize_frame
+from cecelia_mcp.wsclient import api_url_to_ws, feed_raw
+
+
+def _chain_done(uid, fn, project="P"):
+    return {"type": "chain:node:done", "imageUid": uid, "fn": fn, "projectUid": project}
+
+
+def _chain_failed(uid, fn, project="P", status="failed"):
+    return {"type": "chain:node:failed", "imageUid": uid, "fn": fn, "projectUid": project,
+            "status": status}
+
+
+def _task_status(uid, fun, status):
+    return {"type": "task:status", "imageUid": uid, "fun": fun, "status": status}
+
+
+class NormalizeFrameTest(unittest.TestCase):
+    def test_chain_frames_map_to_events(self):
+        self.assertEqual(normalize_frame(_chain_done("img1", "segment.cellpose"))["kind"], "task_completed")
+        self.assertEqual(normalize_frame(_chain_failed("img1", "segment.cellpose"))["kind"], "task_failed")
+        run = normalize_frame({"type": "chain:node:running", "imageUid": "i", "fn": "f"})
+        self.assertEqual(run["kind"], "task_running")
+
+    def test_chain_skipped_and_cancelled_are_not_attempts(self):
+        # node:failed doubles as skipped/cancelled — those aren't real attempts.
+        self.assertIsNone(normalize_frame(_chain_failed("i", "f", status="skipped")))
+        self.assertIsNone(normalize_frame(_chain_failed("i", "f", status="cancelled")))
+
+    def test_task_status_uses_fun_field(self):
+        done = normalize_frame(_task_status("img7", "segment.cellpose", "done"))
+        self.assertEqual(done["kind"], "task_completed")
+        self.assertEqual(done["fn"], "segment.cellpose")
+        self.assertEqual(normalize_frame(_task_status("i", "f", "failed"))["kind"], "task_failed")
+
+    def test_task_status_funName_fallback(self):
+        f = normalize_frame({"type": "task:status", "imageUid": "i", "funName": "measure.labels", "status": "done"})
+        self.assertEqual(f["fn"], "measure.labels")
+
+    def test_task_status_queued_and_cancelled_ignored(self):
+        self.assertIsNone(normalize_frame(_task_status("i", "f", "queued")))
+        self.assertIsNone(normalize_frame(_task_status("i", "f", "cancelled")))
+
+    def test_note_and_lablog_events(self):
+        self.assertEqual(normalize_frame(
+            {"type": "image_note_added", "imageUid": "i", "note": "hi"})["kind"], "image_note_added")
+        self.assertEqual(normalize_frame(
+            {"type": "lab_log_entry_added", "summary": "s"})["kind"], "lab_log_entry_added")
+
+    def test_unknown_frame_is_none(self):
+        self.assertIsNone(normalize_frame({"type": "task:progress", "progress": 0.5}))
+        self.assertIsNone(normalize_frame({"type": "chain:log", "line": "x"}))
+
+
+class RepeatAttemptsTest(unittest.TestCase):
+    def test_fires_only_after_threshold(self):
+        m = SessionMonitor()  # threshold 3 ⇒ fires on the 4th
+        for _ in range(3):
+            m.record(normalize_frame(_chain_done("img7", "segment.cellpose")))
+        self.assertEqual(m.poll("P"), [])  # 3 runs — still silent
+        m.record(normalize_frame(_chain_done("img7", "segment.cellpose")))
+        obs = m.poll("P")
+        self.assertEqual(len(obs), 1)
+        self.assertEqual(obs[0]["type"], "repeat_attempts")
+        self.assertEqual(obs[0]["attempts"], 4)
+        self.assertEqual(obs[0]["fn"], "segment.cellpose")
+
+    def test_counts_across_launch_paths(self):
+        # chain nodes AND module-page task frames for the same (image, fn) share one tally.
+        m = SessionMonitor()
+        m.record(normalize_frame(_chain_done("img7", "segment.cellpose")))
+        m.record(normalize_frame(_chain_failed("img7", "segment.cellpose")))
+        m.record(normalize_frame(_task_status("img7", "segment.cellpose", "done")))
+        m.record(normalize_frame(_task_status("img7", "segment.cellpose", "failed")))
+        obs = m.poll()
+        self.assertEqual(obs[0]["attempts"], 4)
+        self.assertEqual(obs[0]["completed"], 2)
+        self.assertEqual(obs[0]["failed"], 2)
+        self.assertEqual(obs[0]["lastOutcome"], "failed")
+
+    def test_coalesces_and_updates_count(self):
+        m = SessionMonitor()
+        for _ in range(5):
+            m.record(normalize_frame(_chain_done("img7", "segment.cellpose")))
+        first = m.poll()
+        self.assertEqual(len(first), 1)
+        self.assertEqual(first[0]["attempts"], 5)
+        # poll drains; two more runs → a fresh, updated observation (not two duplicates)
+        m.record(normalize_frame(_chain_done("img7", "segment.cellpose")))
+        m.record(normalize_frame(_chain_done("img7", "segment.cellpose")))
+        second = m.poll()
+        self.assertEqual(len(second), 1)
+        self.assertEqual(second[0]["attempts"], 7)
+
+    def test_separate_keys_dont_mix(self):
+        m = SessionMonitor()
+        for _ in range(4):
+            m.record(normalize_frame(_chain_done("imgA", "segment.cellpose")))
+        for _ in range(4):
+            m.record(normalize_frame(_chain_done("imgB", "segment.cellpose")))
+        for _ in range(2):
+            m.record(normalize_frame(_chain_done("imgA", "measure.labels")))  # below threshold
+        obs = {(o["imageUid"], o["fn"]): o for o in m.poll()}
+        self.assertEqual(set(obs), {("imgA", "segment.cellpose"), ("imgB", "segment.cellpose")})
+
+    def test_unattributable_attempt_is_dropped(self):
+        # A module-page task frame from a backend without `fun` — no fn ⇒ can't attribute, don't count.
+        m = SessionMonitor()
+        for _ in range(5):
+            m.record(normalize_frame(_task_status("img7", "", "done")))
+        self.assertEqual(m.poll(), [])
+
+
+class PendingEventsTest(unittest.TestCase):
+    def test_note_and_lablog_surface_and_drain(self):
+        m = SessionMonitor()
+        m.record(normalize_frame({"type": "image_note_added", "imageUid": "i", "note": "odd cells",
+                                  "projectUid": "P"}))
+        m.record(normalize_frame({"type": "lab_log_entry_added", "summary": "user note", "projectUid": "P"}))
+        obs = m.poll("P")
+        kinds = {o["type"] for o in obs}
+        self.assertEqual(kinds, {"image_note_added", "lab_log_entry_added"})
+        self.assertEqual(m.poll("P"), [])  # drained
+
+
+class ProjectFilterTest(unittest.TestCase):
+    def test_poll_filters_by_project_but_keeps_others_pending(self):
+        m = SessionMonitor()
+        for _ in range(4):
+            m.record(normalize_frame(_chain_done("imgP", "f", project="P")))
+        for _ in range(4):
+            m.record(normalize_frame(_chain_done("imgQ", "f", project="Q")))
+        p_obs = m.poll("P")
+        self.assertEqual([o["imageUid"] for o in p_obs], ["imgP"])
+        q_obs = m.poll("Q")  # Q's was left pending, not dropped
+        self.assertEqual([o["imageUid"] for o in q_obs], ["imgQ"])
+
+    def test_unknown_project_observation_always_returned(self):
+        # module-page task frames carry no projectUid → returned for any project poll.
+        m = SessionMonitor()
+        for _ in range(4):
+            m.record(normalize_frame(_task_status("img7", "segment.cellpose", "done")))
+        self.assertEqual(len(m.poll("anything")), 1)
+
+
+class WsClientHelpersTest(unittest.TestCase):
+    def test_api_url_to_ws(self):
+        self.assertEqual(api_url_to_ws("http://127.0.0.1:8080"), "ws://127.0.0.1:8080/ws")
+        self.assertEqual(api_url_to_ws("http://127.0.0.1:8080/"), "ws://127.0.0.1:8080/ws")
+        self.assertEqual(api_url_to_ws("https://host:9000"), "wss://host:9000/ws")
+
+    def test_feed_raw_folds_valid_frame(self):
+        m = SessionMonitor()
+        for _ in range(4):
+            feed_raw(m, '{"type":"chain:node:done","imageUid":"i","fn":"f","projectUid":"P"}')
+        self.assertEqual(len(m.poll("P")), 1)
+
+    def test_feed_raw_ignores_garbage(self):
+        m = SessionMonitor()
+        self.assertIsNone(feed_raw(m, "not json"))
+        self.assertIsNone(feed_raw(m, "[1,2,3]"))       # not a dict
+        self.assertIsNone(feed_raw(m, '{"type":"pong"}'))  # untracked
+        self.assertEqual(m.poll(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Slice B — observer 10-attempts pattern + note/lab-log events

Second slice of the MCP observer arc (`docs/ai-assist/OBSERVER.md` §7 step 3). Adds live pattern detection on top of Slice A's read-only tools.

### MCP server (pure, unit-tested)
- **`monitor.py`** — `SessionMonitor` + `normalize_frame`: counts terminal task outcomes per `(image_uid, fn)` off the WS stream and fires a `repeat_attempts` observation once a function runs **>3× on one image this session**. Session-scoped and launch-path-agnostic (whiteboard chain nodes *and* module-page tasks share one tally), thread-safe, coalescing, with completed/failed breakdown.
- **`wsclient.py`** — thin best-effort WS listener feeding the monitor (auto-reconnect, receive-only). No new dep — `websockets` was already present.
- **`server.py`** — new **`poll_observations`** *pull* tool (MCP is client-pull; server→client push deferred until validated live) + starts the listener in `main()`. Allow-list unchanged; no mutation path added.

### Backend events (`api/`)
- `sockets.jl` — `task:status` frames now carry `fun` so module-page runs are attributable (threaded through all `handle_task_run` sites; movie handler excluded).
- `routes.jl` — broadcast `image_note_added` (from `api_images_inclusion_set`) and `lab_log_entry_added` (from `api_lablog_append`, **user entries only** — skips `[Claude]` to avoid a loop and `[Cecelia]` digests).

### Deferred
- `qc_flag_fired` — needs a `:flagged` node state that doesn't exist yet; ships with the QC work.
- Continuous server→client push — `poll_observations` is the reliable Phase-1 surface; validate live push before building the "sit next to me" streaming version.

### Tests
- `test-mcp` 26/26 (18 new, pure — no socket/Claude Code needed).
- `test-api` +14 new "observer event broadcasts" testset (captures real WS frames via a registered test client).
- Verified in isolation (worktree at the commit, no concurrent work present): both suites green.

### Needs a backend restart to fully exercise
`api/` isn't Revise-tracked. Until restart, module-page attempts arrive without `fun` and the monitor correctly *drops* them (tested) rather than misattributing; chain runs work regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
