### PR TITLE
feat(observer): user-selectable model, default Sonnet (not Opus)

### DIFF
--- a/api/src/observer_api.jl
+++ b/api/src/observer_api.jl
@@ -24,7 +24,9 @@ end
 # status doubles as the per-project session/usage readout when given ?projectUid — one call drives
 # both the availability gate and the token readout on the panel.
 function api_observer_status(req::HTTP.Request)
-    resp = Dict{String,Any}("available" => agent_available(ClaudeAgent()))
+    resp = Dict{String,Any}("available"    => agent_available(ClaudeAgent()),
+                            "models"        => OBSERVER_MODELS,          # the picker's choices
+                            "defaultModel"  => observer_default_model()) # config default (Sonnet)
     puid = get(HTTP.queryparams(HTTP.URI(req.target)), "projectUid", "")
     if !isempty(puid)
         proj = try load_project(puid) catch; nothing end
@@ -44,7 +46,9 @@ function api_observer_feedback(body_bytes::Vector{UInt8})
     catch e
         return 404, JSON3.write((; error = sprint(showerror, e)))
     end
-    agent = ClaudeAgent()
+    # allow-listed model (default Sonnet); the panel sends the user's pick, auto-Watch included.
+    model = observer_valid_model(get(body, :model, ""))
+    agent = ClaudeAgent(; model = model)
     if !agent_available(agent)
         return 200, JSON3.write((; ok = false, available = false,
             error = "No assistant CLI found. Install Claude Code (or set [ai] agent_bin) to enable this."))
@@ -55,7 +59,8 @@ function api_observer_feedback(body_bytes::Vector{UInt8})
                             session_id = String(sess["sessionId"]))     # resume the project's session
     # accumulate real usage + adopt the session id for the next --resume (only on a clean turn)
     updated = res.ok ? record_observer_turn!(proj, res.session_id, res.input_tokens, res.output_tokens) : sess
