### PR TITLE
feat(observer): in-app observer Phase 2 — token readout, sessions, clear-context

### DIFF
--- a/api/src/observer_api.jl
+++ b/api/src/observer_api.jl
@@ -21,8 +21,16 @@ function _write_observer_mcp_config()::String
     path
 end
 
-function api_observer_status(::HTTP.Request)
-    200, JSON3.write((; available = agent_available(ClaudeAgent())))
+# status doubles as the per-project session/usage readout when given ?projectUid — one call drives
+# both the availability gate and the token readout on the panel.
+function api_observer_status(req::HTTP.Request)
+    resp = Dict{String,Any}("available" => agent_available(ClaudeAgent()))
+    puid = get(HTTP.queryparams(HTTP.URI(req.target)), "projectUid", "")
+    if !isempty(puid)
+        proj = try load_project(puid) catch; nothing end
+        proj === nothing || (resp["session"] = read_observer_session(proj))
+    end
+    200, JSON3.write(resp)
 end
 
 function api_observer_feedback(body_bytes::Vector{UInt8})
@@ -31,7 +39,7 @@ function api_observer_feedback(body_bytes::Vector{UInt8})
     end
     project_uid = String(get(body, :projectUid, ""))
     isempty(project_uid) && return 400, JSON3.write((; error = "projectUid required"))
-    try
+    proj = try
         load_project(project_uid)                                # the agent will read this project
     catch e
         return 404, JSON3.write((; error = sprint(showerror, e)))
@@ -41,9 +49,26 @@ function api_observer_feedback(body_bytes::Vector{UInt8})
         return 200, JSON3.write((; ok = false, available = false,
             error = "No assistant CLI found. Install Claude Code (or set [ai] agent_bin) to enable this."))
     end
+    sess = read_observer_session(proj)
     cfg_path = _write_observer_mcp_config()
-    res = run_observer_turn(agent, observer_feedback_prompt(project_uid), cfg_path)
+    res = run_observer_turn(agent, observer_feedback_prompt(project_uid), cfg_path;
+                            session_id = String(sess["sessionId"]))     # resume the project's session
+    # accumulate real usage + adopt the session id for the next --resume (only on a clean turn)
+    updated = res.ok ? record_observer_turn!(proj, res.session_id, res.input_tokens, res.output_tokens) : sess
     200, JSON3.write((; ok = res.ok, available = true, message = res.text, error = res.error,
                         inputTokens = res.input_tokens, outputTokens = res.output_tokens,
-                        session = res.session_id))
+                        session = updated))
+end
+
+# Clear context: reset the project's assistant session + token totals (next run starts fresh).
+function api_observer_clear(body_bytes::Vector{UInt8})
+    body = try JSON3.read(String(body_bytes)) catch
+        return 400, JSON3.write((; error = "Invalid JSON body"))
+    end
+    puid = String(get(body, :projectUid, ""))
+    isempty(puid) && return 400, JSON3.write((; error = "projectUid required"))
+    proj = try load_project(puid) catch e
+        return 404, JSON3.write((; error = sprint(showerror, e)))
+    end
+    200, JSON3.write((; ok = true, session = clear_observer_session!(proj)))
 end

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -324,6 +324,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_lablog_capture(body_bytes)
         elseif path == "/api/observer/feedback"
             api_observer_feedback(body_bytes)
+        elseif path == "/api/observer/clear"
+            api_observer_clear(body_bytes)
         elseif path == "/api/lablog/tune"
             api_lablog_tune(body_bytes)
         elseif path == "/api/lablog/mute"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -605,4 +605,8 @@ end
     # feedback: validated before anything is spawned.
     @test _post(api_observer_feedback, Dict())[1] == 400                       # projectUid missing
     @test _post(api_observer_feedback, Dict("projectUid" => "nope"))[1] == 404 # unknown project
+
+    # clear context: same validation, no spawn.
+    @test _post(api_observer_clear, Dict())[1] == 400                          # projectUid missing
+    @test _post(api_observer_clear, Dict("projectUid" => "nope"))[1] == 404    # unknown project
 end

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -160,7 +160,9 @@ include("napari.jl")
 # docs/todo/OBSERVER_INTEGRATION_PLAN.md.
 include("ai/observer_prompt.jl")
 include("ai/agent_runner.jl")
+include("ai/observer_session.jl")
 export ClaudeAgent, agent_available, run_observer_turn, observer_mcp_config,
