### PR TITLE
feat(observer): in-app observer Phase 1 frontend — Ask Claude button

### DIFF
--- a/docs/todo/OBSERVER_INTEGRATION_PLAN.md
+++ b/docs/todo/OBSERVER_INTEGRATION_PLAN.md
@@ -59,9 +59,13 @@ always-available feature that most users will actually use.
    user answers with a `[User]` entry / reaction (the panel already supports both — see the reactions
    feature). Q&A in the log = the methodology record.
 
-6. **Notify on write.** People won't keep the panel open, so a `[Claude]` append broadcasts a WS frame
-   → a toast ("Claude added a lab-log note") + a badge on the lab-log button. Same mechanism as the
-   update badge / task notifications.
+6. **Notify on write — a glanceable badge, NOT a toast.** People won't keep the panel open, so a
+   `[Claude]` append broadcasts a WS frame → a **bell / Claude icon badge on the lab-log toggle**
+   (persistent, so you can notice it whenever), **plus an abbreviated one-line preview of the addition
+   under the toggle** (the gist without opening the panel). The badge clears when the panel is opened.
+   No transient toast (Cecelia has none; a badge is lighter and doesn't vanish). Same WS→badge
+   mechanism as the update badge. (User: "a bell or claude icon next to lab log, and an abbreviated
+   version of the addition underneath the lab log toggle.")
 
 7. **Signal discipline is enforced by the server-side prompt**, not left to a freeform session: one
    line per event, imperative, numbers in the detail; only write on a >3-attempt pattern / real error

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -11,6 +11,7 @@ import {
   authorKind, correctionPrefill, draftToLines, entryId, decisionPrefill, isRatable, muteChips,
   USER_AUTHOR, CORRECTION_AUTHOR, type LabLogEntry, type Vote,
 } from '../utils/labLog'
+import { observerApi } from '../utils/serviceApi'
 
 const pm = useProjectMetaStore()
 const settings = useSettingsStore()
@@ -29,6 +30,11 @@ const tuning = ref<Record<string, Vote>>({})   // entryId → tuning vote (confi
 const mutes = ref<string[]>([])                // muted digest categories (config, NOT the log)
 const categories = ref<string[]>([])           // all digest categories (task-manager tags), for mute chips
 const mode = computed(() => settings.labLogMode)
+// AI observer (in-app assistant) — availability gates a disabled-with-why button (see
+// docs/todo/OBSERVER_INTEGRATION_PLAN.md); the run is one-shot and may append a [Claude] entry.
+const observerAvailable = ref(false)
+const observerBusy = ref(false)
+const observerNote = ref('')
 // chips include any orphaned mute (category since renamed/removed) so it can always be un-muted
 const muteableCategories = computed(() => muteChips(categories.value, mutes.value))
 const voteOf = (e: LabLogEntry): Vote | undefined => tuning.value[entryId(e.raw)]
@@ -77,8 +83,33 @@ async function capture(silent = false) {
   }
 }
 
+// Ask the assistant for a one-shot review; it may append a [Claude] entry via the observer MCP.
+async function askClaude() {
+  if (!projectUid.value || observerBusy.value || !observerAvailable.value) return
+  observerBusy.value = true
+  observerNote.value = ''
+  error.value = ''
+  try {
+    const res = await observerApi.feedback(projectUid.value)
+    if (res.available === false) {
+      observerAvailable.value = false
+      observerNote.value = res.error ?? 'Assistant unavailable.'
+    } else if (res.ok) {
+      observerNote.value = (res.message ?? '').trim() || 'Reviewed — nothing to flag.'
+      await load()   // surface any new [Claude] entry the assistant appended
+    } else {
+      observerNote.value = res.error ?? 'The assistant could not complete.'
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    observerBusy.value = false
+  }
+}
+
 // (re)load whenever the open project changes, and on first mount; auto-capture activity if enabled.
 watch(projectUid, async () => {
+  observerApi.status().then(s => { observerAvailable.value = s.available })
   await load()
   if (settings.labLogAutoContext) capture(true)
 }, { immediate: true })
@@ -209,7 +240,15 @@ async function toggleMute(category: string) {
       <label class="ll-auto" title="Automatically capture activity when this project opens">
         <input type="checkbox" v-model="settings.labLogAutoContext" /> Auto
       </label>
+      <button class="ll-capture" :disabled="!projectUid || observerBusy || !observerAvailable"
+              @click="askClaude"
+              :title="observerAvailable
+                ? 'Ask the assistant to review recent activity and note anything worth flagging in the lab log'
+                : 'Needs Claude Code — with it, an assistant can watch your analysis and note things in the lab log'">
+        <i class="pi pi-sparkles" /> {{ observerBusy ? 'Asking…' : 'Ask Claude' }}
+      </button>
       <span v-if="captureNote" class="ll-note">{{ captureNote }}</span>
+      <span v-if="observerNote" class="ll-note">{{ observerNote }}</span>
     </div>
 
     <!-- feedback mode: what 👍/👎 mean on the auto/AI entries -->

--- a/frontend/src/utils/serviceApi.test.ts
+++ b/frontend/src/utils/serviceApi.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { svcPost, notebooksApi } from './serviceApi'
+import { svcPost, notebooksApi, observerApi } from './serviceApi'
 
 function mockFetch(status: number, body: unknown) {
   return vi.fn().mockResolvedValue({
@@ -44,5 +44,31 @@ describe('svcPost', () => {
     vi.stubGlobal('fetch', f)
     await notebooksApi.shutdown()
     expect(f.mock.calls[0][0]).toBe('/api/notebooks/shutdown')
+  })
+})
+
+describe('observerApi', () => {
+  it('status returns availability from the endpoint', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { available: true }))
+    expect(await observerApi.status()).toEqual({ available: true })
+  })
+
+  it('status degrades to unavailable on a non-2xx (never throws → drives the disabled UI)', async () => {
+    vi.stubGlobal('fetch', mockFetch(500, {}))
+    expect(await observerApi.status()).toEqual({ available: false })
+  })
+
+  it('status degrades to unavailable when fetch rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    expect(await observerApi.status()).toEqual({ available: false })
+  })
+
+  it('feedback POSTs the projectUid to the feedback endpoint', async () => {
+    const f = mockFetch(200, { ok: true, message: 'noted' })
+    vi.stubGlobal('fetch', f)
+    const r = await observerApi.feedback('NRUBxU')
+    expect(f.mock.calls[0][0]).toBe('/api/observer/feedback')
+    expect(f.mock.calls[0][1].body).toBe(JSON.stringify({ projectUid: 'NRUBxU' }))
+    expect(r).toEqual({ ok: true, message: 'noted' })
   })
 })

