### PR TITLE
fix(cluster): resolve heatmap value_name from the run + per-run pop scoping

### DIFF
--- a/api/src/plotting_api.jl
+++ b/api/src/plotting_api.jl
@@ -178,6 +178,10 @@ function api_plot_data(body_bytes::Vector{UInt8})
     zscore    = Bool(get(body, "zscore", false))
     mnorm_v   = string(get(body, "matrixNormalize", "none"))
     matrix_normalize = mnorm_v in ("row", "col", "total") ? Symbol(mnorm_v) : :none
+    # clustering run suffix (cluster pop_types only): lets the per-population cluster heatmap resolve
+    # value_name to the run's segmentation instead of the drifting active one (plot_data.jl _cluster_pop_vn).
+    sfx_v     = get(body, "suffix", nothing)
+    cluster_suffix = (sfx_v === nothing || isempty(string(sfx_v))) ? nothing : string(sfx_v)
     # group cross-image series by one or MORE image ATTRIBUTES (e.g. "Treatment", or "Treatment" ×
     # "Mouse") instead of per-image — images sharing the combined value pool into one series labelled by
     # the combination (joined with ".", mirroring the old R `paste0(axisX, ".", interaction)`). Accepts a
@@ -236,7 +240,7 @@ function api_plot_data(body_bytes::Vector{UInt8})
                                   normalize = normalize, group_by = group_by, collapse_series = collapse, raw_points = raw_pts, raw = raw, stat_unit = stat_unit, image_agg = image_agg,
                                   matrix_mode = matrix_mode, measures = measures, category = category,
                                   separator = separator, zscore = zscore, matrix_normalize = matrix_normalize,
