### PR TITLE
fix(observer): emit failed frame on param-validation + theme lab-log tooltips

### DIFF
--- a/api/src/sockets.jl
+++ b/api/src/sockets.jl
@@ -261,22 +261,33 @@ function handle_task_run(ws, data)
             end
             rep = first(imgs).uid
             final_status = Ref{Symbol}(:failed)
-            result = run_task(task_struct, imgs, params;
-                              task_id          = task_id,
-                              pool_name        = pool_name,
-                              on_log           = line -> ws_log(ws, task_id, line),
-                              on_progress      = (n, t) -> ws_progress(ws, task_id, n, t),
-                              on_status_change = rec -> begin
-                                  # queued/running forwarded live; also forward :cancelled at once (it
-                                  # has no result to order before it) so a cancelled task — especially a
-                                  # still-QUEUED one — reflects immediately, not only when a worker later
-                                  # dequeues and skips it. :done/:failed still wait for the final send.
-                                  if rec.status in (:queued, :running, :cancelled)
-                                      ws_status(ws, task_id, string(rec.status), rep; fun=fun_name)
-                                  end
-                                  final_status[] = rec.status
-                              end)
-            isnothing(result) || ws_result(ws, task_id, rep, result)
+            # run_task validates params FIRST (throws ParamValidationError before any job runs), so a
+            # bad-param launch never reaches on_status_change. Catch it here so the failure is logged
+            # AND a terminal task:status frame still goes out — otherwise the throw dies in the
+            # @spawn silently (no [ERROR], no frame → the observer's "Watch" auto-trigger, which keys
+            # off the terminal frame, never fires). Same guarantee for any pre-job throw.
+            try
+                result = run_task(task_struct, imgs, params;
+                                  task_id          = task_id,
+                                  pool_name        = pool_name,
+                                  on_log           = line -> ws_log(ws, task_id, line),
+                                  on_progress      = (n, t) -> ws_progress(ws, task_id, n, t),
+                                  on_status_change = rec -> begin
+                                      # queued/running forwarded live; also forward :cancelled at once
+                                      # (it has no result to order before it) so a cancelled task —
+                                      # especially a still-QUEUED one — reflects immediately, not only
+                                      # when a worker later dequeues and skips it. :done/:failed still
+                                      # wait for the final send.
+                                      if rec.status in (:queued, :running, :cancelled)
+                                          ws_status(ws, task_id, string(rec.status), rep; fun=fun_name)
+                                      end
+                                      final_status[] = rec.status
+                                  end)
+                isnothing(result) || ws_result(ws, task_id, rep, result)
+            catch ex
+                ws_log(ws, task_id, "[ERROR] " * sprint(showerror, ex))
+                final_status[] = :failed
+            end
             # a set task touched EVERY member — send the full list so the frontend invalidates all of
             # their plots, not just the representative's (closes the non-rep-member gap).
             ws_status(ws, task_id, string(final_status[]), rep; image_uids=[i.uid for i in imgs], fun=fun_name)
@@ -297,22 +308,28 @@ function handle_task_run(ws, data)
         # Capture the final status so we can send ws_result before ws_status("done"),
         # preserving the result→status ordering the frontend expects.
         final_status = Ref{Symbol}(:failed)
