### PR TITLE
docs(mcp): point get_task_history at runStatus so the observer flags failures

### DIFF
--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -83,7 +83,15 @@ def get_task_log(project_uid: str, image_uid: str, fun: str) -> str:
 
 @mcp.tool()
 def get_task_history(project_uid: str, limit: int = 100) -> list:
-    """Recent task runs across all images, newest first: image, function, value name, timestamp, status."""
+    """Recent task runs across all images, newest first. Each row: `imageUid`, `imageName`, `fun`,
+    `valueName`, `at` (timestamp), `status` (the image's current status), and **`runStatus`** — that
+    run's outcome, `"done"` or `"failed"`.
+
+    Watch `runStatus`: the same `fun` showing `"failed"` repeatedly on one image is a stuck point worth
+    flagging (e.g. "hmm failed 5x on image KDIeEm — want to look at the params?"). **This is the place
+    to catch repeated failures** — a failed task leaves little other trace, and the live-pattern
+    detector (`poll_observations`) starts empty each run, so it won't have older failures. Cross-check
+    `get_task_log` / `get_recent_logs` for the actual error before surfacing."""
     return _client.get_task_history(project_uid, limit).get("history", [])
 
 


### PR DESCRIPTION
Follow-up to #189. The `get_task_history` MCP tool docstring now tells the observer to watch **`runStatus`** and surface a function that failed repeatedly on an image ("hmm failed 5x on KDIeEm — want to look at the params?") — so it **notices** the failures #189 records, not just receives them. Also notes that this is *the* place to catch repeats (`poll_observations` starts empty each in-app run) and to cross-check `get_task_log`/`get_recent_logs` for the actual error.

Docstring only, no behavior change. `test-mcp` 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)