### PR TITLE
fix(ui): right gutter for flush controls on panels with no #right slot

### DIFF
--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -248,7 +248,10 @@ const visibleUids = computed<string[]>(() =>
     <div class="module-body">
 
       <!-- ── Left: image panel ─────────────────────────────────────── -->
-      <div class="image-panel">
+      <!-- no #right panel (e.g. the Analysis page) → the panel runs flush to the viewport edge, jamming
+           the right-aligned controls (filter toggle, board export, pop picker) + their tooltips against
+           it. `no-right` adds a small right gutter so they have room. -->
+      <div class="image-panel" :class="{ 'no-right': !$slots.right }">
 
         <!-- first-use hint (dismissed permanently per hintKey) -->
         <HintCallout v-if="hint && hintKey" :hint-key="hintKey" :text="hint" />
@@ -421,6 +424,12 @@ const visibleUids = computed<string[]>(() =>
   overflow: hidden;
   min-width: 0;
 }
+/* Right gutter when there's no #right panel to provide one — inset the content of the toolbar + plot
+   area so the right-aligned controls (and their tooltips/floating pickers) aren't flush to the edge.
+   Padding on the inner boxes (not image-panel) keeps the action-bar divider spanning full width. */
+.image-panel.no-right > .action-bar { padding-right: 1.1rem; }
+.image-panel.no-right > .attr-filter,
+.image-panel.no-right > .panel-scroll { padding-right: 0.9rem; }
 
 /* ── Right panel (collapsible) ──────────────────────────────────────────────
    A thin always-visible handle on the left edge toggles the slot; when collapsed

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -233,7 +233,8 @@ function exportBoard(kind: string) {
         <option value="svg+csv">SVG + CSV</option>
         <option value="csv">CSV only</option>
       </select>
-      <i class="tab-info pi pi-info-circle" v-tooltip.bottom="'PDF: raster, for viewing/printing. ' +
+      <!-- opens LEFT (into the page): this is the rightmost control, a bottom tooltip would clip the edge -->
+      <i class="tab-info pi pi-info-circle" v-tooltip.left="'PDF: raster, for viewing/printing. ' +
          'SVG: vector, editable in Illustrator. CSV: data → Prism. Image + HMM panels stay raster; huge point clouds warn.'" />
     </div>
 


### PR DESCRIPTION
## What

Give the right-aligned controls (and their tooltips) some breathing room on pages that have no `#right` panel — currently they run flush to the viewport edge.

## Why

The **Analysis** page has no TaskRunner column (`#right` slot), so `.image-panel` extends to the viewport edge. That jams the right-aligned controls against it and squashes their tooltips:

- the board **export** dropdown + its info tooltip
- the **filter / CSV / Excluded** toggles in the action bar
- the floating **population picker** (positions itself relative to the canvas)

## How

- `ModuleLayout.vue`: add a `no-right` class on `.image-panel` when `!$slots.right`, adding a right gutter to the action bar (`1.1rem`) and the plot area + filter panel (`0.9rem`). Padding is on the inner boxes, not `.image-panel`, so the action-bar divider still spans full width. Scoped to `!$slots.right`, so pages **with** a right panel are untouched.
- `TabbedCanvas.vue`: flip the export **info** tooltip to `v-tooltip.left` — it's the rightmost control with the longest text, so a bottom-centered tooltip clips the edge no matter the gutter.

## Test plan

- `npm run typecheck` clean.
- Not browser-verified — worth an eyeball on the Analysis page: the gutter feels right (currently ~15–18px; trivial to bump) and the export tooltip sits fully on-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
