### PR TITLE
feat(qc): clustering QC for clustPops + clustTracks

### DIFF
--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -87,6 +87,76 @@ function track_count_metrics(track_ids)
     (n_tracks, mean_len, n_cells)
 end
 
+# QC thresholds for a clustering run (clustPops/clustTracks). A single dominant cluster holding this
+# fraction of an image's points suggests under-clustering (resolution too low / features don't
+# separate). See cluster_qc_findings.
+const _CLUSTER_DOMINANT_FRAC = 0.9
+
+"""
+    cluster_qc_findings(n_clusters_total, n_here, n_clusters_here, largest_frac; unit="cells")
+
+Advisory findings for ONE image's slice of a set-wide clustering run (PURE → unit-tested). The run
+clusters all images together, so `n_clusters_total` is the run's cluster count; `n_here` /
+`n_clusters_here` / `largest_frac` describe how THIS image's points landed. Degenerate patterns,
+most-severe first:
+  • run collapsed to ≤ 1 cluster ⇒ warn (resolution too low / features don't separate).
+  • this image's points all fell into one cluster while the run found several ⇒ warn (the image
+    separated from the cohort — a batch/normalisation outlier).
+  • one cluster holds ≥ `_CLUSTER_DOMINANT_FRAC` of this image's points ⇒ info (check it's really
+    that uniform, or raise resolution).
+`unit` is "cells" (clustPops) or "tracks" (clustTracks) for the message. Returns a findings vector.
+"""
+function cluster_qc_findings(n_clusters_total::Integer, n_here::Integer, n_clusters_here::Integer,
+                             largest_frac::Real; unit::AbstractString = "cells")
+    findings = Dict{String,Any}[]
+    if n_clusters_total <= 1
+        push!(findings, qc_finding("warn", "clustering.single_cluster",
+            "Only one cluster found",
+            "Resolution too low or features don't separate populations — raise resolution or add features and re-run."))
+    elseif n_here > 0 && n_clusters_here <= 1
+        push!(findings, qc_finding("warn", "clustering.image_one_cluster",
+            "All $unit fell into one cluster",
+            "This image separated from the cohort — check it's the same acquisition and normalisation, then re-run."))
+    elseif n_here > 0 && largest_frac >= _CLUSTER_DOMINANT_FRAC
+        push!(findings, qc_finding("info", "clustering.dominant_cluster",
+            "One cluster holds $(round(Int, 100 * largest_frac))% of $unit",
+            "Check the population is really this uniform, or raise resolution to split it.";
+            detail = Dict{String,Any}("largestClusterFrac" => round(largest_frac; digits = 3))))
+    end
+    findings
+end
+
+# Bank a clustering run's QC from the per-segment JSON its Python runner wrote (see
+# clustering_utils.split_back_and_write → qcOutPath). Shared by clustPops + clustTracks (both are
+# set-scope, cluster all images at once, and write one QC doc per (image, segmentation) keyed by the
+# segmentation value_name). `unit` = "cells" (clustPops) or "tracks" (clustTracks) — drives the
+# banked count key (nCells/nTracks) and the finding wording. Best-effort; never fails the task.
+function write_cluster_qc!(imgs::AbstractVector, fun_name::AbstractString, qc_out_path::AbstractString;
+                           unit::AbstractString = "cells", on_log::Function = _ -> nothing)
+    isfile(qc_out_path) || return
+    img_by_uid = Dict(img.uid => img for img in imgs)
+    count_key = unit == "tracks" ? "nTracks" : "nCells"
+    try
+        qc    = JSON3.read(read(qc_out_path, String))
+        total = Int(get(qc, :nClusters, 0))
+        segs  = get(qc, :perSegment, ())
+        for seg in segs
+            uid = string(get(seg, :uID, "")); vn = string(get(seg, :valueName, ""))
+            img = get(img_by_uid, uid, nothing); img === nothing && continue
+            n    = Int(get(seg, :n, 0))
+            nc   = Int(get(seg, :nClusters, 0))
+            frac = Float64(get(seg, :largestClusterFrac, 0.0))
+            findings = cluster_qc_findings(total, n, nc, frac; unit = unit)
+            write_qc(img, fun_name, vn, findings;
+                     metrics = Dict{String,Any}(count_key => n, "nClusters" => nc,
+                         "largestClusterFrac" => round(frac; digits = 4), "nClustersTotal" => total))
+        end
+        on_log("[QC] $total cluster(s) over $(length(segs)) segment(s).")
+    catch e
+        on_log("[QC] could not compute cluster QC: $e")
+    end
+end
+
 # Reusable spatial check — flag an output whose XY canvas grew abnormally vs its source. Shapes are in
 # `dim_order` (e.g. "TCZYX"). Generic across any spatially-transforming task (drift/AF correction, …);
 # returns a finding or `nothing`. Default threshold 25% (normal drift expands XY ≤~15%).

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -30,6 +30,11 @@ const COHORT_METRICS = Dict{String,Vector{String}}(
     "segment.cellpose"           => ["nCells"],
     "segment.measureLabels"      => ["nCells"],
     "tracking.bayesian_tracking" => ["nTracks", "meanTrackLength", "nTrackedCells"],
+    # clustering is set-scope (one run over all images); per-image QC records how each image's points
+    # landed, so cohort stats flag an image that collapsed into far fewer clusters / one dominant
+    # cluster than its peers (a batch/normalisation outlier). See qc.jl write_cluster_qc!.
+    "clustPops.cluster"          => ["nCells", "nClusters", "largestClusterFrac"],
+    "clustTracks.cluster"        => ["nTracks", "nClusters", "largestClusterFrac"],
 )
 
 # Pure: robust outlier detection. Two regimes:

