### PR TITLE
feat(qc): track-measures QC (tracking.track_measures)

### DIFF
--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -154,6 +154,27 @@ function hmm_transitions_qc_findings(m)
         Dict{String,Any}[]
 end
 
+"""
+    track_measures_qc_findings(n_tracks, dims_param, resolved_dims, auto_dims, confidence, reason) -> Vector
+
+Advisory findings for a track-measures run (PURE → unit-tested). Surfaces the motion-dimensionality
+call the task already computes: when `dims_param == "auto"` and the detector's `confidence` is "low",
+the z axis couldn't be classified as migration vs jitter — feeding an ambiguous z corrupts turning
+angle + speed (see track_measures.jl `_detect_motion_dims`), so it's flagged for review. A confident
+auto call (or a user-set dims) flags nothing. `reason` is carried into the finding detail.
+"""
+function track_measures_qc_findings(n_tracks::Integer, dims_param::AbstractString,
+                                    resolved_dims::Integer, auto_dims::Integer,
+                                    confidence::AbstractString, reason::AbstractString = "")
+    (lowercase(strip(String(dims_param))) == "auto" && String(confidence) == "low") ?
+        [qc_finding("warn", "tracking.motion_dims_uncertain",
+            "Motion dimensionality uncertain ($(resolved_dims)D)",
+            "z couldn't be classified as migration vs jitter — review whether tracking should be 2D or 3D and re-run with dims set.";
+            detail = Dict{String,Any}("resolvedDims" => Int(resolved_dims),
+                                      "autoDims" => Int(auto_dims), "reason" => String(reason)))] :
+        Dict{String,Any}[]
+end
+
 # QC thresholds for a clustering run (clustPops/clustTracks). A single dominant cluster holding this
 # fraction of an image's points suggests under-clustering (resolution too low / features don't
 # separate). See cluster_qc_findings.

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -30,6 +30,7 @@ const COHORT_METRICS = Dict{String,Vector{String}}(
     "segment.cellpose"           => ["nCells"],
     "segment.measureLabels"      => ["nCells"],
     "tracking.bayesian_tracking" => ["nTracks", "meanTrackLength", "nTrackedCells"],
+    "tracking.track_measures"    => ["nTracks", "meanSpeed", "meanDisplacement"],
     # clustering is set-scope (one run over all images); per-image QC records how each image's points
     # landed, so cohort stats flag an image that collapsed into far fewer clusters / one dominant
     # cluster than its peers (a batch/normalisation outlier). See qc.jl write_cluster_qc!.

--- a/app/src/tasks/tracking/track_measures.jl
+++ b/app/src/tasks/tracking/track_measures.jl
@@ -482,6 +482,28 @@ function _run_task(task::TrackMeasures, img::CciaImage, params::Dict{String,Any}
     end
     on_progress(5, 5)
 
+    # QC (advisory): bank per-track counts/means + the motion-dims finding. Means over the per-track
+    # X (skipping NaN→nothing); omitted when non-finite so a degenerate image is excluded from the
+    # cohort rather than polluting it. Never fails the task.
+    try
+        speed_idx = findfirst(==("live.track.speed"), agg_names)
+        disp_idx  = findfirst(==("live.track.displacement"), agg_names)
+        _meas_mean(idx) = isnothing(idx) ? NaN : begin
+            vs = Float64[Float64(row[idx]) for row in X
+                         if row[idx] !== nothing && !(row[idx] isa Real && isnan(row[idx]))]
+            isempty(vs) ? NaN : mean(vs)
+        end
+        ms = _meas_mean(speed_idx); md = _meas_mean(disp_idx)
+        metrics = Dict{String,Any}("nTracks" => n_tracks, "motionDims" => resolved)
+        isnan(ms) || (metrics["meanSpeed"] = round(ms; digits = 4))
+        isnan(md) || (metrics["meanDisplacement"] = round(md; digits = 4))
+        findings = track_measures_qc_findings(n_tracks, dims_param, resolved, det.dims,
+                                              det.confidence, det.reason)
+        write_qc(img, "tracking.track_measures", value_name, findings; metrics = metrics)
+    catch e
+        on_log("[QC] could not compute track-measures QC: $e")
+    end
+
     on_log("[INFO] Track measures complete.")
     Dict{String,Any}("valueName" => value_name, "nTracks" => n_tracks, "trackProps" => track_path,
                      "dims" => resolved, "dimsAuto" => det.dims, "dimsReason" => det.reason)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -4233,6 +4233,12 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test Cecelia.hmm_transitions_qc_findings(Cecelia.category_dist_metrics(Any[nothing]))[1]["code"] == "hmm.no_transitions"
             @test isempty(Cecelia.hmm_transitions_qc_findings(Cecelia.category_dist_metrics(["1_2", "2_1"])))
 
+            # track measures: auto + low-confidence motion dims → warn; confident/user-set → none
+            tm = Cecelia.track_measures_qc_findings(120, "auto", 2, 2, "low", "z ambiguous")
+            @test length(tm) == 1 && tm[1]["code"] == "tracking.motion_dims_uncertain" && tm[1]["level"] == "warn"
+            @test isempty(Cecelia.track_measures_qc_findings(120, "auto", 3, 3, "high", "clear"))
+            @test isempty(Cecelia.track_measures_qc_findings(120, "3D", 3, 2, "low", "user forced"))  # user-set: no flag
+
             # against the tracked fixture: metrics agree with an independent count of track_id
             h5 = fixture_path("testpr", "1", "KDIeEm", "labelProps", "B.h5ad")
             if !have_fixture(h5)

--- a/docs/ai-assist/QC-PROCESS.md
+++ b/docs/ai-assist/QC-PROCESS.md
@@ -41,9 +41,11 @@ Flags are statistical, not interpretive. Claude says "this gate produced 23 cell
 - Absolute count <50 cells
 - Count >3 SD from cohort mean for same population
 
-*Tracking*:
-- Track length distribution — flag bimodal when unimodal expected
-- Fraction of cells tracked vs. segmented — flag <30%
+*Tracking* (`tracking.bayesian_tracking`, `tracking.track_measures`): implemented — banked per image via `write_qc`.
+- Track length distribution — flag bimodal when unimodal expected *(not yet)*
+- Fraction of cells tracked vs. segmented — flag <30% *(not yet)*
+- `bayesian_tracking` cohort: `nTracks`, `meanTrackLength`, `nTrackedCells`
+- `track_measures`: motion dimensionality uncertain (auto + low confidence) → warn (`track_measures_qc_findings`); cohort `nTracks`, `meanSpeed`, `meanDisplacement`
 
 *HMM/behaviour* (`behaviour.hmm_states` / `behaviour.hmm_transitions`, set-scope): implemented — banked per image via `write_qc` in the state/transition write loops (`category_dist_metrics` + `hmm_states_qc_findings` / `hmm_transitions_qc_findings`, `qc.jl`).
 - No cells decoded into a state — tracks too short / measurements incomplete (warn)


### PR DESCRIPTION
> **Stacked on #207 → #206.** Merge #206, then #207, then this (GitHub retargets as bases merge).

## What

QC for `tracking.track_measures` (Julia-native, image-scope). The high-value signal: the task already runs a **motion-dimensionality detector** (`_detect_motion_dims`) that decides 2D-in-plane vs full-3D and can report *low confidence* when z can't be classified as migration vs jitter — feeding an ambiguous z corrupts speed + turning angle. This surfaces that as a whiteboard flag.

### Whiteboard finding (`qc.jl` `track_measures_qc_findings`, pure + unit-tested)
- **Motion dimensionality uncertain** (dims=auto **and** detector confidence low) → warn, with the resolved/auto dims + reason in `detail`. A confident auto call or a user-set `dims` flags nothing.

### Cohort (`COHORT_METRICS`)
`tracking.track_measures` → `nTracks`, `meanSpeed`, `meanDisplacement` (means over the per-track matrix; **omitted when non-finite** so a degenerate image is excluded from the cohort rather than skewing it).

## Tests
`track_measures_qc_findings` (auto+low → warn; confident → none; user-set → none) in `runtests.jl` (1115 pass).

## Reservations
- Pure finding helper unit-tested; the `write_qc` wiring + mean computation is by-inspection, not run live.
- Cohort bites at n≥3 images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