-       observer_feedback_prompt, observer_auto_prompt, observer_agent_bin
+       observer_feedback_prompt, observer_auto_prompt, observer_agent_bin,
+       read_observer_session, record_observer_turn!, clear_observer_session!
 
 end

--- a/app/src/ai/observer_session.jl
+++ b/app/src/ai/observer_session.jl
@@ -1,0 +1,46 @@
+# ── Observer session sidecar — per-project assistant session + cumulative token usage ─────────────
+# Persists the in-app observer's session id (for `--resume` continuity) and running token totals, so
+# the UI can show REAL usage (from the agent's own output) and "clear context" can reset it. One
+# sidecar per project, alongside the lab-log mutes/tuning configs. See
+# docs/todo/OBSERVER_INTEGRATION_PLAN.md (Decisions 3 + 4).
+
+observer_session_path(proj::CciaProject)::String =
+    joinpath(proj.root, "settings", "observer-session.json")
+
+_observer_session_base() = Dict{String,Any}(
+    "sessionId" => "", "inputTokens" => 0, "outputTokens" => 0, "turns" => 0)
+
+function read_observer_session(proj::CciaProject)::Dict{String,Any}
+    p = observer_session_path(proj)
+    isfile(p) || return _observer_session_base()
+    try
+        merge(_observer_session_base(),
+              Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(p, String))))
+    catch
+        _observer_session_base()   # corrupt/legacy → treat as fresh rather than throwing on load
+    end
+end
+
+function _write_observer_session(proj::CciaProject, s::Dict{String,Any})::Dict{String,Any}
+    p = observer_session_path(proj)
+    mkpath(dirname(p))
+    open(p, "w") do io; JSON3.write(io, s); end
+    s
+end
+
+# Fold one completed turn into the session: adopt its session id (so the next run `--resume`s it) and
+# accumulate tokens. An empty `session_id` (agent returned none) keeps the existing one.
+function record_observer_turn!(proj::CciaProject, session_id::AbstractString,
+                               input_tokens::Integer, output_tokens::Integer)::Dict{String,Any}
+    s = read_observer_session(proj)
+    isempty(session_id) || (s["sessionId"] = String(session_id))
+    s["inputTokens"]  = Int(s["inputTokens"])  + Int(input_tokens)
+    s["outputTokens"] = Int(s["outputTokens"]) + Int(output_tokens)
+    s["turns"]        = Int(s["turns"]) + 1
+    _write_observer_session(proj, s)
+end
+
+# Clear context: drop the session id (the next run starts a FRESH session, so no stale assumptions
+# carry over) and zero the token totals.
+clear_observer_session!(proj::CciaProject)::Dict{String,Any} =
+    _write_observer_session(proj, _observer_session_base())

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -187,6 +187,30 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         @test occursin("NRUBxU", fp) && occursin("append_lab_log", fp) && occursin("[Claude]", fp)
     end
 
+    @testset "AI observer session sidecar (tokens + clear)" begin
+        proj = create_project!(name = "obs-sess-$(rand(1000:9999))", kind = "static")
+        # fresh project → zeroed session
+        s0 = read_observer_session(proj)
+        @test s0["sessionId"] == "" && s0["inputTokens"] == 0 && s0["turns"] == 0
+
+        # a turn adopts the session id + accumulates tokens
+        record_observer_turn!(proj, "sessABC", 1000, 40)
+        s1 = read_observer_session(proj)                       # re-read from disk (persisted)
+        @test s1["sessionId"] == "sessABC" && s1["inputTokens"] == 1000 && s1["outputTokens"] == 40
+        @test s1["turns"] == 1
+        # a second turn accumulates; an EMPTY session id keeps the existing one
+        record_observer_turn!(proj, "", 500, 10)
+        s2 = read_observer_session(proj)
+        @test s2["sessionId"] == "sessABC"                     # unchanged (empty id kept prior)
+        @test s2["inputTokens"] == 1500 && s2["outputTokens"] == 50 && s2["turns"] == 2
+
+        # clear resets everything (next run forks a fresh session)
+        cleared = clear_observer_session!(proj)
+        @test cleared["sessionId"] == "" && cleared["inputTokens"] == 0 && cleared["turns"] == 0
+        @test read_observer_session(proj)["inputTokens"] == 0
+        rm(proj.root; recursive = true)
+    end
+
     # ── Model: create project and image ───────────────────────────────────────
     @testset "Model round-trip" begin
         proj = create_project!(name="smoke-test-$(rand(1000:9999))", kind="static")

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -11,7 +11,7 @@ import {
   authorKind, correctionPrefill, draftToLines, entryId, decisionPrefill, isRatable, muteChips,
   USER_AUTHOR, CORRECTION_AUTHOR, type LabLogEntry, type Vote,
 } from '../utils/labLog'
