### PR TITLE
feat(qc): HMM QC (behaviour.hmm_states + hmm_transitions)

### DIFF
--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -154,6 +154,27 @@ function hmm_transitions_qc_findings(m)
         Dict{String,Any}[]
 end
 
+"""
+    track_measures_qc_findings(n_tracks, dims_param, resolved_dims, auto_dims, confidence, reason) -> Vector
+
+Advisory findings for a track-measures run (PURE → unit-tested). Surfaces the motion-dimensionality
+call the task already computes: when `dims_param == "auto"` and the detector's `confidence` is "low",
+the z axis couldn't be classified as migration vs jitter — feeding an ambiguous z corrupts turning
+angle + speed (see track_measures.jl `_detect_motion_dims`), so it's flagged for review. A confident
+auto call (or a user-set dims) flags nothing. `reason` is carried into the finding detail.
+"""
+function track_measures_qc_findings(n_tracks::Integer, dims_param::AbstractString,
+                                    resolved_dims::Integer, auto_dims::Integer,
+                                    confidence::AbstractString, reason::AbstractString = "")
+    (lowercase(strip(String(dims_param))) == "auto" && String(confidence) == "low") ?
+        [qc_finding("warn", "tracking.motion_dims_uncertain",
+            "Motion dimensionality uncertain ($(resolved_dims)D)",
+            "z couldn't be classified as migration vs jitter — review whether tracking should be 2D or 3D and re-run with dims set.";
+            detail = Dict{String,Any}("resolvedDims" => Int(resolved_dims),
+                                      "autoDims" => Int(auto_dims), "reason" => String(reason)))] :
+        Dict{String,Any}[]
+end
+
 # QC thresholds for a clustering run (clustPops/clustTracks). A single dominant cluster holding this
 # fraction of an image's points suggests under-clustering (resolution too low / features don't
 # separate). See cluster_qc_findings.

--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -87,6 +87,73 @@ function track_count_metrics(track_ids)
     (n_tracks, mean_len, n_cells)
 end
 