-        result = run_task(task_struct, img, params;
-                          task_id          = task_id,
-                          pool_name        = pool_name,
-                          on_log           = line -> ws_log(ws, task_id, line),
-                          on_progress      = (n, t) -> ws_progress(ws, task_id, n, t),
-                          on_status_change = rec -> begin
-                              # Forward queued/running immediately, and :cancelled too (no result to
-                              # order before it) so a cancelled — especially still-QUEUED — task
-                              # reflects at once. Hold :done/:failed until after the result is sent.
-                              if rec.status in (:queued, :running, :cancelled)
-                                  ws_status(ws, task_id, string(rec.status), image_uid; fun=fun_name)
-                              end
-                              final_status[] = rec.status
-                          end)
-
-        isnothing(result) || ws_result(ws, task_id, image_uid, result)
+        # See the set-scope branch: run_task validates params first (throws before any job runs), so
+        # a pre-job throw is caught here to guarantee an [ERROR] log + a terminal task:status frame.
+        try
+            result = run_task(task_struct, img, params;
+                              task_id          = task_id,
+                              pool_name        = pool_name,
+                              on_log           = line -> ws_log(ws, task_id, line),
+                              on_progress      = (n, t) -> ws_progress(ws, task_id, n, t),
+                              on_status_change = rec -> begin
+                                  # Forward queued/running immediately, and :cancelled too (no result
+                                  # to order before it) so a cancelled — especially still-QUEUED —
+                                  # task reflects at once. Hold :done/:failed until after the result.
+                                  if rec.status in (:queued, :running, :cancelled)
+                                      ws_status(ws, task_id, string(rec.status), image_uid; fun=fun_name)
+                                  end
+                                  final_status[] = rec.status
+                              end)
+            isnothing(result) || ws_result(ws, task_id, image_uid, result)
+        catch ex
+            ws_log(ws, task_id, "[ERROR] " * sprint(showerror, ex))
+            final_status[] = :failed
+        end
         ws_status(ws, task_id, string(final_status[]), image_uid; fun=fun_name)
     end
 end

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -580,6 +580,51 @@ end
     end
 end
 