--- a/frontend/src/utils/serviceApi.ts
+++ b/frontend/src/utils/serviceApi.ts
@@ -29,3 +29,17 @@ export const napariApi = {
   restart: () => svcPost('/api/napari/restart'),
   close: () => svcPost('/api/napari/close'),
 }
+
+/** In-app AI observer — needs an assistant CLI (e.g. Claude Code) on the machine. */
+export const observerApi = {
+  /** Is an assistant CLI available? Drives the disabled-with-why UI. Never throws → false on error. */
+  status: async (): Promise<{ available: boolean }> => {
+    try {
+      const res = await fetch('/api/observer/status')
+      return res.ok ? await res.json() : { available: false }
+    } catch { return { available: false } }
+  },
+  /** One-shot: the assistant reviews the project and may append a [Claude] lab-log note. Returns
+   *  { ok, available, message, error, inputTokens, outputTokens }. */
+  feedback: (projectUid: string) => svcPost('/api/observer/feedback', { projectUid }),
+}


### PR DESCRIPTION
## In-app observer Phase 1 — the "Ask Claude" button

The user-facing half of Phase 1 (`docs/todo/OBSERVER_INTEGRATION_PLAN.md`), on top of the merged backend route (#186).

- **`serviceApi.ts`** — `observerApi { status, feedback }`. `status` never throws (→ `{available:false}`), so it can drive a *disabled-with-why* control.
- **`LabLogPanel.vue`** — an **"Ask Claude"** button beside "Capture activity":
  - **Greyed-out with an explainer** when no assistant CLI is present (`GET /api/observer/status`) — discoverable, not hidden.
  - On click → one assistant turn (`POST /api/observer/feedback`) → shows the report **inline** → reloads the lab log to surface any `[Claude]` entry it appended.
- **Plan** — notification decision updated: a **glanceable bell/Claude badge** on the lab-log toggle + an abbreviated preview (NOT a toast — Cecelia has none, and a badge doesn't vanish). Phase 3.

### Validated live 🎉
Clicked against project **NRUBxU**: the button spawned `claude -p`, it used the MCP tools (project state, task history, `get_recent_logs`, `poll_observations`, `read_lab_log`), **correctly judged nothing warranted a `[Claude]` line, and reported so inline** — appending nothing. This resolves the prior "live spawn + JSON-parse unverified" reservation, and shows the signal discipline holds (it stayed silent on a clean project rather than writing noise).

### Tests
`serviceApi.test.ts` **9/9** (`observerApi` status/feedback added); `vue-tsc -b` clean.

### Reservations
- The inline readout shows Claude's full report (verbose for that strip) — Phase 3's abbreviated-preview refines it.
- `usage`/`session_id` aren't *displayed* yet, so those fields stay unconfirmed until the Phase 2 token readout (the `result` field is confirmed live).
- Availability re-checks on project-change/mount only; each click = one billed turn (bounded, user-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
