### PR TITLE
feat(observer): expose cohort QC to the observer (get_cohort_qc MCP tool)

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -108,7 +108,7 @@ Last audited: 2026-07-16 (full six-area ground-truth read; against `main` @ c1ce
 
 ## MCP observer (`mcp/`)
 
-- **cecelia_mcp/server.py**: FastMCP stdio server `cecelia-observer` — 9 read tools (incl. `get_recent_logs`, the backend console) + `poll_observations`/`set_observer_active`/`get_observer_stats` + 1 append tool, each delegating to the client/monitor.
+- **cecelia_mcp/server.py**: FastMCP stdio server `cecelia-observer` — 10 read tools (incl. `get_recent_logs` = backend console, and `get_cohort_qc` = per-set outliers via `/api/qc/cohort`) + `poll_observations`/`set_observer_active`/`get_observer_stats` + 1 append tool, each delegating to the client/monitor.
 - **cecelia_mcp/client.py**: `CeceliaClient` (stdlib urllib to the Julia API) with `ALLOWED_ROUTES` allow-list — the read-only guarantee. Never opens images/h5ad itself; talks HTTP to :8080 only.
 - **cecelia_mcp/monitor.py**: `SessionMonitor` + `normalize_frame` — pure, thread-safe session-state for the 10-attempts pattern (counts terminal task outcomes per `(image_uid, fn)` off the WS stream) + note/lab-log events, plus the per-session throttle (`surfaceCap` → silent lab-log flush via `drain_for_log`), token-cost estimate (`stats`), and off switch (`set_enabled`). No I/O; unit-tested. `poll` drains observations.
 - **cecelia_mcp/wsclient.py**: thin WS listener (`observe`/`start_listener`) feeding the monitor from `ws://…/ws`; best-effort, reconnects, receive-only. Backend events it consumes: `chain:node:*`, `task:status` (now carries `fun`), `image_note_added`, `lab_log_entry_added`.

--- a/app/src/ai/observer_prompt.jl
+++ b/app/src/ai/observer_prompt.jl
@@ -14,7 +14,9 @@ lab log is your output, not a chat reply.
 
 Use the tools to see what is happening: get_project_info / list_images / get_task_history for state,
 get_task_log + get_recent_logs when something failed (a Julia-side crash lands in get_recent_logs, NOT
-the task log), read_lab_log for prior context, poll_observations for detected patterns.
+the task log), read_lab_log for prior context, poll_observations for detected patterns. To judge an
+"anomaly vs the rest of the set" objectively, call get_cohort_qc(set) — it returns per-image outliers
+(z-scored) for cell/track counts; only call a run an outlier if it appears there (n ≥ 3).
 
 When something is worth recording, call append_lab_log with ONE short line (it is tagged [Claude]
 automatically — never write the tag yourself). Discipline:

--- a/docs/ai-assist/OBSERVER.md
+++ b/docs/ai-assist/OBSERVER.md
@@ -166,14 +166,15 @@ Implement the configurable per-session cap in the MCP server: after N surfaced o
    with an empty task log the observer can pull the real error. Added because the first live session
    hit exactly this blind spot. Complementary durable fix (separate PR): tee the scheduler's caught
    task exception into the per-image `.log` so `get_task_log` shows Julia failures too.
