### PR TITLE
Custom-module QC observability + lab-log mute cleanup

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -276,7 +276,12 @@ function _custom_module_categories()
             end
         end
         isempty(funs) && continue
-        push!(cats, (; name = category, builtin = category ∈ builtin, funNames = funs))
+        # cohortFuns = the category's funs that bank cohort-comparable metrics (Cecelia.COHORT_METRICS,
+        # populated at load incl. custom modules' register_cohort_metrics!). Drives the "Check cohort"
+        # button on the generic custom page WITHOUT any hardcoded per-page list — a custom module that
+        # declares its metrics gets the button automatically.
+        cohort_funs = String[f for f in funs if haskey(Cecelia.COHORT_METRICS, f)]
+        push!(cats, (; name = category, builtin = category ∈ builtin, funNames = funs, cohortFuns = cohort_funs))
     end
     cats
 end
@@ -1264,7 +1269,8 @@ function api_lablog_read(req::HTTP.Request)
     content = read_lab_log(proj)
     p = lab_log_path(proj)
     200, JSON3.write((; content, entries=parse_lab_log(content),
-                        tuning=read_tuning(proj), mutes=read_mutes(proj), categories=lab_log_categories(),
+                        tuning=read_tuning(proj), mutes=read_mutes(proj),
+                        pageCategories=lab_log_page_categories(), operationCategories=lab_log_operation_categories(),
                         mtime=(isfile(p) ? mtime(p) : nothing)))
 end
 

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -397,10 +397,12 @@ end
         let m = JSON3.read(_post(api_lablog_mute, Dict("projectUid"=>uid, "category"=>"Segment", "muted"=>true))[2])
             @test m.ok == true && "Segment" in m.mutes
         end
-        # read exposes both the mutes and the available category vocabulary (for the panel's chips)
+        # read exposes the mutes and the two category groups the panel's mute chips render (module pages
+        # vs operations) — both dynamic from task specs.
         let r = JSON3.read(api_lablog_read(HTTP.Request("GET", "/api/lablog?projectUid=$uid"))[2])
             @test "Segment" in r.mutes
-            @test "Segment" in r.categories && "Gating" in r.categories   # dynamic from task specs
+            @test "Segment" in r.pageCategories && "Gating" in r.pageCategories   # module pages
+            @test "Edit" in r.operationCategories                                 # operations group
         end
         let m = JSON3.read(_post(api_lablog_mute, Dict("projectUid"=>uid, "category"=>"Segment", "muted"=>false))[2])
             @test !("Segment" in m.mutes)

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -24,12 +24,12 @@ export img_label_props_dir, img_label_props_path, img_track_props_path, img_valu
 export read_module_fun_params, write_module_fun_params!
 export TRACK_PROPS_SUFFIX, is_reserved_value_name
 export write_qc, read_qc, read_all_qc, qc_finding, qc_canvas_expansion, qc_path, track_count_metrics
-export cohort_qc, cohort_qc!, cohort_qc_for, cohort_qc_for!, read_cohort_qc, read_all_cohort_qc, cohort_qc_path, COHORT_METRICS
+export cohort_qc, cohort_qc!, cohort_qc_for, cohort_qc_for!, read_cohort_qc, read_all_cohort_qc, cohort_qc_path, COHORT_METRICS, register_cohort_metrics!
 export cohort_qc_summary_lines, cohort_has_outliers
 export read_run_log, append_run_log!, run_log_path
 export read_lab_log, append_lab_log!, parse_lab_log, lab_log_path, LAB_LOG_FILENAME
 export read_tuning, set_tuning!
-export read_mutes, set_mute!, lab_log_categories
+export read_mutes, set_mute!, lab_log_categories, lab_log_page_categories, lab_log_operation_categories
 export capture_context!, CONTEXT_AUTHOR
 export set_channel_names!, channel_names
 