--- a/app/src/tasks/clustPops/cluster.jl
+++ b/app/src/tasks/clustPops/cluster.jl
@@ -97,6 +97,9 @@ function _run_task(::ClustPops, imgs::Vector{CciaImage}, params::Dict{String,Any
         "usePaga" => Bool(get(params, "usePaga", false)),
         "pagaThreshold" => get(params, "pagaThreshold", 0.1),
         "randomState" => 0)
+    # QC (advisory): the runner writes the per-segment cluster distribution here; banked below.
+    qc_out_path = joinpath(task_run_dir(imgs[1]._dir), "cluster_qc.json")
+    task_params["qcOutPath"] = qc_out_path
     on_progress(3, 4)
 
     # set-scope run config dir (consistent task dir under the project tree, never tmp)
@@ -107,6 +110,8 @@ function _run_task(::ClustPops, imgs::Vector{CciaImage}, params::Dict{String,Any
     for seg in segments
         _write_clust_features!(seg["propsPath"], suffix, feature_cols, uids)
     end
+    # bank per-image cluster QC (cell counts + cluster distribution + degenerate-run findings)
+    write_cluster_qc!(imgs, "clustPops.cluster", qc_out_path; unit = "cells", on_log = on_log)
     on_progress(4, 4)
 
     on_log("[INFO] clustPops done → clusters.$suffix")

--- a/app/src/tasks/clustTracks/cluster.jl
+++ b/app/src/tasks/clustTracks/cluster.jl
@@ -134,6 +134,9 @@ function _run_task(::ClustTracks, imgs::Vector{CciaImage}, params::Dict{String,A
         "usePaga" => Bool(get(params, "usePaga", false)),
         "pagaThreshold" => get(params, "pagaThreshold", 0.1),
         "randomState" => 0)
+    # QC (advisory): the runner writes the per-segment cluster distribution here; banked below.
+    qc_out_path = joinpath(task_run_dir(imgs[1]._dir), "cluster_qc.json")
+    task_params["qcOutPath"] = qc_out_path
     on_progress(3, 4)
 
     ok = run_py("tasks/clustTracks/cluster_run.py", task_params, task_run_dir(imgs[1]._dir);
@@ -143,6 +146,8 @@ function _run_task(::ClustTracks, imgs::Vector{CciaImage}, params::Dict{String,A
     for seg in segments
         _write_clust_features!(seg["propsPath"], suffix, present_cols, uids)
     end
+    # bank per-image cluster QC (track counts + cluster distribution + degenerate-run findings)
+    write_cluster_qc!(imgs, "clustTracks.cluster", qc_out_path; unit = "tracks", on_log = on_log)
     on_progress(4, 4)
 
     on_log("[INFO] clustTracks done → clusters.$suffix (per-track)")

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -4201,6 +4201,21 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             _, pf = Cecelia._segment_qc_findings(Dict("nuc" => 5))
             @test pf == 5
 
+            # clustering findings (set-scope: total = run clusters; the rest = one image's slice)
+            # run collapsed to 1 cluster → warn (regardless of the per-image numbers)
+            c1 = Cecelia.cluster_qc_findings(1, 500, 1, 1.0)
+            @test length(c1) == 1 && c1[1]["code"] == "clustering.single_cluster" && c1[1]["level"] == "warn"
+            # image's cells all in one cluster while the run found several → warn (batch outlier)
+            c2 = Cecelia.cluster_qc_findings(6, 400, 1, 1.0)
+            @test length(c2) == 1 && c2[1]["code"] == "clustering.image_one_cluster" && c2[1]["level"] == "warn"
+            # one cluster dominates this image (≥90%) but not all → info
+            c3 = Cecelia.cluster_qc_findings(6, 400, 3, 0.95; unit = "tracks")
+            @test length(c3) == 1 && c3[1]["code"] == "clustering.dominant_cluster" && c3[1]["level"] == "info"
+            @test occursin("tracks", c3[1]["short"])
+            # a healthy spread flags nothing; an empty image (n=0) never flags
+            @test isempty(Cecelia.cluster_qc_findings(6, 400, 5, 0.4))
+            @test isempty(Cecelia.cluster_qc_findings(6, 0, 0, 0.0))
+
             # against the tracked fixture: metrics agree with an independent count of track_id
             h5 = fixture_path("testpr", "1", "KDIeEm", "labelProps", "B.h5ad")
             if !have_fixture(h5)

--- a/docs/ai-assist/QC-PROCESS.md
+++ b/docs/ai-assist/QC-PROCESS.md
@@ -49,6 +49,12 @@ Flags are statistical, not interpretive. Claude says "this gate produced 23 cell
 - State frequency per image vs. cohort — flag >2 SD deviation
 - Single state >95% dominant in one image but not others
 
+*Clustering* (`clustPops.cluster` / `clustTracks.cluster`, set-scope): implemented — banked per image (how that image's points landed in the set-wide clustering) via `write_cluster_qc!` (`app/src/qc.jl`).
+- Run collapsed to ≤1 cluster — resolution too low / features don't separate (warn)
+- One image's points all fell into a single cluster while the run found several — batch/normalisation outlier (warn)
+- One cluster holds ≥90% of an image's points — under-clustering (info)
+- Cohort: per-image `nClusters` / `largestClusterFrac` / point count vs. the set (`COHORT_METRICS`)
+
 **Cohort statistics**: computed after all images complete a stage. Per-image flags that depend on cohort context are deferred until the cohort is complete — Claude needs the full set to know what's an outlier.
 
 **Cross-experiment memory**: if the lab log contains prior experiment records, Claude cross-references. "This pattern (low cell count + bimodal track lengths) appeared in experiment X on 2026-03-12 — root cause was Z-drift. Check Z-stack integrity."

--- a/python/cecelia/tasks/clustPops/cluster_run.py
+++ b/python/cecelia/tasks/clustPops/cluster_run.py
@@ -15,6 +15,8 @@ Invoked by `app/src/tasks/clustPops/cluster.jl` via a params JSON. Params:
   resolution, normaliseAxis, normaliseToMedian, maxFraction, normalisePercentile,
   normalisePercentileBottom, transformation, logBase, createUmap, usePaga, pagaThreshold, randomState
 """
+import json
+
 import numpy as np
 import pandas as pd
 
@@ -99,7 +101,15 @@ def run(params):
     # ── split back per segment and write into each cell labelProps (shared write-back) ──
     # clusters are scanpy categorical strings ("0".."N"); the helper stores INTEGER codes (a
     # `clusters.*` name-rule pins them categorical above the level cap — see track_props.jl).
-    clustering_utils.split_back_and_write(adata, segments, suffix, log=log.log)
+    qc = clustering_utils.split_back_and_write(adata, segments, suffix, log=log.log)
+
+    # QC (advisory): hand the per-segment cluster distribution to Julia to bank as metrics + findings
+    # (qc.jl). Best-effort; never fails the task. Same qcOutPath pattern as cellpose_run.py.
+    qc_out_path = params.get("qcOutPath")
+    if qc_out_path is not None:
+        with open(qc_out_path, "w") as f:
+            json.dump(qc, f)
+        log.log(f">> saved cluster QC: {qc['nClusters']} clusters over {len(qc['perSegment'])} segment(s)")
 
     log.log(">> cluster_cells done")
 

--- a/python/cecelia/tasks/clustTracks/cluster_run.py
+++ b/python/cecelia/tasks/clustTracks/cluster_run.py
@@ -24,6 +24,8 @@ Invoked by `app/src/tasks/clustTracks/cluster.jl` via a params JSON. Params:
   resolution, normaliseAxis, normaliseToMedian, maxFraction, normalisePercentile,
   normalisePercentileBottom, transformation, logBase, createUmap, usePaga, pagaThreshold, randomState
 """
+import json
+
 import numpy as np
 
 # `cecelia.*` resolves via PYTHONPATH=python/, set by the Julia launcher (app/src/py_runner.jl::run_py).
@@ -77,7 +79,15 @@ def run(params):
     )
 
     # ── split back per segment and write into each per-track table (shared write-back) ──
-    clustering_utils.split_back_and_write(adata, segments, suffix, log=log.log)
+    qc = clustering_utils.split_back_and_write(adata, segments, suffix, log=log.log)
+
+    # QC (advisory): per-segment cluster distribution for Julia to bank (qc.jl). Best-effort; never
+    # fails the task. Same qcOutPath pattern as clustPops/cellpose runners.
+    qc_out_path = params.get("qcOutPath")
+    if qc_out_path is not None:
+        with open(qc_out_path, "w") as f:
+            json.dump(qc, f)
+        log.log(f">> saved cluster QC: {qc['nClusters']} clusters over {len(qc['perSegment'])} segment(s)")
 
     log.log(">> cluster_tracks done")
 

--- a/python/cecelia/tests/test_clustering_utils.py
+++ b/python/cecelia/tests/test_clustering_utils.py
@@ -1,0 +1,44 @@
+"""Unit tests for the pure clustering QC helper (cecelia.utils.clustering_utils.cluster_seg_stats).
+
+Pure/headless — no scanpy, no anndata, no I/O. Pins the per-segment cluster distribution the QC
+sidecar banks: point count, distinct clusters occupied, and the largest-cluster fraction
+(dominance). See qc.jl cluster_qc_findings + COHORT_METRICS."""
+import unittest
+
+import numpy as np
+
+from cecelia.utils.clustering_utils import cluster_seg_stats
+
+
+class TestClusterSegStats(unittest.TestCase):
+    def test_even_spread(self):
+        codes = np.array([0, 0, 1, 1, 2, 2])
+        s = cluster_seg_stats(codes)
+        self.assertEqual(s["n"], 6)
+        self.assertEqual(s["nClusters"], 3)
+        self.assertAlmostEqual(s["largestClusterFrac"], 2 / 6)
+
+    def test_single_cluster(self):
+        s = cluster_seg_stats(np.zeros(10, dtype=int))
+        self.assertEqual(s["nClusters"], 1)
+        self.assertAlmostEqual(s["largestClusterFrac"], 1.0)
+
+    def test_dominant_cluster(self):
+        codes = np.array([0] * 9 + [1])          # 90% in cluster 0
+        s = cluster_seg_stats(codes)
+        self.assertEqual(s["nClusters"], 2)
+        self.assertAlmostEqual(s["largestClusterFrac"], 0.9)
+
+    def test_empty(self):
+        s = cluster_seg_stats(np.array([], dtype=int))
+        self.assertEqual(s, {"n": 0, "nClusters": 0, "largestClusterFrac": 0.0})
+
+    def test_non_contiguous_codes(self):
+        # cluster ids need not be 0..N — count distinct
+        s = cluster_seg_stats(np.array([3, 3, 7, 7, 7]))
+        self.assertEqual(s["nClusters"], 2)
+        self.assertAlmostEqual(s["largestClusterFrac"], 3 / 5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/cecelia/utils/clustering_utils.py
+++ b/python/cecelia/utils/clustering_utils.py
@@ -163,6 +163,23 @@ def find_populations(adata, resolution: float = 1.0, axis: str = "channels",
     return adata.obs["clusters"], adata.obsm.get("X_umap")
 
 
+# ── QC: per-segment cluster distribution ─────────────────────────────────────────
+def cluster_seg_stats(seg_codes):
+    """Objective QC stats for one segment's cluster assignment (PURE → unit-tested).
+
+    `seg_codes` is the integer cluster code of every point (cell/track) belonging to one
+    (image, segmentation). Returns `{n, nClusters, largestClusterFrac}` — the point count, how
+    many distinct clusters those points occupy, and the fraction in the single largest cluster
+    (dominance). An image whose points collapse into far fewer clusters (or one dominant cluster)
+    than the cohort is a batch/quality outlier — see qc.jl `cluster_qc_findings` + COHORT_METRICS."""
+    n = int(np.asarray(seg_codes).size)
+    if n == 0:
+        return {"n": 0, "nClusters": 0, "largestClusterFrac": 0.0}
+    _uniq, counts = np.unique(seg_codes, return_counts=True)
+    return {"n": n, "nClusters": int(counts.size),
+            "largestClusterFrac": float(counts.max() / n)}
+
+
 # ── shared write-back (cells + tracks) ─────────────────────────────────────────────
 def split_back_and_write(adata, segments, suffix: str, log=None):
     """Split a pooled, clustered AnnData back per segment and write the cluster assignment
@@ -181,7 +198,11 @@ def split_back_and_write(adata, segments, suffix: str, log=None):
 
     Writes integer-code `clusters.{suffix}` obs (the new stack auto-detects integer obs as a
     categorical code set; a `clusters.*` name-rule pins it categorical above the level cap — see
-    track_props.jl) and, when present, `obsm['X_umap.{suffix}']`. Returns the number of clusters."""
+    track_props.jl) and, when present, `obsm['X_umap.{suffix}']`.
+
+    Returns a QC dict `{nClusters, nTotal, perSegment:[{uID, valueName, n, nClusters,
+    largestClusterFrac}]}` — the run total plus each segment's cluster distribution (via
+    `cluster_seg_stats`), so the Julia caller can bank per-image QC metrics + findings (qc.jl)."""
     _log = log if callable(log) else (lambda _m: None)
 
     cluster_col = f"clusters.{suffix}"
@@ -197,6 +218,7 @@ def split_back_and_write(adata, segments, suffix: str, log=None):
     vn_arr    = adata.obs["valueName"].to_numpy()
     label_arr = adata.obs["label"].to_numpy()
 
+    per_segment = []
     for seg in segments:
         mask = (uid_arr == seg["uID"]) & (vn_arr == seg["valueName"])
         if not mask.any():
@@ -208,9 +230,11 @@ def split_back_and_write(adata, segments, suffix: str, log=None):
             view = view.add_obsm(umap_key, sub_labels, adata.obsm["X_umap"][mask])
         view.save()
         view.close()
+        stats = cluster_seg_stats(codes[mask])
+        per_segment.append({"uID": seg["uID"], "valueName": seg["valueName"], **stats})
         _log(f"> wrote {seg['uID']}/{seg['valueName']}: {int(mask.sum())} rows")
 
-    return n_clusters
+    return {"nClusters": int(n_clusters), "nTotal": int(codes.size), "perSegment": per_segment}
 
 
 def _find_gpu(adata, resolution: float, create_umap: bool, random_state: int):


### PR DESCRIPTION
## What

Adds QC to the two set-scope clustering tasks — the highest-value gap from Dom's testing. Both the **whiteboard badge** (per-run findings) and **Claude/cohort** layers.

### Whiteboard findings (`qc.jl` `cluster_qc_findings`, pure + unit-tested)
- **Run collapsed to ≤1 cluster** → warn (resolution too low / features don't separate).
- **One image's points all fell into one cluster** while the run found several → warn (batch/normalisation outlier).
- **One cluster holds ≥90% of an image's points** → info (under-clustering).

### Cohort (`COHORT_METRICS`)
Per-image `nCells`/`nTracks`, `nClusters`, `largestClusterFrac` are banked so cohort stats flag an image that clustered separately from its peers. (Clustering is set-scope — one run over all images — so per-image QC records *how each image's points landed*.)

## How
- **Python**: `clustering_utils.split_back_and_write` now returns a per-segment cluster distribution via a new pure `cluster_seg_stats`; each runner writes it to `params['qcOutPath']` (same pattern as `cellpose_run.py`).
- **Julia**: `write_cluster_qc!` (shared by both tasks) reads that JSON and `write_qc`'s one doc per (image, segmentation).

## Tests
- `test_clustering_utils.py` — `cluster_seg_stats` (python, 77 pass).
- `cluster_qc_findings` cases in `runtests.jl` (julia, 1103 pass).

## Reservations
- **Never run live** — pure helpers are unit-tested; the full path (Python `cluster_qc.json` → Julia `write_cluster_qc!`) is by-inspection, not yet exercised against a real clustering run.
- Cohort metrics only bite at n≥3 images clustered together. `nClustersTotal` is excluded from `COHORT_METRICS` (identical across images → zero variance).
- `largestClusterFrac` cohort flagging is two-tailed (robust-z); a high value is the real concern, a low one would also flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
