### PR TITLE
feat(observer): show the observer's prompt in-app (transparency)

### DIFF
--- a/api/src/observer_api.jl
+++ b/api/src/observer_api.jl
@@ -40,7 +40,8 @@ end
 function api_observer_status(req::HTTP.Request)
     resp = Dict{String,Any}("available"    => agent_available(ClaudeAgent()),
                             "models"        => OBSERVER_MODELS,          # the picker's choices
-                            "defaultModel"  => observer_default_model()) # config default (Sonnet)
+                            "defaultModel"  => observer_default_model(), # config default (Sonnet)
+                            "prompt"        => observer_prompt_display()) # transparency: what it runs under
     puid = get(HTTP.queryparams(HTTP.URI(req.target)), "projectUid", "")
     if !isempty(puid)
         proj = try load_project(puid) catch; nothing end

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -164,7 +164,7 @@ include("ai/observer_prompt.jl")
 include("ai/agent_runner.jl")
 include("ai/observer_session.jl")
 export ClaudeAgent, agent_available, run_observer_turn, observer_mcp_config,
-       observer_feedback_prompt, observer_auto_prompt, observer_agent_bin,
+       observer_feedback_prompt, observer_auto_prompt, observer_prompt_display, observer_agent_bin,
        OBSERVER_MODELS, observer_default_model, observer_valid_model,
        read_observer_session, record_observer_turn!, log_observer_pass!, clear_observer_session!
 

--- a/app/src/ai/observer_prompt.jl
+++ b/app/src/ai/observer_prompt.jl
@@ -55,3 +55,13 @@ function observer_auto_prompt(project_uid::AbstractString)::String
         "single most important new thing (a fired pattern, a real error, an anomaly). If it is routine ",
         "or already noted, append nothing.")
 end
+
+# The exact prompt the observer runs under — surfaced in-app for transparency (the user can read what
+# the assistant is instructed to do). Shows the shared rules + how each mode extends them.
+function observer_prompt_display()::String
+    fb = strip(replace(observer_feedback_prompt("<project>"), _OBSERVER_RULES => ""))
+    au = strip(replace(observer_auto_prompt("<project>"),     _OBSERVER_RULES => ""))
+    string(strip(_OBSERVER_RULES),
+           "\n\n— Ask Claude adds —\n", fb,
+           "\n\n— Watch adds —\n", au)
+end

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -333,6 +333,12 @@ async function toggleMute(category: string) {
       </div>
     </details>
 
+    <!-- transparency: the exact prompt the observer runs under (read-only), collapsed like the log -->
+    <details v-if="observerAvailable && observer.prompt" class="ll-activity ll-prompt">
+      <summary>Observer prompt</summary>
+      <pre class="ll-prompt-body">{{ observer.prompt }}</pre>
+    </details>
+
     <!-- feedback mode: what 👍/👎 mean on the auto/AI entries -->
     <div class="ll-modebar">
       <span class="ll-modelabel">Rating:</span>
@@ -473,6 +479,10 @@ async function toggleMute(category: string) {
 }
 .ll-observer-body {
   font-size: 0.72rem; color: var(--cc-text); line-height: 1.45; white-space: pre-wrap;
+}
+.ll-prompt-body {
+  margin: 0.3rem 0 0; font-size: 0.66rem; color: var(--cc-text); line-height: 1.45;
+  white-space: pre-wrap; word-break: break-word; font-family: inherit;
 }
 /* Claude activity log — collapsible; shows each pass (Ask/Watch), its cost + verdict, even when silent */
 .ll-activity {

--- a/frontend/src/stores/observer.ts
+++ b/frontend/src/stores/observer.ts
@@ -15,6 +15,7 @@ export const useObserverStore = defineStore('observer', () => {
 
   const available = ref(false)
   const models = ref<string[]>(['haiku', 'sonnet', 'opus'])
+  const prompt = ref('')                 // the exact instructions the observer runs under (transparency)
   const session = ref<ObserverSession | null>(null)
   const busy = ref(false)
   const appendTick = ref(0)              // bumped when a pass appends → the open panel reloads entries
@@ -25,6 +26,7 @@ export const useObserverStore = defineStore('observer', () => {
     const s = await observerApi.status(projectUid() || undefined)
     available.value = s.available
     if (s.models?.length) models.value = s.models
+    if (s.prompt) prompt.value = s.prompt
     session.value = s.session ?? null
   }
 
@@ -63,5 +65,5 @@ export const useObserverStore = defineStore('observer', () => {
   })
   const installAutoWatch = () => watcher.install()
 
-  return { available, models, session, busy, appendTick, refresh, runPass, clear, installAutoWatch }
+  return { available, models, prompt, session, busy, appendTick, refresh, runPass, clear, installAutoWatch }
 })

--- a/frontend/src/utils/serviceApi.ts
+++ b/frontend/src/utils/serviceApi.ts
@@ -54,7 +54,7 @@ export interface ObserverSession {
 export const observerApi = {
   /** Availability (drives the disabled-with-why UI) + this project's session/usage when a uid is
    *  given. Never throws → unavailable on error. */
-  status: async (projectUid?: string): Promise<{ available: boolean; models?: string[]; defaultModel?: string; session?: ObserverSession }> => {
+  status: async (projectUid?: string): Promise<{ available: boolean; models?: string[]; defaultModel?: string; prompt?: string; session?: ObserverSession }> => {
     try {
       const q = projectUid ? `?projectUid=${encodeURIComponent(projectUid)}` : ''
       const res = await fetch(`/api/observer/status${q}`)


### PR DESCRIPTION
You could read the **activity log** but not what the assistant is actually *told*. This surfaces the prompt in-app, collapsed like the activity log.

- `observer_prompt_display()` (`observer_prompt.jl`) returns the exact prompt: the shared `_OBSERVER_RULES` + what **Ask Claude** and **Watch** each append (with a `<project>` placeholder).
- `GET /api/observer/status` returns it as `prompt`; the store holds it; `LabLogPanel` shows a collapsed **"Observer prompt"** block beside "Claude activity".
- Read-only. Makes it easy to see — and iterate on — what the observer runs under (pairs with the activity log for "figure out what actually works in practice").

## Tests
`observer_prompt_display()` sanity (contains rules + both mode additions + the cohort nudge); typecheck + `test-pkg` + `test-api` green.

## Reservations
- The ~2.7KB prompt rides in every `status` response (negligible).
- `api/src/observer_api.jl` needs a backend restart; `app/src` is Revise-tracked. Not eyeballed in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)