--- a/app/src/lab_log_context.jl
+++ b/app/src/lab_log_context.jl
@@ -86,13 +86,30 @@ _category_of_pop_type(pt::AbstractString)::String =
 non-task ones. Ordered by `_CATEGORY_ORDER`, extras appended. Backs the panel's per-category mutes."""
 function lab_log_categories()::Vector{String}
     cats = Set{String}([CATEGORY_GATING, "Clustering", CATEGORY_IMAGES])
-    for (_fun, task) in _fun_name_map()
-        spec = try _task_spec(task) catch; nothing end
-        spec !== nothing && haskey(spec, "category") && push!(cats, String(spec["category"]))
+    # built-ins (static registry) PLUS loaded custom modules (runtime registry) — so a new task/page,
+    # or a user's custom-module category (e.g. customExamples), appears automatically with no change here.
+    for fun in vcat(collect(keys(_fun_name_map())), collect(_custom_task_keys()))
+        push!(cats, _category_of_fun(fun))
     end
     ordered = String[c for c in _CATEGORY_ORDER if c in cats]
     vcat(ordered, sort(String[c for c in cats if !(c in _CATEGORY_ORDER)]))
 end
+
+# Categories that are OPERATIONS — an action, not a module page (crop lives in Edit; include/exclude in
+# Manage images). Everything else the app emits is a module page. Small + explicit; the mute bar shows
+# these as one general "Operations" group, separate from the per-module-page chips.
+const _OPERATION_CATEGORIES = ("Manage images", "Edit")
+_is_operation_category(c::AbstractString)::Bool = String(c) in _OPERATION_CATEGORIES
+
+"""Module-page digest categories — everything `lab_log_categories` can emit that ISN'T an operation —
+ordered by `_CATEGORY_ORDER`. Backs the mute bar's 'Module pages' group (all pages, always shown)."""
+lab_log_page_categories()::Vector{String} =
+    String[c for c in lab_log_categories() if !_is_operation_category(c)]
+
+"""Operation digest categories (actions with no module page of their own — Edit, Manage images),
+ordered by `_CATEGORY_ORDER`. Backs the mute bar's general 'Operations' group."""
+lab_log_operation_categories()::Vector{String} =
+    String[c for c in lab_log_categories() if _is_operation_category(c)]
 
 # rank for digest ordering (index in _CATEGORY_ORDER; unknown categories sort last, then alphabetical)
 _category_rank(c::AbstractString)::Int = (i = findfirst(==(String(c)), _CATEGORY_ORDER); i === nothing ? typemax(Int) : i)

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -42,6 +42,17 @@ const COHORT_METRICS = Dict{String,Vector{String}}(
     "behaviour.hmm_transitions"  => ["nTransitions", "nDistinctTransitions"],
 )
 
+"""
+    register_cohort_metrics!(fun_name, keys) -> Vector{String}
+
+Declare the cohort-comparable metric keys a task banks, so `get_cohort_qc` / the `/api/qc/cohort` route
+can run on `fun_name`. Built-ins are listed in `COHORT_METRICS` above; **custom modules call this at
+registration time** to opt their QC into cohort checks (mirrors `register_task!`). Idempotent.
+"""
+function register_cohort_metrics!(fun_name::AbstractString, keys::AbstractVector)::Vector{String}
+    COHORT_METRICS[String(fun_name)] = String[String(k) for k in keys]
+end
+
 # Pure: robust outlier detection. Two regimes:
 #  • MAD > 0 — modified z-score (Iglewicz & Hoaglin): Mᵢ = 0.6745·(xᵢ − median)/MAD, flag |Mᵢ| ≥
 #    threshold. Robust: one bad image doesn't inflate the scale and mask itself, so a clear outlier

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -528,6 +528,24 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         rm(proj.root; recursive=true)
     end
 