-import { observerApi } from '../utils/serviceApi'
+import { observerApi, type ObserverSession } from '../utils/serviceApi'
 
 const pm = useProjectMetaStore()
 const settings = useSettingsStore()
@@ -35,6 +35,16 @@ const mode = computed(() => settings.labLogMode)
 const observerAvailable = ref(false)
 const observerBusy = ref(false)
 const observerNote = ref('')
+const observerSession = ref<ObserverSession | null>(null)
+// running token total for the readout (real usage from the assistant's own output, accumulated
+// per project — see docs/todo/OBSERVER_INTEGRATION_PLAN.md Decisions 3/4)
+const observerTokens = computed(() => {
+  const s = observerSession.value
+  if (!s || (s.inputTokens + s.outputTokens) === 0) return ''
+  const total = s.inputTokens + s.outputTokens
+  const fmt = total >= 1000 ? `${(total / 1000).toFixed(1)}k` : `${total}`
+  return `~${fmt} tokens · ${s.turns} turn${s.turns === 1 ? '' : 's'}`
+})
 // chips include any orphaned mute (category since renamed/removed) so it can always be un-muted
 const muteableCategories = computed(() => muteChips(categories.value, mutes.value))
 const voteOf = (e: LabLogEntry): Vote | undefined => tuning.value[entryId(e.raw)]
