### PR TITLE
feat(observer): in-app AI observer — plan + Phase 1 backend

### DIFF
--- a/api/src/observer_api.jl
+++ b/api/src/observer_api.jl
@@ -1,0 +1,49 @@
+# ── Observer (in-app AI assistant) API ────────────────────────────────────────────────────────────
+# The in-app driver for the MCP observer: spawn a headless assistant that reads project state and
+# appends to the lab log via the cecelia-observer MCP. Phase 1 = the one-shot "give feedback" button.
+# See docs/todo/OBSERVER_INTEGRATION_PLAN.md and app/src/ai/agent_runner.jl.
+#
+#   GET  /api/observer/status    → { available } — is an assistant CLI present (drives the UI gate:
+#                                   controls render disabled-with-why when false, not hidden).
+#   POST /api/observer/feedback  → run ONE assistant turn on {projectUid}; returns usage + its text.
+#                                   The lab-log write is a side effect the agent performs through the
+#                                   MCP append tool, so the frontend just refreshes the lab log after.
+
+_observer_repo_root() = dirname(dirname(@__DIR__))              # api/src → api → repo root
+_observer_mcp_dir()   = joinpath(_observer_repo_root(), "mcp")
+_observer_api_url()   = "http://127.0.0.1:$(PORT)"
+
+# (Re)write the MCP config the spawned agent loads — cheap, keeps the resolved paths current.
+function _write_observer_mcp_config()::String
+    cfg  = observer_mcp_config(_observer_mcp_dir(), python_bin_path(), _observer_api_url())
+    path = joinpath(config_dir(), "observer-mcp.json")
+    open(path, "w") do io; JSON3.write(io, cfg); end
+    path
+end
+
+function api_observer_status(::HTTP.Request)
+    200, JSON3.write((; available = agent_available(ClaudeAgent())))
+end
+
+function api_observer_feedback(body_bytes::Vector{UInt8})
+    body = try JSON3.read(String(body_bytes)) catch
+        return 400, JSON3.write((; error = "Invalid JSON body"))
+    end
+    project_uid = String(get(body, :projectUid, ""))
+    isempty(project_uid) && return 400, JSON3.write((; error = "projectUid required"))
+    try
+        load_project(project_uid)                                # the agent will read this project
+    catch e
+        return 404, JSON3.write((; error = sprint(showerror, e)))
+    end
+    agent = ClaudeAgent()
+    if !agent_available(agent)
+        return 200, JSON3.write((; ok = false, available = false,
+            error = "No assistant CLI found. Install Claude Code (or set [ai] agent_bin) to enable this."))
+    end
+    cfg_path = _write_observer_mcp_config()
+    res = run_observer_turn(agent, observer_feedback_prompt(project_uid), cfg_path)
+    200, JSON3.write((; ok = res.ok, available = true, message = res.text, error = res.error,
+                        inputTokens = res.input_tokens, outputTokens = res.output_tokens,
+                        session = res.session_id))
+end

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -16,6 +16,7 @@ Cecelia.load_custom_modules!()
 include("sockets.jl")
 include("routes.jl")
 include("napari_api.jl")
+include("observer_api.jl")
 include("gating_api.jl")
 include("plotting_api.jl")
 include("tracking_api.jl")
@@ -227,6 +228,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_chains_run(req)
         elseif path == "/api/logs/recent"
             api_logs_recent()
+        elseif path == "/api/observer/status"
+            api_observer_status(req)
         elseif path == "/api/napari/status"
             api_napari_status(req)
         elseif path == "/api/napari/gpu"
@@ -319,6 +322,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_lablog_append(body_bytes)
         elseif path == "/api/lablog/capture"
             api_lablog_capture(body_bytes)
+        elseif path == "/api/observer/feedback"
+            api_observer_feedback(body_bytes)
         elseif path == "/api/lablog/tune"
             api_lablog_tune(body_bytes)
         elseif path == "/api/lablog/mute"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -591,3 +591,18 @@ end
     d2 = JSON3.read(body2)
     @test haskey(d2, :loaded) && haskey(d2, :failed) && haskey(d2, :categories)
 end