-5. ✅ **DONE (compute + route)** — Cohort stats: per-image objective metrics are banked by the
-   tasks (segment/measure/tracking → `write_qc`; `app/src/qc_cohort.jl` aggregates them per `CciaSet`),
-   surfaced via `GET /api/qc/cohort?projectUid&setUid&funName[&valueName][&sdThreshold]` (mean/SD +
-   `z`-scored outliers over the *included* images, advisory, recompute-on-demand + set sidecar).
-   **Remaining:** wire the MCP `get_qc_metrics` to read this route; auto-recompute on stage-complete
-   (the "cohort complete" trigger, `QC-PROCESS.md` step 3) — today it's on-demand; and per-image
-   cohort findings (write outliers back through `write_qc` so they badge on the image). `qc_flag_fired`
-   still waits on the `:flagged` state (`QC-PROCESS.md` step 1).
+5. ✅ **DONE (compute + route + MCP tool)** — Cohort stats: per-image objective metrics are banked by
+   the tasks (segment/measure/tracking → `write_qc`; `app/src/qc_cohort.jl` aggregates them per
+   `CciaSet`), surfaced via `GET /api/qc/cohort?projectUid&setUid&funName[&valueName][&sdThreshold]`
+   (mean/SD + `z`-scored outliers over the *included* images, advisory, recompute-on-demand + set
+   sidecar), and exposed to the observer as the **`get_cohort_qc`** MCP tool (the prompt tells it to
+   call this before calling any run an "anomaly vs the set"). **Remaining:** auto-recompute on
+   stage-complete (the "cohort complete" trigger, `QC-PROCESS.md` step 3) — today it's on-demand; and
+   per-image cohort findings (write outliers back through `write_qc` so they badge on the image).
+   `qc_flag_fired` still waits on the `:flagged` state (`QC-PROCESS.md` step 1).
 
 > **Status (Slice C):** steps 1–4 landed (minus `qc_flag_fired`, which waits on QC flag state).
 > **Validated end-to-end against live Claude Code (2026-07-17):** with a real project open, the

