### PR TITLE
fix(observer): make the Chat-to-Claude prompt paste-and-run

### DIFF
--- a/frontend/src/lib/chatHandoff.test.ts
+++ b/frontend/src/lib/chatHandoff.test.ts
@@ -7,7 +7,13 @@ describe('buildChatPrompt', () => {
     expect(p).toContain('my-experiment (NRUBxU)')
     expect(p).toContain('cecelia-observer MCP')
     expect(p).toContain('get_cohort_qc')
-    expect(p).toContain('OBSERVER-SETUP.md')
+  })
+
+  it('is paste-and-run: no placeholder, no relative doc path, tells it not to self-setup', () => {
+    const p = buildChatPrompt('NRUBxU')
+    expect(p).not.toContain('<')            // no <describe what you need> placeholder
+    expect(p).not.toContain('docs/')        // no unresolvable relative doc reference
+    expect(p).toMatch(/do not try to install/i)   // explicitly: don't chase MCP setup
   })
 
   it('falls back to the uid when no name', () => {

--- a/frontend/src/lib/chatHandoff.ts
+++ b/frontend/src/lib/chatHandoff.ts
@@ -5,17 +5,18 @@
 // docs/todo/QC_OBSERVER_PLAN.md (B3) + docs/ai-assist/OBSERVER-SETUP.md.
 export function buildChatPrompt(projectUid: string, projectName?: string): string {
   const proj = projectName ? `${projectName} (${projectUid})` : projectUid
+  // Deliberately a COMPLETE, paste-and-run instruction — no <placeholder> (users paste as-is) and no
+  // relative doc reference (an external session can't resolve it, and chasing it wastes a whole
+  // session). If the MCP is missing we tell the user, we don't send the assistant to configure it.
   return [
     `I'm working in the Cecelia project ${proj}.`,
     ``,
-    `Use the cecelia-observer MCP tools to read my project — get_project_info, get_task_history, ` +
-      `get_qc_metrics, get_cohort_qc, get_image_notes and the lab log — to review my recent analysis ` +
-      `activity and QC, then help me with:`,
+    `Use the cecelia-observer MCP tools (get_project_info, get_task_history, get_qc_metrics, ` +
+      `get_cohort_qc, get_image_notes, and the lab log) to review my recent analysis activity and QC ` +
+      `across this project, and flag anything that looks off or inconsistent across the set. ` +
+      `Read only — do not append to the lab log unless I ask.`,
     ``,
-    `<describe what you need — e.g. "check my segmentation counts are consistent across the set", or ` +
-      `"summarise what I did today and flag anything off">`,
-    ``,
-    `(If the cecelia-observer MCP isn't connected in this session, set it up first — see ` +
-      `docs/ai-assist/OBSERVER-SETUP.md. Please read only; append to the lab log only if I ask.)`,
+    `If the cecelia-observer MCP tools are not available in this session, just tell me — do not try ` +
+      `to install, register, or configure anything.`,
   ].join('\n')
 }


### PR DESCRIPTION
From trying it live: the copied prompt has to work pasted **as-is** into any chat bot.

- **Removed the `<describe what you need>` placeholder** — users paste verbatim, so the prompt now carries a complete default task ("review my recent activity + QC and flag anything off across the set").
- **Removed the relative `docs/ai-assist/OBSERVER-SETUP.md` reference** — an external session can't resolve a relative repo path, and chasing it sent Claude on a multi-minute goose chase (reading CLAUDE.md, the mcp README, diagnosing PYTHONPATH, re-registering the server).
- **Tells the assistant to NOT self-configure** — if the cecelia-observer MCP tools aren't available, just say so rather than trying to install/register/configure.

Test updated. Vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