+
+# Observer (in-app AI assistant) — status shape + request validation. The actual agent spawn (a real
+# billed CLI call) is NOT exercised here; only the guard rails around it. See
+# docs/todo/OBSERVER_INTEGRATION_PLAN.md + app/src/ai/agent_runner.jl (pure pieces tested in app/test).
+@testset "API: observer status + feedback validation" begin
+    # status: availability is a bool (true/false depending on whether `claude` is on PATH — don't
+    # assert which, so it passes both in CI and on a dev box with Claude Code installed).
+    st, body = api_observer_status(HTTP.Request("GET", "/api/observer/status"))
+    @test st == 200
+    @test JSON3.read(body).available isa Bool
+
+    # feedback: validated before anything is spawned.
+    @test _post(api_observer_feedback, Dict())[1] == 400                       # projectUid missing
+    @test _post(api_observer_feedback, Dict("projectUid" => "nope"))[1] == 404 # unknown project
+end

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -155,4 +155,12 @@ include("tasks/scheduler.jl")
 include("tasks/chain.jl")
 include("napari.jl")
 
+# AI observer (in-app assistant) — spawns a headless agent that reads state + appends to the lab log
+# through the cecelia-observer MCP. After scheduler.jl (uses _kill_proc_tree). See
+# docs/todo/OBSERVER_INTEGRATION_PLAN.md.
+include("ai/observer_prompt.jl")
+include("ai/agent_runner.jl")
+export ClaudeAgent, agent_available, run_observer_turn, observer_mcp_config,
+       observer_feedback_prompt, observer_auto_prompt, observer_agent_bin
+
 end

