### PR TITLE
chore(observer): scrap Observer-prompt block; hide Claude activity

### DIFF
--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -40,6 +40,7 @@ const observerModels = computed(() => observer.models)
 const observerSession = computed(() => observer.session)
 const observerNote = ref('')                 // last MANUAL pass verdict, shown in the report block
 const observerPasses = computed(() => observer.session?.passes ?? [])   // activity log (newest-first)
+const SHOW_ACTIVITY = false   // "Claude activity" list hidden for now (kept for easy re-enable)
 // Setup guidance: availability only means `claude` is on PATH — not logged in. Show install/login
 // steps when the CLI is missing, or when the most recent pass failed with an auth-shaped error.
 const observerSetup = computed(() =>
@@ -303,9 +304,9 @@ async function toggleMute(category: string) {
       <div class="ll-observer-body">{{ observerNote }}</div>
     </div>
 
-    <!-- Claude activity log: every Ask-Claude pass, whether or not it wrote to the log — so a silent
-         "looked, nothing to flag" run is still visible, with its token cost. -->
-    <details v-if="observerAvailable && observerPasses.length" class="ll-activity">
+    <!-- Claude activity log: every Ask-Claude pass with its token cost. HIDDEN for now (SHOW_ACTIVITY)
+         — it has little use with Claude on-demand only; kept (not deleted) so it's easy to re-enable. -->
+    <details v-if="SHOW_ACTIVITY && observerAvailable && observerPasses.length" class="ll-activity">
       <summary>Claude activity ({{ observerPasses.length }})</summary>
       <div v-for="(p, i) in observerPasses" :key="i" class="ll-pass" :class="{ appended: p.appended, failed: !p.ok }">
         <div class="ll-pass-head">
@@ -314,12 +315,6 @@ async function toggleMute(category: string) {
         </div>
         <div v-if="p.note" class="ll-pass-note">{{ p.note }}</div>
       </div>
-    </details>
-
-    <!-- transparency: the exact prompt the observer runs under (read-only), collapsed like the log -->
-    <details v-if="observerAvailable && observer.prompt" class="ll-activity ll-prompt">
-      <summary>Observer prompt</summary>
-      <pre class="ll-prompt-body">{{ observer.prompt }}</pre>
     </details>
 
     <!-- feedback mode: what 👍/👎 mean on the auto/AI entries -->
@@ -450,10 +445,6 @@ async function toggleMute(category: string) {
 }
 .ll-observer-body {
   font-size: 0.72rem; color: var(--cc-text); line-height: 1.45; white-space: pre-wrap;
-}
-.ll-prompt-body {
-  margin: 0.3rem 0 0; font-size: 0.66rem; color: var(--cc-text); line-height: 1.45;
-  white-space: pre-wrap; word-break: break-word; font-family: inherit;
 }
 /* Claude activity log — collapsible; shows each Ask-Claude pass, its cost + verdict, even when silent */
 .ll-activity {

--- a/frontend/src/stores/observer.ts
+++ b/frontend/src/stores/observer.ts
@@ -15,7 +15,6 @@ export const useObserverStore = defineStore('observer', () => {
 
   const available = ref(false)
   const models = ref<string[]>(['haiku', 'sonnet', 'opus'])
-  const prompt = ref('')                 // the exact instructions the observer runs under (transparency)
   const session = ref<ObserverSession | null>(null)
   const busy = ref(false)
   const appendTick = ref(0)              // bumped when a pass appends → the open panel reloads entries
@@ -26,7 +25,6 @@ export const useObserverStore = defineStore('observer', () => {
     const s = await observerApi.status(projectUid() || undefined)
     available.value = s.available
     if (s.models?.length) models.value = s.models
-    if (s.prompt) prompt.value = s.prompt
     session.value = s.session ?? null
   }
 
@@ -57,5 +55,5 @@ export const useObserverStore = defineStore('observer', () => {
     session.value = res?.session ?? null
   }
 
-  return { available, models, prompt, session, busy, appendTick, refresh, runPass, clear }
+  return { available, models, session, busy, appendTick, refresh, runPass, clear }
 })


### PR DESCRIPTION
Two small lab-log-panel trims you flagged (Claude is on-demand only now):

- **Scrapped** the "Observer prompt" collapsible (the read-only prompt dump) + the now-unused `prompt` state in the observer store + its CSS.
- **Hid** the "Claude activity" list behind a `SHOW_ACTIVITY = false` flag — little use with Watch gone; kept (not deleted) so re-enabling is a one-line change, per your call.

Backend `observer_prompt_display` + the status `prompt` field are left in place (harmless, just unread now).

Tests: frontend 225, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