@@ -91,6 +101,7 @@ async function askClaude() {
   error.value = ''
   try {
     const res = await observerApi.feedback(projectUid.value)
+    if (res.session) observerSession.value = res.session   // updated running token total
     if (res.available === false) {
       observerAvailable.value = false
       observerNote.value = res.error ?? 'Assistant unavailable.'
@@ -107,9 +118,25 @@ async function askClaude() {
   }
 }
 
+// Clear context: reset the project's assistant session + token totals (next run starts fresh).
+async function clearContext() {
+  if (!projectUid.value || observerBusy.value) return
+  try {
+    const res = await observerApi.clear(projectUid.value)
+    observerSession.value = res.session ?? null
+    observerNote.value = ''
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
 // (re)load whenever the open project changes, and on first mount; auto-capture activity if enabled.
 watch(projectUid, async () => {
-  observerApi.status().then(s => { observerAvailable.value = s.available })
+  observerNote.value = ''
+  observerApi.status(projectUid.value).then(s => {
+    observerAvailable.value = s.available
+    observerSession.value = s.session ?? null
+  })
   await load()
   if (settings.labLogAutoContext) capture(true)
 }, { immediate: true })
@@ -247,8 +274,17 @@ async function toggleMute(category: string) {
                 : 'Needs Claude Code — with it, an assistant can watch your analysis and note things in the lab log'">
         <i class="pi pi-sparkles" /> {{ observerBusy ? 'Asking…' : 'Ask Claude' }}
       </button>
+      <span v-if="observerTokens" class="ll-tokens"
+            title="Assistant token use for this project's observer session (real usage)">{{ observerTokens }}</span>
+      <button v-if="observerTokens" class="ll-clearctx" @click="clearContext"
+              title="Clear the assistant's session and reset the token count">clear</button>
       <span v-if="captureNote" class="ll-note">{{ captureNote }}</span>
-      <span v-if="observerNote" class="ll-note">{{ observerNote }}</span>
+    </div>
+
+    <!-- assistant report: the full text of the last Ask-Claude pass, in a readable block -->
+    <div v-if="observerNote" class="ll-observer-report">
+      <div class="ll-observer-head"><i class="pi pi-sparkles" /> Claude</div>
+      <div class="ll-observer-body">{{ observerNote }}</div>
     </div>
 
     <!-- feedback mode: what 👍/👎 mean on the auto/AI entries -->
@@ -347,6 +383,24 @@ async function toggleMute(category: string) {
 .ll-capture:disabled { opacity: 0.5; cursor: default; }
 .ll-auto { display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.7rem; color: var(--cc-text-dim); cursor: pointer; }
 .ll-note { font-size: 0.66rem; color: var(--cc-text-dim); margin-left: auto; }
+.ll-tokens { font-size: 0.66rem; color: var(--cc-text-dim); margin-left: auto; }
+.ll-clearctx {
+  border: none; background: transparent; color: var(--cc-text-dim);
+  font-size: 0.66rem; cursor: pointer; text-decoration: underline; padding: 0;
+}
+.ll-clearctx:hover { color: var(--cc-text); }
+/* the last Ask-Claude report — its own readable block, not crammed in the toolbar */
+.ll-observer-report {
+  flex-shrink: 0; border-bottom: 1px solid var(--cc-border);
+  background: var(--cc-surface-2); padding: 0.4rem 0.6rem; max-height: 8rem; overflow-y: auto;
+}
+.ll-observer-head {
+  display: inline-flex; align-items: center; gap: 0.3rem;
+  font-size: 0.66rem; color: var(--cc-text-dim); margin-bottom: 0.2rem;
+}
+.ll-observer-body {
+  font-size: 0.72rem; color: var(--cc-text); line-height: 1.45; white-space: pre-wrap;
+}
 
 .ll-modebar {
   display: flex; align-items: center; gap: 0.35rem;

--- a/frontend/src/utils/serviceApi.ts
+++ b/frontend/src/utils/serviceApi.ts
@@ -30,16 +30,28 @@ export const napariApi = {
   close: () => svcPost('/api/napari/close'),
 }
 
+/** Per-project observer session: the assistant session id + cumulative token totals. */
+export interface ObserverSession {
+  sessionId: string
+  inputTokens: number
+  outputTokens: number
+  turns: number
+}
+
 /** In-app AI observer — needs an assistant CLI (e.g. Claude Code) on the machine. */
 export const observerApi = {
-  /** Is an assistant CLI available? Drives the disabled-with-why UI. Never throws → false on error. */
-  status: async (): Promise<{ available: boolean }> => {
+  /** Availability (drives the disabled-with-why UI) + this project's session/usage when a uid is
+   *  given. Never throws → unavailable on error. */
+  status: async (projectUid?: string): Promise<{ available: boolean; session?: ObserverSession }> => {
     try {
-      const res = await fetch('/api/observer/status')
+      const q = projectUid ? `?projectUid=${encodeURIComponent(projectUid)}` : ''
+      const res = await fetch(`/api/observer/status${q}`)
       return res.ok ? await res.json() : { available: false }
     } catch { return { available: false } }
   },
   /** One-shot: the assistant reviews the project and may append a [Claude] lab-log note. Returns
-   *  { ok, available, message, error, inputTokens, outputTokens }. */
+   *  { ok, available, message, error, inputTokens, outputTokens, session }. */
   feedback: (projectUid: string) => svcPost('/api/observer/feedback', { projectUid }),
+  /** Clear context: reset the project's session + token totals. Returns { ok, session }. */
+  clear: (projectUid: string) => svcPost('/api/observer/clear', { projectUid }),
 }


### PR DESCRIPTION
## In-app observer Phase 2 — token readout · sessions · clear-context

Phase 2 of `docs/todo/OBSERVER_INTEGRATION_PLAN.md` (the two readouts you asked for), on the merged Phase 1.

- **`app/src/ai/observer_session.jl`** — per-project sidecar (`settings/observer-session.json`): the assistant **session id** (for `--resume` continuity) + cumulative **real** token totals. `read_observer_session` / `record_observer_turn!` / `clear_observer_session!`.
- **`api/src/observer_api.jl`** — feedback now resumes the project's session and accumulates usage; `GET /api/observer/status?projectUid` returns the session; `POST /api/observer/clear`.
- **`LabLogPanel.vue`** — a running **"~Nk tokens · M turns"** readout + a **"clear"** (context) button; and the Ask-Claude report now renders in **its own readable block** (`white-space: pre-wrap`, scrollable) instead of crammed into the toolbar.

### Tests
app **1047 / 0** (session round-trip: accumulate + empty-id-keeps-prior + clear); api observer **6/6** (clear validation); frontend `serviceApi.test.ts` **9/9**; `vue-tsc -b` clean.

### Reservations
- Token/session **display** isn't verified against a real multi-turn run yet (the `result` field is confirmed live; `usage`/`session_id` parse is unit-tested but not eyeballed live).
- `api/` needs a **backend restart**.
- The new UI blocks (token readout, clear, report block) are test-green but not eyeballed in-browser.

### Known follow-up (next PR) — failure visibility
Surfaced by live use: 5 failed HMM runs were invisible to the observer because the **run log records successes only** (`scheduler.jl:300`), so `get_task_history` + the `[Cecelia]` digest show nothing, and the one-shot MCP monitor is empty. Fix = record failures (with status) so the observer can spot repeated failures. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