--- a/app/src/ai/agent_runner.jl
+++ b/app/src/ai/agent_runner.jl
@@ -1,0 +1,103 @@
+# ── Agent runner — spawn a headless AI assistant to observe + comment in the lab log ──────────────
+#
+# The app runs an assistant (Claude Code today) as a subprocess: it reads project state and appends to
+# the lab log via the cecelia-observer MCP, then exits. Mirrors the napari-bridge spawn pattern
+# (napari.jl `_bridge_cmd` / `Base.Process`). The MCP server is model-agnostic, so the assistant is a
+# swappable adapter — `AgentBackend`, with `ClaudeAgent` the first implementation (Gemini/ChatGPT can
+# slot in later without touching the server or the prompt). See docs/todo/OBSERVER_INTEGRATION_PLAN.md.
+
+abstract type AgentBackend end
+
+# The CLI binary for the agent — default "claude", overridable via config.toml [ai] agent_bin.
+observer_agent_bin()::String = string(get(get(cecelia_conf(), "ai", Dict()), "agent_bin", "claude"))
+
+struct ClaudeAgent <: AgentBackend
+    bin::String
+    model::String     # "" = the CLI's default model
+end
+ClaudeAgent(; bin::AbstractString = observer_agent_bin(), model::AbstractString = "") =
+    ClaudeAgent(String(bin), String(model))
+
+# One turn's outcome — backend-agnostic. The lab-log write itself is a side effect the agent performs
+# through the MCP append tool; this carries the usage/session data for the in-app readouts.
+struct AgentResult
+    ok::Bool
+    text::String
+    input_tokens::Int
+    output_tokens::Int
+    session_id::String
+    error::String
+end
+
+# Is the agent CLI available on PATH? Drives the UI availability gate (feature hidden if absent).
+agent_available(a::AgentBackend)::Bool = !isnothing(Sys.which(_agent_bin(a)))
+_agent_bin(a::ClaudeAgent)::String = a.bin
+
+# The MCP config the spawned agent loads — points at the SAME `cecelia_mcp.server`, talking back to
+# this API. `mcp_dir` is repo-root/mcp (on PYTHONPATH); `api_url` is this server. Reuses mcp/ unchanged.
+function observer_mcp_config(mcp_dir::AbstractString, python_bin::AbstractString,
+                             api_url::AbstractString)::Dict{String,Any}
+    Dict{String,Any}("mcpServers" => Dict{String,Any}(
+        "cecelia-observer" => Dict{String,Any}(
+            "command" => String(python_bin),
+            "args"    => ["-m", "cecelia_mcp.server"],
+            "env"     => Dict{String,Any}("PYTHONPATH" => String(mcp_dir),
+                                          "CECELIA_API_URL" => String(api_url)))))
+end
+
+# Build the `claude -p` command. PURE given its inputs → unit-tested without spawning anything.
+# --allowedTools mcp__cecelia-observer lets the agent call the observer tools non-interactively; the
+# MCP allow-list (read routes + lablog/append only) remains the hard no-mutation guarantee.
+function _build_claude_cmd(a::ClaudeAgent, prompt::AbstractString, mcp_config_path::AbstractString;
+                           session_id::AbstractString = "", system_prompt::AbstractString = "")::Cmd
+    args = String[a.bin, "-p", String(prompt),
+                  "--output-format", "json",
+                  "--mcp-config", String(mcp_config_path),
+                  "--allowedTools", "mcp__cecelia-observer"]
+    isempty(system_prompt) || append!(args, ["--append-system-prompt", String(system_prompt)])
+    isempty(session_id)    || append!(args, ["--resume", String(session_id)])
+    isempty(a.model)       || append!(args, ["--model", a.model])
+    Cmd(args)
+end
+
+# Parse `claude --output-format json` output. PURE → unit-tested. Claude prints one JSON object with
+# `result` (final text), `session_id`, `is_error`, and `usage {input_tokens, output_tokens}`. Tolerant
+# of missing keys (the exact schema is an adapter detail — confirm against a live run, see the PLAN).
+function _parse_claude_result(json_str::AbstractString)::AgentResult
+    j = try
+        JSON3.read(json_str)
+    catch
+        return AgentResult(false, "", 0, 0, "", "could not parse agent output")
+    end
+    j isa AbstractDict || return AgentResult(false, "", 0, 0, "", "unexpected agent output")
+    usage = get(j, :usage, nothing)
+    intok = usage isa AbstractDict ? Int(get(usage, :input_tokens, 0)) : 0
+    outok = usage isa AbstractDict ? Int(get(usage, :output_tokens, 0)) : 0
+    is_err = get(j, :is_error, false) == true
+    text   = string(get(j, :result, ""))
+    AgentResult(!is_err, text, intok, outok, string(get(j, :session_id, "")),
+                is_err ? (isempty(text) ? "agent reported an error" : text) : "")
+end
+
+# Run one observer turn: spawn the agent, let it read + append through the MCP, return usage/session.
+# Bounded by a timeout so a hung agent can't wedge the request. LIVE path (needs the agent CLI + a
+# running API) — not exercised in CI; the pure builders/parsers above are the tested surface.
+function run_observer_turn(a::ClaudeAgent, prompt::AbstractString, mcp_config_path::AbstractString;
+                           system_prompt::AbstractString = "", session_id::AbstractString = "",
+                           timeout_s::Real = 180, on_process::Function = _ -> nothing)::AgentResult
+    agent_available(a) || return AgentResult(false, "", 0, 0, "", "assistant CLI not found: $(a.bin)")
+    cmd = _build_claude_cmd(a, prompt, mcp_config_path; session_id, system_prompt)
+    out = Pipe()
+    proc = run(pipeline(cmd; stdout = out, stderr = out); wait = false)
+    close(out.in)
+    on_process(proc)
+    timer = Timer(_ -> (try; _kill_proc_tree(proc); catch; end), timeout_s)
+    output = read(out, String)
+    wait(proc)
+    close(timer)
+    if proc.exitcode != 0 && !occursin("\"result\"", output)
+        return AgentResult(false, "", 0, 0, "",
+                           isempty(strip(output)) ? "agent exited $(proc.exitcode)" : output)
+    end
+    _parse_claude_result(output)
+end