--- a/mcp/cecelia_mcp/client.py
+++ b/mcp/cecelia_mcp/client.py
@@ -28,6 +28,7 @@ ALLOWED_ROUTES = frozenset(
         ("GET", "/api/images/meta"),
         ("GET", "/api/images/tasklog"),
         ("GET", "/api/tasks/history"),
+        ("GET", "/api/qc/cohort"),       # cohort QC: per-set mean/SD + outliers over banked metrics
         ("GET", "/api/logs/recent"),     # the backend console ring (server @info/@warn/@error)
         ("GET", "/api/lablog"),
         ("POST", "/api/lablog/append"),  # the ONLY write — append-only, server-guarded
@@ -105,6 +106,17 @@ class CeceliaClient:
     def get_task_history(self, project_uid: str, limit: int | None = None):
         return self._request(
             "GET", "/api/tasks/history", {"projectUid": project_uid, "limit": limit}
+        )
+
+    def get_cohort_qc(self, project_uid: str, set_uid: str, fun_name: str,
+                      value_name: str | None = None, sd_threshold: float | None = None):
+        return self._request(
+            "GET",
+            "/api/qc/cohort",
+            {
+                "projectUid": project_uid, "setUid": set_uid, "funName": fun_name,
+                "valueName": value_name, "sdThreshold": sd_threshold,
+            },
         )
 
     def read_lab_log(self, project_uid: str):

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -69,9 +69,31 @@ def get_image_notes(project_uid: str, image_uid: str) -> str:
 
 @mcp.tool()
 def get_qc_metrics(project_uid: str, image_uid: str) -> dict:
-    """Per-image QC flags/metrics computed after tasks run ({} if none yet)."""
+    """Per-image QC flags/metrics computed after tasks run ({} if none yet). For "is THIS image an
+    outlier vs the rest of the set?", use get_cohort_qc instead — a single image's number means little
+    without the cohort."""
     img = _client.get_image_meta(project_uid, image_uid).get("image", {})
     return img.get("qc", {}) or {}
+
+
+@mcp.tool()
+def get_cohort_qc(project_uid: str, set_uid: str, fun_name: str, value_name: str = "default") -> dict:
+    """Cohort QC for one task across a set's images — the way to spot an outlier run ("image 7 has 8×
+    fewer cells than the cohort"). Aggregates the objective metric each task banks, over the set's
+    INCLUDED images, into mean/SD + z-scored outliers.
+
+    `set_uid` comes from get_project_info's `sets` / list_images' per-image set. `fun_name` must be a
+    metric producer (else the call errors):
+      - "segment.cellpose"           → nCells
+      - "segment.measureLabels"      → nCells
+      - "tracking.bayesian_tracking" → nTracks, meanTrackLength, nTrackedCells
+    `value_name` is the output variant (default "default").
+
+    Returns {funName, valueName, nIncluded, metrics: {<key>: {n, mean, sd, sdThreshold,
+    outliers: {imageUid: {value, z}}}}}. An `outliers` map with entries is the flag worth a note
+    (name the image, its value, and the cohort mean — numbers in the detail). `n` < 3 ⇒ too few
+    images to judge (never call an outlier then). Advisory only; reads current data (nothing cached)."""
+    return _client.get_cohort_qc(project_uid, set_uid, fun_name, value_name)
 
 
 @mcp.tool()

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -70,6 +70,23 @@ class ClientTest(unittest.TestCase):
             self.c.get_task_history("p", limit=5)
         self.assertIn("limit=5", u.call_args[0][0].full_url)
 
+    def test_cohort_qc_builds_url_and_drops_unset(self):
+        self.assertIn(("GET", "/api/qc/cohort"), ALLOWED_ROUTES)
+        with _patch_urlopen({"metrics": {}}) as u:
+            self.c.get_cohort_qc("p", "set1", "segment.measureLabels")
+        url = u.call_args[0][0].full_url
+        self.assertIn("/api/qc/cohort?", url)
+        self.assertIn("setUid=set1", url)
+        self.assertIn("funName=segment.measureLabels", url)
+        self.assertNotIn("sdThreshold", url)          # unset optional dropped
+        # explicit optionals are passed through
+        with _patch_urlopen({"metrics": {}}) as u:
+            self.c.get_cohort_qc("p", "set1", "tracking.bayesian_tracking",
+                                 value_name="A", sd_threshold=3.0)
+        url = u.call_args[0][0].full_url
+        self.assertIn("valueName=A", url)
+        self.assertIn("sdThreshold=3.0", url)
+
     def test_recent_logs_is_an_allowed_get(self):
         self.assertIn(("GET", "/api/logs/recent"), ALLOWED_ROUTES)
         with _patch_urlopen({"logs": [{"level": "error", "message": "boom"}]}) as u:


### PR DESCRIPTION
## What

Closes the loop on cohort QC: the backend could **compute** per-set outliers (#196) but the observer couldn't **see** them. This exposes them as an MCP tool, so an Ask/Watch pass can say *"image 7 has 8× fewer cells than the cohort"* objectively instead of eyeballing.

## How

- **`mcp/client.py`** — allow-list `("GET","/api/qc/cohort")` (still read-only) + `get_cohort_qc(project_uid, set_uid, fun_name, value_name?, sd_threshold?)`.
- **`mcp/server.py`** — new `get_cohort_qc` tool. Its docstring tells the model where `set_uid` comes from (`get_project_info.sets` / `list_images`), which funs are valid metric producers (segment/measure → `nCells`; tracking → `nTracks`/`meanTrackLength`/`nTrackedCells`), and to only call a run an outlier if it appears in `outliers` with `n ≥ 3`. `get_qc_metrics` now points here for cross-image comparison.
- **`observer_prompt.jl`** — the rules now instruct: to judge an "anomaly vs the set", call `get_cohort_qc` and only flag runs that show up as z-scored outliers (n ≥ 3). Makes the anomaly signal objective, not a guess (directly addresses the earlier false-positive where it over-read a user slip as a bug).

## Tests

`mcp/tests/test_client.py`: cohort route on the allow-list, URL/param building, unset optionals dropped. `test-mcp` (32) + `test-pkg` green.

## Reservations

- The observer only calls it when relevant, and only flags at `n ≥ 3` (small sets won't flag — correct). Needs banked cohort data (tasks re-run post-#193) or it reads `n=0`.
- The MCP server is spawned fresh per observer run, so the tool is live on the next pass — but the running backend must include #196's `/api/qc/cohort`.
- Live spawn path un-CI-tested; pure client route-building is tested.

## Remaining in the arc (after this)

Auto-recompute cohort stats on stage-complete (the "cohort complete" trigger); per-image cohort findings (badge outliers on the image); then Phase-2 `:flagged` state (needs the QC_PLAN.md advisory-vs-blocking ratification) → `qc_flag_fired` → morning summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