-                                  attr_map = attr_map) :
+                                  attr_map = attr_map, cluster_suffix = cluster_suffix) :
                 plot_summary_data(first.(pairs), last.(pairs), pop_type, targets, chart;
                                   scope = scope, granularity = gran, measure = measure,
                                   nbins = nbins, normalize = normalize, group_by = group_by,
@@ -251,11 +255,15 @@ function api_plot_data(body_bytes::Vector{UInt8})
         err === nothing || return err
         result = targets === nothing ?
             plot_summary_data(img, pop_type, [string(p) for p in get(body, "pops", String[])], chart;
-                              value_name = _resolve_vn(img, vn_req), granularity = gran,
+                              # empty → nothing (pop_df falls back to the active segmentation, same as
+                              # _resolve_vn); leaving it nothing lets the cluster run-resolver in
+                              # plot_data.jl (_cluster_pop_vn) pick the run's value_name from `suffix`.
+                              value_name = isempty(vn_req) ? nothing : _resolve_vn(img, vn_req), granularity = gran,
                               measure = measure, nbins = nbins, normalize = normalize,
                               group_by = group_by, collapse_series = collapse, raw_points = raw_pts, raw = raw, stat_unit = stat_unit, image_agg = image_agg,
                               matrix_mode = matrix_mode, measures = measures, category = category,
-                              separator = separator, zscore = zscore, matrix_normalize = matrix_normalize) :
+                              separator = separator, zscore = zscore, matrix_normalize = matrix_normalize,
+                              cluster_suffix = cluster_suffix) :
             plot_summary_data(img, pop_type, targets, chart;
                               granularity = gran, measure = measure, nbins = nbins,
                               normalize = normalize, group_by = group_by, collapse_series = collapse, raw_points = raw_pts, raw = raw, stat_unit = stat_unit, image_agg = image_agg,

--- a/app/src/gating/gating_engine.jl
+++ b/app/src/gating/gating_engine.jl
@@ -21,6 +21,16 @@ function _filter_mask(col::AbstractVector, fun, vals, default_all::Bool)::BitVec
     BitVector(!ismissing(x) && cmp(x, vals) for x in col)
 end
 
+# A gate/filter column the map references isn't in the fetched frame → the population resolves to no
+# members (empty mask) rather than crashing the whole recompute. Warns once per (pop, column) so the
+# cause is visible in the server log without spamming. See the call sites in `recompute!`.
+function _missing_col_mask(n::Int, path::AbstractString, col::AbstractString)::BitVector
+    @warn "gating: column '$col' absent from the fetched data for population '$path' — treating as \
+           empty (no members). For a cluster pop this usually means it's being evaluated against a \
+           segmentation that didn't take part in its clustering run."
+    falses(n)
+end
+
 # columns the gates + filters in this map need from the H5AD
 function _needed_columns(m::PopulationMap)::Vector{String}
     cols = String[]
@@ -46,6 +56,7 @@ function recompute!(m::PopulationMap, fetch_cols::Function)
     "label" in names(df) || error("recompute!: fetch_cols must return a `label` column")
     labels = df.label
     n = length(labels)
+    cols = Set(names(df))
     memb = Dict{String,BitVector}()
     memb[ROOT] = trues(n)
     for path in topo_order(m)
@@ -56,9 +67,21 @@ function recompute!(m::PopulationMap, fetch_cols::Function)
             sel = Set(p.explicit_labels)
             parent_mask .& BitVector(l in sel for l in labels)
         elseif p.gate !== nothing
-            parent_mask .& inside(p.gate, df[!, p.gate.x_channel], df[!, p.gate.y_channel])
+            # a gate whose axis column is absent from the fetched frame → no members, not a crash. See
+            # the filter case below for the rationale (missing column ≠ hard 500).
+            (p.gate.x_channel in cols && p.gate.y_channel in cols) ?
+                parent_mask .& inside(p.gate, df[!, p.gate.x_channel], df[!, p.gate.y_channel]) :
+                _missing_col_mask(n, path, string(p.gate.x_channel, " / ", p.gate.y_channel))
         elseif p.filter_measure !== nothing
-            parent_mask .& _filter_mask(df[!, p.filter_measure], p.filter_fun, p.filter_values, p.filter_default_all)
+            # A filter's column can legitimately be absent from THIS frame — e.g. a cluster pop
+            # (`clusters.{suffix}`) evaluated against a segmentation that didn't take part in that
+            # clustering run. `fetch_cols` intersects with the table's columns and silently drops the
+            # missing one, so an unguarded `df[!, col]` would raise `ArgumentError: column name … not
+            # found` and 500 the whole plot. Degrade to empty membership + a warning instead: the pop
+            # shows no members rather than taking down every other population on the map.
+            (p.filter_measure in cols) ?
+                parent_mask .& _filter_mask(df[!, p.filter_measure], p.filter_fun, p.filter_values, p.filter_default_all) :
+                _missing_col_mask(n, path, string(p.filter_measure))
         else
             copy(parent_mask)
         end

--- a/app/src/plotting/plot_data.jl
+++ b/app/src/plotting/plot_data.jl
@@ -626,6 +626,21 @@ _pool_co_clustered(vns, fetch_vn)::DataFrame = begin
     isempty(frames) ? DataFrame() : reduce((a, b) -> vcat(a, b; cols=:union), frames)
 end
 
+# Per-POPULATION cluster heatmap (category="pop", bare cluster-pop paths): the pops must be evaluated
+# against a segmentation that actually took part in the clustering run — NOT the drifting *active*
+# value_name, which may not be in the run at all (its track/label table then lacks `clusters.{suffix}`,
+# which is exactly what produced the `column name :clusters.default not found` crash). Mirror the UMAP
+# endpoint's resolution (api/src/gating_api.jl `api_plots_umap`): pick a co-clustered value_name for the
+# run's suffix. Only kicks in for cluster pop_types with a known suffix and NO explicit value_name — the
+# per-cluster path (category="clusters.{suffix}") still pools via `_pool_co_clustered`, and an explicit
+# value_name is always honoured.
+function _cluster_pop_vn(img, pop_type, value_name, cluster_suffix, granularity)
+    (value_name === nothing && _is_cluster_pop_type(pop_type) &&
+        cluster_suffix !== nothing && !isempty(String(cluster_suffix))) || return value_name
+    cc = co_clustered_value_names(img, String(cluster_suffix); granularity=granularity)
+    isempty(cc) ? value_name : first(cc)
+end
+
 function plot_summary_data(img::CciaImage, pop_type::AbstractString, pops, chart_type::AbstractString;
                            value_name::Union{AbstractString,Nothing}=nothing,
                            granularity::Symbol=:cell, measure::Union{AbstractString,Nothing}=nothing,
@@ -636,19 +651,21 @@ function plot_summary_data(img::CciaImage, pop_type::AbstractString, pops, chart
                            measures::Union{Nothing,AbstractVector{<:AbstractString}}=nothing,
                            category::Union{AbstractString,Nothing}=nothing,
                            separator::AbstractString="_", zscore::Bool=false,
-                           matrix_normalize::Symbol=:none)::Dict{String,Any}
+                           matrix_normalize::Symbol=:none,
+                           cluster_suffix::Union{AbstractString,Nothing}=nothing)::Dict{String,Any}
     pops = String.(collect(pops))
     cols = _cols_for(chart_type, measure, group_by, measures, category)
     sfx = _cluster_matrix_suffix(chart_type, category)
+    eff_vn = _cluster_pop_vn(img, pop_type, value_name, cluster_suffix, granularity)
     df = (sfx !== nothing && _is_cluster_pop_type(pop_type)) ?
         _pool_co_clustered(co_clustered_value_names(img, sfx; granularity=granularity),
             vn -> pop_df(img, pop_type, pops; value_name=vn, granularity=granularity,
                          pop_cols=cols, raw_channel_names=true)) :
-        pop_df(img, pop_type, pops; value_name=value_name, granularity=granularity,
+        pop_df(img, pop_type, pops; value_name=eff_vn, granularity=granularity,
                pop_cols=cols, raw_channel_names=(chart_type == "matrix"))
     _summary_agg(df, chart_type; measure=measure, granularity=granularity,
                  nbins=nbins, normalize=normalize, by_image=false, group_by=group_by,
-                 var_cols=_var_measure_set(img, value_name),
+                 var_cols=_var_measure_set(img, eff_vn),
                  collapse_series=collapse_series, raw_points=raw_points, max_points=max_points, raw=raw, stat_unit=stat_unit, image_agg=image_agg,
                  matrix_mode=matrix_mode, measures=measures, category=category,
                  separator=separator, zscore=zscore, matrix_normalize=matrix_normalize)
@@ -667,10 +684,15 @@ function plot_summary_data(imgs::AbstractVector{<:CciaImage}, uids::AbstractVect
                            category::Union{AbstractString,Nothing}=nothing,
                            separator::AbstractString="_", zscore::Bool=false,
                            matrix_normalize::Symbol=:none,
-                           attr_map::Union{Nothing,AbstractDict}=nothing)::Dict{String,Any}
+                           attr_map::Union{Nothing,AbstractDict}=nothing,
+                           cluster_suffix::Union{AbstractString,Nothing}=nothing)::Dict{String,Any}
     pops = String.(collect(pops))
     cols = _cols_for(chart_type, measure, group_by, measures, category)
     sfx = _cluster_matrix_suffix(chart_type, category)
+    # per-population cluster heatmap: resolve value_name to the run's segmentation (see _cluster_pop_vn),
+    # taking the run from the first image — clustering is set-scope so the value_name set is consistent.
+    eff_vn = isempty(imgs) ? value_name :
+             _cluster_pop_vn(first(imgs), pop_type, value_name, cluster_suffix, granularity)
     # per-cluster heatmap → pool across the run's co-clustered segmentations (clustering is set-scope,
     # so the value_name set is consistent; take it from the first image). Each vn still pools across
     # images via the multi-image pop_df.
@@ -678,11 +700,11 @@ function plot_summary_data(imgs::AbstractVector{<:CciaImage}, uids::AbstractVect
         _pool_co_clustered(co_clustered_value_names(first(imgs), sfx; granularity=granularity),
             vn -> pop_df(imgs, uids, pop_type, pops; value_name=vn, granularity=granularity,
                          pop_cols=cols, raw_channel_names=true)) :
-        pop_df(imgs, uids, pop_type, pops; value_name=value_name, granularity=granularity,
+        pop_df(imgs, uids, pop_type, pops; value_name=eff_vn, granularity=granularity,
                pop_cols=cols, raw_channel_names=(chart_type == "matrix"))
     result = _summary_agg(df, chart_type; measure=measure, granularity=granularity,
                           nbins=nbins, normalize=normalize, by_image=(scope == :per_image),
-                          group_by=group_by, var_cols=_var_measure_set(imgs, value_name),
+                          group_by=group_by, var_cols=_var_measure_set(imgs, eff_vn),
                           collapse_series=collapse_series,
                           raw_points=raw_points, max_points=max_points, raw=raw, stat_unit=stat_unit, image_agg=image_agg,
                           matrix_mode=matrix_mode, measures=measures, category=category,

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2554,6 +2554,28 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         @test Set(pop_at(m2, "/myeloid").filter_values) == Set([1, 3])
     end
 
+    @testset "recompute! — a missing filter/gate column degrades to empty (no crash)" begin
+        # A cluster pop whose `clusters.{suffix}` column isn't in the fetched frame — e.g. evaluated
+        # against a segmentation that didn't take part in that run, so `fetch_cols` silently dropped it
+        # — must resolve to NO members, not raise `ArgumentError: column name … not found` and 500 the
+        # whole plot. Regression: the trackclust heatmap crash (clusters.default not found).
+        m = PopulationMap(pop_type="trackclust", value_name="C")
+        add_pop!(m, "present"; filter_measure="clusters.movement", filter_fun="in", filter_values=[1, 2], colour="#10b981")
+        add_pop!(m, "absent";  filter_measure="clusters.default",  filter_fun="in", filter_values=[0, 1], colour="#ef4444")
+        # frame HAS clusters.movement but NOT clusters.default
+        fetch = _ -> DataFrame("label" => [10, 11, 12, 13], "clusters.movement" => [0, 1, 2, 1])
+        @test_logs (:warn, r"clusters\.default") match_mode=:any recompute!(m, fetch)  # warns, doesn't throw
+        @test Set(cells_in_pop(m, "/present")) == Set([11, 12, 13])   # present column resolves normally
+        @test isempty(cells_in_pop(m, "/absent"))                     # missing column → empty membership
+
+        # same guard for a GATE whose axis column is absent from the frame
+        mg = PopulationMap(pop_type="flow", value_name="C")
+        add_pop!(mg, "g"; gate=RectangleGate("x", "missingY", 0.0, 10.0, 0.0, 10.0), colour="#abcdef")
+        fetchg = _ -> DataFrame("label" => [1, 2], "x" => [1.0, 2.0])   # no "missingY"
+        @test_logs (:warn, r"missingY") match_mode=:any recompute!(mg, fetchg)
+        @test isempty(cells_in_pop(mg, "/g"))
+    end
+
     @testset "colour_by_palette — pop colour else default" begin
         # a value a user pop FILTERS for on the column → that pop's colour; the rest → OKABE_ITO by
         # sorted position. Generalises "use the population's colour where one exists" (a cluster pop is

--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -147,6 +147,23 @@ clustered segmentation):
   value_name-prefixed ref (`"T/A"`) stays scoped to that one segmentation. `co_clustered_value_names`
   is the source of truth (the value_names whose clustfeatures sidecar carries the run's suffix).
 
+**Per-RUN scoping (one sidecar, many runs).** A segmentation's `{vn}__{clust|trackclust}.json` holds
+the pops for *every* clustering run on it — each pop is tagged by its run via
+`filter_measure="clusters.{suffix}"`. The cluster page views **one run at a time** (the suffix
+dropdown), so the population manager shows only the pops for the active suffix
+(`PopulationManager.visiblePops`), new pops are created against the active suffix, and cluster-ID
+assignment is exclusive *within* a run. Switching the run dropdown therefore swaps the visible pop
+set — pops from a different run on the same segmentation are hidden, not shown.
+
+**Cluster plots resolve value_name from the RUN, not the active segmentation.** The UMAP endpoint
+(`api_plots_umap`) and the per-population cluster heatmap (`/api/plot_data`) both take a `suffix` and
+resolve their value_name via `co_clustered_value_names(img, suffix)` — a segmentation that actually
+took part in the run — instead of the drifting *active* value_name. This is load-bearing: evaluating a
+cluster pop against a segmentation not in its run means the `clusters.{suffix}` column is absent, which
+otherwise 500'd the plot (`_cluster_pop_vn` in `plot_data.jl` does the resolution; the frontend always
+sends `suffix`). As a backstop, `recompute!` treats a gate/filter column missing from the fetched frame
+as **empty membership + a warning**, never a hard error — one absent column can't take down the whole map.
+
 ## `pop_df` — unified accessor
 
 > **Home:** `pop_df`/`_pop_df` live in `gating/population_manager.jl`, alongside the `pop_map`

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -119,11 +119,21 @@ const POP_PALETTE = [
   '#ef4444', '#f59e0b', '#10b981', '#3b82f6', '#a78bfa', '#ec4899', '#14b8a6', '#eab308',
   '#f97316', '#22d3ee', '#84cc16', '#8b5cf6', '#f43f5e', '#06b6d4', '#a3e635', '#d946ef',
 ]
+// PER-RUN scoping (cluster mode): a run's populations are exactly the pops whose filter targets THIS
+// run's `clusters.{suffix}` column. The store holds every run's pops for the segmentation in ONE
+// sidecar (gating/{vn}__{popType}.json), so we scope to the active run here — switching the run
+// (suffix) dropdown then shows that run's pops, not another run's. Non-cluster surfaces are unfiltered.
+const visiblePops = computed<FlatPop[]>(() =>
+  clusterMode.value
+    ? g.flat.filter(p => p.filter?.measure === `clusters.${props.suffix}`)
+    : g.flat)
 const popClusterIds = (p: FlatPop): number[] => {
   const v = p.filter?.values
   return Array.isArray(v) ? (v as unknown[]).map(Number) : []
 }
-const clusterOwner = (id: number): FlatPop | undefined => g.flat.find(p => popClusterIds(p).includes(id))
+// a cluster ID belongs to at most one pop WITHIN the current run (scope to visiblePops so ticking is
+// exclusive per run, not across runs that happen to share the segmentation's sidecar)
+const clusterOwner = (id: number): FlatPop | undefined => visiblePops.value.find(p => popClusterIds(p).includes(id))
 
 async function toggleCluster(p: FlatPop, id: number) {
   const owner = clusterOwner(id)
@@ -137,13 +147,13 @@ async function toggleCluster(p: FlatPop, id: number) {
 }
 
 async function addClusterPopulation() {
-  const n = g.flat.length
+  const n = visiblePops.value.length
   await g.addClusterPop(`Population ${n + 1}`, props.suffix, POP_PALETTE[n % POP_PALETTE.length])
 }
 </script>
 
 <template>
-  <PopulationPanelShell :count="g.flat.length" :scope="scope" :vis="vis" :docked="docked"
+  <PopulationPanelShell :count="visiblePops.length" :scope="scope" :vis="vis" :docked="docked"
                         @update:scope="emit('update:scope', $event)" @update:vis="emit('update:vis', $event)">
     <!-- ── population list (default slot) ── -->
       <!-- cluster mode: pops are made here (no gate to draw), then clusters ticked into them -->
@@ -154,11 +164,11 @@ async function addClusterPopulation() {
         </button>
       </div>
 
-      <div v-if="!g.flat.length" class="pm-empty">
+      <div v-if="!visiblePops.length" class="pm-empty">
         {{ clusterMode ? 'No populations yet — add one, then tick clusters into it.' : 'No populations yet — draw a gate.' }}
       </div>
 
-      <template v-for="p in g.flat" :key="p.path">
+      <template v-for="p in visiblePops" :key="p.path">
         <div class="pm-row" :class="{ active: p.path === props.selected, transient: p.transient }"
              :style="{ paddingLeft: 6 + p.depth * 14 + 'px' }"
              @click="pick(p)">

--- a/frontend/src/composables/useClusterContext.ts
+++ b/frontend/src/composables/useClusterContext.ts
@@ -79,15 +79,20 @@ export function useClusterContext(opts: {
   const missingUids = computed<string[]>(() =>
     runMembers.value.filter(u => !imageUids.value.includes(u)))
 
-  // resolve a highlight set (pop paths) to shown populations (colour + owned cluster IDs) via the store
+  // resolve a highlight set (pop paths) to shown populations (colour + owned cluster IDs) via the store.
+  // Scoped to the CURRENT run: only pops filtering this run's `clusters.{suffix}` — the store holds every
+  // run's pops for the segmentation in one sidecar, so a stale highlight from another run is ignored here
+  // (keeps the per-population heatmap / UMAP colouring on the run you're viewing).
   const shownPopsFor = (hl: string[]): ShownPop[] => g.flat
-    .filter(p => hl.includes(p.path))
+    .filter(p => hl.includes(p.path) && p.filter?.measure === `clusters.${suffix.value}`)
     .map(p => ({ path: p.path, name: p.name, colour: p.colour,
                  clusterIds: Array.isArray(p.filter?.values) ? (p.filter!.values as unknown[]).map(Number) : [] }))
 
   // drive the (shared, pop_type-agnostic) gating store for the pop tree: primary = first valid image,
   // the rest mirror every mutation so cluster pops land set-wide. Re-sync on selection/suffix change.
-  watch([validUids, suffix, popType, projectUid, enabled], () => {
+  // `resolvedVn` is a dependency (not just read): loadFeatures resolves it asynchronously, so without it
+  // the tree could stay pinned to the initial 'default' after the real segmentation value_name lands.
+  watch([validUids, suffix, popType, projectUid, enabled, resolvedVn], () => {
     if (!enabled.value || !projectUid.value || !validUids.value.length) return
     g.selectImage(validUids.value[0], resolvedVn.value, popType.value).then(() => {
       g.mirrorUids = validUids.value.slice(1)

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -18,6 +18,7 @@ import PlotChart from '../../components/plots/PlotChart.vue'
 import { defaultVis, plotDataToCsv, type BuildOpts, type VisProps } from '../../plots/plot'
 import { downloadDataUrl, downloadBlob } from '../../plots/export'
 import type { PlotDataResponse } from '../../plots/types'
+import { buildClusterHeatmapBody } from '../../utils/clusterHeatmapBody'
 
 const props = defineProps<{
   index: number; active: boolean; arrange?: ArrangeCmd | null; persistKey?: string
@@ -73,18 +74,15 @@ async function load() {
   loading.value = true
   try {
     // per-population when pops are shown (category = the pop_df `pop` column over those pops);
-    // otherwise per-cluster (category = the cluster column over root).
+    // otherwise per-cluster (category = the cluster column over root). `suffix` is always sent so the
+    // backend resolves value_name to the run's segmentation (see clusterHeatmapBody / _cluster_pop_vn).
     const pops = props.shownPops ?? []
+    const body = buildClusterHeatmapBody({
+      projectUid: props.projectUid, popType: props.popType, suffix: props.suffix,
+      granularity: granularity.value, features: features.value,
+      popPaths: pops.map(p => p.path), setUid: props.setUid, imageUids: props.imageUids,
+    })
     const popMode = pops.length > 0
-    const body: Record<string, unknown> = {
-      projectUid: props.projectUid, popType: props.popType, granularity: granularity.value,
-      chartType: 'matrix', matrixMode: 'profile',
-      category: popMode ? 'pop' : `clusters.${props.suffix}`,
-      separator: '_', pops: popMode ? pops.map(p => p.path) : ['root'],
-      measures: features.value, zscore: true,
-    }
-    if (props.setUid) { body.setUid = props.setUid; if (props.imageUids.length) body.imageUids = props.imageUids }
-    else if (props.imageUids[0]) body.imageUid = props.imageUids[0]
     const res = await fetch('/api/plot_data', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
     if (!res.ok) { heatmap.value = null; err.value = (await res.json()).error ?? res.statusText; return }
     const r = await res.json() as PlotDataResponse & { yLabels?: string[]; xLabels?: string[]; cells?: { x: string; y: string }[] }

--- a/frontend/src/utils/clusterHeatmapBody.test.ts
+++ b/frontend/src/utils/clusterHeatmapBody.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { buildClusterHeatmapBody } from './clusterHeatmapBody'
+
+const base = {
+  projectUid: 'P', popType: 'trackclust' as const, suffix: 'movement',
+  granularity: 'track' as const, features: ['live.track.speed'],
+  popPaths: [] as string[], setUid: null as string | null, imageUids: ['img1'],
+}
+
+describe('buildClusterHeatmapBody', () => {
+  it('always sends the run suffix (so the backend resolves the run value_name)', () => {
+    expect(buildClusterHeatmapBody(base).suffix).toBe('movement')
+    expect(buildClusterHeatmapBody({ ...base, popPaths: ['/A'] }).suffix).toBe('movement')
+  })
+
+  it('per-cluster mode (no pops): category = clusters.{suffix}, root pop', () => {
+    const b = buildClusterHeatmapBody(base)
+    expect(b.category).toBe('clusters.movement')
+    expect(b.pops).toEqual(['root'])
+  })
+
+  it('per-population mode (pops shown): category = "pop", the shown paths', () => {
+    const b = buildClusterHeatmapBody({ ...base, popPaths: ['/A', '/B'] })
+    expect(b.category).toBe('pop')
+    expect(b.pops).toEqual(['/A', '/B'])
+  })
+
+  it('single-image request carries imageUid, no setUid/imageUids', () => {
+    const b = buildClusterHeatmapBody(base)
+    expect(b.imageUid).toBe('img1')
+    expect(b.setUid).toBeUndefined()
+    expect(b.imageUids).toBeUndefined()
+  })
+
+  it('set request carries setUid + imageUids, no single imageUid', () => {
+    const b = buildClusterHeatmapBody({ ...base, setUid: 'S', imageUids: ['a', 'b'] })
+    expect(b.setUid).toBe('S')
+    expect(b.imageUids).toEqual(['a', 'b'])
+    expect(b.imageUid).toBeUndefined()
+  })
+
+  it('carries the matrix profile shape + granularity', () => {
+    const b = buildClusterHeatmapBody({ ...base, granularity: 'cell', popType: 'clust' })
+    expect(b.chartType).toBe('matrix')
+    expect(b.matrixMode).toBe('profile')
+    expect(b.granularity).toBe('cell')
+    expect(b.zscore).toBe(true)
+    expect(b.measures).toEqual(['live.track.speed'])
+  })
+})

--- a/frontend/src/utils/clusterHeatmapBody.ts
+++ b/frontend/src/utils/clusterHeatmapBody.ts
@@ -1,0 +1,48 @@
+// Request-body builder for the cluster heatmap (POST /api/plot_data, chartType=matrix/profile).
+// Extracted from ClusterHeatmapPanel.vue so the two modes + the suffix threading are unit-testable
+// (docs/DEV.md — frontend logic lives in src/utils/*.ts, not the SFC).
+//
+// Two modes (docs/PLOTS.md §9, docs/ANALYSIS.md):
+//   • per-cluster    (no pops shown)  → category = `clusters.{suffix}` over root; the backend pools
+//                                        across the run's co-clustered segmentations.
+//   • per-population (pops shown)      → category = "pop" over the shown cluster-pop paths.
+//
+// `suffix` is ALWAYS sent: the per-population path needs it server-side to resolve value_name to the
+// clustering run's segmentation (plot_data.jl `_cluster_pop_vn`) rather than the drifting active one —
+// which is what caused `column name :clusters.default not found`.
+
+export interface ClusterHeatmapBodyInput {
+  projectUid: string
+  popType: 'clust' | 'trackclust'
+  suffix: string
+  granularity: 'cell' | 'track'
+  features: string[]
+  popPaths: string[]              // shown cluster-pop paths; empty → per-cluster mode
+  setUid: string | null
+  imageUids: string[]
+}
+
+export function buildClusterHeatmapBody(i: ClusterHeatmapBodyInput): Record<string, unknown> {
+  const popMode = i.popPaths.length > 0
+  const body: Record<string, unknown> = {
+    projectUid: i.projectUid,
+    popType: i.popType,
+    suffix: i.suffix,
+    granularity: i.granularity,
+    chartType: 'matrix',
+    matrixMode: 'profile',
+    category: popMode ? 'pop' : `clusters.${i.suffix}`,
+    separator: '_',
+    pops: popMode ? i.popPaths : ['root'],
+    measures: i.features,
+    zscore: true,
+  }
+  // cross-image (set) vs single-image, exactly as the panel resolved it before extraction
+  if (i.setUid) {
+    body.setUid = i.setUid
+    if (i.imageUids.length) body.imageUids = i.imageUids
+  } else if (i.imageUids[0]) {
+    body.imageUid = i.imageUids[0]
+  }
+  return body
+}


### PR DESCRIPTION
## Problem

Two symptoms on the cluster page, one root cause. Track clustering in jFWePN (run "movement") produced:
1. **Heatmap crash** — `ArgumentError: column name :clusters.default not found in the data frame`.
2. **Population dropdown didn't sync** — switching the clustering run still showed the pops defined for the previous run.

The UMAP for the same run rendered fine.

## Root cause

`ClusterHeatmapPanel` sent the plot request with **no `valueName`**, so `/api/plot_data` resolved it to the image's *active* segmentation. With `labelProps: null` in this image's `ccid.json` that falls back to `"default"`, whose `default__tracks.h5ad` doesn't exist — so the fetched frame lacked the pop's `clusters.default` filter column and `recompute!` raised on an unguarded `df[!, col]`. The clustering data actually lives under segmentation **C**. The UMAP escaped this because `api_plots_umap` self-resolves `value_name` from the `suffix` via `co_clustered_value_names`.

The dropdown "didn't sync" because all `C__trackclust.json` pops filter `clusters.default` (authored under an earlier run) and the manager showed every run's pops regardless of the selected suffix.

## Fix

**Backend**
- `plot_data.jl` — `_cluster_pop_vn` resolves the per-population cluster heatmap's `value_name` from the run's `suffix` (mirrors the UMAP endpoint); `cluster_suffix` kwarg threaded through both `plot_summary_data` methods.
- `plotting_api.jl` — parse `suffix`; single-image path passes `nothing` (active fallback, unchanged for non-cluster) so the run-resolver engages for cluster pop types.
- `gating_engine.jl` — `recompute!` degrades a gate/filter column absent from the fetched frame to **empty membership + a warning**, never `ArgumentError`. Backstop independent of resolution.

**Frontend**
- `ClusterHeatmapPanel.vue` + new `utils/clusterHeatmapBody.ts` — always send `suffix`; body-building extracted for unit testing.
- `PopulationManager.vue` — `visiblePops`: per-run scoping (only pops whose `filter.measure == clusters.{suffix}`); new-pop creation + cluster-ID assignment scoped to the active run.
- `useClusterContext.ts` — `resolvedVn` added to the pop-tree watch deps; `shownPopsFor` scoped to the current suffix.

**Design decision:** cluster populations are **per-run** — one segmentation sidecar holds every run's pops, each tagged by `clusters.{suffix}`; the page views one run at a time.

## Tests / verification
- Package: 1056 pass (incl. new `recompute!` missing-column guard testset).
- API: pass.
- Vitest: `clusterHeatmapBody` 6/6.
- Typecheck: `vue-tsc -b` clean.

## Caveats
- **Not driven in the running app** — verified across all four test layers but not click-tested against jFWePN (needs this branch's backend restarted; `api/src/*` isn't Revise-tracked).
- Existing jFWePN trackclust pops filter `clusters.default`, so they appear under the *default* run; movement-run pops are created under the movement suffix (no auto-migration, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