--- a/app/src/ai/observer_prompt.jl
+++ b/app/src/ai/observer_prompt.jl
@@ -1,0 +1,49 @@
+# ── Observer prompt — the canonical instructions the in-app assistant runs under ──────────────────
+#
+# One place for the "sit next to me" behaviour, passed to the agent via --append-system-prompt (see
+# agent_runner.jl). Kept server-side (not a freeform terminal session) so the rules are consistent
+# across every run AND across whichever agent backend is used (Claude today; Gemini/ChatGPT later).
+# See docs/todo/OBSERVER_INTEGRATION_PLAN.md (Decision 7) and docs/ai-assist/OBSERVER.md.
+
+# The shared behaviour — signal discipline. Deliberately strict: the failure mode is a chatty lab log
+# nobody trusts.
+const _OBSERVER_RULES = """
+You are Cecelia's observer, sitting next to an immunologist as they analyse imaging data. You watch a
+running project through the cecelia-observer MCP tools and record what matters in the lab log — the
+lab log is your output, not a chat reply.
+
+Use the tools to see what is happening: get_project_info / list_images / get_task_history for state,
+get_task_log + get_recent_logs when something failed (a Julia-side crash lands in get_recent_logs, NOT
+the task log), read_lab_log for prior context, poll_observations for detected patterns.
+
+When something is worth recording, call append_lab_log with ONE short line (it is tagged [Claude]
+automatically — never write the tag yourself). Discipline:
+- One line per event, imperative, put numbers in the detail.
+- Only write on: a function run >3 times on one image (the 10-attempts pattern), a real error, or a
+  genuine anomaly vs the rest of the set/cohort. Most of the time, write NOTHING.
+- Never re-note the same stuck task you already noted (check the lab log first; the monitor coalesces).
+- If you cannot explain a choice the user made, append a short [Claude] QUESTION instead of a guess —
+  the user answers with their own entry. That question-and-answer is the methodology record.
+- Do not summarise the whole project or narrate routine successful runs.
+
+You can only read state and append to the lab log — you cannot change data, run tasks, or edit gates.
+"""
+
+# Feedback mode (the one-shot "give feedback on what I did" button): a single considered pass.
+function observer_feedback_prompt(project_uid::AbstractString)::String
+    string(_OBSERVER_RULES, "\n\n",
+        "The user just asked for your feedback on project $(project_uid). Do one focused pass: look at ",
+        "the recent task history + any failures + the current lab log, and append at most a couple of ",
+        "concise [Claude] lines IF something is genuinely worth flagging (a stuck point, an error, an ",
+        "anomaly, or a why-question). If nothing warrants it, append nothing and say so briefly.")
+end
+
+# Auto mode (the "sit next to me" heartbeat tick): only invoked when there is new activity (the backend
+# gates on the run-log delta), so bias toward the single most important thing since last time.
+function observer_auto_prompt(project_uid::AbstractString)::String
+    string(_OBSERVER_RULES, "\n\n",
+        "You are watching project $(project_uid) in the background; something just changed. Check ",
+        "poll_observations + the recent task history/logs and append a [Claude] line ONLY for the ",
+        "single most important new thing (a fired pattern, a real error, an anomaly). If it is routine ",
+        "or already noted, append nothing.")
+end

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -142,6 +142,51 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         end
     end
 
+    # ── AI observer (in-app assistant) — pure command/result pieces ─────────────
+    # The live spawn (needs the agent CLI + a running API) isn't tested here; these pin the pure
+    # builders/parsers that the runner + api route depend on. See docs/todo/OBSERVER_INTEGRATION_PLAN.md.
+    @testset "AI observer agent runner (pure pieces)" begin
+        a   = Cecelia.ClaudeAgent(bin = "claude")
+        cmd = Cecelia._build_claude_cmd(a, "hello", "/tmp/mcp.json"; system_prompt = "be brief")
+        argv = cmd.exec
+        @test argv[1] == "claude"
+        @test "-p" in argv && "hello" in argv
+        @test "--output-format" in argv && "json" in argv
+        @test "--mcp-config" in argv && "/tmp/mcp.json" in argv
+        @test "--allowedTools" in argv                                    # observer tools allowed
+        @test "--append-system-prompt" in argv && "be brief" in argv
+        @test !("--resume" in argv)                                       # no session → no resume
+        @test !("--model" in argv)                                        # default model → no flag
+
+        cmd2 = Cecelia._build_claude_cmd(Cecelia.ClaudeAgent(bin = "claude", model = "claude-opus-4-8"),
+                                         "hi", "/tmp/m.json"; session_id = "sess123")
+        @test "--resume" in cmd2.exec && "sess123" in cmd2.exec
+        @test "--model" in cmd2.exec && "claude-opus-4-8" in cmd2.exec
+
+        # result parsing — success carries text + usage + session
+        r = Cecelia._parse_claude_result(
+            """{"is_error":false,"result":"noted a stuck task","session_id":"s1","usage":{"input_tokens":1200,"output_tokens":40}}""")
+        @test r.ok && r.text == "noted a stuck task"
+        @test r.input_tokens == 1200 && r.output_tokens == 40 && r.session_id == "s1"
+        # error result surfaces the message; garbage is a clean failure, not a throw
+        e = Cecelia._parse_claude_result("""{"is_error":true,"result":"tool failed"}""")
+        @test !e.ok && occursin("tool failed", e.error)
+        g = Cecelia._parse_claude_result("not json")
+        @test !g.ok && g.input_tokens == 0
+
+        # MCP config points the spawned agent at the same cecelia_mcp server + this API
+        cfg = Cecelia.observer_mcp_config("/repo/mcp", "/env/python", "http://127.0.0.1:8080")
+        srv = cfg["mcpServers"]["cecelia-observer"]
+        @test srv["command"] == "/env/python"
+        @test srv["args"] == ["-m", "cecelia_mcp.server"]
+        @test srv["env"]["PYTHONPATH"] == "/repo/mcp"
+        @test srv["env"]["CECELIA_API_URL"] == "http://127.0.0.1:8080"
+
+        # the prompt carries the project + the discipline rules
+        fp = Cecelia.observer_feedback_prompt("NRUBxU")
+        @test occursin("NRUBxU", fp) && occursin("append_lab_log", fp) && occursin("[Claude]", fp)
+    end
+
     # ── Model: create project and image ───────────────────────────────────────
     @testset "Model round-trip" begin
         proj = create_project!(name="smoke-test-$(rand(1000:9999))", kind="static")

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -43,6 +43,21 @@ when a set-level mutating task lands.
 
 ## Medium priority
 