+@testset "API: bad-param launch still emits [ERROR] + terminal failed frame" begin
+    # run_task validates params FIRST and throws before any job runs. handle_task_run must catch that
+    # and STILL emit a task log + a terminal task:status:failed frame — otherwise the throw dies in
+    # the @spawn silently and the observer's "Watch" auto-trigger (which keys off the terminal frame)
+    # never fires. This is the regression the HMM-with-no-params case exposed.
+    cap = Channel{String}(64)
+    key = gensym("test-taskfail")
+    lock(_ws_clients_lock) do; _ws_clients[key] = cap; end
+    drain() = (fs = Any[]; while isready(cap); push!(fs, JSON3.read(take!(cap))); end; fs)
+
+    conf = cecelia_conf()
+    dirs = get!(conf, "dirs", Dict{String,Any}())
+    had  = haskey(dirs, "projects"); old = get(dirs, "projects", nothing)
+    tmp  = mktempdir(); dirs["projects"] = tmp
+    try
+        proj = create_project!(name="api-taskfail", kind="static")
+        s    = add_set!(proj; name="set-A")
+        img  = add_image!(s; name="img-1", meta=Dict{String,Any}("ori_path"=>"/tmp/a.tif"))
+
+        # importImages.omezarr with pyramidScale=99 fails validate_params (min/max) before any job.
+        drain()
+        handle_task_run(nothing, Dict{Symbol,Any}(
+            :taskId => "t-fail", :funName => "importImages.omezarr",
+            :projectUid => proj.uid, :imageUid => img.uid,
+            :params => Dict{String,Any}("pyramidScale" => 99)))
+
+        # the handler runs the task on a @spawn — poll until the terminal frame lands (or time out)
+        frames = Any[]
+        for _ in 1:200
+            append!(frames, drain())
+            any(f -> f.type == "task:status" && f.status == "failed", frames) && break
+            sleep(0.05)
+        end
+        status = filter(f -> f.type == "task:status", frames)
+        @test any(f -> f.status == "failed" && f.fun == "importImages.omezarr", status)
+        # the [ERROR] log names the offending param → confirms we reached (and reported) validation
+        errs = filter(f -> f.type == "task:log" && occursin("[ERROR]", String(f.line)), frames)
+        @test any(f -> occursin("pyramidScale", String(f.line)), errs)
+    finally
+        lock(_ws_clients_lock) do; delete!(_ws_clients, key); end
+        had ? (dirs["projects"] = old) : delete!(dirs, "projects")
+        rm(tmp; recursive=true, force=true)
+    end
+end
+
 @testset "API: custom modules status/reload" begin
     # Read-only status: shape is { dir, modules: [...], categories: [...] }; dir is <config_dir>/modules.
     st, body = api_custom_modules_status(HTTP.Request("GET", "/api/tasks/custom-modules"))

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -294,34 +294,34 @@ async function toggleMute(category: string) {
     <!-- activity capture: manual button + auto-on-open toggle -->
     <div class="ll-toolbar">
       <button class="ll-capture" :disabled="!projectUid || capturing" @click="capture(false)"
-              title="Append an app-generated [Cecelia] digest of recent activity (tasks run, …)">
+              v-tooltip.top="'Append an app-generated [Cecelia] digest of recent activity (tasks run, …)'">
         <i class="pi pi-history" /> {{ capturing ? 'Capturing…' : 'Capture activity' }}
       </button>
-      <label class="ll-auto" title="Automatically capture activity when this project opens">
+      <label class="ll-auto" v-tooltip.top="'Automatically capture activity when this project opens'">
         <input type="checkbox" v-model="settings.labLogAutoContext" /> Auto
       </label>
       <button class="ll-capture" :disabled="!projectUid || observerBusy || !observerAvailable"
               @click="askClaude"
-              :title="observerAvailable
+              v-tooltip.top="observerAvailable
                 ? 'Ask the assistant to review recent activity and note anything worth flagging in the lab log'
                 : 'Needs Claude Code — with it, an assistant can watch your analysis and note things in the lab log'">
         <i class="pi pi-sparkles" /> {{ observerBusy ? 'Asking…' : 'Ask Claude' }}
       </button>
       <label v-if="observerAvailable" class="ll-auto"
-             title="Sit next to me: after a task finishes, Claude reviews and may note something in the lab log (spends tokens)">
+             v-tooltip.top="'Sit next to me: after a task finishes, Claude reviews and may note something in the lab log (spends tokens)'">
         <input type="checkbox" v-model="settings.labLogObserverAuto" /> Watch
       </label>
       <span v-if="observerTokens" class="ll-tokens"
-            title="Assistant token use for this project's observer session (real usage)">{{ observerTokens }}</span>
+            v-tooltip.top="'Assistant token use for this observer session (real usage)'">{{ observerTokens }}</span>
       <button v-if="observerTokens" class="ll-clearctx" @click="clearContext"
-              title="Clear the assistant's session and reset the token count">clear</button>
+              v-tooltip.top="'Clear the assistant session and reset the token count'">clear</button>
       <span v-if="captureNote" class="ll-note">{{ captureNote }}</span>
     </div>
 
     <!-- what "Watch" triggers on: read-only green/red lights (only task-completion is wired today) -->
     <div v-if="observerAvailable && settings.labLogObserverAuto" class="ll-triggers">
       <span class="ll-triggers-label">Watching:</span>
-      <span v-for="t in observerTriggers" :key="t.key" class="ll-trigger" :title="t.note">
+      <span v-for="t in observerTriggers" :key="t.key" class="ll-trigger" v-tooltip.top="t.note">
         <span class="ll-trigger-dot" :class="t.active ? 'on' : 'off'" /> {{ t.label }}
       </span>
     </div>
@@ -336,9 +336,9 @@ async function toggleMute(category: string) {
     <div class="ll-modebar">
       <span class="ll-modelabel">Rating:</span>
       <button class="ll-modebtn" :class="{ on: mode === 'notes' }" @click="settings.labLogMode = 'notes'"
-              title="Thumbs + comment judge the DECISION → saved as a note in the log">decisions</button>
+              v-tooltip.top="'Thumbs + comment judge the DECISION → saved as a note in the log'">decisions</button>
       <button class="ll-modebtn" :class="{ on: mode === 'tuning' }" @click="settings.labLogMode = 'tuning'"
-              title="Thumbs judge the ENTRY TYPE (useful / noise) → tunes what gets logged, not the log">entry types</button>
+              v-tooltip.top="'Thumbs judge the ENTRY TYPE (useful / noise) → tunes what gets logged, not the log'">entry types</button>
     </div>
 
     <!-- mute whole categories from future digests (Tuning mode) -->
@@ -346,7 +346,7 @@ async function toggleMute(category: string) {
       <span class="ll-modelabel">Mute:</span>
       <button v-for="c in muteableCategories" :key="c" class="ll-mutebtn"
               :class="{ muted: mutes.includes(c) }" @click="toggleMute(c)"
-              :title="mutes.includes(c) ? `${c} muted — click to log again` : `Stop logging ${c}`">
+              v-tooltip.top="mutes.includes(c) ? `${c} muted — click to log again` : `Stop logging ${c}`">
         <i :class="['pi', mutes.includes(c) ? 'pi-bell-slash' : 'pi-bell']" /> {{ c }}
       </button>
     </div>
@@ -368,15 +368,15 @@ async function toggleMute(category: string) {
             <span class="ll-actions">
               <template v-if="isRatable(e.author)">
                 <button class="ll-thumb" :class="{ voted: mode === 'tuning' && voteOf(e) === 'up' }"
-                        :title="mode === 'notes' ? 'Good decision — add a note' : 'Useful entry type'"
+                        v-tooltip.top="mode === 'notes' ? 'Good decision — add a note' : 'Useful entry type'"
                         @click="mode === 'notes' ? rateDecision(e, 'up') : tune(e, 'up')">👍</button>
                 <button class="ll-thumb" :class="{ voted: mode === 'tuning' && voteOf(e) === 'down' }"
-                        :title="mode === 'notes' ? 'Bad decision — add a note' : 'Noisy entry type'"
+                        v-tooltip.top="mode === 'notes' ? 'Bad decision — add a note' : 'Noisy entry type'"
                         @click="mode === 'notes' ? rateDecision(e, 'down') : tune(e, 'down')">👎</button>
-                <button v-if="mode === 'notes'" class="ll-link" title="Comment (saved as a note)"
+                <button v-if="mode === 'notes'" class="ll-link" v-tooltip.top="'Comment (saved as a note)'"
                         @click="startComment(e)">💬</button>
               </template>
-              <button v-else class="ll-link" title="Add a correction (never edits the original)"
+              <button v-else class="ll-link" v-tooltip.top="'Add a correction (never edits the original)'"
                       @click="startCorrection(e)">correct</button>
             </span>
           </div>


### PR DESCRIPTION
## What

Two observer-arc fixes found via live validation.

### 1. Bad-param launches were invisible to "Watch" (the real bug behind the HMM case)

`run_task` validates params **first** and throws `ParamValidationError` *before* any job is scheduled. But the `run_task` calls in `handle_task_run` (`api/src/sockets.jl`) weren't wrapped — so the throw died silently inside the `Threads.@spawn`: **no `[ERROR]` log, no terminal `task:status` frame**.

The observer's auto **"Watch"** trigger keys off that terminal frame, so a failed run (e.g. HMM with no params) never triggered a pass and never badged — even though "Ask Claude" worked (it reads persisted logs directly). This is also the #189 gap ("param-validation rejects still unlogged").

**Fix:** wrap both `run_task` call sites (set- and image-scope) so a pre-job throw now emits an `[ERROR] <message>` log **and** a terminal `failed` frame. API regression test added (`importImages.omezarr` + `pyramidScale=99` → asserts both frames arrive).

### 2. Lab-log tooltips looked like browser defaults

The panel used native `title=` attributes → unthemed browser tooltips. Converted all 13 to the app's PrimeVue `v-tooltip` directive.

## Tests

`pixi run test-api` (+ new bad-param test), `pixi run test-frontend` (200), `npm run typecheck` — all green.

## Reservations

- `api/src/sockets.jl` is **not** Revise-tracked → needs a **backend restart** to take effect.
- Tooltip change is template-only (typecheck + vitest green) but not eyeballed in a browser here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
