### PR TITLE
feat(qc): bank objective count metrics from segment/measure/tracking

### DIFF
--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -23,7 +23,7 @@ export img_filepath, img_zero_dir, img_physical_sizes, image_included
 export img_label_props_dir, img_label_props_path, img_track_props_path, img_value_names, img_has_value_name
 export read_module_fun_params, write_module_fun_params!
 export TRACK_PROPS_SUFFIX, is_reserved_value_name
-export write_qc, read_qc, read_all_qc, qc_finding, qc_canvas_expansion, qc_path
+export write_qc, read_qc, read_all_qc, qc_finding, qc_canvas_expansion, qc_path, track_count_metrics
 export read_run_log, append_run_log!, run_log_path
 export read_lab_log, append_lab_log!, parse_lab_log, lab_log_path, LAB_LOG_FILENAME
 export read_tuning, set_tuning!
@@ -35,7 +35,7 @@ export set_channel_names!, channel_names
 export with_transaction
 
 # ── LabelProps reader (H5AD via HDF5.jl) ──────────────────────────────────────
-export LabelProps, label_props, as_df, as_matrix, add_obs, drop_obs, write_categorical_obs
+export LabelProps, label_props, as_df, as_matrix, add_obs, drop_obs, write_categorical_obs, n_obs
 export select_cols, view_cols, view_channel_cols, view_centroid_cols, view_label_col
 export filter_rows, sort_by, rename_channels!
 export col_names, channel_columns, centroid_columns, temporal_columns

--- a/app/src/label_props.jl
+++ b/app/src/label_props.jl
@@ -191,6 +191,19 @@ function col_names(lp::LabelProps; data_type::Symbol=:vars)::Vector{String}
     end
 end
 
+"""
+    n_obs(lp) -> Int
+
+Number of observations (cells) — the length of the obs index. Reads the dataset **dims only**
+(no column materialised), so it's a cheap count for QC/banking. `0` if the file has no obs index.
+"""
+function n_obs(lp::LabelProps)::Int
+    _with_h5(lp.path, "r") do fid
+        haskey(fid, "obs/_index") || return 0
+        Int(first(size(fid["obs/_index"])))
+    end
+end
+
 _intensity_measure(fid) = haskey(fid, "uns/intensity_measure") ?
                           String(read(fid["uns/intensity_measure"])) : "mean"
 

--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -59,6 +59,34 @@ function read_all_qc(img::CciaImage)
     out
 end
 
+# ── Objective count metrics (QC banking) ─────────────────────────────────────────
+# Tasks bank objective counts (cells measured, tracks + mean length) into the qc/ sidecar so future
+# cohort stats can flag anomalies (a run that produced 10× fewer cells/tracks than usual). There is
+# no cohort threshold yet, so a count is recorded as a METRIC (the doc's `metrics` field) — the
+# bankable datum — with an advisory `finding` only for the unambiguous "produced nothing" case.
+
+"""
+    track_count_metrics(track_ids) -> (n_tracks, mean_length, n_tracked_cells)
+
+From a per-cell `track_id` vector, count distinct tracks, mean cells-per-track, and total tracked
+cells. Untracked cells (`missing`/`nothing`/`NaN`/`≤ 0`) are ignored — matching the `track_id > 0`
+"tracked" convention used across gating/pop_df. Pure (no I/O) so it's unit-tested directly.
+"""
+function track_count_metrics(track_ids)
+    counts = Dict{Int,Int}()
+    for t in track_ids
+        (ismissing(t) || t === nothing) && continue
+        (t isa Real && isnan(t)) && continue
+        ti = t isa Integer ? Int(t) : Int(round(t))
+        ti > 0 || continue
+        counts[ti] = get(counts, ti, 0) + 1
+    end
+    n_tracks = length(counts)
+    n_cells  = sum(values(counts); init = 0)
+    mean_len = n_tracks == 0 ? 0.0 : n_cells / n_tracks
+    (n_tracks, mean_len, n_cells)
+end
+
 # Reusable spatial check — flag an output whose XY canvas grew abnormally vs its source. Shapes are in
 # `dim_order` (e.g. "TCZYX"). Generic across any spatially-transforming task (drift/AF correction, …);
 # returns a finding or `nothing`. Default threshold 25% (normal drift expands XY ≤~15%).