+**#00083** — **QC engine: tasks emit metrics → cohort stats → `qc_flag_fired`**
+The AI observer (and any "is this image an outlier?" surfacing) needs QC *data* that mostly isn't
+produced yet. The writing API already exists — `qc_finding` / `write_qc` in `app/src/qc.jl` — but only
+`cleanupImages/drift_correct.jl` uses it. To make QC (and the observer's deferred `qc_flag_fired` +
+cohort `get_qc_metrics`) useful:
+1. **Encourage tasks to emit QC metrics.** Make it a task-authoring convention (document in
+   `docs/MODULES.md`) and retrofit the high-value tasks — cellpose segment (cell count, mean
+   confidence, % flagged), measure (feature ranges), tracking (track count, mean track length).
+2. **Cohort statistics** — per-set baselines so an image can be compared to its group
+   (`QC-PROCESS.md` step 3).
+3. **`qc_flag_fired` event + a `:flagged` node state** so a bad metric surfaces automatically
+   (`QC-PROCESS.md` step 1/8); then wire it into the observer (small once the data exists — see
+   `docs/ai-assist/OBSERVER.md` §7 step 5 and `docs/todo/OBSERVER_INTEGRATION_PLAN.md`).
+Full design sketch lives in [`docs/ai-assist/QC-PROCESS.md`](ai-assist/QC-PROCESS.md).
+
 **#00082** — **User-drop-in custom modules (restore the old R capability)** 🔹 needs-input
 Let users add custom task/module functions by dropping files into their user dir (beside
 `custom.toml`, resolved by `config_dir()`) — no package edit/rebuild — like old R cecelia's