-    200, JSON3.write((; ok = res.ok, available = true, message = res.text, error = res.error,
+    200, JSON3.write((; ok = res.ok, available = true, model = model,
+                        message = res.text, error = res.error,
                         inputTokens = res.input_tokens, outputTokens = res.output_tokens,
                         session = updated))
 end

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -649,7 +649,12 @@ end
     # assert which, so it passes both in CI and on a dev box with Claude Code installed).
     st, body = api_observer_status(HTTP.Request("GET", "/api/observer/status"))
     @test st == 200
-    @test JSON3.read(body).available isa Bool
+    let s = JSON3.read(body)
+        @test s.available isa Bool
+        # the picker's choices + shipped default are exposed so the panel can populate the dropdown
+        @test Set(String.(s.models)) == Set(["haiku", "sonnet", "opus"])
+        @test String(s.defaultModel) in Set(["haiku", "sonnet", "opus"])
+    end
 
     # feedback: validated before anything is spawned.
     @test _post(api_observer_feedback, Dict())[1] == 400                       # projectUid missing

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -163,6 +163,7 @@ include("ai/agent_runner.jl")
 include("ai/observer_session.jl")
 export ClaudeAgent, agent_available, run_observer_turn, observer_mcp_config,
        observer_feedback_prompt, observer_auto_prompt, observer_agent_bin,
+       OBSERVER_MODELS, observer_default_model, observer_valid_model,
        read_observer_session, record_observer_turn!, clear_observer_session!
 
 end

--- a/app/src/ai/agent_runner.jl
+++ b/app/src/ai/agent_runner.jl
@@ -11,11 +11,24 @@ abstract type AgentBackend end
 # The CLI binary for the agent — default "claude", overridable via config.toml [ai] agent_bin.
 observer_agent_bin()::String = string(get(get(cecelia_conf(), "ai", Dict()), "agent_bin", "claude"))
 
+# The models the observer offers (Claude CLI `--model` aliases). Opus is deliberately NOT the
+# default: the observer's work — spot a repeat pattern, read a task log to diagnose a failure, write
+# a brief lab-log line — fits Sonnet, and Haiku is enough for the frequent auto-Watch passes; Opus
+# just costs more and runs slower. Default overridable via config.toml [ai] model, picked per-run by
+# the panel. A second backend (Gemini/…) would define its own list.
+const OBSERVER_MODELS = ["haiku", "sonnet", "opus"]
+observer_default_model()::String =
+    (m = string(get(get(cecelia_conf(), "ai", Dict()), "model", "sonnet"));
+     m in OBSERVER_MODELS ? m : "sonnet")
+# Coerce a requested model to a safe allow-listed value (never pass an arbitrary string to --model).
+observer_valid_model(m)::String =
+    (s = string(m); s in OBSERVER_MODELS ? s : observer_default_model())
+
 struct ClaudeAgent <: AgentBackend
     bin::String
     model::String     # "" = the CLI's default model
 end
-ClaudeAgent(; bin::AbstractString = observer_agent_bin(), model::AbstractString = "") =
+ClaudeAgent(; bin::AbstractString = observer_agent_bin(), model::AbstractString = observer_default_model()) =
     ClaudeAgent(String(bin), String(model))
 
 # One turn's outcome — backend-agnostic. The lab-log write itself is a side effect the agent performs

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -146,7 +146,7 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
     # The live spawn (needs the agent CLI + a running API) isn't tested here; these pin the pure
     # builders/parsers that the runner + api route depend on. See docs/todo/OBSERVER_INTEGRATION_PLAN.md.
     @testset "AI observer agent runner (pure pieces)" begin
-        a   = Cecelia.ClaudeAgent(bin = "claude")
+        a   = Cecelia.ClaudeAgent(bin = "claude", model = "")               # explicit empty → no flag
         cmd = Cecelia._build_claude_cmd(a, "hello", "/tmp/mcp.json"; system_prompt = "be brief")
         argv = cmd.exec
         @test argv[1] == "claude"
@@ -156,12 +156,22 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         @test "--allowedTools" in argv                                    # observer tools allowed
         @test "--append-system-prompt" in argv && "be brief" in argv
         @test !("--resume" in argv)                                       # no session → no resume
-        @test !("--model" in argv)                                        # default model → no flag
+        @test !("--model" in argv)                                        # empty model → no flag
 
         cmd2 = Cecelia._build_claude_cmd(Cecelia.ClaudeAgent(bin = "claude", model = "claude-opus-4-8"),
                                          "hi", "/tmp/m.json"; session_id = "sess123")
         @test "--resume" in cmd2.exec && "sess123" in cmd2.exec
         @test "--model" in cmd2.exec && "claude-opus-4-8" in cmd2.exec
+
+        # model choice: shipped default is Sonnet (Opus not needed for observer work); the request
+        # model is allow-listed — an arbitrary string never reaches --model. (default_model reads
+        # config [ai] model, so assert it stays within the allow-list rather than a hard "sonnet".)
+        @test Set(Cecelia.OBSERVER_MODELS) == Set(["haiku", "sonnet", "opus"])
+        @test Cecelia.observer_default_model() in Cecelia.OBSERVER_MODELS
+        @test Cecelia.observer_valid_model("haiku") == "haiku"
+        @test Cecelia.observer_valid_model("gpt-4") == Cecelia.observer_default_model()   # unknown → default
+        @test Cecelia.observer_valid_model("")     == Cecelia.observer_default_model()
+        @test Cecelia.ClaudeAgent(bin = "claude").model == Cecelia.observer_default_model()
 
         # result parsing — success carries text + usage + session
         r = Cecelia._parse_claude_result(

--- a/docs/todo/OBSERVER_INTEGRATION_PLAN.md
+++ b/docs/todo/OBSERVER_INTEGRATION_PLAN.md
@@ -35,6 +35,12 @@ always-available feature that most users will actually use.
    first implementation**; adding Gemini/ChatGPT later is a new adapter, not a rewrite. The observer
    *prompt* lives server-side (shared across backends). This is an explicit product requirement (user:
    "it would be nice if people could choose other agents in the future").
+   - **Model is user-selectable, default Sonnet.** The observer's work (spot a repeat pattern, read a
+     task log to diagnose a failure, write a brief lab-log line) fits Sonnet; Haiku is enough for the
+     frequent auto-Watch passes; **Opus is overkill** (slower, costlier). The panel exposes a
+     Haiku/Sonnet/Opus picker (`settings.labLogObserverModel`), sent per run (Ask-Claude + Watch) and
+     allow-listed server-side (`OBSERVER_MODELS`); the default is overridable via config.toml
+     `[ai] model`. A second backend would define its own list.
 
 3. **The control surface is exactly four things** (user: "that's the only two readouts we need" +
    two actions):

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -38,6 +38,7 @@ const observerAvailable = ref(false)
 const observerBusy = ref(false)
 const observerNote = ref('')
 const observerSession = ref<ObserverSession | null>(null)
+const observerModels = ref<string[]>(['haiku', 'sonnet', 'opus'])   // populated from status
 const observerTriggers = OBSERVER_TRIGGERS   // read-only trigger status row (green/red)
 // running token total for the readout (real usage from the assistant's own output, accumulated
 // per project — see docs/todo/OBSERVER_INTEGRATION_PLAN.md Decisions 3/4)
@@ -103,7 +104,7 @@ async function askClaude() {
   observerNote.value = ''
   error.value = ''
   try {
-    const res = await observerApi.feedback(projectUid.value)
+    const res = await observerApi.feedback(projectUid.value, settings.labLogObserverModel)
     if (res.session) observerSession.value = res.session   // updated running token total
     if (res.available === false) {
       observerAvailable.value = false
@@ -169,6 +170,7 @@ watch(projectUid, async () => {
   observerApi.status(projectUid.value).then(s => {
     observerAvailable.value = s.available
     observerSession.value = s.session ?? null
+    if (s.models?.length) observerModels.value = s.models
   })
   await load()
   if (settings.labLogAutoContext) capture(true)
@@ -311,6 +313,10 @@ async function toggleMute(category: string) {
              v-tooltip.top="'Sit next to me: after a task finishes, Claude reviews and may note something in the lab log (spends tokens)'">
         <input type="checkbox" v-model="settings.labLogObserverAuto" /> Watch
       </label>
+      <select v-if="observerAvailable" class="ll-model" v-model="settings.labLogObserverModel"
+              v-tooltip.top="'Which model the observer runs (Ask Claude + Watch). Sonnet is the default; Haiku is cheapest, Opus is overkill here.'">
+        <option v-for="m in observerModels" :key="m" :value="m">{{ m }}</option>
+      </select>
       <span v-if="observerTokens" class="ll-tokens"
             v-tooltip.top="'Assistant token use for this observer session (real usage)'">{{ observerTokens }}</span>
       <button v-if="observerTokens" class="ll-clearctx" @click="clearContext"
@@ -427,6 +433,10 @@ async function toggleMute(category: string) {
 .ll-capture:hover:not(:disabled) { border-color: #8b949e; }
 .ll-capture:disabled { opacity: 0.5; cursor: default; }
 .ll-auto { display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.7rem; color: var(--cc-text-dim); cursor: pointer; }
+.ll-model {
+  font-size: 0.66rem; color: var(--cc-text-dim); cursor: pointer; padding: 0.05rem 0.2rem;
+  background: var(--cc-surface); border: 1px solid var(--cc-border); border-radius: 3px;
+}
 .ll-note { font-size: 0.66rem; color: var(--cc-text-dim); margin-left: auto; }
 .ll-tokens { font-size: 0.66rem; color: var(--cc-text-dim); margin-left: auto; }
 .ll-clearctx {

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -67,6 +67,10 @@ export const useSettingsStore = defineStore('settings', () => {
   // [Claude] note. Frontend-driven (fires while you're using the app), gated on the availability of an
   // assistant CLI. Default off — it spends tokens. See components/LabLogPanel.vue.
   const labLogObserverAuto = ref(localStorage.getItem('cc.labLogObserverAuto') === 'true')
+  // which model the observer spawns (Claude CLI --model alias). Default Sonnet — Opus is overkill for
+  // the observer's work; Haiku is the cheap option for frequent auto-Watch passes. Sent per feedback
+  // call; the backend allow-lists it. See app/src/ai/agent_runner.jl OBSERVER_MODELS.
+  const labLogObserverModel = ref(localStorage.getItem('cc.labLogObserverModel') || 'sonnet')
   // transient (not persisted): a one-line preview of an unseen [Claude] lab-log addition — set when
   // the observer appends while the panel is closed, drives the sidebar badge, cleared when opened.
   const labLogUnseen = ref('')
@@ -220,7 +224,8 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(labLogAutoContext,        v => localStorage.setItem('cc.labLogAutoContext',        String(v)))
   watch(labLogMode,               v => localStorage.setItem('cc.labLogMode',               String(v)))
   watch(labLogObserverAuto,       v => localStorage.setItem('cc.labLogObserverAuto',       String(v)))
+  watch(labLogObserverModel,      v => localStorage.setItem('cc.labLogObserverModel',      v))
   watch(labLogPanelOpen,          open => { if (open) labLogUnseen.value = '' })   // opening clears the badge
 
-  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, cleanCapture, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, napariDiscreteGpu, sidebarCollapsed, rightPanelCollapsed, viewerPanelOpen, labLogPanelOpen, labLogAutoContext, labLogMode, labLogObserverAuto, labLogUnseen, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible, getColourOverrides, setColourOverride, clearColourOverrides, getMovieConfig, setMovieConfig, getCropZ, setCropZ, getCropT, setCropT, getBatchMovieConfig, setBatchMovieConfig }
+  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, cleanCapture, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, napariDiscreteGpu, sidebarCollapsed, rightPanelCollapsed, viewerPanelOpen, labLogPanelOpen, labLogAutoContext, labLogMode, labLogObserverAuto, labLogObserverModel, labLogUnseen, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible, getColourOverrides, setColourOverride, clearColourOverrides, getMovieConfig, setMovieConfig, getCropZ, setCropZ, getCropT, setCropT, getBatchMovieConfig, setBatchMovieConfig }
 })

--- a/frontend/src/utils/serviceApi.ts
+++ b/frontend/src/utils/serviceApi.ts
@@ -42,16 +42,17 @@ export interface ObserverSession {
 export const observerApi = {
   /** Availability (drives the disabled-with-why UI) + this project's session/usage when a uid is
    *  given. Never throws → unavailable on error. */
-  status: async (projectUid?: string): Promise<{ available: boolean; session?: ObserverSession }> => {
+  status: async (projectUid?: string): Promise<{ available: boolean; models?: string[]; defaultModel?: string; session?: ObserverSession }> => {
     try {
       const q = projectUid ? `?projectUid=${encodeURIComponent(projectUid)}` : ''
       const res = await fetch(`/api/observer/status${q}`)
       return res.ok ? await res.json() : { available: false }
     } catch { return { available: false } }
   },
-  /** One-shot: the assistant reviews the project and may append a [Claude] lab-log note. Returns
-   *  { ok, available, message, error, inputTokens, outputTokens, session }. */
-  feedback: (projectUid: string) => svcPost('/api/observer/feedback', { projectUid }),
+  /** One-shot: the assistant reviews the project and may append a [Claude] lab-log note. `model` is a
+   *  CLI alias (haiku|sonnet|opus); the backend allow-lists it. Returns
+   *  { ok, available, model, message, error, inputTokens, outputTokens, session }. */
+  feedback: (projectUid: string, model?: string) => svcPost('/api/observer/feedback', { projectUid, model }),
   /** Clear context: reset the project's session + token totals. Returns { ok, session }. */
   clear: (projectUid: string) => svcPost('/api/observer/clear', { projectUid }),
 }


### PR DESCRIPTION
## What

The in-app observer spawned `claude -p` with **no `--model`**, so it inherited the CLI's default (often **Opus**) — slower and costlier than the observer's work needs. Make the model **explicit and user-selectable**, defaulting to **Sonnet**.

Rationale: the observer's job — spot a repeat pattern, read a task log to diagnose a failure, write a brief lab-log line — fits **Sonnet**; **Haiku** is enough for the frequent auto-Watch passes; **Opus is overkill** here.

## How

- **Backend** (`agent_runner.jl`): default model = config `[ai] model` → falls back to `sonnet` (`observer_default_model`). Requested models are **allow-listed** to `haiku|sonnet|opus` (`OBSERVER_MODELS` / `observer_valid_model`) so an arbitrary string never reaches `--model`. `ClaudeAgent()` now defaults to Sonnet.
- **API** (`observer_api.jl`): `POST /api/observer/feedback` accepts an optional `model` (validated); `GET /api/observer/status` returns `models` + `defaultModel` so the picker populates from the backend.
- **Frontend**: a Haiku/Sonnet/Opus `<select>` in the lab-log control strip, persisted (`settings.labLogObserverModel`), sent per run — **Ask-Claude AND Watch use the same knob**.

## Tests

Pure builder/validator unit-tested (default within allow-list; unknown/empty → default; explicit-empty → no `--model` flag); API status test asserts the exposed choices + default. `test-pkg` / `test-api` / `test-frontend` / typecheck all green.

## Reservations

- **Default changes** from CLI-default → explicit Sonnet (intended, but a behaviour change for the running observer).
- Live `--model haiku|sonnet|opus` alias resolution depends on the installed CLI version (these are the standard aliases; the CLI surfaces its own error otherwise) — not CI-tested.
- `api/src/observer_api.jl` isn't Revise-tracked → **backend restart** needed.
- One knob covers Ask-Claude + auto-Watch (no per-mode split — easy follow-up if you'd want Haiku-always for auto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