+    # ── Mute-bar taxonomy: module pages vs operations (two separate groups) ──
+    @testset "Lab log mute categories — pages vs operations" begin
+        pages = lab_log_page_categories()
+        ops   = lab_log_operation_categories()
+        # the pipeline module pages are all present, in _CATEGORY_ORDER, and carry NO operation tags
+        for p in ("Segment", "Gating", "Tracking", "Clustering", "Behaviour")
+            @test p in pages
+        end
+        @test !("Edit" in pages) && !("Manage images" in pages)
+        # operations are the non-page actions, shown as one general group
+        @test Set(ops) == Set(["Edit", "Manage images"])
+        # the two groups partition the full universe (no overlap, union == all)
+        @test isempty(intersect(Set(pages), Set(ops)))
+        @test Set(vcat(pages, ops)) == Set(lab_log_categories())
+        # ordering follows _CATEGORY_ORDER (Segment before Tracking before Clustering)
+        @test findfirst(==("Segment"), pages) < findfirst(==("Tracking"), pages) < findfirst(==("Clustering"), pages)
+    end
+
     # ── Param validation ──────────────────────────────────────────────────────
     @testset "Param validation" begin
         task = ImportOmezarr()
@@ -4399,6 +4417,16 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test cohort_qc_for!(set, "segment.measureLabels", "default")["nIncluded"] == 9
             # unknown fun errors (not a metric producer)
             @test_throws ErrorException cohort_qc_for!(set, "not.aTask", "default")
+        end
+
+        @testset "register_cohort_metrics! (custom-module opt-in)" begin
+            fun = "customExamples.qcProbeTest"
+            @test !haskey(COHORT_METRICS, fun)                       # unknown → cohort errors
+            register_cohort_metrics!(fun, ["nCells"])
+            @test COHORT_METRICS[fun] == ["nCells"]                  # now a known producer
+            register_cohort_metrics!(fun, ["nCells", "nClusters"])   # idempotent overwrite
+            @test COHORT_METRICS[fun] == ["nCells", "nClusters"]
+            delete!(COHORT_METRICS, fun)                             # don't leak into other testsets
         end
     end
 