--- a/docs/todo/OBSERVER_INTEGRATION_PLAN.md
+++ b/docs/todo/OBSERVER_INTEGRATION_PLAN.md
@@ -1,0 +1,159 @@
+# Observer-in-app integration — parked plan
+
+Bring the MCP observer (Slices A–C, see `docs/ai-assist/OBSERVER.md`) *inside* Cecelia: the user runs
+the AI assistant from the app — a toggle to have it watch and comment in the lab log automatically, a
+button to ask for feedback on demand — instead of wiring a separate terminal Claude session. The lab
+log is the medium; the assistant's output is `[Claude]` entries, not a chat window.
+
+Status: **not built.** Phase 1 (observe/read/append + the 10-attempts pattern + throttle) is done and
+validated live; this plan is the in-app *driver* on top of it.
+
+---
+
+## Why (the payoff)
+
+The observer arc's real value is a self-filling **methodology record** — the assistant notices patterns
+and records the *why*, so it survives into figures/papers. Today that only happens if a human runs a
+terminal Claude session and prompts it. Integrating it into the app makes it a one-click,
+always-available feature that most users will actually use.
+
+---
+
+## Locked decisions
+
+1. **The app spawns a headless assistant; it does not reimplement an agent loop.** The backend runs
+   `claude -p "<prompt>" --output-format json --mcp-config <cfg> --allowedTools <observer tools>`
+   (Claude Code print mode) as a subprocess — the same shape as the napari bridge spawn
+   (`app/src/napari.jl` `_bridge_cmd` / `python_bin_path()` / `Base.Process`). The assistant uses the
+   MCP tools it already has to read state + append to the lab log, then exits. We reuse: the MCP
+   server (unchanged), `run_py`-style process management, `append_lab_log`, and `broadcast_ws` for
+   notifications.
+
+2. **The MCP server stays model-agnostic; the runner is a swappable adapter.** MCP is an open protocol
+   (Claude, OpenAI Agents SDK/ChatGPT, Gemini CLI, … all consume it). Only the *spawn command + auth*
+   is assistant-specific. So the agent-runner is an interface — `AgentBackend` — with **Claude as the
+   first implementation**; adding Gemini/ChatGPT later is a new adapter, not a rewrite. The observer
+   *prompt* lives server-side (shared across backends). This is an explicit product requirement (user:
+   "it would be nice if people could choose other agents in the future").
+
+3. **The control surface is exactly four things** (user: "that's the only two readouts we need" +
+   two actions):
+   - **Toggle — "sit next to me"** (auto-observe; default **off**). While on, the backend runs an
+     observer turn on a heartbeat, gated on new activity.
+   - **Button — "give feedback on what I did"** (one-shot, on demand; not continuous).
+   - **Readout — token use** (REAL usage, accumulated from each run's `--output-format json` result —
+     supersedes Slice C's estimate). Per project + session.
+   - **Button — clear context** (reset the assistant's accumulated session; see Decision 4).
+   - (+ a **"Chat about this"** button that hands off to the real Claude Code console — see Decision 9;
+     it's a launch/handoff, not part of the in-app readouts.)
+
+4. **Context continuity via a per-project assistant session; "clear context" starts a fresh one.**
+   Each project keeps an assistant session id so the observer remembers within a work session (better
+   "you've been at this a while" continuity than N stateless turns). Runs use `--resume <sid>` (or
+   `--continue`); **clear context** drops the stored sid so the next run forks a new session
+   (`--fork-session`) — and resets that session's token counter. Sid + token totals persist in a
+   sidecar (`settings/observer-session.json`), like the lab-log mutes/tuning sidecars.
+
+5. **The lab log is the conversation surface — no separate chat.** The assistant writes short
+   `[Claude]` observations, and when it can't explain a choice, writes a `[Claude]` *question*; the
+   user answers with a `[User]` entry / reaction (the panel already supports both — see the reactions
+   feature). Q&A in the log = the methodology record.
+
+6. **Notify on write.** People won't keep the panel open, so a `[Claude]` append broadcasts a WS frame
+   → a toast ("Claude added a lab-log note") + a badge on the lab-log button. Same mechanism as the
+   update badge / task notifications.
+
+7. **Signal discipline is enforced by the server-side prompt**, not left to a freeform session: one
+   line per event, imperative, numbers in the detail; only write on a >3-attempt pattern / real error
+   / genuine anomaly; never re-note the same stuck task (the monitor already coalesces); respect the
+   throttle + `set_observer_active`.
+
+8. **Shipped, it's an opt-in feature gated on availability — shown DISABLED, not hidden.** It requires
+   an assistant CLI installed + authenticated (dev: `claude` at `~/.local/bin`). When none is
+   available, the controls render **greyed-out with an explainer** ("Needs Claude Code — with it, an
+   assistant can watch your analysis and note things in the lab log") + a link on how to set it up.
+   Rationale (user): hiding it means nobody discovers the capability; a disabled-with-why state teaches
+   people it exists and that it *would* be useful. `GET /api/observer/status`'s `available` flag drives
+   the disabled state + the hint (not removal).
+
+9. **NEVER build an in-app chat console.** The app does only *autonomous/one-shot* work (the toggle +
+   the feedback button → headless `claude -p` → lab log). When the user wants a real back-and-forth
+   ("chat about this"), we **hand off to the actual Claude Code console** — a "Chat about this" button
+   that launches interactive `claude` with the observer MCP + a seeded starter prompt referencing the
+   current project/image. Rationale (user): building an in-app chat means rebuilding + maintaining a
+   Claude Code console, which we explicitly won't own. Handoff mechanism, cross-platform-safe:
+   best-effort launch in the OS terminal (`x-terminal-emulator -e` / `open -a Terminal` / `wt`), with
+   a **copy-the-command fallback** always shown (zero-spawn, works everywhere, nothing to maintain).
+   This keeps the two modes cleanly separated: app owns *observation → lab log*; Claude Code owns
+   *conversation*.
+
+---
+
+## Architecture (cross-file)
+
+**Backend (`app/` + `api/`)**
+- `app/src/ai/agent_runner.jl` (**new**) — the `AgentBackend` interface + `ClaudeAgent` impl. Builds
+  the command (mirrors `_bridge_cmd`), spawns via `Base.Process` (register for cancel like tasks),
+  captures the `--output-format json` result (assistant text + `usage` tokens + `session_id`),
+  bounded by a timeout. Model-agnostic entry: `run_observer_turn(project, prompt; session, mode)`.
+- `app/src/ai/observer_prompt.jl` (**new**) — the canonical observer prompt text (Decision 7), one
+  place, passed via `--append-system-prompt`. Feedback-mode vs auto-mode variants.
+- `app/src/ai/observer_session.jl` (**new**) — the per-project session sidecar
+  (`settings/observer-session.json`): session id + cumulative token/cost totals; read/clear/add.
+- MCP config for the spawn: a small generated JSON pointing at the same `cecelia_mcp.server` (reuse
+  `mcp/`), `--allowedTools mcp__cecelia-observer__*` (read tools + append only — the MCP allow-list is
+  still the hard guarantee).
+- `api/src/observer_api.jl` (**new**, wired into `server.jl`): `POST /api/observer/feedback`
+  (one-shot), `POST /api/observer/auto` ({enabled}), `GET /api/observer/status` (enabled, tokens,
+  session, availability), `POST /api/observer/clear`. Auto-mode heartbeat: a backend async loop that,
+  while enabled, every N min checks the run-log delta (reuse the `capture_context!` "new activity"
+  gate) and runs a turn only if something changed.
+- On a `[Claude]` append (already flows through `api_lablog_append`), broadcast an `observer:wrote`
+  WS frame (extend the existing `lab_log_entry_added` path — it currently fires for user entries only).
+
+**Frontend (`frontend/`)**
+- `LabLogPanel.vue` — add the control strip: [🟢 sit next to me] toggle · [Ask Claude] button ·
+  token readout · [clear context]. Also a settings entry point (SettingsModule) mirroring the toggle.
+- `stores/observer.ts` (**new**) + `utils/serviceApi.ts` — `observerApi` {feedback, setAuto, status,
+  clear}; poll/subscribe status.
+- WS handler (`stores/ws.ts`) — on `observer:wrote`: toast + lab-log badge + refresh the panel.
+- Availability gate: hide controls when `GET /api/observer/status` reports the assistant CLI absent.
+
+**Reused as-is:** `mcp/` (the server), `append_lab_log!` + the panel + reactions, `broadcast_ws`,
+the `capture_context!` new-activity gate, the task-cancel/process registry, `python_bin_path`-style
+executable resolution.
+
+---
+
+## Build order (phases — each its own PR)
+
+1. **One-shot feedback, end-to-end (the proof).** `agent_runner.jl` (Claude impl) +
+   `observer_prompt.jl` + `POST /api/observer/feedback` + a minimal [Ask Claude] button in
+   `LabLogPanel` + toast. No heartbeat, no session, no token readout yet — one click → one turn →
+   a `[Claude]` entry appears. Proves the whole spawn→MCP→append→notify loop with a hard cost ceiling.
+2. **Token readout + session continuity + clear-context.** `observer_session.jl` sidecar; parse
+   `usage` from the JSON result; `--resume`; `GET /api/observer/status` + `POST /api/observer/clear`;
+   the token readout + clear button in the UI.
+3. **Auto "sit next to me".** The heartbeat loop + new-activity gate + `POST /api/observer/auto`
+   toggle; default off; respects the throttle. The `observer:wrote` notification + badge.
+4. **Availability gating + polish + the AgentBackend seam made real** (document how a second backend
+   would slot in; hide UI when unavailable).
+
+Cohort QC / `qc_flag_fired` remain out of scope (blocked on QC work).
+
+---
+
+## Reservations / open questions
+
+- **Assistant availability & auth for shipped builds** — dev works (`claude` present + authed).
+  Shipping needs: detect the CLI, surface "connect your assistant" onboarding, hide if absent. Decide
+  before Phase 4.
+- **Cost of auto mode** — mitigated by the new-activity gate + throttle + explicit off-default toggle
+  + notify-on-write + the real token readout. Still real; the readout is the safeguard.
+- **Exact `claude -p` result schema** (`usage` fields, `session_id` key) — confirm against a real
+  `--output-format json` run in Phase 1/2; treat as adapter detail.
+- **Concurrency** — one observer turn per project at a time (a run in flight blocks another); the
+  heartbeat must not stack turns. Guard in `observer_session.jl`.
+- **Prompt-injection surface** — the assistant reads task logs / user notes, which are user-authored;
+  it can only append to the lab log (MCP allow-list), so the blast radius is bounded to lab-log noise,
+  not mutation. Keep the allow-list as the guarantee; never widen it for this feature.


### PR DESCRIPTION
## In-app AI observer — plan + Phase 1 backend

Brings the MCP observer *inside* Cecelia: the backend spawns a headless assistant (Claude Code today) that reads project state and appends to the lab log via the `cecelia-observer` MCP. The lab log is the medium; `[Claude]` entries are the output — no chat UI in the app.

### The plan (`docs/todo/OBSERVER_INTEGRATION_PLAN.md`)
Locked decisions worth calling out:
- **Swappable agent-runner.** MCP is an open standard, so the *server* is model-agnostic; only the spawn command is assistant-specific. `AgentBackend` interface, `ClaudeAgent` first — Gemini/ChatGPT are later adapters, not a rewrite.
- **Control surface = toggle ("sit next to me") · "give feedback" button · token readout · clear-context.** Token readout uses **real** usage from `claude --output-format json`; clear-context resets a per-project session (`--resume`/`--fork-session`).
- **Never build an in-app chat console.** A "Chat about this" button hands off to the *real* Claude Code console (interactive `claude` + the observer MCP), so we don't rebuild/maintain a console.
- **Disabled-with-why, not hidden,** when no assistant CLI is present — so people discover the feature.

### Phase 1 backend (this PR)
- `app/src/ai/agent_runner.jl` — `AgentBackend`/`ClaudeAgent`; the **pure, tested** pieces: `_build_claude_cmd`, `_parse_claude_result` (usage + session), `observer_mcp_config`, `agent_available`. `run_observer_turn` spawns `claude -p` (mirrors `napari.jl`'s `_bridge_cmd`).
- `app/src/ai/observer_prompt.jl` — the canonical observer prompt (signal discipline; server-side so it's consistent and shared across backends).
- `api/src/observer_api.jl` — `GET /api/observer/status` (availability → the greyed-out gate) + `POST /api/observer/feedback` (one-shot turn).
- `docs/TODO.md #00083` — the QC engine dependency (tasks must emit metrics via the existing `qc_finding`/`write_qc` API — only `drift_correct` does today — before `qc_flag_fired`/cohort QC are useful).

### Tests
- app `test-pkg` **1040 / 0** — the pure runner pieces (command build, result parse, MCP config, prompt).
- api `test-api` **+4** — status shape + feedback validation. The **real agent spawn is NOT exercised** (would be a billed CLI call).

### Reservations
1. **The live spawn is unverified** — `run_observer_turn` (the actual `claude -p`) has never run; the `--output-format json` field names are assumed from the CLI docs and need a real run to confirm (the parser is defensive).
2. `api/` changes need a **backend restart** to expose the routes.
3. **Backend-only** — not usable from the UI until the frontend slice (button + greyed-out state + toast).
4. Phase 1 only — no token readout / sessions / auto-toggle / notifications / chat-handoff yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
