### PR TITLE
docs: make QC mandatory for every new task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,12 @@ When adding a new task, also register it in `app/src/tasks/task_registry.jl`:
 - Add a `_spec_path(::MyTask)` overload pointing at the `.json` file
 - Add `"category.myTask" => MyTask()` to `_fun_name_map()`
 
+**And emit QC** — every result-producing task MUST bank sensible QC via `write_qc` (an objective
+`metrics` count + a `warn` finding for the bad case) and add cohort-comparable metrics to
+`COHORT_METRICS`. This is mandatory, not optional; the only exemption is a task with genuinely no
+objective signal (e.g. perceptual denoising), and it must be an explicit comment. Full guide + the
+pattern: [`docs/MODULES.md`](docs/MODULES.md) → *QC — REQUIRED for every new task*.
+
 ---
 
 ## Development
@@ -494,6 +500,13 @@ ok = proc.exitcode == 0 && proc.termsignal == 0
 ```
 
 **`resource_pool` is required in every task JSON.** Standard values: `"gpu"` (limit 1), `"gpu-light"` (4), `"io"` (8), `"default"` (20). Defined in `app/config.toml`. The `tasksLimit` field and concurrent-task slider have been removed — use pools instead.
+
+**QC is required for every result-producing task.** After the work succeeds, bank an objective
+`metrics` count + a `warn` finding for the unambiguous bad case via `write_qc` (`app/src/qc.jl`), and
+add cohort-comparable metrics to `COHORT_METRICS` (`app/src/qc_cohort.jl`). Advisory only (never
+`error`, never gates). Keep the finding logic in a pure, unit-tested helper. The only exemption is a
+task with genuinely no objective signal, stated as an explicit comment. See `docs/MODULES.md` → *QC —
+REQUIRED for every new task*.
 
 ---
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -113,6 +113,51 @@ plot — a `plotDefinitions/*.json` registry id (e.g. `segment.cellposeMeasure` 
 `segment.measureLabels` → `"segmentation_qc"`). The whiteboard Live view then auto-shows a QC
 thumbnail for that node (see `docs/SCHEDULER.md` → *Live QC row*); no other wiring needed.
 
+### QC — REQUIRED for every new task
+
+**Every task that produces a result must emit sensible QC.** This is a hard convention, not a
+nice-to-have: QC is how the image-table indicator, the chain whiteboard, the lab log and the AI
+observer all learn "this ran, and here's whether the output looks right." A task with no QC is
+invisible to all of them. QC is **advisory** — it never fails or gates a task (`level ∈ info|warn`,
+never `error`; the run either succeeded or it didn't, separately). See `docs/ai-assist/QC-PROCESS.md`
+and the traffic-light model in `docs/todo/QC_OBSERVER_PLAN.md`.
+
+After the work succeeds, bank two things through `write_qc` (`app/src/qc.jl`) — the one canonical
+writer, never a hand-rolled sidecar:
+
+1. **Objective metric(s)** — a countable, cohort-comparable number your task produces (`nCells`,
+   `nTracks`, `nClusters`, a mean/fraction). Stored under `metrics`; it's the datum cohort QC and the
+   observer aggregate across a set.
+2. **A `warn` finding for the unambiguous bad case** — "produced nothing", "collapsed to one
+   cluster/state", "canvas grew abnormally". Keep the text brief + actionable (short = the problem;
+   long = the imperative action; numbers go in `detail`).
+
+```julia
+# after the task's work succeeds, inside _run_task
+n = <objective count you already computed>
+findings = n == 0 ?
+    [qc_finding("warn", "mycat.no_output", "No objects produced",
+        "Check the inputs/params and re-run this step.")] : Dict{String,Any}[]
+write_qc(img, "mycat.myTask", out_value_name, findings;
+         metrics = Dict{String,Any}("nCells" => n))
+```
+
+- **Keep the finding logic in a PURE helper and unit-test it** (like `_segment_qc_findings`,
+  `cluster_qc_findings`, `hmm_states_qc_findings`, `track_measures_qc_findings` in `qc.jl`) — the
+  thresholds live in one testable place, the task just calls it and writes.
+- **If the metric is comparable across a set's images, add it to `COHORT_METRICS`** (`app/src/qc_cohort.jl`,
+  `"mycat.myTask" => ["nCells", …]`) so cohort-outlier detection and the observer pick it up for free.
+- **Set-scope / Python tasks:** compute per-image stats in Python and hand them back via a `qcOutPath`
+  JSON the Julia handler reads (the `segment.cellpose` / clustering pattern — `qcOutPath` param →
+  `write_qc` per image), so counting stays where the data is.
+- **Genuinely no objective signal** (e.g. a denoising/correction whose only failure mode is
+  perceptual)? Say so in a comment and skip QC deliberately — do **not** invent a meaningless metric.
+  This is the *only* exemption, and it must be explicit.
+
+Reuse the shared helpers in `qc.jl` rather than re-deriving: `qc_finding`, `write_qc`,
+`qc_canvas_expansion` (spatial-transform tasks), `category_dist_metrics` (state/label distributions),
+`track_count_metrics`. Add a test in `app/test/runtests.jl` in the same change.
+
 ### Running a Python subprocess
 
 Spawn the task's Python runner through **`run_py`** (`app/src/py_runner.jl`) — the single place


### PR DESCRIPTION
Documents "every result-producing task must emit sensible QC" as a hard convention, so future module functions always add a QC measure — where authors (human or AI) actually look.

## What
- **`docs/MODULES.md`** — new *QC — REQUIRED for every new task* section under the Julia task handler: the `write_qc` pattern (objective `metrics` count + a `warn` finding for the unambiguous bad case), the pure-helper-and-unit-test rule, adding to `COHORT_METRICS`, the Python `qcOutPath` pattern for set-scope/Python tasks, and the ONE explicit exemption (a task with genuinely no objective signal, e.g. perceptual denoising — stated as a comment, never a meaningless metric).
- **`CLAUDE.md`** — QC added to the "adding a new task" checklist + a bold task invariant in *Key invariants*. CLAUDE.md loads every session, so it's the real enforcement anchor.

Advisory framing preserved throughout: QC is `info|warn`, never `error`, never gates a task.

Docs-only; no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
