### PR TITLE
feat(analysis): unify board export into one dropdown (figure and/or CSV)

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -39,7 +39,7 @@ migrated to sidecars on load. See `docs/todo/ANIMATION_PLAN.md`.
 Each tab renders through `components/canvas/LayoutCanvas.vue`: a **comic-plate** grid (templates in
 `plots/layoutTemplates.ts` — header banners, splits, hero+N) whose slots each hold one plot. A slot's
 content is `{ kind, ref, state }`; the `⚙` popover tunes cols/rows/row-height. `TabbedCanvas.vue` wraps
-it with the tab bar + the PDF/CSV export buttons. Each tab has a **duplicate** action (`pi-copy`):
+it with the tab bar + the single `⤓ Export` dropdown. Each tab has a **duplicate** action (`pi-copy`):
 `analysisTabs.addTab('… copy')` + `analysisLayout.duplicateEntry` deep-clones the source board's whole
 layout (plots + their state + shared view-state); sidecar assets (filmstrip/image PNGs) are re-copied
 to fresh ids via `/api/board-assets/copy` so the two boards are independent (deleting a frame in one
@@ -111,7 +111,7 @@ caption (bottom-centre) and actions (recapture / remove, bottom-right) sit **abo
 toolbar (`.cc-panel-controls`, z-index 6) — they used to live at the top and were masked when the
 hover toolbar appeared.
 
-## Export — Figure (PDF / SVG) + CSV
+## Export — one dropdown: figure (PDF / SVG) and/or CSV
 
 `TabbedCanvas` drives export; `LayoutCanvas.capturePage(vector?)` measures the on-screen grid so the
 output reproduces the layout exactly (spans, plates, gaps). `plots/pdf.ts` `layoutPages(pages)` computes
@@ -120,16 +120,24 @@ title strip) — **one geometry, two backends**: the PDF builder (`exportTabsToP
 board SVG builder (`plots/boardSvg.ts` `buildBoardSvgs`) both consume it, so the two exports land
 identically.
 
-**Figure dropdown — PDF (raster) / SVG (vector).** The board's `⤓ Figure` control offers:
-- **PDF (raster)** — the original: one A4 page per board, each slot a hi-res PNG, with each summary
-  plot's data CSV attached to the file.
+**One `⤓ Export` dropdown — figure, data, or both in a single pass.** The board's single export control
+offers: **PDF (raster)**, **SVG (vector)**, **PDF + CSV**, **SVG + CSV**, **CSV only**. Figure and CSV
+share the exact same visit-each-tab-and-capture walk, so the combined items do BOTH in **one pass** —
+`runExport(figure, csv)` walks the tabs once, capturing a figure page (raster for PDF, vector for SVG)
+and/or the per-plot CSVs, then emits whichever outputs were requested. One control, **one spinner**; the
+two exports can't interleave over the shared active-tab slot (only the active board is mounted).
+- **PDF (raster)** — one A4 page per board, each slot a hi-res PNG.
 - **SVG (vector)** — one `.svg` per board (zipped when >1), **editable in Illustrator**. Each slot is a
   **nested `<svg>`** when the panel can emit vector (summary + cluster heatmap via
   `PlotChart.toImageURL('svg')`; UMAP + gating via their `exportSvg`, dots grouped by colour for
   recolouring — see `docs/PLOTS.md`), stitched via `export.ts` `nestSvg`. **Deliberate raster
   exception:** image/filmstrip slots (already screenshots) and the **HMM-transition** panels (HTML
-  overlay legends, no clean vector form) embed as a raster `<image>`. An **info icon** by the dropdown
-  says which stay raster — no silent surprise.
+  overlay legends, no clean vector form) embed as a raster `<image>`.
+- **CSV** — one CSV per summary plot across all boards, zipped (`analysis_csvs.zip`), ready to re-plot
+  in Prism. Available alone or bundled with a figure.
+
+An **info icon** by the dropdown says which slot types stay raster and that a huge point cloud warns —
+no silent surprise.
 
 The vector contract each panel exposes: `exportSvg(): string | Promise<string>` (a full light-theme
 `<svg>`), collected by `capturePage(true)` (falls back to the panel's `exportImage()` PNG when absent).
@@ -144,7 +152,7 @@ The vector contract each panel exposes: `exportSvg(): string | Promise<string>` 
   blank. Every plot host feeds a board-wide load counter through `useDelayedLoading` (the one spinner
   composable they all use — no per-plot wiring), and `waitForPlotsIdle()` blocks until the counter has
   been 0 for a continuous settle window (+2 RAF frames for the final WebGL/canvas paint), capped by a
-  timeout. Both the PDF and CSV export await it after switching tabs.
+  timeout. The single export pass awaits it after switching to each tab.
 
 - **Per-slot title (figure caption)**: each filled slot has an editable title line (`.lc-slot-cap`,
   persisted in the slot's `state.title`), shown above the plot on-screen and drawn above the slot image

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -112,94 +112,72 @@ function onDrop(targetId: number) {
 type CapturedPage = { aspect: number; slots: { rect: { x: number; y: number; w: number; h: number }; png: string | null; svg?: string | null; name?: string; csv?: string | null }[] }
 const layoutRef = useTemplateRef<{ capturePage: (vector?: boolean) => Promise<CapturedPage>
   collectCsvs: () => Promise<{ name: string; csv: string | null }[]> }>('layoutRef')
+// ONE export pass for the whole board — a single spinner, a single walk over the tabs. Figure and CSV
+// share the exact same "visit each tab, let it render, capture" dance, so the dropdown offers combined
+// items (PDF + CSV, …) that do BOTH in one pass: no second click, no two spinners, and no chance of two
+// exports interleaving over the shared active-tab slot (only the active board is mounted at a time).
 const exporting = ref(false)
 const safe = (s: string) => s.replace(/[^\w.-]+/g, '_')
-async function exportPdf() {
-  if (exporting.value || !group.value || !tabs.value.length) return
+async function runExport(figure: 'pdf' | 'svg' | null, csv: boolean) {
+  if (exporting.value || !group.value || !tabs.value.length || (!figure && !csv)) return
   exporting.value = true
   const original = group.value.activeId
   try {
-    const pages = []
+    const pages: { title: string; aspect: number; slots: CapturedPage['slots'] }[] = []
+    const csvFiles: { name: string; text: string }[] = []
     for (const t of tabs.value) {
       tabsStore.setActive(groupKey, t.id)
       await nextTick()
       await waitForPlotsIdle()   // wait for THIS board's plots to finish fetching + rendering — a fixed
                                  // sleep captured slow plots blank; idle-tracking waits exactly as long
-                                 // as needed (a mid-render WebGL frame exports sparse/blurry)
-      const page = await layoutRef.value?.capturePage?.()
-      if (page) pages.push({ title: t.name, aspect: page.aspect, slots: page.slots })
-    }
-    tabsStore.setActive(groupKey, original)
-    await nextTick()
-    if (pages.length) await exportTabsToPdf(pages, 'analysis.pdf')
-    log.info('Exported analysis boards to PDF.', { source: 'analysis' })
-  } catch (e) {
-    log.error(`PDF export failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'analysis' })
-  } finally { exporting.value = false }
-}
-
-// Export every board tab as a VECTOR SVG (docs/ANALYSIS.md) — dots/gates/summary charts are editable in
-// Illustrator; image + HMM slots embed as raster. Same visit-each-tab + idle-wait dance as the PDF, but
-// captures each slot's vector SVG (`capturePage(true)`) and stitches one SVG per board with the SAME A4
-// layout as the PDF. One `.svg` for a single board; a `.zip` of per-board files when there are several.
-async function exportSvgBoard() {
-  if (exporting.value || !group.value || !tabs.value.length) return
-  exporting.value = true
-  const original = group.value.activeId
-  try {
-    const pages = []
-    for (const t of tabs.value) {
-      tabsStore.setActive(groupKey, t.id)
-      await nextTick()
-      await waitForPlotsIdle()
-      const page = await layoutRef.value?.capturePage?.(true)
-      if (page) pages.push({ title: t.name, aspect: page.aspect, slots: page.slots })
-    }
-    tabsStore.setActive(groupKey, original)
-    await nextTick()
-    const boards = buildBoardSvgs(pages)
-    // non-blocking heads-up if a board came out heavy (a big UMAP/point cloud kept as vector)
-    for (const b of boards) { const warn = svgSizeWarning(b.svg, `Board “${b.title}”`); if (warn) log.warn(warn, { source: 'analysis' }) }
-    if (boards.length === 1) downloadText(`${safe(boards[0].title) || 'analysis'}.svg`, boards[0].svg, 'image/svg+xml')
-    else if (boards.length > 1) {
-      downloadBlob('analysis_svgs.zip', zipTextFiles(boards.map((b, i) => ({ name: `${String(i + 1).padStart(2, '0')}_${safe(b.title)}.svg`, text: b.svg }))))
-    }
-    log.info(`Exported ${boards.length} analysis board${boards.length === 1 ? '' : 's'} to SVG.`, { source: 'analysis' })
-  } catch (e) {
-    log.error(`SVG export failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'analysis' })
-  } finally { exporting.value = false }
-}
-function exportBoard(kind: string) { if (kind === 'pdf') exportPdf(); else if (kind === 'svg') exportSvgBoard() }
-
-// Export the shown data of every summary plot — collected across all boards into ONE .zip (one CSV
-// per plot, ready to re-plot in Prism). Same visit-each-tab dance as the PDF (only the active board is
-// mounted); a single zip download replaces the old dozens-of-CSVs "allow multiple downloads" prompt.
-async function exportCsv() {
-  if (exporting.value || !group.value || !tabs.value.length) return
-  exporting.value = true
-  const original = group.value.activeId
-  try {
-    const files: { name: string; text: string }[] = []
-    for (const t of tabs.value) {
-      tabsStore.setActive(groupKey, t.id)
-      await nextTick()
-      await waitForPlotsIdle()   // wait for the board's plots to finish fetching before reading their data
-      for (const { name, csv } of (await layoutRef.value?.collectCsvs?.()) ?? []) {
-        if (!csv) continue
-        files.push({ name: `${safe(t.name)}_${safe(name)}.csv`, text: csv })
+                                 // as needed (a mid-render frame exports sparse/blurry)
+      if (figure) {
+        // raster page for PDF, vector page for SVG (same layout math, different slot content)
+        const page = await layoutRef.value?.capturePage?.(figure === 'svg')
+        if (page) pages.push({ title: t.name, aspect: page.aspect, slots: page.slots })
+      }
+      if (csv) {
+        for (const { name, csv: data } of (await layoutRef.value?.collectCsvs?.()) ?? []) {
+          if (data) csvFiles.push({ name: `${safe(t.name)}_${safe(name)}.csv`, text: data })
+        }
       }
     }
     tabsStore.setActive(groupKey, original)
     await nextTick()
-    if (files.length) {
-      downloadBlob('analysis_csvs.zip', zipTextFiles(files))
-      log.info(`Exported ${files.length} plot CSV${files.length === 1 ? '' : 's'} → analysis_csvs.zip.`, { source: 'analysis' })
-    } else {
-      log.info('No summary-plot data to export.', { source: 'analysis' })
+
+    if (figure === 'pdf' && pages.length) {
+      await exportTabsToPdf(pages, 'analysis.pdf')
+      log.info('Exported analysis boards to PDF.', { source: 'analysis' })
+    } else if (figure === 'svg' && pages.length) {
+      // stitch one SVG per board (same A4 layout as the PDF); dots/gates/summary are editable vector,
+      // image + HMM slots embed as raster. One `.svg` for a single board; a `.zip` when several.
+      const boards = buildBoardSvgs(pages)
+      // non-blocking heads-up if a board came out heavy (a big UMAP/point cloud kept as vector)
+      for (const b of boards) { const warn = svgSizeWarning(b.svg, `Board “${b.title}”`); if (warn) log.warn(warn, { source: 'analysis' }) }
+      if (boards.length === 1) downloadText(`${safe(boards[0].title) || 'analysis'}.svg`, boards[0].svg, 'image/svg+xml')
+      else if (boards.length > 1) downloadBlob('analysis_svgs.zip', zipTextFiles(boards.map((b, i) => ({ name: `${String(i + 1).padStart(2, '0')}_${safe(b.title)}.svg`, text: b.svg }))))
+      log.info(`Exported ${boards.length} analysis board${boards.length === 1 ? '' : 's'} to SVG.`, { source: 'analysis' })
+    }
+    if (csv) {
+      if (csvFiles.length) {
+        downloadBlob('analysis_csvs.zip', zipTextFiles(csvFiles))   // one CSV per plot, ready to re-plot in Prism
+        log.info(`Exported ${csvFiles.length} plot CSV${csvFiles.length === 1 ? '' : 's'} → analysis_csvs.zip.`, { source: 'analysis' })
+      } else {
+        log.info('No summary-plot data to export.', { source: 'analysis' })
+      }
     }
   } catch (e) {
-    log.error(`CSV export failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'analysis' })
+    log.error(`Export failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'analysis' })
   } finally { exporting.value = false }
+}
+// dropdown value → (figure format, include CSV)
+function exportBoard(kind: string) {
+  const map: Record<string, ['pdf' | 'svg' | null, boolean]> = {
+    pdf: ['pdf', false], svg: ['svg', false],
+    'pdf+csv': ['pdf', true], 'svg+csv': ['svg', true], csv: [null, true],
+  }
+  const sel = map[kind]
+  if (sel) runExport(sel[0], sel[1])
 }
 </script>
 
@@ -245,22 +223,18 @@ async function exportCsv() {
       <button class="tab-add" type="button" @click="addTab" v-tooltip.bottom="'New board'" aria-label="New board">
         <i class="pi pi-plus" />
       </button>
-      <!-- board image export: PDF (raster) or SVG (vector, editable in Illustrator) -->
-      <select class="tab-pdf" :disabled="exporting" v-tooltip.bottom="'Export all boards as one file per board'"
+      <!-- one export control: figure (PDF/SVG), data (CSV), or both in a single pass -->
+      <select class="tab-pdf" :disabled="exporting" v-tooltip.bottom="'Export each board — figure, data, or both'"
               @change="exportBoard(($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
-        <option value="">{{ exporting ? '⋯ exporting…' : '⤓ Figure' }}</option>
+        <option value="">{{ exporting ? '⋯ exporting…' : '⤓ Export' }}</option>
         <option value="pdf">PDF (raster)</option>
         <option value="svg">SVG (vector)</option>
+        <option value="pdf+csv">PDF + CSV</option>
+        <option value="svg+csv">SVG + CSV</option>
+        <option value="csv">CSV only</option>
       </select>
-      <i class="tab-info pi pi-info-circle" v-tooltip.bottom="'PDF = raster image, best for viewing/printing (data CSVs attached). ' +
-         'SVG = vector, editable in Illustrator (recolour dots, edit text/axes). ' +
-         'In SVG, image and HMM-transition panels stay raster (no clean vector form). ' +
-         'A very large point cloud (e.g. a 100k+ UMAP) makes a heavy SVG that can be slow in Illustrator — ' +
-         'you’ll get a warning in the log if a figure is large.'" />
-      <button class="tab-csv" type="button" @click="exportCsv" :disabled="exporting"
-              v-tooltip.bottom="'Export the raw datapoints of every summary plot as CSV (one file per plot, → Prism)'">
-        <i :class="exporting ? 'pi pi-spin pi-spinner' : 'pi pi-file-excel'" /> {{ exporting ? 'exporting…' : 'CSV' }}
-      </button>
+      <i class="tab-info pi pi-info-circle" v-tooltip.bottom="'PDF: raster, for viewing/printing. ' +
+         'SVG: vector, editable in Illustrator. CSV: data → Prism. Image + HMM panels stay raster; huge point clouds warn.'" />
     </div>
 
     <!-- only the active board is mounted; keyed by its canvas key so a tab switch re-binds the layout -->
@@ -306,10 +280,4 @@ async function exportCsv() {
 /* info hint for the figure-export format choice */
 .tab-info { align-self: center; margin-left: 4px; margin-bottom: 2px; font-size: 12px; color: var(--cc-text-dim); cursor: help; }
 .tab-info:hover { color: var(--cc-text); }
-/* CSV sits right next to PDF (PDF already carries the margin-left:auto that pushes the pair right) */
-.tab-csv { display: inline-flex; align-items: center; gap: 5px; margin-left: 4px; margin-bottom: 2px;
-  padding: 3px 10px; font-size: 11px; border: 1px solid var(--cc-border); border-radius: 5px;
-  background: var(--cc-surface-1); color: var(--cc-text-dim); cursor: pointer; }
-.tab-csv:hover:not(:disabled) { color: var(--cc-text); border-color: #7c3aed; }
-.tab-csv:disabled { opacity: 0.5; cursor: default; }
 </style>


### PR DESCRIPTION
## What

Collapse the Analysis board's export controls into a **single `⤓ Export` dropdown**:

- PDF (raster)
- SVG (vector)
- PDF + CSV
- SVG + CSV
- CSV only

## Why

The board had a **Figure (PDF/SVG) dropdown** plus a **separate CSV button** that shared one busy flag — so exporting a figure also spun the CSV button. Splitting the flags fixed that but left **two spinners**, which read as "it's exporting both". One combined control removes the confusion.

## How

Figure and CSV already do the exact same walk (visit each tab → let it render → capture), so the combined items do **both in a single pass**: `runExport(figure, csv)` walks the tabs once, capturing a figure page (raster for PDF, vector for SVG) and/or the per-plot CSVs, then emits whichever outputs were requested. **One spinner.**

Bonus: this removes the interleave hazard where two exports could walk the shared active-tab slot at once (only the active board is mounted) — there's now only ever one sequential export flow.

Tooltips trimmed to one line each.

## Test plan

- `npm run typecheck` clean; export/boardSvg vitest (16) pass (pure builders unchanged).
- Not browser-verified — worth clicking each of the 5 options once, especially a combined one (PDF + CSV) to confirm both files come from a single pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
