### PR TITLE
fix(observer): self-heal a stale --resume session

### DIFF
--- a/app/src/ai/agent_runner.jl
+++ b/app/src/ai/agent_runner.jl
@@ -73,6 +73,17 @@ function _build_claude_cmd(a::ClaudeAgent, prompt::AbstractString, mcp_config_pa
     Cmd(args)
 end
 
+# A stored session id goes stale when Claude Code prunes/expires it (its own log rotation, or a
+# different working dir). `--resume <gone-sid>` then makes the CLI exit non-zero with
+# "No conversation found with session ID: …" — which, before the self-heal below, made EVERY
+# subsequent Watch pass fail permanently until the user hit Clear. Detected here (PURE → unit-tested)
+# so `run_observer_turn` can drop the dead id and retry fresh. Matched loosely (message wording is a
+# CLI detail): the "no conversation found" phrase plus a session-id mention.
+function _is_stale_session_error(msg::AbstractString)::Bool
+    m = lowercase(String(msg))
+    occursin("no conversation found", m) && occursin("session id", m)
+end
+
 # Parse `claude --output-format json` output. PURE → unit-tested. Claude prints one JSON object with
 # `result` (final text), `session_id`, `is_error`, and `usage {input_tokens, output_tokens}`. Tolerant
 # of missing keys (the exact schema is an adapter detail — confirm against a live run, see the PLAN).
@@ -92,13 +103,12 @@ function _parse_claude_result(json_str::AbstractString)::AgentResult
                 is_err ? (isempty(text) ? "agent reported an error" : text) : "")
 end
 
-# Run one observer turn: spawn the agent, let it read + append through the MCP, return usage/session.
-# Bounded by a timeout so a hung agent can't wedge the request. LIVE path (needs the agent CLI + a
-# running API) — not exercised in CI; the pure builders/parsers above are the tested surface.
-function run_observer_turn(a::ClaudeAgent, prompt::AbstractString, mcp_config_path::AbstractString;
-                           system_prompt::AbstractString = "", session_id::AbstractString = "",
-                           timeout_s::Real = 180, on_process::Function = _ -> nothing)::AgentResult
-    agent_available(a) || return AgentResult(false, "", 0, 0, "", "assistant CLI not found: $(a.bin)")
+# Spawn the agent once and parse its result. Bounded by a timeout so a hung agent can't wedge the
+# request. LIVE path (needs the agent CLI) — not exercised in CI; the pure builders/parsers above are
+# the tested surface.
+function _run_observer_once(a::ClaudeAgent, prompt::AbstractString, mcp_config_path::AbstractString;
+                            system_prompt::AbstractString, session_id::AbstractString,
+                            timeout_s::Real, on_process::Function)::AgentResult
     cmd = _build_claude_cmd(a, prompt, mcp_config_path; session_id, system_prompt)
     out = Pipe()
     proc = run(pipeline(cmd; stdout = out, stderr = out); wait = false)
@@ -113,4 +123,21 @@ function run_observer_turn(a::ClaudeAgent, prompt::AbstractString, mcp_config_pa
                            isempty(strip(output)) ? "agent exited $(proc.exitcode)" : output)
     end
     _parse_claude_result(output)
+end
+
+# Run one observer turn: spawn the agent, let it read + append through the MCP, return usage/session.
+# Self-heals a stale session: if we passed `--resume <sid>` and the CLI reports the conversation is
+# gone, drop the dead id and retry ONCE fresh — otherwise a pruned session would fail every Watch
+# pass forever (see _is_stale_session_error). A fresh turn just loses the prior context, not the pass.
+function run_observer_turn(a::ClaudeAgent, prompt::AbstractString, mcp_config_path::AbstractString;
+                           system_prompt::AbstractString = "", session_id::AbstractString = "",
+                           timeout_s::Real = 180, on_process::Function = _ -> nothing)::AgentResult
+    agent_available(a) || return AgentResult(false, "", 0, 0, "", "assistant CLI not found: $(a.bin)")
+    res = _run_observer_once(a, prompt, mcp_config_path;
+                             system_prompt, session_id, timeout_s, on_process)
+    if !res.ok && !isempty(session_id) && _is_stale_session_error(res.error)
+        res = _run_observer_once(a, prompt, mcp_config_path;
+                                 system_prompt, session_id = "", timeout_s, on_process)
+    end
+    res
 end

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -184,6 +184,14 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         g = Cecelia._parse_claude_result("not json")
         @test !g.ok && g.input_tokens == 0
 
+        # stale-session detection: a pruned/expired --resume id makes the CLI say "No conversation
+        # found with session ID: …" → run_observer_turn drops the id and retries fresh (self-heal).
+        @test Cecelia._is_stale_session_error(
+            "No conversation found with session ID: 0df65af8-ae13-4ec5-964a-7231cd8bf005")
+        @test Cecelia._is_stale_session_error("no conversation found with session id: x")  # case-insensitive
+        @test !Cecelia._is_stale_session_error("agent exited 1")                            # other failures don't retry
+        @test !Cecelia._is_stale_session_error("tool failed")
+
         # MCP config points the spawned agent at the same cecelia_mcp server + this API
         cfg = Cecelia.observer_mcp_config("/repo/mcp", "/env/python", "http://127.0.0.1:8080")
         srv = cfg["mcpServers"]["cecelia-observer"]


### PR DESCRIPTION
## Problem

The in-app observer stores a Claude Code `sessionId` and passes `--resume <sid>` each Watch/Ask pass to keep context. When Claude Code prunes or expires that session (its own log rotation, or a different working dir), `--resume` makes the CLI exit non-zero with:

```
No conversation found with session ID: 0df65af8-…
```

Before this fix that made **every** subsequent Watch pass fail permanently (0 tokens, `error`) until the user manually hit **Clear**. Observed live in the lab log.

## Fix

`app/src/ai/agent_runner.jl`:
- New pure `_is_stale_session_error(msg)` — matches "no conversation found" + "session id" (case-insensitive, loosely matched since the wording is a CLI detail). Unit-tested.
- Split the spawn into `_run_observer_once`; `run_observer_turn` now **self-heals** — if a `--resume` turn fails with a stale-session error, it drops the dead id and retries **once fresh**. A fresh turn loses prior conversation context, not the pass, and the next successful turn re-adopts a live session id via `record_observer_turn!`.
- Tests in `app/test/runtests.jl` for the detector.

## Reservations
- The retry path itself (live spawn) isn't exercised in CI — only the pure detector is.
- A genuinely stale session now costs two CLI spawns on that one pass (failed resume + fresh retry). One-off; heals immediately after.
- Detection keys on the CLI's wording; a phrasing change would silently revert to fail-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
