### PR TITLE
feat(mcp): observer throttle + token reporting + backend-console tool (Slice C)

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -104,7 +104,7 @@ Last audited: 2026-07-16 (full six-area ground-truth read; against `main` @ c1ce
 
 ## MCP observer (`mcp/`)
 
-- **cecelia_mcp/server.py**: FastMCP stdio server `cecelia-observer` — 8 read tools + `poll_observations` + 1 append tool, each delegating to the client/monitor.
+- **cecelia_mcp/server.py**: FastMCP stdio server `cecelia-observer` — 9 read tools (incl. `get_recent_logs`, the backend console) + `poll_observations`/`set_observer_active`/`get_observer_stats` + 1 append tool, each delegating to the client/monitor.
 - **cecelia_mcp/client.py**: `CeceliaClient` (stdlib urllib to the Julia API) with `ALLOWED_ROUTES` allow-list — the read-only guarantee. Never opens images/h5ad itself; talks HTTP to :8080 only.
-- **cecelia_mcp/monitor.py**: `SessionMonitor` + `normalize_frame` — pure, thread-safe session-state for the 10-attempts pattern (counts terminal task outcomes per `(image_uid, fn)` off the WS stream) + note/lab-log events. No I/O; unit-tested. `poll` drains observations.
+- **cecelia_mcp/monitor.py**: `SessionMonitor` + `normalize_frame` — pure, thread-safe session-state for the 10-attempts pattern (counts terminal task outcomes per `(image_uid, fn)` off the WS stream) + note/lab-log events, plus the per-session throttle (`surfaceCap` → silent lab-log flush via `drain_for_log`), token-cost estimate (`stats`), and off switch (`set_enabled`). No I/O; unit-tested. `poll` drains observations.
 - **cecelia_mcp/wsclient.py**: thin WS listener (`observe`/`start_listener`) feeding the monitor from `ws://…/ws`; best-effort, reconnects, receive-only. Backend events it consumes: `chain:node:*`, `task:status` (now carries `fun`), `image_note_added`, `lab_log_entry_added`.

--- a/docs/ai-assist/OBSERVER-VALIDATION.md
+++ b/docs/ai-assist/OBSERVER-VALIDATION.md
@@ -1,0 +1,90 @@
+# Observer — live validation checklist
+
+The MCP observer (Slices A–C, see [`OBSERVER.md`](OBSERVER.md)) is fully unit-tested but has **not**
+been run end-to-end against a live Claude Code session. Everything can be unit-tested *except* the one
+thing that matters most: Claude connecting over stdio, calling a tool, and getting a real response
+from the running Julia server — and whether the pull-based "sit next to me" loop actually surfaces
+useful signal in practice. This doc is that manual pass. Run it whenever the observer changes shape.
+
+It has two jobs:
+1. **Confirm the stack works end-to-end** — reads, the 10-attempts pattern, note/lab-log events, the
+   no-mutation guarantee.
+2. **Measure real token cost** so the Slice C throttle defaults (`surfaceCap`, per-observation token
+   estimate in `mcp/cecelia_mcp/monitor.py`) can be calibrated against a number instead of a guess.
+
+---
+
+## Prerequisites
+
+**A backend with Slice B's events on `:8080`.** Slice B added `fun` to the `task:status` frame plus the
+`image_note_added` / `lab_log_entry_added` broadcasts. Any checkout at or ahead of the Slice B merge
+(#178) has them — `main`, or a feature branch rebased on it. Slice C added **no** backend changes, so
+running the backend from the Slice C worktree is fine.
+
+- Backend: `pixi run dev` from a checkout with Slice B (the Slice C worktree works).
+- Frontend: if the worktree has no `frontend/node_modules`, don't install them — run `pixi run frontend`
+  from a checkout that does (it only proxies `/api` + `/ws` to `:8080`; the backend branch is what
+  matters, not the frontend's). One backend only — don't start a second on `:8080`.
+
+**The observer wired into a Claude session.** The MCP server just talks HTTP/WS to `:8080`, so it's
+independent of which checkout's backend is running. Point it at the code you want to validate (use the
+main env's Python; a worktree has no `.pixi`):
+
+```
+claude mcp add cecelia-observer \
+  --env PYTHONPATH=<abs-path-to>/mcp \
+  -- <abs-path-to>/.pixi/envs/default/bin/python -m cecelia_mcp.server
+```
+
+e.g. `PYTHONPATH=/home/dominik/cc-workspace/cecelia/mcp-observer-slice-c/mcp` and the pixi Python at
+`/home/dominik/cc-workspace/cecelia/cecelia-pineapple/.pixi/envs/default/bin/python`. Override the API
+with `CECELIA_API_URL` if not `http://127.0.0.1:8080`.
+
+Then start a **fresh** `claude` session as the observer ("just sit next to me / watch what I'm doing")
+with a project open in the app.
+
+---
+
+## Validation script
+
+Against the test project (`NRUBxU` / set `jFWePN`, images `KDIeEm` / `CHWgkH` / `hVNx8o`), or any real
+project you have open.
+
+| # | In the observer session… | In the app… | Expect |
+|---|---|---|---|
+| a | "Describe project NRUBxU" | — | correct name / kind / image count / per-status breakdown — reads work end-to-end |
+| b | "Read the task history, and the segment log for KDIeEm" | — | real history + log content |
+| c | "poll for observations" | **re-run one task on KDIeEm 4×** (chain node or module page) | one `repeat_attempts` for that `(image, fn)`, `attempts: 4`, with `completed`/`failed` tally |
+| d | "poll again" | **add a note** to CHWgkH | an `image_note_added` (`imageUid`, `note`) |
+| e | "what are your observer stats?" | — | `surfacedCount`, `surfaceCap`, `throttled`, `estimatedTokens`, `enabled` |
+| f | "turn the observer off" then "poll" | re-run a task again | `poll` returns nothing; counting continues (turn it back on → history intact) |
+| g | "delete image X" / "run cellpose for me" | — | it declines / has no such tool — the no-mutation guarantee holds |
+
+### What to record
+- **Did each observation actually surface?** (c, d) — the core question.
+- **Real token cost of the session** (from Claude Code's own usage readout) vs. the number of
+  observations surfaced → this calibrates `surfaceCap` and `EST_TOKENS_PER_OBSERVATION`.
+- **How often the throttle fires** in a realistic session → informs the open decision below.
+
+### Pass criteria
+- Reads (a, b) correct without being told where to look.
+- `repeat_attempts` fires at the 4th run (c); `image_note_added` fires (d).
+- Off switch silences surfacing but preserves counting (f).
+- No mutation possible beyond the lab-log append (g).
+
+---
+
+## Open decision to settle from this run
+
+**The throttle's silent lab-log flush** (`_flush_to_lab_log` in `server.py`). When `surfaceCap` is hit,
+suppressed observations are appended to the lab log as a `[Claude]` block so nothing is lost. Concern:
+it's an *unprompted* `[Claude]` write (vs. Claude deciding to log), it blurs provenance (mechanical
+spillover looks like considered notes), and it can recreate the noise the throttle exists to suppress.
+Options, to pick based on how often the throttle actually fires:
+
+- **(a)** keep the full dump, `[Claude]` tag (current);
+- **(b)** log a single summary line ("observer throttled — N further patterns suppressed") — *leaning*;
+- **(c)** use a distinct tag (e.g. `[Observer]`) so it never reads as a Claude decision;
+- **(d)** drop silently.
+
+If the throttle rarely fires, this barely matters; if it fires constantly, (b)/(c) become clearly right.

--- a/docs/ai-assist/OBSERVER.md
+++ b/docs/ai-assist/OBSERVER.md
@@ -152,15 +152,33 @@ Implement the configurable per-session cap in the MCP server: after N surfaced o
    `qc_flag_fired` — needs the `:flagged` node state that doesn't exist yet (`QC-PROCESS.md` step 1/8);
    ships with the QC work. Also deferred: server→client *push* (MCP is client-pull; `poll_observations`
    is the reliable Phase-1 surface — validate live push before building the continuous version).
-4. Throttle + token reporting (§6). **← next slice**
-5. Cohort `get_qc_metrics` route once cohort stats land (`QC-PROCESS.md` step 3).
+4. ✅ **DONE (Slice C)** — Throttle + token reporting (§6), all in `mcp/cecelia_mcp/monitor.py`
+   (pure, unit-tested). Configurable per-session `surfaceCap` (default 20): once that many
+   observations have been surfaced, `poll_observations` goes quiet and suppressed patterns are flushed
+   to the lab log as a compact `[Claude]` block (silent-equivalent) rather than spending chat tokens.
+   Running per-session `stats` (`get_observer_stats` / on every poll): surfaced count, cap, throttled,
+   and an `estimatedTokens` gauge (surfaced × ~2.5k — an estimate; the server can't see Claude's real
+   usage). Off switch: `set_observer_active(false)` stops surfacing but keeps counting. **Calibration**
+   (the cap and per-observation token estimate) are defaults to tune against a real live run.
+   Also in this slice: **`get_recent_logs`** (`GET /api/logs/recent`, allow-listed) — the backend
+   console ring (server `@info`/`@warn`/`@error`). A **Julia-side task crash lands here, not in
+   `get_task_log`** (which only captures the Python subprocess's stdout), so when a task keeps failing
+   with an empty task log the observer can pull the real error. Added because the first live session
+   hit exactly this blind spot. Complementary durable fix (separate PR): tee the scheduler's caught
+   task exception into the per-image `.log` so `get_task_log` shows Julia failures too.
+5. Cohort `get_qc_metrics` route once cohort stats land (`QC-PROCESS.md` step 3). **← next**
 
-> **Status (Slice B):** steps 1–3 landed (minus `qc_flag_fired`, which waits on QC flag state). The
-> observer can describe project state, read task logs + history + the lab log, append `[Claude]`
-> entries, and now **detect the 10-attempts pattern live** (chain + module-page runs, session-scoped)
-> plus surface user notes / lab-log entries via `poll_observations` — and can do nothing else
-> (allow-list enforced + tested; the WS connection is receive-only). Throttling/token reporting
-> (step 4) is next.
+> **Status (Slice C):** steps 1–4 landed (minus `qc_flag_fired`, which waits on QC flag state).
+> **Validated end-to-end against live Claude Code (2026-07-17):** with a real project open, the
+> observer independently flagged "segment.cellposeMeasure has run 11×, all failed" — `repeat_attempts`
+> firing through `poll_observations` and Claude acting on it, unprompted. The observer can describe
+> project state, read task logs + history + the lab log + the backend console (`get_recent_logs`),
+> append `[Claude]` entries, detect the 10-attempts pattern live (chain + module-page, session-scoped),
+> surface notes / lab-log entries, and throttle itself (cap → silent lab-log logging, token estimate,
+> off switch) — and can do nothing else (allow-list enforced + tested; WS + console are receive-only).
+> Remaining: the cohort QC route (step 5, waits on `QC-PROCESS.md` step 3) and `qc_flag_fired`; and
+> calibrating the cap/token estimate against measured cost (note: retry storms inflate attempt counts,
+> so an "N attempts" may be fewer real user actions than it looks).
 
 ## Verify
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -36,7 +36,10 @@ mcp/
 | `get_task_log(project_uid, image_uid, fun)` | `GET /api/images/tasklog` | raw log text for one task fn on one image |
 | `get_task_history(project_uid, limit=100)` | `GET /api/tasks/history` | recent runs across all images, newest first |
 | `read_lab_log(project_uid)` | `GET /api/lablog` | the full lab-log markdown |
-| `poll_observations(project_uid)` | *(in-process, WS-fed)* | pending observations since the last poll — the "sit next to me" signal (see below) |
+| `get_recent_logs(level="", limit=100)` | `GET /api/logs/recent` | recent backend console lines (server `@info`/`@warn`/`@error`) — where a Julia-side task crash lands (not in `get_task_log`) |
+| `poll_observations(project_uid)` | *(in-process, WS-fed)* | `{observations, stats}` since the last poll — the "sit next to me" signal (see below) |
+| `set_observer_active(active)` | *(in-process)* | the off switch — stop/resume surfacing; counting continues while off |
+| `get_observer_stats()` | *(in-process)* | session throttle/cost state without draining (surfaced count, cap, throttled, token estimate) |
 | `append_lab_log(project_uid, lines)` | `POST /api/lablog/append` | **the only write** — appends a dated `[Claude]` entry, append-only |
 
 ## Live observation — the 10-attempts pattern (Slice B)
@@ -45,7 +48,8 @@ Beyond the on-demand reads, the server keeps a **session monitor** fed by the AP
 stream (`ws://…/ws`, best-effort — reconnects on its own, never blocks the read tools). It watches for
 patterns the user is too close to notice and exposes them through **`poll_observations`** — a *pull*
 tool Claude calls periodically while watching a project (MCP is client-pull; unsolicited server→client
-push is a later slice). Each poll drains and returns a (usually empty) list:
+push is a later slice). Each poll returns `{observations, stats}`, where `observations` is a
+(usually empty) list of:
 
 - **`repeat_attempts`** — the same function has run **>3 times on one image this session**
   (`imageUid`, `fn`, `attempts`, `completed`/`failed` tallies, `lastOutcome`). The core signal.
@@ -56,6 +60,18 @@ push is a later slice). Each poll drains and returns a (usually empty) list:
 
 The monitor is pure and unit-tested (`tests/test_monitor.py`); the WS listener only decodes frames and
 feeds it. The connection is receive-only — no mutation path is added.
+
+### Throttle, token cost & off switch (Slice C)
+
+To bound token cost (the doc's honest caveat: heavy sessions can be ~10× the ~10-20-event estimate),
+the monitor caps how many observations it surfaces per session (`surfaceCap`, default 20). Once the
+cap is hit it **goes quiet**: `poll_observations` returns no new `observations`, and the suppressed
+patterns are appended to the **lab log** silently instead (a single compact `[Claude]` block) — so
+nothing is lost, but no chat tokens are spent narrating them. `stats` (also via `get_observer_stats`)
+reports `surfacedCount`, `surfaceCap`, `throttled`, `enabled`, and an `estimatedTokens` running gauge
+(surfaced × ~2.5k — an estimate; the server can't see Claude's real usage). **`set_observer_active(false)`**
+is the off switch: surfacing stops but attempt counting keeps running, so re-enabling resumes with full
+history.
 
 ## The no-mutation guarantee
 

--- a/mcp/cecelia_mcp/client.py
+++ b/mcp/cecelia_mcp/client.py
@@ -28,6 +28,7 @@ ALLOWED_ROUTES = frozenset(
         ("GET", "/api/images/meta"),
         ("GET", "/api/images/tasklog"),
         ("GET", "/api/tasks/history"),
+        ("GET", "/api/logs/recent"),     # the backend console ring (server @info/@warn/@error)
         ("GET", "/api/lablog"),
         ("POST", "/api/lablog/append"),  # the ONLY write — append-only, server-guarded
     }
@@ -108,6 +109,12 @@ class CeceliaClient:
 
     def read_lab_log(self, project_uid: str):
         return self._request("GET", "/api/lablog", {"projectUid": project_uid})
+
+    def get_recent_logs(self):
+        # The backend console ring — server-level @info/@warn/@error (task crashes land here, NOT in
+        # the per-image task log, which only captures the Python subprocess's stdout). Not scoped to a
+        # project (it's the process-wide console).
+        return self._request("GET", "/api/logs/recent")
 
     # ── the one write (append-only) ─────────────────────────────────────────────────
     def append_lab_log(self, project_uid: str, author: str, lines: list[str]):

--- a/mcp/cecelia_mcp/monitor.py
+++ b/mcp/cecelia_mcp/monitor.py
@@ -30,6 +30,17 @@ _NON_ATTEMPT_NODE_STATES = frozenset({"skipped", "cancelled"})
 # task:status values that are not a terminal outcome — ignored for counting.
 _NON_TERMINAL_TASK_STATUS = frozenset({"queued", "cancelled"})
 
+# ── Throttle / token-cost defaults (OBSERVER.md §6) ───────────────────────────────────────────────
+# Max observations SURFACED to the chat per session before the observer goes quiet — after this it
+# stops emitting to chat and the suppressed observations are logged to the lab log instead
+# ("silent-equivalent"). The doc's honest caveat: heavy sessions can be ~10x the ~10-20-event
+# estimate, so this cap is the hard stop. Calibrate against a real live run (it's just a default).
+DEFAULT_SURFACE_CAP = 20
+# Rough tokens per surfaced observation packet (event + the context Claude pulls around it), from the
+# doc's "~2-3k tokens of context" estimate. Used ONLY for a running per-session ESTIMATE the observer
+# can report — the server can't see Claude's real token usage. Deliberately conservative.
+EST_TOKENS_PER_OBSERVATION = 2500
+
 
 def normalize_frame(frame: dict) -> dict | None:
     """Map one raw WS frame to a normalized observer event, or None if it isn't one we track.
@@ -82,8 +93,10 @@ class SessionMonitor:
     Thread-safe: ``record`` runs on the WS listener thread, ``poll`` on the MCP tool thread.
     """
 
-    def __init__(self, threshold: int = DEFAULT_ATTEMPT_THRESHOLD):
+    def __init__(self, threshold: int = DEFAULT_ATTEMPT_THRESHOLD,
+                 surface_cap: int = DEFAULT_SURFACE_CAP):
         self._threshold = threshold
+        self._surface_cap = surface_cap
         self._lock = threading.Lock()
         # (image_uid, fn) → {"completed": int, "failed": int}
         self._outcomes: dict[tuple[str, str], dict[str, int]] = {}
@@ -91,6 +104,11 @@ class SessionMonitor:
         self._pending_attempts: dict[tuple[str, str], dict] = {}
         # note / lab-log events — each distinct, kept as an ordered list
         self._pending_events: list[dict] = []
+        # ── throttle / off-switch state ──
+        self._enabled = True             # the off switch: when False, poll surfaces nothing
+        self._surfaced_count = 0         # observations returned to the chat this session
+        # observations suppressed by the cap, awaiting a silent flush to the lab log (server drains)
+        self._to_log: list[dict] = []
 
     def record(self, event: dict) -> None:
         """Fold one normalized event into session state. Unknown/None-ish events are ignored."""
@@ -142,23 +160,69 @@ class SessionMonitor:
                 }
 
     def poll(self, project_uid: str = "") -> list[dict]:
-        """Return and clear pending observations. If ``project_uid`` is given, only observations for
-        that project (or of unknown project — module-page task frames don't carry one) are returned;
-        others are left pending for a poll that names their project."""
+        """Return and clear pending observations for surfacing to the chat.
+
+        - If ``project_uid`` is given, only observations for that project (or of unknown project —
+          module-page task frames don't carry one) are drained; others stay pending for a poll that
+          names their project.
+        - **Off switch:** when disabled, returns [] and leaves everything pending (so re-enabling
+          resurfaces it). The WS listener keeps counting attempts regardless.
+        - **Throttle:** once ``surface_cap`` observations have been surfaced this session, further
+          drained observations are NOT returned — they're queued for a silent lab-log flush
+          (``drain_for_log``) instead. This is the doc's "stop emitting to chat, only append to the
+          lab log" cap that bounds token cost.
+        """
         with self._lock:
-            keep_attempts: dict[tuple[str, str], dict] = {}
-            out: list[dict] = []
-            for key, obs in self._pending_attempts.items():
-                if _matches_project(obs, project_uid):
-                    out.append(obs)
-                else:
-                    keep_attempts[key] = obs
-            keep_events: list[dict] = []
-            for obs in self._pending_events:
-                (out if _matches_project(obs, project_uid) else keep_events).append(obs)
-            self._pending_attempts = keep_attempts
-            self._pending_events = keep_events
+            if not self._enabled:
+                return []
+            drained = self._drain_matching(project_uid)
+            remaining = max(0, self._surface_cap - self._surfaced_count)
+            surface, overflow = drained[:remaining], drained[remaining:]
+            self._surfaced_count += len(surface)
+            self._to_log.extend(overflow)   # suppressed → silent lab-log flush
+            return surface
+
+    def _drain_matching(self, project_uid: str) -> list[dict]:
+        """Remove and return pending observations matching project_uid (attempts first, then events).
+        Non-matching ones are left pending. Caller holds the lock."""
+        keep_attempts: dict[tuple[str, str], dict] = {}
+        out: list[dict] = []
+        for key, obs in self._pending_attempts.items():
+            if _matches_project(obs, project_uid):
+                out.append(obs)
+            else:
+                keep_attempts[key] = obs
+        keep_events: list[dict] = []
+        for obs in self._pending_events:
+            (out if _matches_project(obs, project_uid) else keep_events).append(obs)
+        self._pending_attempts = keep_attempts
+        self._pending_events = keep_events
+        return out
+
+    def drain_for_log(self) -> list[dict]:
+        """Return and clear observations the throttle suppressed — the server flushes these to the
+        lab log so a throttled session still records patterns silently, without spending chat tokens."""
+        with self._lock:
+            out, self._to_log = self._to_log, []
             return out
+
+    def set_enabled(self, enabled: bool) -> None:
+        """The off switch. Disabling stops chat surfacing (poll → []); attempt counting continues."""
+        with self._lock:
+            self._enabled = bool(enabled)
+
+    def stats(self) -> dict:
+        """Running per-session observer state — surfaced count, throttle status, token ESTIMATE."""
+        with self._lock:
+            return {
+                "enabled": self._enabled,
+                "surfacedCount": self._surfaced_count,
+                "surfaceCap": self._surface_cap,
+                "throttled": self._surfaced_count >= self._surface_cap,
+                "estimatedTokens": self._surfaced_count * EST_TOKENS_PER_OBSERVATION,
+                "estTokensPerObservation": EST_TOKENS_PER_OBSERVATION,
+                "pendingLogFlush": len(self._to_log),
+            }
 
 
 def _matches_project(obs: dict, project_uid: str) -> bool:

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -103,12 +103,31 @@ def append_lab_log(project_uid: str, lines: list[str]) -> dict:
 
 
 @mcp.tool()
-def poll_observations(project_uid: str) -> list:
+def get_recent_logs(level: str = "", limit: int = 100) -> list:
+    """Recent lines from the backend's own console — server `@info`/`@warn`/`@error`, newest last.
+
+    This is where a **Julia-side task crash lands** (e.g. a task that dies before its Python
+    subprocess starts) — it does NOT appear in `get_task_log`, which only captures the Python
+    process's stdout. When `poll_observations` shows a `repeat_attempts` / a task keeps failing but
+    the task log looks empty, call this to find the actual error.
+
+    `level` optionally filters to one of "info" / "warn" / "error" (default: all). `limit` caps how
+    many of the most-recent lines are returned. It's a process-wide ring buffer (~500 lines, not
+    persisted, not per-project), so it's for *live/recent* diagnosis, not historical forensics.
+    """
+    logs = _client.get_recent_logs().get("logs", [])
+    if level:
+        logs = [l for l in logs if str(l.get("level", "")).lower() == level.lower()]
+    return logs[-limit:] if limit and limit > 0 else logs
+
+
+@mcp.tool()
+def poll_observations(project_uid: str) -> dict:
     """Drain the observer's pending observations since the last poll — the "sit next to me" signal.
 
-    Call this periodically while watching a project. Returns a list (often empty — most of the time
-    nothing is worth surfacing) of observations detected from the live task stream:
+    Call this periodically while watching a project. Returns `{observations, stats}`:
 
+    `observations` is a list (often empty — most of the time nothing is worth surfacing) of:
     - `repeat_attempts`: the same function has run >3 times on one image this session
       (`imageUid`, `fn`, `attempts`, `completed`/`failed` tallies, `lastOutcome`). This is the core
       signal — surface it: "you've run cellpose on this image N times; want to talk through the goal?"
@@ -116,9 +135,60 @@ def poll_observations(project_uid: str) -> list:
       decision looks unusual; the answer belongs in the lab log.
     - `lab_log_entry_added`: a user (non-[Claude]) lab-log entry appeared (`summary`).
 
-    Observations are cleared once returned. Empty list ⇒ stay silent.
+    `stats` reports the session throttle/cost state (`surfacedCount`, `surfaceCap`, `throttled`,
+    `estimatedTokens`, `enabled`). Once `surfaceCap` observations have been surfaced, the observer
+    goes quiet: `observations` stays empty and further patterns are appended to the lab log silently
+    (so nothing is lost) — see `stats.throttled`. When `enabled` is false (see `set_observer_active`)
+    `observations` is always empty.
+
+    Empty `observations` ⇒ stay silent.
     """
-    return _monitor.poll(project_uid)
+    observations = _monitor.poll(project_uid)
+    # Throttle-suppressed observations are flushed to the lab log silently, so a busy session still
+    # records its patterns without spending chat tokens narrating them (OBSERVER.md §6).
+    suppressed = _monitor.drain_for_log()
+    if suppressed:
+        _flush_to_lab_log(project_uid, suppressed)
+    return {"observations": observations, "stats": _monitor.stats()}
+
+
+@mcp.tool()
+def set_observer_active(active: bool) -> dict:
+    """Turn the live observer on or off (the off switch, per OBSERVER.md §6).
+
+    When off, `poll_observations` surfaces nothing — but attempt counting keeps running in the
+    background, so turning it back on resumes with full history. Use this if the observer becomes
+    noisy or the user wants to work undisturbed. Returns the current session stats.
+    """
+    _monitor.set_enabled(active)
+    return _monitor.stats()
+
+
+@mcp.tool()
+def get_observer_stats() -> dict:
+    """The observer's running per-session state without draining anything: whether it's `enabled`,
+    how many observations were `surfacedCount` (vs the `surfaceCap`), whether it's `throttled`, and a
+    rough `estimatedTokens` cost. The token figure is an ESTIMATE (surfaced x ~2.5k) — the server
+    can't see Claude's real usage — meant as a running gauge, not a bill."""
+    return _monitor.stats()
+
+
+def _flush_to_lab_log(project_uid: str, suppressed: list) -> None:
+    """Append throttle-suppressed observations to the lab log as one compact [Claude] block. Best-
+    effort — never let a lab-log write failure break a poll."""
+    lines = ["_(observer throttled — logged silently, not surfaced)_"]
+    for obs in suppressed:
+        if obs.get("type") == "repeat_attempts":
+            lines.append(f"- repeat: `{obs.get('fn')}` on image {obs.get('imageUid')} "
+                         f"x{obs.get('attempts')} ({obs.get('completed')} ok / {obs.get('failed')} failed)")
+        elif obs.get("type") == "image_note_added":
+            lines.append(f"- note on image {obs.get('imageUid')}: {obs.get('note')}")
+        elif obs.get("type") == "lab_log_entry_added":
+            lines.append(f"- user log entry: {obs.get('summary')}")
+    try:
+        _client.append_lab_log(project_uid, CLAUDE_AUTHOR, lines)
+    except Exception:  # noqa: BLE001 — best-effort; a poll must not fail on a lab-log write error
+        pass
 
 
 def main():

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -70,6 +70,15 @@ class ClientTest(unittest.TestCase):
             self.c.get_task_history("p", limit=5)
         self.assertIn("limit=5", u.call_args[0][0].full_url)
 
+    def test_recent_logs_is_an_allowed_get(self):
+        self.assertIn(("GET", "/api/logs/recent"), ALLOWED_ROUTES)
+        with _patch_urlopen({"logs": [{"level": "error", "message": "boom"}]}) as u:
+            out = self.c.get_recent_logs()
+        req = u.call_args[0][0]
+        self.assertEqual(req.method, "GET")
+        self.assertTrue(req.full_url.endswith("/api/logs/recent"))
+        self.assertEqual(out["logs"][0]["message"], "boom")
+
     def test_append_posts_json_body(self):
         with _patch_urlopen({"ok": True}) as u:
             self.c.append_lab_log("p", "Claude", ["hello", "world"])

--- a/mcp/tests/test_monitor.py
+++ b/mcp/tests/test_monitor.py
@@ -5,8 +5,12 @@ than left to a live Claude Code session.
 """
 import unittest
 
-from cecelia_mcp.monitor import SessionMonitor, normalize_frame
+from cecelia_mcp.monitor import EST_TOKENS_PER_OBSERVATION, SessionMonitor, normalize_frame
 from cecelia_mcp.wsclient import api_url_to_ws, feed_raw
+
+
+def _note(n, project="P"):
+    return {"type": "image_note_added", "imageUid": f"i{n}", "note": f"n{n}", "projectUid": project}
 
 
 def _chain_done(uid, fn, project="P"):
@@ -168,6 +172,52 @@ class WsClientHelpersTest(unittest.TestCase):
         self.assertIsNone(feed_raw(m, "[1,2,3]"))       # not a dict
         self.assertIsNone(feed_raw(m, '{"type":"pong"}'))  # untracked
         self.assertEqual(m.poll(), [])
+
+
+class ThrottleTest(unittest.TestCase):
+    def test_cap_limits_surfaced_and_overflow_queued_for_log(self):
+        m = SessionMonitor(surface_cap=3)
+        for n in range(5):
+            m.record(normalize_frame(_note(n)))
+        surfaced = m.poll("P")
+        self.assertEqual(len(surfaced), 3)                 # cap hit
+        self.assertTrue(m.stats()["throttled"])
+        self.assertEqual(m.stats()["surfacedCount"], 3)
+        self.assertEqual(len(m.drain_for_log()), 2)        # overflow queued for silent lab-log flush
+        self.assertEqual(m.drain_for_log(), [])            # drained once
+
+    def test_once_capped_further_polls_surface_nothing(self):
+        m = SessionMonitor(surface_cap=2)
+        for n in range(2):
+            m.record(normalize_frame(_note(n)))
+        self.assertEqual(len(m.poll("P")), 2)
+        m.record(normalize_frame(_note(99)))               # new observation after cap
+        self.assertEqual(m.poll("P"), [])                  # nothing surfaced
+        self.assertEqual(len(m.drain_for_log()), 1)        # it went to the log queue
+
+    def test_off_switch_surfaces_nothing_but_keeps_counting(self):
+        m = SessionMonitor()
+        m.set_enabled(False)
+        for _ in range(4):
+            m.record(normalize_frame(_chain_done("img7", "segment.cellpose")))
+        self.assertEqual(m.poll("P"), [])                  # disabled → silent
+        self.assertEqual(m.stats()["surfacedCount"], 0)
+        m.set_enabled(True)
+        surfaced = m.poll("P")                             # history preserved → resurfaces
+        self.assertEqual(len(surfaced), 1)
+        self.assertEqual(surfaced[0]["attempts"], 4)
+
+    def test_stats_shape_and_token_estimate(self):
+        m = SessionMonitor(surface_cap=10)
+        for n in range(3):
+            m.record(normalize_frame(_note(n)))
+        m.poll("P")
+        s = m.stats()
+        self.assertEqual(s["surfacedCount"], 3)
+        self.assertEqual(s["surfaceCap"], 10)
+        self.assertFalse(s["throttled"])
+        self.assertTrue(s["enabled"])
+        self.assertEqual(s["estimatedTokens"], 3 * EST_TOKENS_PER_OBSERVATION)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Slice C — observer throttle, token reporting, off switch + backend-console tool

Third slice of the MCP observer arc (`docs/ai-assist/OBSERVER.md` §6), plus a console tool that came straight out of the first live session.

### Throttle / token / off switch (all in `monitor.py`, pure + unit-tested)
- **Per-session `surfaceCap`** (default 20). Once that many observations have been surfaced, `poll_observations` goes quiet and suppressed patterns are flushed to the lab log as a compact `[Claude]` block (silent-equivalent) instead of spending chat tokens.
- **Running `stats`** (`get_observer_stats`, and on every poll): `surfacedCount`, `surfaceCap`, `throttled`, `estimatedTokens` (surfaced × ~2.5k — an *estimate*; the server can't see Claude's real usage).
- **Off switch:** `set_observer_active(false)` stops surfacing but keeps counting, so re-enabling resumes with full history.
- `poll_observations` now returns `{observations, stats}`.

### Backend-console visibility — `get_recent_logs`
The first live session hit a real blind spot: a task kept failing but `get_task_log` was empty, because the crash was **Julia-side** (before the Python subprocess started) and the per-image task log only captures Python stdout. `get_recent_logs(level, limit)` over `GET /api/logs/recent` (allow-listed) exposes the backend console ring (`@info`/`@warn`/`@error`) where that error actually lands.

### Validated live (2026-07-17)
With a real project open, the observer independently flagged *"segment.cellposeMeasure has run 11×, all failed"* — `repeat_attempts` firing through `poll_observations` and Claude acting on it unprompted. The whole arc (stdio handshake, WS stream, cross-run counting, pattern firing) works in practice.

### Reservations
- **Cap (20) + token estimate (2.5k/obs) are uncalibrated defaults** — tune against measured cost. Retry storms inflate attempt counts, so an "N attempts" can be fewer real actions than it looks.
- **Throttle's silent flush is a full-dump `[Claude]` write** (open decision: full / one-line summary / distinct tag / drop) — left as-is pending a session where it actually fires.
- **`get_recent_logs` is the process-wide console** — interleaved, 500-line transient ring, not per-project/durable. The durable per-task fix (tee the scheduler's caught exception into the per-image `.log`) is a **separate follow-up PR**.
- Throttle + `get_recent_logs` are unit-tested but not yet exercised in a live session.

### Tests
`test-mcp` 31/31 (throttle + recent-logs added). Rebased on `main` (incl. #180).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
