### PR TITLE
fix(observer): cohort check follows what actually ran (incl. clustering)

### DIFF
--- a/app/src/ai/observer_prompt.jl
+++ b/app/src/ai/observer_prompt.jl
@@ -16,13 +16,18 @@ Use the tools to see what is happening: get_project_info / list_images / get_tas
 get_task_log + get_recent_logs when something failed (a Julia-side crash lands in get_recent_logs, NOT
 the task log), read_lab_log for prior context, poll_observations for detected patterns.
 
-ALWAYS check cohort QC when a segmentation / measurement / tracking run has completed since you last
-looked: call get_cohort_qc(project, set, fun) for that task (funs: segment.cellpose,
-segment.measureLabels, tracking.bayesian_tracking). A task that finished "done" can still have
-produced far too few cells/tracks — that is INVISIBLE in get_task_history (the run succeeded), so the
-only way to catch it is the cohort numbers. If the returned `outliers` map is non-empty, that image
-IS an anomaly worth a note — cite its value + the cohort median (n ≥ 3 to judge). Do not call a run an
-outlier on your own hunch; use get_cohort_qc.
+ALWAYS check cohort QC for WHATEVER task(s) actually ran since you last looked — read get_task_history
+first, then call get_cohort_qc(project, set, fun) for the fun of each completed task. Check what RAN,
+not a fixed list: if the recent activity was clustering, check clustPops.cluster / clustTracks.cluster
+— NOT segmentation (which will just return n=0 and tell you nothing). The cohort funs that bank
+metrics: segment.cellpose, segment.measureLabels, tracking.bayesian_tracking, tracking.track_measures,
+behaviour.hmm_states, behaviour.hmm_transitions, clustPops.cluster, clustTracks.cluster (get_cohort_qc
+errors and lists the valid funs if you pass one with no metrics). A task that finished "done" can
+still have produced far too few cells/tracks, or clustered degenerately (one dominant cluster) — that
+is INVISIBLE in get_task_history (the run succeeded), so the cohort numbers are the only way to catch
+it. If the returned `outliers` map is non-empty, that image IS an anomaly worth a note — cite its
+value + the cohort median (n ≥ 3 to judge). Do not call a run an outlier on your own hunch; use
+get_cohort_qc.
 
 When something is worth recording, call append_lab_log with ONE short line (it is tagged [Claude]
 automatically — never write the tag yourself). Discipline:

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -83,10 +83,17 @@ def get_cohort_qc(project_uid: str, set_uid: str, fun_name: str, value_name: str
     INCLUDED images, into mean/SD + z-scored outliers.
 
     `set_uid` comes from get_project_info's `sets` / list_images' per-image set. `fun_name` must be a
-    metric producer (else the call errors):
+    metric producer (else the call errors AND lists the current valid funs). Check the fun of WHATEVER
+    task actually ran (from get_task_history) — e.g. if you just clustered, check clustPops/clustTracks,
+    not segmentation. The metric producers:
       - "segment.cellpose"           → nCells
       - "segment.measureLabels"      → nCells
       - "tracking.bayesian_tracking" → nTracks, meanTrackLength, nTrackedCells
+      - "tracking.track_measures"    → nTracks, meanSpeed, meanDisplacement
+      - "behaviour.hmm_states"       → nDecoded, nStates, dominantStateFrac
+      - "behaviour.hmm_transitions"  → nTransitions, nDistinctTransitions
+      - "clustPops.cluster"          → nCells, nClusters, largestClusterFrac
+      - "clustTracks.cluster"        → nTracks, nClusters, largestClusterFrac
     `value_name` is the output variant (default "default").
 
     Returns {funName, valueName, nIncluded, metrics: {<key>: {n, median, mad, mean, sd, threshold,


### PR DESCRIPTION
## The bug (from Dom's live comparison)
The in-app "Ask Claude" reported "cohort QC (tracking + measureLabels — both n=0, nothing to judge)" and flagged nothing — while a full external Chat-to-Claude session found real cohort outliers in **clustering** (M3a B nTracks, M2b T largestClusterFrac).

Root cause: the observer prompt **and** the `get_cohort_qc` tool docstring hardcoded the cohort funs as `segment.cellpose` / `segment.measureLabels` / `tracking.bayesian_tracking`. The recent activity was `clustTracks.cluster`, so the observer checked the (empty) segmentation/tracking funs and **never queried the clustering cohort** where the outliers live.

## Fix
Both the prompt and the tool docstring now say: read `get_task_history` and call `get_cohort_qc` for the fun of **whatever actually ran** — with the full producer set listed (adds `tracking.track_measures`, `behaviour.hmm_states/transitions`, `clustPops.cluster`, `clustTracks.cluster`). The route already errors and lists the current valid funs, so it can't silently drift again.

(The remaining depth gap — the external session also cross-referenced per-image QC + metadata — is by design: Ask Claude is a cheap single pass; the deep dive is what Chat-to-Claude is for. This just makes the quick pass check the *right* numbers.)

MCP tests green (32). No test pinned the old list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