+# One HMM state holding ≥ this fraction of an image's cells is flagged as dominant. (Clustering uses
+# its own _CLUSTER_DOMINANT_FRAC — a single cluster is a weaker signal than a single behavioural
+# state, so the thresholds differ.) See hmm_states_qc_findings.
+const _DOMINANT_FRAC = 0.95
+
+"""
+    category_dist_metrics(vals) -> (; n, n_distinct, dominant_frac)
+
+Distribution stats for one image's categorical/state column (PURE → unit-tested). Counts the valid
+entries (skips `nothing`/`missing`/`NaN`), the number of distinct values, and the fraction in the
+single most common value (dominance). Shared by HMM states (numeric state codes) + HMM transitions
+(string labels) — an image whose cells collapse into one state/transition is a QC signal.
+"""
+function category_dist_metrics(vals)
+    counts = Dict{Any,Int}(); n = 0
+    for v in vals
+        (v === nothing || ismissing(v)) && continue
+        (v isa Real && isnan(v)) && continue
+        counts[v] = get(counts, v, 0) + 1; n += 1
+    end
+    n == 0 && return (; n = 0, n_distinct = 0, dominant_frac = 0.0)
+    (; n = n, n_distinct = length(counts), dominant_frac = maximum(values(counts)) / n)
+end
+
+"""
+    hmm_states_qc_findings(m) -> Vector
+
+Advisory findings for one image's HMM state assignment, from `category_dist_metrics` `m`
+(PURE → unit-tested). Most-severe first:
+  • no cells decoded (`n == 0`) ⇒ warn (tracks too short / measurements incomplete).
+  • all decoded cells in one state (`n_distinct ≤ 1`) ⇒ warn (image didn't switch states — check
+    it's the same acquisition/measurements, or the model has too few states).
+  • one state holds ≥ `_DOMINANT_FRAC` of cells ⇒ info (check it's really this uniform).
+"""
+function hmm_states_qc_findings(m)
+    findings = Dict{String,Any}[]
+    if m.n == 0
+        push!(findings, qc_finding("warn", "hmm.no_states_decoded",
+            "No cells decoded into a state",
+            "Tracks may be too short or measurements incomplete — check segmentation/tracking and re-run."))
+    elseif m.n_distinct <= 1
+        push!(findings, qc_finding("warn", "hmm.single_state",
+            "All cells sat in one state",
+            "This image didn't switch states — check it's the same acquisition and measurements, or reduce the state count."))
+    elseif m.dominant_frac >= _DOMINANT_FRAC
+        push!(findings, qc_finding("info", "hmm.dominant_state",
+            "One state holds $(round(Int, 100 * m.dominant_frac))% of cells",
+            "Check the behaviour is really this uniform, or the model may have too many states.";
+            detail = Dict{String,Any}("dominantStateFrac" => round(m.dominant_frac; digits = 3))))
+    end
+    findings
+end
+
+"""
+    hmm_transitions_qc_findings(m) -> Vector
+
+Advisory finding for one image's HMM transitions, from `category_dist_metrics` `m` (PURE). Only the
+unambiguous "no transitions" case flags (warn) — transition dominance isn't clearly actionable.
+"""
+function hmm_transitions_qc_findings(m)
+    m.n == 0 ?
+        [qc_finding("warn", "hmm.no_transitions",
+            "No state transitions found",
+            "Tracks may be too short or the model produced one state — check HMM states and track lengths.")] :
+        Dict{String,Any}[]
+end
+
 # QC thresholds for a clustering run (clustPops/clustTracks). A single dominant cluster holding this
 # fraction of an image's points suggests under-clustering (resolution too low / features don't
 # separate). See cluster_qc_findings.

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -30,6 +30,7 @@ const COHORT_METRICS = Dict{String,Vector{String}}(
     "segment.cellpose"           => ["nCells"],
     "segment.measureLabels"      => ["nCells"],
     "tracking.bayesian_tracking" => ["nTracks", "meanTrackLength", "nTrackedCells"],
+    "tracking.track_measures"    => ["nTracks", "meanSpeed", "meanDisplacement"],
     # clustering is set-scope (one run over all images); per-image QC records how each image's points
     # landed, so cohort stats flag an image that collapsed into far fewer clusters / one dominant
     # cluster than its peers (a batch/normalisation outlier). See qc.jl write_cluster_qc!.

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -35,6 +35,10 @@ const COHORT_METRICS = Dict{String,Vector{String}}(
     # cluster than its peers (a batch/normalisation outlier). See qc.jl write_cluster_qc!.
     "clustPops.cluster"          => ["nCells", "nClusters", "largestClusterFrac"],
     "clustTracks.cluster"        => ["nTracks", "nClusters", "largestClusterFrac"],
+    # HMM (set-scope, one joint fit): per image, how its cells distributed over the states — an image
+    # that collapsed to one state / a very different dominant-state fraction is an outlier.
+    "behaviour.hmm_states"       => ["nDecoded", "nStates", "dominantStateFrac"],
+    "behaviour.hmm_transitions"  => ["nTransitions", "nDistinctTransitions"],
 )
 
 # Pure: robust outlier detection. Two regimes:

--- a/app/src/tasks/behaviour/hmm_states.jl
+++ b/app/src/tasks/behaviour/hmm_states.jl
@@ -109,6 +109,12 @@ function _run_task(::HmmStates, imgs::Vector{CciaImage}, params::Dict{String,Any
             try
                 label_props(props) |> add_obs(cell_df) |> save!   # overwrites any existing column
                 n_ok += 1
+                # QC (advisory): bank this image-segmentation's state distribution (numeric state
+                # codes; NaN = undecoded) + degenerate-state findings. Never fails the write.
+                m = category_dist_metrics(vals)
+                write_qc(img, "behaviour.hmm_states", string(vn), hmm_states_qc_findings(m);
+                         metrics = Dict{String,Any}("nDecoded" => m.n, "nStates" => m.n_distinct,
+                             "dominantStateFrac" => round(m.dominant_frac; digits = 4)))
             catch e
                 on_log("[WARN] write failed: $(img.uid)/$vn — $e")
             end

--- a/app/src/tasks/behaviour/hmm_transitions.jl
+++ b/app/src/tasks/behaviour/hmm_transitions.jl
@@ -67,7 +67,17 @@ function _run_task(::HmmTransitions, imgs::Vector{CciaImage}, params::Dict{Strin
             ok = write_categorical_obs(props,
                      [(name=trans_col, labels=Int.(vsub.label), values=vals)];
                      drop=[trans_col], on_log=on_log, on_process=on_process)
-            ok ? (n_ok += 1) : on_log("[WARN] write failed: $(img.uid)/$vn")
+            if ok
+                n_ok += 1
+                # QC (advisory): bank this image-segmentation's transition distribution + the
+                # no-transitions finding. Never fails the write.
+                m = category_dist_metrics(vals)
+                write_qc(img, "behaviour.hmm_transitions", string(vn), hmm_transitions_qc_findings(m);
+                         metrics = Dict{String,Any}("nTransitions" => m.n,
+                             "nDistinctTransitions" => m.n_distinct))
+            else
+                on_log("[WARN] write failed: $(img.uid)/$vn")
+            end
         end
     end
     on_progress(3, 3)

--- a/app/src/tasks/tracking/track_measures.jl
+++ b/app/src/tasks/tracking/track_measures.jl
@@ -482,6 +482,28 @@ function _run_task(task::TrackMeasures, img::CciaImage, params::Dict{String,Any}
     end
     on_progress(5, 5)
 
+    # QC (advisory): bank per-track counts/means + the motion-dims finding. Means over the per-track
+    # X (skipping NaN→nothing); omitted when non-finite so a degenerate image is excluded from the
+    # cohort rather than polluting it. Never fails the task.
+    try
+        speed_idx = findfirst(==("live.track.speed"), agg_names)
+        disp_idx  = findfirst(==("live.track.displacement"), agg_names)
+        _meas_mean(idx) = isnothing(idx) ? NaN : begin
+            vs = Float64[Float64(row[idx]) for row in X
+                         if row[idx] !== nothing && !(row[idx] isa Real && isnan(row[idx]))]
+            isempty(vs) ? NaN : mean(vs)
+        end
+        ms = _meas_mean(speed_idx); md = _meas_mean(disp_idx)
+        metrics = Dict{String,Any}("nTracks" => n_tracks, "motionDims" => resolved)
+        isnan(ms) || (metrics["meanSpeed"] = round(ms; digits = 4))
+        isnan(md) || (metrics["meanDisplacement"] = round(md; digits = 4))
+        findings = track_measures_qc_findings(n_tracks, dims_param, resolved, det.dims,
+                                              det.confidence, det.reason)
+        write_qc(img, "tracking.track_measures", value_name, findings; metrics = metrics)
+    catch e
+        on_log("[QC] could not compute track-measures QC: $e")
+    end
+
     on_log("[INFO] Track measures complete.")
     Dict{String,Any}("valueName" => value_name, "nTracks" => n_tracks, "trackProps" => track_path,
                      "dims" => resolved, "dimsAuto" => det.dims, "dimsReason" => det.reason)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -4233,6 +4233,12 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test Cecelia.hmm_transitions_qc_findings(Cecelia.category_dist_metrics(Any[nothing]))[1]["code"] == "hmm.no_transitions"
             @test isempty(Cecelia.hmm_transitions_qc_findings(Cecelia.category_dist_metrics(["1_2", "2_1"])))
 
+            # track measures: auto + low-confidence motion dims → warn; confident/user-set → none
+            tm = Cecelia.track_measures_qc_findings(120, "auto", 2, 2, "low", "z ambiguous")
+            @test length(tm) == 1 && tm[1]["code"] == "tracking.motion_dims_uncertain" && tm[1]["level"] == "warn"
+            @test isempty(Cecelia.track_measures_qc_findings(120, "auto", 3, 3, "high", "clear"))
+            @test isempty(Cecelia.track_measures_qc_findings(120, "3D", 3, 2, "low", "user forced"))  # user-set: no flag
+
             # against the tracked fixture: metrics agree with an independent count of track_id
             h5 = fixture_path("testpr", "1", "KDIeEm", "labelProps", "B.h5ad")
             if !have_fixture(h5)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -4216,6 +4216,23 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test isempty(Cecelia.cluster_qc_findings(6, 400, 5, 0.4))
             @test isempty(Cecelia.cluster_qc_findings(6, 0, 0, 0.0))
 
+            # category distribution metrics (HMM states/transitions): skip NaN/missing/nothing
+            m1 = Cecelia.category_dist_metrics([1.0, 1.0, 2.0, NaN, missing])
+            @test m1.n == 3 && m1.n_distinct == 2 && m1.dominant_frac ≈ 2/3
+            ms = Cecelia.category_dist_metrics(["1_2", "1_2", nothing, "2_1"])
+            @test ms.n == 3 && ms.n_distinct == 2
+            @test Cecelia.category_dist_metrics(Any[NaN, missing, nothing]).n == 0
+
+            # HMM state findings: no decode → warn; single state → warn; ≥95% one state → info; else none
+            @test Cecelia.hmm_states_qc_findings(Cecelia.category_dist_metrics(Float64[]))[1]["code"] == "hmm.no_states_decoded"
+            @test Cecelia.hmm_states_qc_findings(Cecelia.category_dist_metrics([1.0, 1.0, 1.0]))[1]["code"] == "hmm.single_state"
+            fd = Cecelia.hmm_states_qc_findings(Cecelia.category_dist_metrics(vcat(fill(1.0, 96), fill(2.0, 4))))
+            @test fd[1]["code"] == "hmm.dominant_state" && fd[1]["level"] == "info"
+            @test isempty(Cecelia.hmm_states_qc_findings(Cecelia.category_dist_metrics([1.0, 1.0, 2.0, 2.0])))
+            # HMM transitions: only the no-transitions case flags
+            @test Cecelia.hmm_transitions_qc_findings(Cecelia.category_dist_metrics(Any[nothing]))[1]["code"] == "hmm.no_transitions"
+            @test isempty(Cecelia.hmm_transitions_qc_findings(Cecelia.category_dist_metrics(["1_2", "2_1"])))
+
             # against the tracked fixture: metrics agree with an independent count of track_id
             h5 = fixture_path("testpr", "1", "KDIeEm", "labelProps", "B.h5ad")
             if !have_fixture(h5)

--- a/docs/ai-assist/QC-PROCESS.md
+++ b/docs/ai-assist/QC-PROCESS.md
@@ -41,9 +41,11 @@ Flags are statistical, not interpretive. Claude says "this gate produced 23 cell
 - Absolute count <50 cells
 - Count >3 SD from cohort mean for same population
 
-*Tracking*:
-- Track length distribution — flag bimodal when unimodal expected
-- Fraction of cells tracked vs. segmented — flag <30%
+*Tracking* (`tracking.bayesian_tracking`, `tracking.track_measures`): implemented — banked per image via `write_qc`.
+- Track length distribution — flag bimodal when unimodal expected *(not yet)*
+- Fraction of cells tracked vs. segmented — flag <30% *(not yet)*
+- `bayesian_tracking` cohort: `nTracks`, `meanTrackLength`, `nTrackedCells`
+- `track_measures`: motion dimensionality uncertain (auto + low confidence) → warn (`track_measures_qc_findings`); cohort `nTracks`, `meanSpeed`, `meanDisplacement`
 
 *HMM/behaviour* (`behaviour.hmm_states` / `behaviour.hmm_transitions`, set-scope): implemented — banked per image via `write_qc` in the state/transition write loops (`category_dist_metrics` + `hmm_states_qc_findings` / `hmm_transitions_qc_findings`, `qc.jl`).
 - No cells decoded into a state — tracks too short / measurements incomplete (warn)

--- a/docs/ai-assist/QC-PROCESS.md
+++ b/docs/ai-assist/QC-PROCESS.md
@@ -45,9 +45,11 @@ Flags are statistical, not interpretive. Claude says "this gate produced 23 cell
 - Track length distribution — flag bimodal when unimodal expected
 - Fraction of cells tracked vs. segmented — flag <30%
 
-*HMM/behaviour*:
-- State frequency per image vs. cohort — flag >2 SD deviation
-- Single state >95% dominant in one image but not others
+*HMM/behaviour* (`behaviour.hmm_states` / `behaviour.hmm_transitions`, set-scope): implemented — banked per image via `write_qc` in the state/transition write loops (`category_dist_metrics` + `hmm_states_qc_findings` / `hmm_transitions_qc_findings`, `qc.jl`).
+- No cells decoded into a state — tracks too short / measurements incomplete (warn)
+- All of an image's cells sat in one state — no state switching / too many model states (warn)
+- One state holds ≥95% of an image's cells — dominant state (info)
+- No transitions found (warn); cohort: per-image `nDecoded` / `nStates` / `dominantStateFrac`, `nTransitions` / `nDistinctTransitions` (`COHORT_METRICS`)
 
 *Clustering* (`clustPops.cluster` / `clustTracks.cluster`, set-scope): implemented — banked per image (how that image's points landed in the set-wide clustering) via `write_cluster_qc!` (`app/src/qc.jl`).
 - Run collapsed to ≤1 cluster — resolution too low / features don't separate (warn)


### PR DESCRIPTION
> **Stacked on #206** (base = `feat/qc-clustering`). Merge #206 first; GitHub will retarget this to `main`.

## What

QC for the two set-scope HMM tasks — whiteboard findings + Claude/cohort. Julia-native, so QC is computed inline in the existing per-(image, segmentation) write loops (no Python round-trip).

### Whiteboard findings (`qc.jl`, pure + unit-tested)
- **No cells decoded into a state** → warn (tracks too short / measurements incomplete).
- **All of an image's cells sat in one state** → warn (no switching / too many model states).
- **One state holds ≥95% of an image's cells** → info (dominant state).
- **No transitions found** → warn.

### Cohort (`COHORT_METRICS`)
- `behaviour.hmm_states` → `nDecoded`, `nStates`, `dominantStateFrac`
- `behaviour.hmm_transitions` → `nTransitions`, `nDistinctTransitions`

So an image that collapsed to one state (or a very different dominant-state fraction) flags against its cohort.

## How
- `qc.jl`: pure `category_dist_metrics` (valid count / distinct / dominant fraction, skipping NaN/missing/nothing — shared by numeric state codes + string transitions), `hmm_states_qc_findings`, `hmm_transitions_qc_findings`.
- `hmm_states.jl` / `hmm_transitions.jl`: `write_qc` per (image, segmentation) in the write loop.

## Tests
`category_dist_metrics` + both findings helpers in `runtests.jl` (1112 pass).

## Reservations
- Pure helpers unit-tested; the per-image `write_qc` wiring is by-inspection, not run live.
- QC is keyed by segmentation `value_name`, so a second HMM run with a different `colName` overwrites that segmentation's QC doc (reflects the latest run).
- Cohort metrics bite at n≥3 images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
