### PR TITLE
fix(scheduler): record task crashes in the per-image log, not just the console

### DIFF
--- a/app/src/tasks/scheduler.jl
+++ b/app/src/tasks/scheduler.jl
@@ -284,7 +284,15 @@ function _execute_job!(job::TaskJob)
                       Base.invokelatest(job.on_process, proc)
                   end)
     catch e
-        @warn "Unhandled error in task" task_id = job.id exception = e
+        bt = catch_backtrace()
+        @warn "Unhandled error in task" task_id = job.id exception = (e, bt)
+        # Also tee the crash into the per-image task log (job.on_log appends to
+        # {img._dir}/logs/{fun}.log). Without this, a Julia-side failure — e.g. one thrown before the
+        # Python subprocess even starts — leaves the task log ending mid-run with no error, invisible
+        # to `get_task_log` and to anyone debugging after the fact (the error only went to the console).
+        try
+            Base.invokelatest(job.on_log, "[ERROR] Task crashed: " * sprint(showerror, e, bt))
+        catch; end
         nothing
     end
     _set_status!(rec, is_cancelled(job.id) ? :cancelled :

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -46,6 +46,12 @@ end
 # Custom drop-in task fixture — structs must live at module top level, not inside a @testset block.
 struct _TestCustomTask <: CciaTask end
 
+# A task whose _run_task always throws — used to assert the scheduler tees a crash into the task log.
+struct _CrashTask <: CciaTask end
+Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
+                  on_log::Function = _ -> nothing, on_progress::Function = (_, _) -> nothing,
+                  on_process::Function = _ -> nothing) = error("boom in _run_task (test)")
+
 @testset "Cecelia package smoke tests" begin
 
     # ── Config ────────────────────────────────────────────────────────────────
@@ -764,6 +770,28 @@ struct _TestCustomTask <: CciaTask end
         reloaded = init_object(proj.uid, img.uid)
         @test reloaded.status == "pending"        # primary removal reset status
         @test !haskey(reloaded.filepath, "default")  # version entry gone
+        rm(proj.root; recursive=true)
+    end
+
+    # ── A task crash is recorded in the per-image log, not just the console ──────
+    # Regression: a Julia-side failure (caught in _execute_job!) used to only @warn to the console —
+    # it never reached {img._dir}/logs/{fun}.log, so a crashed task looked like it just stopped
+    # mid-run with no error (invisible to get_task_log + on-disk debugging).
+    @testset "Task crash is teed into the per-image log" begin
+        proj = create_project!(name="crash-test-$(rand(1000:9999))", kind="static")
+        s    = add_set!(proj; name="s")
+        img  = add_image!(s; name="img")
+
+        logs = String[]
+        result = run_task(_CrashTask(), img, Dict{String,Any}(); on_log = l -> push!(logs, l))
+
+        @test result === nothing                                       # crash → nil result
+        @test any(l -> occursin("Task crashed", l) && occursin("boom", l), logs)  # reached on_log
+
+        fun_name = Cecelia._fun_name_from_task(_CrashTask())
+        logfile  = joinpath(img._dir, "logs", fun_name * ".log")
+        @test isfile(logfile)                                          # ...and the on-disk log
+        @test occursin("boom", read(logfile, String))
         rm(proj.root; recursive=true)
     end
 


### PR DESCRIPTION
## Record task crashes in the per-image log, not just the console

### The gap
A Julia-side task failure caught in `_execute_job!` (`scheduler.jl:286`) only `@warn`ed to the console — it never reached `{img._dir}/logs/{fun}.log`. So when a task crashes *before* (or around) its Python subprocess — as with the `run_py` shadow (#180) — the per-image task log just ends mid-run with no error, and `get_task_log` (and anyone debugging on disk) sees nothing.

### The fix
- Tee the caught exception **+ backtrace** into the per-image log via the same `on_log` that writes normal task output (`job.on_log` → `_wrap_log_with_file`).
- Include the backtrace in the console `@warn` too (`exception = (e, bt)`).
- Regression test: a task whose `_run_task` throws now lands `[ERROR] Task crashed … boom` in both the `on_log` sink and the on-disk log file.

### Why now
Surfaced directly by the MCP observer during its first live session: a task kept failing but its task log was empty, because the real error was Julia-side. This closes that blind spot on disk (the observer-side complement — `get_recent_logs`, the live backend console — shipped in the observer Slice C PR).

### Reservations
- Set-scope task crash → error tees to the **representative** image's log only (mirrors existing set-task logging).
- Full backtrace in the log (verbose, but only on failure).
- Only helps **new** crashes.

### Tests
`test-pkg` 1021 pass / 0 fail (+4 from the new testset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