--- a/app/src/tasks/segment/cellpose.jl
+++ b/app/src/tasks/segment/cellpose.jl
@@ -1,5 +1,17 @@
 struct CellposeSegment <: CciaTask end
 
+# Pure QC helper (drift pattern): objective segment counts → findings + the primary (base) count.
+# Only the "0 cells" case is an advisory finding; the counts themselves are banked as metrics.
+function _segment_qc_findings(counts::AbstractDict)
+    primary = haskey(counts, "base") ? counts["base"] :
+              (isempty(counts) ? 0 : first(values(counts)))
+    findings = primary == 0 ?
+        [qc_finding("warn", "segment.no_cells", "No cells segmented",
+            "Segmentation produced no objects — check the channels/diameter and re-run this step.")] :
+        Dict{String,Any}[]
+    findings, primary
+end
+
 function _run_task(task::CellposeSegment, img::CciaImage, params::Dict{String,Any};
                    on_log::Function      = line -> println(line),
                    on_progress::Function = (n, t) -> nothing,
@@ -54,10 +66,13 @@ function _run_task(task::CellposeSegment, img::CciaImage, params::Dict{String,An
     on_log("[INFO] Output: $(joinpath(task_dir, "labels", out_value_name)).zarr")
     on_log("[INFO] Models: $(length(models_converted))")
 
+    qc_out_path = joinpath(task_run_dir(task_dir), "segment_counts.json")
+
     ok = run_py("tasks/segment/cellpose_run.py",
         (; imPath              = im_path,
            taskDir             = task_dir,
            outputValueName     = out_value_name,
+           qcOutPath           = qc_out_path,
            models              = models_converted,
            blockSize           = Int(get(params, "blockSize", 512)),
            overlap             = Int(get(params, "overlap", 64)),
@@ -95,6 +110,21 @@ function _run_task(task::CellposeSegment, img::CciaImage, params::Dict{String,An
     labels_dict[out_value_name] = label_files
     raw2["labels"] = labels_dict
     open(ccid, "w") do io; JSON3.write(io, raw2); end
+
+    # QC (advisory): bank the objective per-type cell count the Python runner wrote (drift pattern).
+    if isfile(qc_out_path)
+        try
+            qmeta  = JSON3.read(read(qc_out_path, String))
+            counts = Dict{String,Any}(String(k) => Int(v) for (k, v) in get(qmeta, :labelCounts, ()))
+            findings, primary = _segment_qc_findings(counts)
+            write_qc(img, "segment.cellpose", out_value_name, findings;
+                     metrics = Dict{String,Any}("nCells" => primary, "byType" => counts))
+            on_log("[QC] segmented $primary cell(s)" *
+                   (length(counts) > 1 ? " ($(join(["$k=$v" for (k, v) in counts], ", ")))" : "") * ".")
+        catch e
+            on_log("[QC] could not compute segment QC: $e")
+        end
+    end
 
     Dict{String,Any}("outputValueName"  => out_value_name,
                      "labelValueName"   => out_value_name,

--- a/app/src/tasks/segment/measure_labels.jl
+++ b/app/src/tasks/segment/measure_labels.jl
@@ -62,6 +62,24 @@ function _run_task(task::MeasureLabels, img::CciaImage, params::Dict{String,Any}
     on_log("[INFO] Measurement complete.")
 
     h5ad_filename = "$(out_value_name).h5ad"
+
+    # QC (advisory): bank the objective cell count so cohort stats can later flag anomalies. A count
+    # of 0 (measured nothing) is the one unambiguous problem → an advisory finding. Read the count
+    # from the just-written .h5ad by path (img.label_props in-memory isn't refreshed here yet).
+    try
+        h5ad_path = joinpath(task_dir, "labelProps", h5ad_filename)
+        n = n_obs(label_props(h5ad_path))
+        findings = n == 0 ?
+            [qc_finding("warn", "measure.no_cells", "No cells measured",
+                "The segmentation produced no measurable objects — check the segmentation and re-run this step.")] :
+            Dict{String,Any}[]
+        write_qc(img, "segment.measureLabels", out_value_name, findings;
+                 metrics = Dict{String,Any}("nCells" => n))
+        on_log("[QC] measured $n cell(s).")
+    catch e
+        on_log("[QC] could not compute measure QC: $e")
+    end
+
     raw2 = Dict{String,Any}(String(k) => v for (k, v) in JSON3.read(read(ccid, String)))
     lp   = Dict{String,String}(String(k) => string(v)
                                for (k, v) in get(raw2, "label_props", Dict{String,Any}()))

--- a/app/src/tasks/tracking/bayesian_tracking.jl
+++ b/app/src/tasks/tracking/bayesian_tracking.jl
@@ -73,5 +73,27 @@ function _run_task(task::BayesianTracking, img::CciaImage, params::Dict{String,A
     ok || return nothing
 
     on_log("[INFO] Tracking complete.")
+
+    # QC (advisory): bank the track count + mean track length from the track_id column btrack just
+    # wrote back into the segmentation's obs. 0 tracks (btrack linked nothing) is the one unambiguous
+    # problem → an advisory finding; the counts are always recorded as metrics for cohort stats.
+    try
+        cells = label_props(props_path) |> select_cols(["track_id"]) |> as_df
+        tids  = "track_id" in names(cells) ? cells.track_id : Float64[]
+        n_tracks, mean_len, n_tracked = track_count_metrics(tids)
+        findings = n_tracks == 0 ?
+            [qc_finding("warn", "tracking.no_tracks", "No tracks formed",
+                "btrack linked no cells into tracks — check segmentation continuity and the tracking parameters, then re-run.")] :
+            Dict{String,Any}[]
+        write_qc(img, "tracking.bayesian_tracking", value_name, findings;
+                 metrics = Dict{String,Any}("nTracks"         => n_tracks,
+                                            "meanTrackLength" => round(mean_len, digits = 2),
+                                            "nTrackedCells"   => n_tracked))
+        on_log(n_tracks == 0 ? "[QC] no tracks formed — see the image's QC badge." :
+               "[QC] $n_tracks track(s), mean length $(round(mean_len, digits = 1)) frames.")
+    catch e
+        on_log("[QC] could not compute tracking QC: $e")
+    end
+
     Dict{String,Any}("valueName" => value_name)
 end

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2091,6 +2091,8 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             # live.cell.* from tracking.track_measures) = 40 cols, 1377 rows
             df = label_props(h5) |> as_df
             @test size(df) == (1377, 40)
+            # n_obs is the cheap dims-only count — must agree with the materialised row count
+            @test n_obs(label_props(h5)) == 1377
             @test "label" in names(df)
             @test eltype(df.label) == Int64
             @test df.label[1:5] == [0, 1, 2, 3, 4]
@@ -4128,6 +4130,44 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
                                        "outputShape" => [20, 4, 19, 541, 527], "shifts" => smooth))
             fo, _, _ = Cecelia._drift_qc_findings(meta_ok)
             @test isempty(fo)
+        end
+
+        @testset "count metrics" begin
+            # pure: distinct tracks, mean cells/track, tracked-cell total; untracked = missing/NaN/≤0
+            nt, ml, ntc = track_count_metrics([1, 1, 1, 2, 2, 0, -1, NaN, missing, 3])
+            @test nt == 3                       # tracks 1, 2, 3
+            @test ntc == 6                      # 3 + 2 + 1 cells tracked
+            @test ml ≈ 2.0                      # 6 cells / 3 tracks
+
+            # no tracks at all → zeros (drives the "No tracks formed" advisory)
+            @test track_count_metrics([0, NaN, missing]) == (0, 0.0, 0)
+            @test track_count_metrics(Float64[]) == (0, 0.0, 0)
+
+            # floats round to the nearest track id
+            n2, _, c2 = track_count_metrics([1.0, 1.0, 2.0])
+            @test (n2, c2) == (2, 3)
+
+            # segment counts → findings: 0 base cells warns; any base count is clean
+            f0, p0 = Cecelia._segment_qc_findings(Dict("base" => 0))
+            @test p0 == 0 && length(f0) == 1 && f0[1]["code"] == "segment.no_cells"
+            fN, pN = Cecelia._segment_qc_findings(Dict("base" => 812, "nuc" => 790))
+            @test pN == 812 && isempty(fN)
+            # no explicit "base" key → primary falls back to the sole type's count
+            _, pf = Cecelia._segment_qc_findings(Dict("nuc" => 5))
+            @test pf == 5
+
+            # against the tracked fixture: metrics agree with an independent count of track_id
+            h5 = fixture_path("testpr", "1", "KDIeEm", "labelProps", "B.h5ad")
+            if !have_fixture(h5)
+                @test_skip "track_count_metrics fixture (missing)"
+            else
+                tids = (label_props(h5) |> select_cols(["track_id"]) |> as_df).track_id
+                valid = Int.(filter(t -> !isnan(t) && t > 0, tids))
+                fnt, fml, fntc = track_count_metrics(tids)
+                @test fnt == length(unique(valid))
+                @test fntc == length(valid)
+                @test fml ≈ length(valid) / length(unique(valid))
+            end
         end
     end
 

--- a/python/cecelia/tasks/segment/cellpose_run.py
+++ b/python/cecelia/tasks/segment/cellpose_run.py
@@ -39,6 +39,7 @@ Parameter contract (JSON written by Julia):
 
 import sys
 import os
+import json
 # `cecelia.*` resolves via PYTHONPATH=python/, set by the Julia launcher (app/src/py_runner.jl::run_py).
 import cecelia.utils.zarr_utils as zarr_utils
 import cecelia.utils.ome_xml_utils as ome_xml_utils
@@ -67,7 +68,15 @@ def run(params):
     log.log(f'>> GPU: {cp.gpu_device if cp.use_gpu else "none (CPU)"}')
     log.log(f'>> tiling: block={cp.block_size} overlap={cp.overlap} normalise_to_whole={cp.normalise_to_whole}')
 
-    cp.predict_from_zarr(im_dat)
+    label_counts = cp.predict_from_zarr(im_dat)
+
+    # Bank the objective per-type cell count for QC (the Julia handler reads this and writes the qc/
+    # sidecar — same qcOutPath pattern as drift_correct_run.py). Best-effort; never fails the task.
+    qc_out_path = params.get('qcOutPath')
+    if qc_out_path:
+        with open(qc_out_path, 'w') as f:
+            json.dump({'labelCounts': label_counts}, f)
+        log.log(f'>> saved segment QC counts: {label_counts}')
 
     log.log('>> done')
 

--- a/python/cecelia/tests/test_segmentation_utils.py
+++ b/python/cecelia/tests/test_segmentation_utils.py
@@ -1,0 +1,36 @@
+"""Unit tests for the pure segment-count helper (cecelia.utils.segmentation_utils.count_labels).
+
+Pure/headless — no zarr, no cellpose. Pins that the objective cell count = distinct non-zero label
+IDs (background 0 ignored, repeats collapsed, non-contiguous IDs handled), which is what the QC
+sidecar banks for segmentation."""
+import unittest
+
+import numpy as np
+
+from cecelia.utils.segmentation_utils import count_labels
+
+
+class TestCountLabels(unittest.TestCase):
+    def test_counts_distinct_nonzero(self):
+        arr = np.array([[0, 1, 1], [2, 2, 0], [3, 0, 3]], dtype=np.uint32)
+        self.assertEqual(count_labels(arr), 3)          # ids 1,2,3
+
+    def test_background_only_is_zero(self):
+        self.assertEqual(count_labels(np.zeros((4, 4), dtype=np.uint32)), 0)
+
+    def test_non_contiguous_ids(self):
+        # ids need not be 1..N (post-processing removes objects → gaps); count the distinct ones
+        arr = np.array([10, 10, 500, 0, 7], dtype=np.uint32)
+        self.assertEqual(count_labels(arr), 3)          # ids 7,10,500
+
+    def test_3d_timecourse_like(self):
+        # globally-unique ids across a stack → total object instances
+        arr = np.zeros((2, 3, 3), dtype=np.uint32)
+        arr[0, 0, 0] = 1
+        arr[0, 1, 1] = 2
+        arr[1, 2, 2] = 3
+        self.assertEqual(count_labels(arr), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/cecelia/utils/segmentation_utils.py
+++ b/python/cecelia/utils/segmentation_utils.py
@@ -19,6 +19,13 @@ from skimage import morphology, segmentation
 from scipy import ndimage
 
 
+def count_labels(arr):
+    """Number of distinct non-zero label IDs in a label array — the objective cell count for QC.
+    Label IDs are assigned globally-incrementing across tiles AND timepoints, so this is the total
+    number of segmented object instances (matching one row per object in the measured .h5ad)."""
+    return int(np.unique(arr[arr > 0]).size)
+
+
 class SegmentationUtils:
 
     LABEL_DTYPE = np.uint32
@@ -150,6 +157,9 @@ class SegmentationUtils:
                     arr,
                     os.path.join(labels_dir, f'{self.output_value_name}_{ma}.zarr'),
                     label_axes, nscales)
+
+        # Objective QC count per label type (banked by the Julia handler via the qc/ sidecar).
+        return {ma: count_labels(arr) for ma, arr in label_arrs.items()}
 
     # ── Tile helpers ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Start banking **objective QC count metrics** from the segmentation/measurement/tracking tasks, so future cohort stats can flag anomalies (a run producing far fewer cells/tracks than usual). Each task writes counts to the `qc/` sidecar via the existing `write_qc` path (the one `drift_correct` already uses). Counts are recorded as `metrics`; an advisory `finding` is emitted only for the unambiguous "produced nothing" case.

## Metrics banked

| Task | fun_name | Metrics | Warn finding |
|---|---|---|---|
| Segment | `segment.cellpose` | `nCells` (+ per-type `byType`) | 0 base cells → `segment.no_cells` |
| Measure | `segment.measureLabels` | `nCells` | 0 cells → `measure.no_cells` |
| Tracking | `tracking.bayesian_tracking` | `nTracks`, `meanTrackLength`, `nTrackedCells` | 0 tracks → `tracking.no_tracks` |

## How

- **Segment** — the Python runner counts distinct non-zero labels (new pure `count_labels` in `segmentation_utils.py`, returned from `predict_from_zarr`) and writes them to `qcOutPath` (same pattern as `drift_correct_run.py`); the Julia handler reads that and banks them.
- **Measure** — new cheap `n_obs(lp)` reads the obs-index **dims only** (no column materialised) → cell count.
- **Tracking** — new pure `track_count_metrics` computes tracks / mean length / tracked cells from the `track_id` obs column btrack wrote back.

## Tests

Pure helpers unit-tested: `count_labels` (python), `n_obs` + `track_count_metrics` + `_segment_qc_findings` (julia, incl. a fixture-backed track check). `pixi run test-pkg` / `test-py` green.

## Reservations

- The live `run_py` spawn paths aren't CI-exercised (only the pure helpers + the h5ad reader against the fixture) — same coverage shape as `drift_correct`.
- QC is best-effort (`try/catch`) and **never** fails a task.
- Segment count does one `np.unique` over the full label array at the end of segmentation (negligible vs the segmentation itself).
- Banks data for the deferred cohort / `qc_flag_fired` features, which remain **blocked on the QC engine** (TODO #00083).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