--- a/docs/CUSTOM_MODULES.md
+++ b/docs/CUSTOM_MODULES.md
@@ -112,6 +112,26 @@ on `PYTHONPATH`, writes the params JSON, streams `[PROGRESS] n/total` → `on_pr
 clean exit. Your `_run.py` reads params via `cecelia.utils.script_utils.script_params()` — see the
 built-in runners under `python/cecelia/tasks/` for the pattern. **No `sys.path` bootstrapping.**
 
+## QC (recommended)
+
+Like a built-in task, a result-producing custom module should bank advisory QC so its output flows to
+the image badge, the `[Cecelia]` lab-log digest and the observer. Call **`Cecelia.write_qc(img, fun,
+value_name, findings; metrics)`** after the work succeeds — `metrics` is an objective count, `findings`
+a vector of `Cecelia.qc_finding("warn", code, short, long)` for the bad case (advisory only; never
+blocks). Write it under **your own `fun_name`** — that is the fun the image badge and the digest ⚠️
+resolve against.
+
+To make your metric cohort-comparable across a set (the `get_cohort_qc` / `/api/qc/cohort` outlier
+check), declare its keys **at load time**, next to your `register_task!`:
+
+```julia
+Cecelia.register_cohort_metrics!("customExamples.myTask", ["nCells"])
+```
+
+The category you tag in the JSON (`"category": "customExamples"`) automatically appears in the lab-log
+mute bar's **Module pages** group — so a user can mute your module's `[Cecelia]` digest lines. A
+runnable QC example lives in `dev/modules/…/customExamples/qcProbe.jl`.
+
 ## Loading & reloading
 
 Custom modules are loaded once on server start. To pick up **newly dropped** files without a restart,

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import { useAppControlStore } from '../stores/appControl'
@@ -21,6 +21,11 @@ const showPanel = ref(false)
 // quick app controls in the footer: Quit (everyone) + Restart backend (dev only). Same shared store
 // the Settings → System panel uses. Quit is destructive → two-click ConfirmButton (no native dialog).
 onMounted(() => { appCtl.refreshDev(); customModules.ensureLoaded() })
+
+// Re-scan custom modules when a project opens — the custom-module nav group needs a project anyway, and
+// this way a module dropped after startup appears without a detour through Settings (the old symptom:
+// `ensureLoaded` fetched once at boot and never retried). Also refreshes the per-category cohortFuns.
+watch(() => projectMeta.current?.uid, uid => { if (uid) customModules.refresh() })
 
 // Track which groups are collapsed (all open by default)
 const collapsed = ref<Set<string>>(new Set())

--- a/frontend/src/components/CohortCheckButton.vue
+++ b/frontend/src/components/CohortCheckButton.vue
@@ -10,12 +10,14 @@ import { cohortFunsFor } from '../lib/cohortStages'
 import { runCohortCheck } from '../lib/cohortCheck'
 import { SEVERITY } from '../lib/severity'
 
-const props = defineProps<{ module?: string; setUid?: string }>()
+// `funs` overrides the built-in COHORT_STAGES lookup — passed by pages whose cohort funs come from the
+// backend (custom modules: funNames ∩ COHORT_METRICS), so the button needs no hardcoded per-page entry.
+const props = defineProps<{ module?: string; setUid?: string; funs?: string[] }>()
 const toast = useToast()
 const projectMeta = useProjectMetaStore()
 const busy = ref(false)
 
-const funs = computed(() => cohortFunsFor(props.module))
+const funs = computed(() => props.funs?.length ? props.funs : cohortFunsFor(props.module))
 const canCheck = computed(() => funs.value.length > 0 && !!props.setUid && !!projectMeta.current?.uid)
 
 async function check() {

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -13,8 +13,8 @@ import { useObserverStore } from '../stores/observer'
 import { useLabCaptureStore } from '../stores/labCapture'
 import { buildChatPrompt } from '../lib/chatHandoff'
 import {
-  authorKind, correctionPrefill, draftToLines, entryId, decisionPrefill, isRatable, muteChips,
-  USER_AUTHOR, CORRECTION_AUTHOR, type LabLogEntry, type Vote,
+  authorKind, correctionPrefill, draftToLines, entryId, decisionPrefill, isRatable, muteGroups,
+  muteCategoryLabel, USER_AUTHOR, CORRECTION_AUTHOR, type LabLogEntry, type Vote,
 } from '../utils/labLog'
 
 const pm = useProjectMetaStore()
@@ -32,7 +32,8 @@ const error = ref('')
 const inputEl = ref<HTMLTextAreaElement | null>(null)
 const tuning = ref<Record<string, Vote>>({})   // entryId → tuning vote (config, NOT the log)
 const mutes = ref<string[]>([])                // muted digest categories (config, NOT the log)
-const categories = ref<string[]>([])           // all digest categories (task-manager tags), for mute chips
+const pageCategories = ref<string[]>([])       // module-page digest categories (mute chips: Pages group)
+const operationCategories = ref<string[]>([])  // operation digest categories (mute chips: Operations group)
 const mode = computed(() => settings.labLogMode)
 // AI observer (in-app assistant, on-demand only). State lives in the observer STORE (survives this
 // v-if'd panel closing); the panel just drives the "Ask Claude" pass + shows its activity.
@@ -79,8 +80,8 @@ const observerTokens = computed(() => {
   const fmt = total >= 1000 ? `${(total / 1000).toFixed(1)}k` : `${total}`
   return `~${fmt} tokens · ${s.turns} turn${s.turns === 1 ? '' : 's'}`
 })
-// chips include any orphaned mute (category since renamed/removed) so it can always be un-muted
-const muteableCategories = computed(() => muteChips(categories.value, mutes.value))
+// two mute groups: all module pages, and a general Operations group (orphaned mutes fold into it)
+const muteGroupsView = computed(() => muteGroups(pageCategories.value, operationCategories.value, mutes.value))
 const voteOf = (e: LabLogEntry): Vote | undefined => tuning.value[entryId(e.raw)]
 
 async function load() {
@@ -94,7 +95,8 @@ async function load() {
     entries.value = body.entries ?? []
     tuning.value = body.tuning ?? {}
     mutes.value = body.mutes ?? []
-    categories.value = body.categories ?? []
+    pageCategories.value = body.pageCategories ?? []
+    operationCategories.value = body.operationCategories ?? []
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
     entries.value = []
@@ -341,14 +343,34 @@ async function toggleMute(category: string) {
               v-tooltip.top="'Thumbs judge the ENTRY TYPE (useful / noise) → tunes what gets logged, not the log'">entry types</button>
     </div>
 
-    <!-- mute whole categories from future digests (Tuning mode) -->
+    <!-- Mute [Cecelia] auto-digest categories (Tuning mode). Two groups: every module page, and a
+         general Operations group (Edit, Manage images — actions with no page of their own). Muting a
+         category stops its [Cecelia] activity lines; your own notes + Claude entries are never muted. -->
     <div v-if="mode === 'tuning' && projectUid" class="ll-mutebar">
-      <span class="ll-modelabel">Mute:</span>
-      <button v-for="c in muteableCategories" :key="c" class="ll-mutebtn"
-              :class="{ muted: mutes.includes(c) }" @click="toggleMute(c)"
-              v-tooltip.top="mutes.includes(c) ? `${c} muted — click to log again` : `Stop logging ${c}`">
-        <i :class="['pi', mutes.includes(c) ? 'pi-bell-slash' : 'pi-bell']" /> {{ c }}
-      </button>
+      <span class="ll-modelabel ll-mutelabel"
+            v-tooltip.top="'Categories Cecelia auto-logs. Click one to mute its [Cecelia] activity lines — only these auto-digests, never your notes or Claude entries.'">
+        <i class="pi pi-bell-slash" /> Mute Cecelia digests:
+      </span>
+      <div class="ll-mutegroup">
+        <span class="ll-mutegrouplabel">Module pages</span>
+        <div class="ll-mutechips">
+          <button v-for="c in muteGroupsView.pages" :key="c" class="ll-mutebtn"
+                  :class="{ muted: mutes.includes(c) }" @click="toggleMute(c)"
+                  v-tooltip.top="mutes.includes(c) ? `Muted — click to log ${muteCategoryLabel(c)} again` : `Stop logging ${muteCategoryLabel(c)} activity`">
+            {{ muteCategoryLabel(c) }}
+          </button>
+        </div>
+      </div>
+      <div v-if="muteGroupsView.operations.length" class="ll-mutegroup">
+        <span class="ll-mutegrouplabel">Operations</span>
+        <div class="ll-mutechips">
+          <button v-for="c in muteGroupsView.operations" :key="c" class="ll-mutebtn"
+                  :class="{ muted: mutes.includes(c) }" @click="toggleMute(c)"
+                  v-tooltip.top="mutes.includes(c) ? `Muted — click to log ${muteCategoryLabel(c)} again` : `Stop logging ${muteCategoryLabel(c)} activity`">
+            {{ muteCategoryLabel(c) }}
+          </button>
+        </div>
+      </div>
     </div>
 
     <div v-if="error" class="ll-error">{{ error }}</div>
@@ -479,17 +501,28 @@ async function toggleMute(category: string) {
 }
 .ll-modebtn.on { color: var(--cc-text); border-color: #8b949e; background: rgba(139, 148, 158, 0.15); }
 
+/* label on its own line, then the chips wrap on the line below (a clean grid, not a mixed row) */
 .ll-mutebar {
-  display: flex; align-items: center; gap: 0.35rem; flex-wrap: wrap;
+  display: flex; flex-direction: column; align-items: flex-start; gap: 0.3rem;
   padding: 0.3rem 0.5rem; border-bottom: 1px solid var(--cc-border); flex-shrink: 0; font-size: 0.68rem;
 }
+/* each group: a small sub-label, then its wrapping chip row */
+.ll-mutegroup { display: flex; align-items: baseline; gap: 0.4rem; width: 100%; }
+.ll-mutegrouplabel {
+  flex-shrink: 0; width: 5.5rem; text-align: right;
+  font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.03em; color: var(--cc-text-dim);
+}
+.ll-mutechips { display: flex; flex-wrap: wrap; gap: 0.3rem; }
 .ll-mutebtn {
   display: inline-flex; align-items: center; gap: 0.25rem;
   border: 1px solid var(--cc-border); background: var(--cc-surface-2); color: var(--cc-text-dim);
   border-radius: 0.3rem; padding: 0.1rem 0.4rem; font-size: 0.64rem; cursor: pointer;
 }
-.ll-mutebtn:hover { color: var(--cc-text); }
-.ll-mutebtn.muted { color: #d29922; border-color: #d29922; background: rgba(210, 153, 34, 0.12); }
+.ll-mutebtn:hover { color: var(--cc-text); border-color: #8b949e; }
+/* muted state carries itself (struck + amber) — no per-chip bell needed; the one bell is on the label */
+.ll-mutebtn.muted { color: #d29922; border-color: #d29922; background: rgba(210, 153, 34, 0.12); text-decoration: line-through; }
+.ll-mutelabel { display: inline-flex; align-items: center; gap: 0.3rem; }
+.ll-mutelabel .pi { font-size: 0.66rem; }
 
 .ll-error { padding: 0.4rem 0.6rem; color: #f85149; font-size: 0.72rem; }
 

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -65,6 +65,7 @@ const props = withDefaults(defineProps<{
   hint?:        string   // first-use-only one-liner shown above the panel (dismissed per hintKey)
   hintKey?:     string   // stable id for the hint's localStorage dismissal (required if hint set)
   rightDefaultWidth?: number   // starting width (px) for the #right panel; omitted → sizes to content
+  cohortFuns?:  string[]  // explicit cohort funs for the "Check cohort" button (custom pages); overrides COHORT_STAGES
 }>(), {
   allowManage: false,
   allowDelete: false,
@@ -277,7 +278,7 @@ const visibleUids = computed<string[]>(() =>
 
           <div class="table-tools" v-if="activeSet && activeSet.images.length > 0">
             <!-- Cohort consistency: self-hides unless this module banks cohort metrics (cohortStages) -->
-            <CohortCheckButton :module="module" :set-uid="activeSet.uid" />
+            <CohortCheckButton :module="module" :set-uid="activeSet.uid" :funs="cohortFuns" />
 
             <!-- CSV export: the whole table, including excluded images + their notes -->
             <button class="filter-toggle" @click="exportCsv"

--- a/frontend/src/modules/CustomModule.vue
+++ b/frontend/src/modules/CustomModule.vue
@@ -12,6 +12,7 @@ import { useRoute } from 'vue-router'
 import ModuleLayout from '../components/ModuleLayout.vue'
 import TaskRunner from '../tasks/TaskRunner.vue'
 import { useTaskDefs } from '../composables/useTaskDefs'
+import { useCustomModulesStore } from '../stores/customModules'
 
 const route    = useRoute()
 // Category comes from the route; useTaskDefs is re-created per navigation because vue-router reuses
@@ -19,10 +20,15 @@ const route    = useRoute()
 // the route by full path, so a fresh instance (and fresh defs) is created per category.
 const category = computed(() => String(route.params.category ?? ''))
 const { defs, reload } = useTaskDefs(category.value)
+// cohort funs come from the backend (funNames ∩ COHORT_METRICS), so the "Check cohort" button appears
+// automatically for a custom module that registered cohort metrics — no hardcoded per-page list.
+const customModules = useCustomModulesStore()
+const cohortFuns = computed(() =>
+  customModules.categories.find(c => c.name === category.value)?.cohortFuns ?? [])
 </script>
 
 <template>
-  <ModuleLayout :module="category" :show-attrs="true" :show-filter="true">
+  <ModuleLayout :module="category" :show-attrs="true" :show-filter="true" :cohort-funs="cohortFuns">
     <template #right="{ selectedUids, selectedNames }">
       <TaskRunner
         :defs="defs"

--- a/frontend/src/stores/customModules.ts
+++ b/frontend/src/stores/customModules.ts
@@ -6,7 +6,7 @@ import { ref } from 'vue'
 // custom specs. `categories` with builtin === false drive a generic page + a "Custom" nav group;
 // tasks in a builtin category already surface on that category's existing page.
 export interface CustomModuleEntry { path: string; status: 'ok' | 'error'; error: string | null }
-export interface CustomCategory { name: string; builtin: boolean; funNames: string[] }
+export interface CustomCategory { name: string; builtin: boolean; funNames: string[]; cohortFuns?: string[] }
 
 export const useCustomModulesStore = defineStore('customModules', () => {
   const dir        = ref('')

--- a/frontend/src/utils/labLog.test.ts
+++ b/frontend/src/utils/labLog.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   authorKind, correctionPrefill, draftToLines, unseenClaudeCount,
-  entryId, decisionPrefill, isRatable, muteChips,
+  entryId, decisionPrefill, isRatable, muteGroups, muteCategoryLabel,
   type LabLogEntry,
 } from './labLog'
 
@@ -37,18 +37,33 @@ describe('labLog.draftToLines', () => {
   })
 })
 
-describe('labLog.muteChips', () => {
-  it('keeps canonical order and appends orphaned mutes at the end', () => {
-    expect(muteChips(['Segment', 'Gating', 'Clustering'], ['Gating']))
-      .toEqual(['Segment', 'Gating', 'Clustering'])
-    // a muted category no longer in the canonical list is still shown (so it can be un-muted)
-    expect(muteChips(['Segment', 'Gating'], ['OldName', 'Gating']))
-      .toEqual(['Segment', 'Gating', 'OldName'])
+describe('labLog.muteGroups', () => {
+  it('splits into all pages + a general operations group, keeping order', () => {
+    const g = muteGroups(['Segment', 'Gating', 'Clustering'], ['Edit', 'Manage images'], ['Gating'])
+    expect(g.pages).toEqual(['Segment', 'Gating', 'Clustering'])   // all pages, always
+    expect(g.operations).toEqual(['Edit', 'Manage images'])
+  })
+  it('folds an orphaned mute (in neither list) into operations so it can be un-muted', () => {
+    const g = muteGroups(['Segment'], ['Edit'], ['OldCustom', 'Segment'])
+    expect(g.pages).toEqual(['Segment'])
+    expect(g.operations).toEqual(['Edit', 'OldCustom'])            // orphan appended to operations
   })
   it('handles empty / missing inputs', () => {
-    expect(muteChips([], [])).toEqual([])
-    expect(muteChips(undefined as any, undefined as any)).toEqual([])
-    expect(muteChips([], ['Stuck'])).toEqual(['Stuck'])
+    expect(muteGroups([], [], [])).toEqual({ pages: [], operations: [] })
+    expect(muteGroups(undefined as any, undefined as any, undefined as any))
+      .toEqual({ pages: [], operations: [] })
+  })
+})
+
+describe('labLog.muteCategoryLabel', () => {
+  it('capitalises the first letter so chips read uniformly', () => {
+    expect(muteCategoryLabel('import')).toBe('Import')      // task-spec lower-case tag
+    expect(muteCategoryLabel('Segment')).toBe('Segment')    // already title-case → unchanged
+    expect(muteCategoryLabel('Manage images')).toBe('Manage images')
+  })
+  it('handles empty / missing input', () => {
+    expect(muteCategoryLabel('')).toBe('')
+    expect(muteCategoryLabel(undefined as any)).toBe('')
   })
 })
 

--- a/frontend/src/utils/labLog.ts
+++ b/frontend/src/utils/labLog.ts
@@ -81,14 +81,25 @@ export function draftToLines(draft: string): string[] {
     .filter(l => l.length > 0)
 }
 
-/** Categories to show as mute chips: the canonical category list (in the backend's order) plus any
- *  currently-muted category no longer in it (e.g. a task category later renamed/removed), appended
- *  at the end. Without the union such an orphaned mute would render no chip and could never be
- *  un-muted. */
-export function muteChips(categories: string[], mutes: string[]): string[] {
-  const cats = categories ?? []
-  const orphans = (mutes ?? []).filter(m => !cats.includes(m))
-  return [...cats, ...orphans]
+/** Split the muteable digest categories into the panel's two display groups: all module-page
+ *  categories (always shown), and the general Operations group. Any orphaned mute — a category no
+ *  longer in either backend list (e.g. a renamed/removed custom category) — is folded into Operations
+ *  so it still renders and can be un-muted. Both lists keep the backend's (pipeline) order. */
+export function muteGroups(pageCategories: string[], operationCategories: string[], mutes: string[]):
+  { pages: string[]; operations: string[] } {
+  const pages = pageCategories ?? []
+  const ops = operationCategories ?? []
+  const known = new Set<string>([...pages, ...ops])
+  const orphans = (mutes ?? []).filter(m => !known.has(m))
+  return { pages: [...pages], operations: [...ops, ...orphans] }
+}
+
+/** Display label for a mute chip: the category tag with a capitalised first letter, so the chips read
+ *  uniformly (task specs tag some categories lower-case, e.g. "import"). The raw category stays the
+ *  mute KEY — only the label is prettified. */
+export function muteCategoryLabel(category: string): string {
+  const c = category ?? ''
+  return c ? c.charAt(0).toUpperCase() + c.slice(1) : c
 }
 
 /** Count entries authored by Claude that are newer than the last one the user has seen (by date +


### PR DESCRIPTION
## Custom-module QC observability + lab-log mute cleanup

Makes the QC/observer surfaces work uniformly for user **custom modules**, and cleans up the lab-log mute UI.

### Lab-log mute bar → two clear groups
- **Module pages** (all pages, always shown) + a general **Operations** group (`Edit`, `Manage images` — actions with no page of their own). Uniform Title-case, chips on their own line, one bell on the label.
- `lab_log_categories()` now reads the **custom-module runtime registry** too, so a custom category (e.g. `customExamples`) shows up and is muteable — it didn't before (static map only).
- New pure helpers `muteGroups` / `muteCategoryLabel` (replace `muteChips`).

### Cohort opt-in for any task (incl. custom modules)
- New exported `register_cohort_metrics!(fun, keys)` — a task (built-in *or* a user drop-in module) declares its cohort-comparable metrics, mirroring `register_task!`.
- The generic custom page's **"Check cohort"** button now appears **automatically** via the backend's `cohortFuns` (a category's `funNames ∩ COHORT_METRICS`) — no hardcoded per-page list. A custom module that calls `register_cohort_metrics!` gets the button with zero page edits.

### Custom-module nav
- Loads on **project-open**, not only after visiting Settings (the sidebar previously fetched once at boot and never retried).

### Tests
- Mute taxonomy: pages-vs-operations partition of the category universe.
- `register_cohort_metrics!` round-trip (unknown → errors, register → known, idempotent).
- `muteGroups` / `muteCategoryLabel`.
- Package **1167 pass**, frontend **13 pass**, typecheck clean.

### Docs
- `docs/CUSTOM_MODULES.md` — QC section (`write_qc` + `register_cohort_metrics!`).

> ⚠️ Requires a **backend restart** to take effect (`api/src/routes.jl` isn't Revise-tracked; the mute-group payload + `cohortFuns` come from there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
