### PR TITLE
feat(observer): in-app observer Phase 3 — auto "sit next to me" + sidebar badge

### DIFF
--- a/docs/todo/OBSERVER_INTEGRATION_PLAN.md
+++ b/docs/todo/OBSERVER_INTEGRATION_PLAN.md
@@ -138,8 +138,16 @@ executable resolution.
 2. **Token readout + session continuity + clear-context.** `observer_session.jl` sidecar; parse
    `usage` from the JSON result; `--resume`; `GET /api/observer/status` + `POST /api/observer/clear`;
    the token readout + clear button in the UI.
-3. **Auto "sit next to me".** The heartbeat loop + new-activity gate + `POST /api/observer/auto`
-   toggle; default off; respects the throttle. The `observer:wrote` notification + badge.
+3. ✅ **DONE — Auto "sit next to me".** Implemented **frontend-driven** (not a backend heartbeat): the
+   panel subscribes to task-completion WS frames (`task:status`/`chain:node:*` terminal, via
+   `utils/observerAuto.ts` `isObserverTrigger`) and, while the `labLogObserverAuto` toggle is on + an
+   assistant is available, fires a **debounced** (8s) observer pass (reusing the feedback path). Chosen
+   over a server loop because it's simpler, spends nothing when the app is closed, and is naturally
+   scoped to "while you're working." Default off. **Badge:** when the observer appends a `[Claude]`
+   entry while the lab-log panel is closed, `settings.labLogUnseen` (a one-line preview) lights a
+   sparkles badge on the sidebar lab-log toggle (`AppSidebar.vue`), cleared on open — the glanceable
+   notification (no toast, per Decision 6). (A backend heartbeat for closed-app/overnight watching is
+   Phase 3 of the *arc* — the Analyst — not this integration.)
 4. **Availability gating + polish + the AgentBackend seam made real** (document how a second backend
    would slot in; hide UI when unavailable).
 

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -193,12 +193,16 @@ function isNavDisabled(item: NavItem): boolean {
     <!-- ── Lab log ──────────────────────────────────────────────────────────
          Per-project append-only analysis memory (you + Claude). Like the viewer, a floating panel
          toggled here (see App.vue / LabLogPanel). -->
-    <button class="viewer-cta lablog-cta" :class="{ 'viewer-on': settings.labLogPanelOpen }"
+    <button class="viewer-cta lablog-cta" :class="{ 'viewer-on': settings.labLogPanelOpen, 'lablog-unseen': !!settings.labLogUnseen }"
             style="margin-top: 0.4rem"
             @click="settings.labLogPanelOpen = !settings.labLogPanelOpen"
-            v-tooltip.right="'Lab log: append-only analysis notes for this project (you + Claude). Floating panel — drag it anywhere.'">
+            v-tooltip.right="settings.labLogUnseen
+              ? ('Claude noted: ' + settings.labLogUnseen)
+              : 'Lab log: append-only analysis notes for this project (you + Claude). Floating panel — drag it anywhere.'">
       <i class="pi pi-book viewer-cta-icon" />
       <span class="viewer-cta-title">Lab log</span>
+      <!-- badge: Claude added something while the panel was closed (cleared on open) -->
+      <i v-if="settings.labLogUnseen" class="pi pi-sparkles lablog-badge" />
       <i :class="['pi', settings.labLogPanelOpen ? 'pi-eye' : 'pi-eye-slash', 'viewer-cta-state']" />
     </button>
 
@@ -349,6 +353,9 @@ function isNavDisabled(item: NavItem): boolean {
 .viewer-cta-icon { font-size: 0.95rem; color: var(--cc-viewer); flex-shrink: 0; }
 .viewer-cta-title { flex: 1; min-width: 0; font-size: 0.78rem; font-weight: 700; }
 .viewer-cta-state { font-size: 0.8rem; opacity: 0.75; flex-shrink: 0; }
+/* badge: Claude added a lab-log note while the panel was closed */
+.lablog-badge { font-size: 0.8rem; color: var(--cc-accent); flex-shrink: 0; margin-left: 0.2rem; }
+.lablog-cta.lablog-unseen { border-color: var(--cc-accent); }
 /* Lab log CTA: a neutral/whiteish variant so it reads as its own thing, distinct from the coloured
    Viewer control. Overrides the .viewer-cta base (defined above → these win on equal specificity). */
 .lablog-cta .viewer-cta-icon { color: #e6edf3; }

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -4,7 +4,9 @@
 // Zero-friction by design: an always-focused entry field at the top, submit on Enter, newest-first
 // list with a distinct colour per author, one-click correction (append-only — never edits). Mounted
 // as a FloatingPanel in App.vue so it's reachable from any page.
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick, onUnmounted } from 'vue'
+import { useWsStore } from '../stores/ws'
+import { isObserverTrigger, OBSERVER_AUTO_FRAME_TYPES } from '../utils/observerAuto'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import {
@@ -107,7 +109,14 @@ async function askClaude() {
       observerNote.value = res.error ?? 'Assistant unavailable.'
     } else if (res.ok) {
       observerNote.value = (res.message ?? '').trim() || 'Reviewed — nothing to flag.'
+      const claudeBefore = entries.value.filter(e => authorKind(e.author) === 'claude').length
       await load()   // surface any new [Claude] entry the assistant appended
+      const claudeNow = entries.value.filter(e => authorKind(e.author) === 'claude')
+      // if it actually appended AND the panel is closed, flag the sidebar badge with a preview
+      if (claudeNow.length > claudeBefore && !settings.labLogPanelOpen) {
+        const line = (claudeNow[0]?.lines ?? []).find(l => l.trim()) ?? 'added a note'
+        settings.labLogUnseen = line.replace(/^[-*]\s*/, '').trim()
+      }
     } else {
       observerNote.value = res.error ?? 'The assistant could not complete.'
     }
@@ -117,6 +126,29 @@ async function askClaude() {
     observerBusy.value = false
   }
 }
+
+// ── "sit next to me" auto-mode: a finished task triggers a debounced observer pass ──────────────
+// Frontend-driven (fires while the app is open); subscribes to task/chain terminal frames only while
+// the toggle is on + an assistant is available. Debounced so a burst of completions → one pass.
+const ws = useWsStore()
+const AUTO_DEBOUNCE_MS = 8000
+let autoTimer: ReturnType<typeof setTimeout> | null = null
+function onTaskFrame(frame: any) {
+  if (!settings.labLogObserverAuto || !observerAvailable.value || !projectUid.value) return
+  if (!isObserverTrigger(frame)) return
+  if (autoTimer) clearTimeout(autoTimer)
+  autoTimer = setTimeout(() => {
+    autoTimer = null
+    if (settings.labLogObserverAuto && observerAvailable.value && !observerBusy.value) askClaude()
+  }, AUTO_DEBOUNCE_MS)
+}
+watch(() => settings.labLogObserverAuto, (on) => {
+  OBSERVER_AUTO_FRAME_TYPES.forEach(t => on ? ws.on(t, onTaskFrame) : ws.off(t, onTaskFrame))
+}, { immediate: true })
+onUnmounted(() => {
+  OBSERVER_AUTO_FRAME_TYPES.forEach(t => ws.off(t, onTaskFrame))
+  if (autoTimer) clearTimeout(autoTimer)
+})
 
 // Clear context: reset the project's assistant session + token totals (next run starts fresh).
 async function clearContext() {
@@ -274,6 +306,10 @@ async function toggleMute(category: string) {
                 : 'Needs Claude Code — with it, an assistant can watch your analysis and note things in the lab log'">
         <i class="pi pi-sparkles" /> {{ observerBusy ? 'Asking…' : 'Ask Claude' }}
       </button>
+      <label v-if="observerAvailable" class="ll-auto"
+             title="Sit next to me: after a task finishes, Claude reviews and may note something in the lab log (spends tokens)">
+        <input type="checkbox" v-model="settings.labLogObserverAuto" /> Watch
+      </label>
       <span v-if="observerTokens" class="ll-tokens"
             title="Assistant token use for this project's observer session (real usage)">{{ observerTokens }}</span>
       <button v-if="observerTokens" class="ll-clearctx" @click="clearContext"

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -6,7 +6,7 @@
 // as a FloatingPanel in App.vue so it's reachable from any page.
 import { ref, computed, watch, nextTick, onUnmounted } from 'vue'
 import { useWsStore } from '../stores/ws'
-import { isObserverTrigger, OBSERVER_AUTO_FRAME_TYPES } from '../utils/observerAuto'
+import { isObserverTrigger, OBSERVER_AUTO_FRAME_TYPES, OBSERVER_TRIGGERS } from '../utils/observerAuto'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import {
@@ -38,6 +38,7 @@ const observerAvailable = ref(false)
 const observerBusy = ref(false)
 const observerNote = ref('')
 const observerSession = ref<ObserverSession | null>(null)
+const observerTriggers = OBSERVER_TRIGGERS   // read-only trigger status row (green/red)
 // running token total for the readout (real usage from the assistant's own output, accumulated
 // per project — see docs/todo/OBSERVER_INTEGRATION_PLAN.md Decisions 3/4)
 const observerTokens = computed(() => {
@@ -317,6 +318,14 @@ async function toggleMute(category: string) {
       <span v-if="captureNote" class="ll-note">{{ captureNote }}</span>
     </div>
 
+    <!-- what "Watch" triggers on: read-only green/red lights (only task-completion is wired today) -->
+    <div v-if="observerAvailable && settings.labLogObserverAuto" class="ll-triggers">
+      <span class="ll-triggers-label">Watching:</span>
+      <span v-for="t in observerTriggers" :key="t.key" class="ll-trigger" :title="t.note">
+        <span class="ll-trigger-dot" :class="t.active ? 'on' : 'off'" /> {{ t.label }}
+      </span>
+    </div>
+
     <!-- assistant report: the full text of the last Ask-Claude pass, in a readable block -->
     <div v-if="observerNote" class="ll-observer-report">
       <div class="ll-observer-head"><i class="pi pi-sparkles" /> Claude</div>
@@ -425,6 +434,17 @@ async function toggleMute(category: string) {
   font-size: 0.66rem; cursor: pointer; text-decoration: underline; padding: 0;
 }
 .ll-clearctx:hover { color: var(--cc-text); }
+/* trigger status row — what "Watch" fires on (read-only green/red lights) */
+.ll-triggers {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem;
+  padding: 0.3rem 0.6rem; border-bottom: 1px solid var(--cc-border); flex-shrink: 0;
+  font-size: 0.64rem; color: var(--cc-text-dim);
+}
+.ll-triggers-label { text-transform: uppercase; letter-spacing: 0.03em; }
+.ll-trigger { display: inline-flex; align-items: center; gap: 0.25rem; cursor: help; }
+.ll-trigger-dot { width: 0.5rem; height: 0.5rem; border-radius: 50%; display: inline-block; }
+.ll-trigger-dot.on  { background: #3fb950; }   /* watched */
+.ll-trigger-dot.off { background: #f85149; opacity: 0.55; }   /* not a trigger */
 /* the last Ask-Claude report — its own readable block, not crammed in the toolbar */
 .ll-observer-report {
   flex-shrink: 0; border-bottom: 1px solid var(--cc-border);

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -63,6 +63,13 @@ export const useSettingsStore = defineStore('settings', () => {
   // judge the entry type useful/noise (config). Default 'notes'. See components/LabLogPanel.vue.
   const labLogMode = ref<'notes' | 'tuning'>(
     localStorage.getItem('cc.labLogMode') === 'tuning' ? 'tuning' : 'notes')
+  // "sit next to me": when on, a finished task triggers a (debounced) observer pass that may append a
+  // [Claude] note. Frontend-driven (fires while you're using the app), gated on the availability of an
+  // assistant CLI. Default off — it spends tokens. See components/LabLogPanel.vue.
+  const labLogObserverAuto = ref(localStorage.getItem('cc.labLogObserverAuto') === 'true')
+  // transient (not persisted): a one-line preview of an unseen [Claude] lab-log addition — set when
+  // the observer appends while the panel is closed, drives the sidebar badge, cleared when opened.
+  const labLogUnseen = ref('')
 
   // per-image label-layer visibility: { [imageUid]: { [valueName]: boolean } }
   // unknown labels default to true; persisted across sessions
@@ -212,6 +219,8 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(labLogPanelOpen,          v => localStorage.setItem('cc.labLogPanelOpen',          String(v)))
   watch(labLogAutoContext,        v => localStorage.setItem('cc.labLogAutoContext',        String(v)))
   watch(labLogMode,               v => localStorage.setItem('cc.labLogMode',               String(v)))
+  watch(labLogObserverAuto,       v => localStorage.setItem('cc.labLogObserverAuto',       String(v)))
+  watch(labLogPanelOpen,          open => { if (open) labLogUnseen.value = '' })   // opening clears the badge
 
-  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, cleanCapture, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, napariDiscreteGpu, sidebarCollapsed, rightPanelCollapsed, viewerPanelOpen, labLogPanelOpen, labLogAutoContext, labLogMode, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible, getColourOverrides, setColourOverride, clearColourOverrides, getMovieConfig, setMovieConfig, getCropZ, setCropZ, getCropT, setCropT, getBatchMovieConfig, setBatchMovieConfig }
+  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, cleanCapture, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, napariDiscreteGpu, sidebarCollapsed, rightPanelCollapsed, viewerPanelOpen, labLogPanelOpen, labLogAutoContext, labLogMode, labLogObserverAuto, labLogUnseen, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible, getColourOverrides, setColourOverride, clearColourOverrides, getMovieConfig, setMovieConfig, getCropZ, setCropZ, getCropT, setCropT, getBatchMovieConfig, setBatchMovieConfig }
 })

--- a/frontend/src/utils/observerAuto.test.ts
+++ b/frontend/src/utils/observerAuto.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isObserverTrigger, OBSERVER_AUTO_FRAME_TYPES } from './observerAuto'
+import { isObserverTrigger, OBSERVER_AUTO_FRAME_TYPES, OBSERVER_TRIGGERS } from './observerAuto'
 
 describe('isObserverTrigger', () => {
   it('fires on terminal module-page task outcomes', () => {
@@ -27,5 +27,13 @@ describe('isObserverTrigger', () => {
 
   it('subscribes to exactly the terminal frame types', () => {
     expect(OBSERVER_AUTO_FRAME_TYPES).toEqual(['task:status', 'chain:node:done', 'chain:node:failed'])
+  })
+})
+
+describe('OBSERVER_TRIGGERS (status row)', () => {
+  it('only task-completion is an active trigger today; each has an explanatory note', () => {
+    const active = OBSERVER_TRIGGERS.filter(t => t.active).map(t => t.key)
+    expect(active).toEqual(['task'])
+    expect(OBSERVER_TRIGGERS.every(t => t.label && t.note)).toBe(true)
   })
 })

--- a/frontend/src/utils/observerAuto.test.ts
+++ b/frontend/src/utils/observerAuto.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { isObserverTrigger, OBSERVER_AUTO_FRAME_TYPES } from './observerAuto'
+
+describe('isObserverTrigger', () => {
+  it('fires on terminal module-page task outcomes', () => {
+    expect(isObserverTrigger({ type: 'task:status', status: 'done' })).toBe(true)
+    expect(isObserverTrigger({ type: 'task:status', status: 'failed' })).toBe(true)
+  })
+
+  it('ignores non-terminal task states', () => {
+    expect(isObserverTrigger({ type: 'task:status', status: 'queued' })).toBe(false)
+    expect(isObserverTrigger({ type: 'task:status', status: 'running' })).toBe(false)
+    expect(isObserverTrigger({ type: 'task:status', status: 'cancelled' })).toBe(false)
+  })
+
+  it('fires on terminal chain nodes (both launch paths trigger)', () => {
+    expect(isObserverTrigger({ type: 'chain:node:done' })).toBe(true)
+    expect(isObserverTrigger({ type: 'chain:node:failed' })).toBe(true)
+    expect(isObserverTrigger({ type: 'chain:node:running' })).toBe(false)
+  })
+
+  it('ignores unrelated frames', () => {
+    expect(isObserverTrigger({ type: 'task:progress' })).toBe(false)
+    expect(isObserverTrigger({ type: 'chain:log' })).toBe(false)
+    expect(isObserverTrigger({})).toBe(false)
+  })
+
+  it('subscribes to exactly the terminal frame types', () => {
+    expect(OBSERVER_AUTO_FRAME_TYPES).toEqual(['task:status', 'chain:node:done', 'chain:node:failed'])
+  })
+})

--- a/frontend/src/utils/observerAuto.ts
+++ b/frontend/src/utils/observerAuto.ts
@@ -15,3 +15,21 @@ export function isObserverTrigger(frame: { type?: string; status?: string }): bo
   if (t === 'task:status') return TERMINAL_TASK_STATUS.has(String(frame?.status ?? ''))
   return t === 'chain:node:done' || t === 'chain:node:failed'
 }
+
+// The event categories the observer COULD watch, for the read-only green/red status row under the
+// Watch toggle. `active` = wired as a live trigger today (only task-completion is). The rest are shown
+// red with a `note` explaining why — flip `active` (and wire the frame) when a signal exists. Single
+// source of truth so adding a trigger is one edit here. See docs/todo/OBSERVER_INTEGRATION_PLAN.md.
+export interface ObserverTrigger { key: string; label: string; active: boolean; note: string }
+export const OBSERVER_TRIGGERS: ObserverTrigger[] = [
+  { key: 'task',       label: 'Task finished', active: true,
+    note: 'A task or chain node completes (done or failed) — the current trigger.' },
+  { key: 'note',       label: 'Image note',    active: false,
+    note: 'A live event exists (image_note_added) but is not wired as a trigger yet.' },
+  { key: 'population', label: 'Population',     active: false,
+    note: 'No live signal yet — gating changes are captured at digest time, not pushed live.' },
+  { key: 'workflow',   label: 'Workflow',      active: false,
+    note: 'No live signal for saving a workflow yet.' },
+  { key: 'figure',     label: 'Figure',        active: false,
+    note: 'No live signal for creating a figure yet.' },
+]

--- a/frontend/src/utils/observerAuto.ts
+++ b/frontend/src/utils/observerAuto.ts
@@ -1,0 +1,17 @@
+// "Sit next to me" auto-mode trigger logic (kept out of the .vue SFC so it's unit-testable).
+// A finished task worth a (debounced) auto observer pass = a terminal outcome from either launch
+// path: a module-page task (`task:status` done/failed) or a whiteboard chain node
+// (`chain:node:done`/`chain:node:failed`). queued/running/cancelled don't warrant a pass.
+// See docs/todo/OBSERVER_INTEGRATION_PLAN.md (Phase 3).
+
+const TERMINAL_TASK_STATUS = new Set(['done', 'failed'])
+
+/** Frame types the panel subscribes to for auto-mode. */
+export const OBSERVER_AUTO_FRAME_TYPES = ['task:status', 'chain:node:done', 'chain:node:failed']
+
+/** Should this WS frame trigger an auto observer pass? */
+export function isObserverTrigger(frame: { type?: string; status?: string }): boolean {
+  const t = frame?.type
+  if (t === 'task:status') return TERMINAL_TASK_STATUS.has(String(frame?.status ?? ''))
+  return t === 'chain:node:done' || t === 'chain:node:failed'
+}


### PR DESCRIPTION
## In-app observer Phase 3 — auto "sit next to me" + sidebar badge

Completes the interactive observer. **Frontend-driven** (not a backend heartbeat): simpler, spends nothing when the app is closed, and naturally scoped to "while you're working." (A backend loop for closed-app/overnight watching is the *arc's* Phase 3 Analyst — out of scope here.)

- **`utils/observerAuto.ts`** (+test) — `isObserverTrigger`: a terminal task/chain frame (`task:status` done/failed, `chain:node:done`/`failed`) worth an auto pass. Pure, unit-tested.
- **`LabLogPanel.vue`** — a **"Watch"** toggle (`settings.labLogObserverAuto`, persisted, **default off**). While on + an assistant is available, a finished task fires a **debounced (8s)** observer pass via the existing feedback path. If it appends a `[Claude]` entry while the panel is **closed**, it sets `settings.labLogUnseen` (a one-line preview).
- **`AppSidebar.vue`** — a **sparkles badge + accent border** on the lab-log toggle when `labLogUnseen` is set (cleared on open) — the glanceable notification (no toast, per Decision 6).

### Tests
`vue-tsc -b` clean; vitest **146/146** (5 new `observerAuto`).

### Reservations
- **No hard token cap on auto-mode** — one turn per debounced burst; the Slice C `surfaceCap` doesn't apply to one-shot spawns. Mitigated by default-off + debounce + the token readout; a per-session cap is a sensible follow-up.
- **Only watches while the app is open** (frontend-driven).
- **Not eyeballed in-browser** — the pure trigger logic is tested; the debounce + badge DOM wiring needs a live click-through.

### The observer arc is now feature-complete
Phases 1–3 done + the failure-visibility + runStatus fixes. Remaining: the **QC data-collection** setup (make key tasks emit metrics via `qc_finding`/`write_qc` — only `drift_correct` does today, #00083) so the deferred cohort/`qc_flag_fired` features have back-data when built. That's the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
