### PR TITLE
Lab log: hide entries + digest flagged-count

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -1271,6 +1271,7 @@ function api_lablog_read(req::HTTP.Request)
     200, JSON3.write((; content, entries=parse_lab_log(content),
                         tuning=read_tuning(proj), mutes=read_mutes(proj),
                         pageCategories=lab_log_page_categories(), operationCategories=lab_log_operation_categories(),
+                        dismissed=read_dismissed(proj),
                         mtime=(isfile(p) ? mtime(p) : nothing)))
 end
 
@@ -1316,6 +1317,28 @@ function api_lablog_mute(body_bytes::Vector{UInt8})
         return 400, JSON3.write((; error=sprint(showerror, e)))
     end
     200, JSON3.write((; ok=true, mutes))
+end
+
+# dismiss → hide/un-hide a single entry from the PANEL (config sidecar; the log file is never edited —
+# append-only). Body {projectUid, id, dismissed}. Returns the updated dismissed-id list.
+function api_lablog_dismiss(body_bytes::Vector{UInt8})
+    body = try JSON3.read(String(body_bytes)) catch
+        return 400, JSON3.write((; error="Invalid JSON body"))
+    end
+    project_uid = String(get(body, :projectUid, ""))
+    entry_id    = String(get(body, :id, ""))
+    dismissed   = Bool(get(body, :dismissed, false))
+    isempty(project_uid) && return 400, JSON3.write((; error="projectUid required"))
+    isempty(entry_id)    && return 400, JSON3.write((; error="id required"))
+    proj = try load_project(project_uid) catch e
+        return 404, JSON3.write((; error=sprint(showerror, e)))
+    end
+    ids = try
+        set_dismissed!(proj, entry_id, dismissed)
+    catch e
+        return 400, JSON3.write((; error=sprint(showerror, e)))
+    end
+    200, JSON3.write((; ok=true, dismissed=ids))
 end
 
 # append → one dated, author-tagged block. Server injects date + author tag (append-only, lock-guarded

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -334,6 +334,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_lablog_tune(body_bytes)
         elseif path == "/api/lablog/mute"
             api_lablog_mute(body_bytes)
+        elseif path == "/api/lablog/dismiss"
+            api_lablog_dismiss(body_bytes)
         elseif path == "/api/images/meta/resync"
             api_images_meta_resync(body_bytes)
         elseif path == "/api/images/labels/delete"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -409,6 +409,17 @@ end
         end
         @test _post(api_lablog_mute, Dict("projectUid"=>uid, "category"=>"", "muted"=>true))[1] == 400   # empty rejected
         @test _post(api_lablog_mute, Dict("projectUid"=>uid, "muted"=>true))[1] == 400                   # category missing
+
+        # ── dismiss (hide an entry → config sidecar; the log file stays append-only) ──
+        let d = JSON3.read(_post(api_lablog_dismiss, Dict("projectUid"=>uid, "id"=>"ff00aa", "dismissed"=>true))[2])
+            @test d.ok == true && "ff00aa" in d.dismissed
+        end
+        @test "ff00aa" in JSON3.read(api_lablog_read(HTTP.Request("GET", "/api/lablog?projectUid=$uid"))[2]).dismissed  # surfaced on read
+        let d = JSON3.read(_post(api_lablog_dismiss, Dict("projectUid"=>uid, "id"=>"ff00aa", "dismissed"=>false))[2])
+            @test !("ff00aa" in d.dismissed)                                                             # un-hidden
+        end
+        @test _post(api_lablog_dismiss, Dict("projectUid"=>uid, "dismissed"=>true))[1] == 400            # id missing
+        @test _post(api_lablog_dismiss, Dict("id"=>"x", "dismissed"=>true))[1] == 400                    # projectUid missing
     finally
         had ? (dirs["projects"] = old) : delete!(dirs, "projects")
         rm(tmp; recursive=true, force=true)

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -30,6 +30,7 @@ export read_run_log, append_run_log!, run_log_path
 export read_lab_log, append_lab_log!, parse_lab_log, lab_log_path, LAB_LOG_FILENAME
 export read_tuning, set_tuning!
 export read_mutes, set_mute!, lab_log_categories, lab_log_page_categories, lab_log_operation_categories
+export read_dismissed, set_dismissed!
 export capture_context!, CONTEXT_AUTHOR
 export set_channel_names!, channel_names
 

--- a/app/src/lab_log.jl
+++ b/app/src/lab_log.jl
@@ -166,3 +166,41 @@ function set_mute!(proj::CciaProject, category::AbstractString, muted::Bool)::Ve
     end
     out
 end
+
+# ── Dismissed (hidden) entries ───────────────────────────────────────────────────
+# "Hide this entry": drop a single [Cecelia]/[Claude]/user line from the PANEL view without touching
+# the log. The lab log stays APPEND-ONLY (the methodology record is never rewritten) — this is a config
+# sidecar of entry ids, exactly like tuning/mutes; the panel filters them out. Un-hide by removing the
+# id. The id is the same `entryId(raw)` the frontend computes for tuning.
+_dismissed_path(proj::CciaProject)::String = joinpath(proj.root, "settings", "lab-log-dismissed.json")
+
+# the dismissed entry ids; [] when none.
+function read_dismissed(proj::CciaProject)::Vector{String}
+    p = _dismissed_path(proj)
+    isfile(p) || return String[]
+    try
+        String[String(x) for x in JSON3.read(read(p, String), Vector{Any})]
+    catch
+        String[]
+    end
+end
+
+"""
+Hide (`dismissed=true`) or un-hide a lab-log entry by its id. Config sidecar only — the log file is
+never modified (append-only). Lock-guarded. Returns the updated id list.
+"""
+function set_dismissed!(proj::CciaProject, entry_id::AbstractString, dismissed::Bool)::Vector{String}
+    id = strip(String(entry_id))
+    isempty(id) && error("dismiss entry id required")
+    s = Set(read_dismissed(proj))
+    dismissed ? push!(s, id) : delete!(s, id)
+    out = sort(collect(s))
+    with_transaction(proj) do
+        p = _dismissed_path(proj)
+        mkpath(dirname(p))
+        open(p, "w") do io
+            JSON3.write(io, out)
+        end
+    end
+    out
+end

--- a/app/src/lab_log_context.jl
+++ b/app/src/lab_log_context.jl
@@ -140,6 +140,7 @@ const _SEV_RANK = Dict("ok" => 0, "warn" => 1, "fail" => 2)
 function _task_items_by_module(proj::CciaProject, cutoff::AbstractString)::Tuple{Dict{String,Vector{String}},Dict{String,String},String}
     by_mod_fun = Dict{String,Dict{String,Set{String}}}()   # module => fun-display => image names
     fail_count = Dict{Tuple{String,String},Int}()          # (module, fun-display) => # failed runs
+    warn_imgs  = Dict{Tuple{String,String},Set{String}}()  # (module, fun-display) => images with a warn QC finding
     mod_sev    = Dict{String,String}()                     # module => "ok"|"warn"|"fail" (worst)
     bump(mod, sev) = (get(_SEV_RANK, sev, 0) > get(_SEV_RANK, get(mod_sev, mod, "ok"), 0)) &&
                      (mod_sev[mod] = sev)
@@ -158,6 +159,7 @@ function _task_items_by_module(proj::CciaProject, cutoff::AbstractString)::Tuple
                 fail_count[(mod, disp)] = get(fail_count, (mod, disp), 0) + 1   # surface failures too
                 bump(mod, "fail")
             elseif _has_warn_qc(img, fun, vn)
+                push!(get!(warn_imgs, (mod, disp), Set{String}()), img.name)   # count the flagged images
                 bump(mod, "warn")
             end
             at > max_at && (max_at = at)
@@ -167,9 +169,13 @@ function _task_items_by_module(proj::CciaProject, cutoff::AbstractString)::Tuple
     for (mod, funs) in by_mod_fun
         items = String[]
         for disp in sort(collect(keys(funs)))
-            n  = length(funs[disp])
+            names = funs[disp]
+            n  = length(names)
+            item = "$disp on $n image$(n == 1 ? "" : "s")"
+            n <= 2 && (item *= " ($(join(sort(collect(names)), ", ")))")   # name them when few; for more, the count says it
+            w  = length(get(warn_imgs, (mod, disp), Set{String}()))
             fc = get(fail_count, (mod, disp), 0)
-            item = "$disp on $n image$(n == 1 ? "" : "s") ($(_where(funs[disp])))"
+            w  > 0 && (item *= " — $w flagged")   # how many banked a warn QC finding (not just that one did)
             fc > 0 && (item *= " — $fc failed")
             push!(items, item)
         end

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -407,10 +407,19 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         write_qc(iS2, "tracking.track_measures", "default",
                  [Dict{String,Any}("level"=>"warn","code"=>"c","short"=>"s","long"=>"l")])
         append_run_log!(iS2, "tracking.track_measures", "default")
+        # a fun run on 3 images with a warn banked on 2 of them → the digest reports "— 2 flagged"
+        iS3 = add_image!(sS; name="s-3", meta=Dict{String,Any}("ori_path"=>"/tmp/s3.tif"))
+        for im in (iS1, iS2, iS3); append_run_log!(im, "behaviour.hmm_states", "default"); end
+        for im in (iS1, iS2)      # only 2 of the 3 get a warn
+            write_qc(im, "behaviour.hmm_states", "default",
+                     [Dict{String,Any}("level"=>"warn","code"=>"c","short"=>"s","long"=>"l")])
+        end
         sev = capture_context!(projS)
         @test sev !== nothing
         @test occursin("❌ Segment", sev)      # measureLabels failed → worst outcome for the module
         @test occursin("⚠️ Tracking", sev)     # track_measures produced a warn finding
+        @test occursin("hmm_states on 3 images — 2 flagged", sev)   # count of flagged images, not just "≥1"
+        @test !occursin("(3 images)", sev)     # redundant parenthetical dropped for >2 images
 
         # new activity strictly after the cutoff → a fresh digest that doesn't repeat old activity
         sleep(1)   # run-log timestamps are second-granular; ensure a strictly-later `at`
@@ -455,6 +464,7 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         @test capture_context!(proj) === nothing            # no further change
 
         rm(proj.root; recursive=true)
+        rm(projS.root; recursive=true)                      # severity sub-project — also clean up (was leaking)
     end
 
     @testset "Lab log context — first capture seeds silently" begin
@@ -504,6 +514,26 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         @test read_mutes(proj) == ["Segment"]
         @test read_mutes(load_project(proj.uid)) == ["Segment"]           # persists
         @test_throws ErrorException set_mute!(proj, "  ", true)            # empty rejected (else lenient)
+        rm(proj.root; recursive=true)
+    end
+
+    # ── Lab log dismiss (hide a single entry — config sidecar, log stays append-only) ──
+    @testset "Lab log dismiss" begin
+        proj = create_project!(name="dismiss-test-$(rand(1000:9999))", kind="static")
+        @test read_dismissed(proj) == String[]
+        set_dismissed!(proj, "e1a2", true)
+        set_dismissed!(proj, "b3c4", true)
+        @test Set(read_dismissed(proj)) == Set(["e1a2", "b3c4"])
+        set_dismissed!(proj, "e1a2", false)                                # un-hide
+        @test read_dismissed(proj) == ["b3c4"]
+        @test read_dismissed(load_project(proj.uid)) == ["b3c4"]           # persists
+        @test_throws ErrorException set_dismissed!(proj, "  ", true)       # empty id rejected
+
+        # hiding NEVER edits the log file (append-only): the entry text is still on disk
+        append_lab_log!(proj, "Cecelia", ["a digest line to hide"])
+        before = read_lab_log(proj)
+        set_dismissed!(proj, "deadbeef", true)
+        @test read_lab_log(proj) == before                                 # file untouched
         rm(proj.root; recursive=true)
     end
 

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -12,9 +12,11 @@ import { useToast } from 'primevue/usetoast'
 import { useObserverStore } from '../stores/observer'
 import { useLabCaptureStore } from '../stores/labCapture'
 import { buildChatPrompt } from '../lib/chatHandoff'
+import ConfirmDeleteButton from './ConfirmDeleteButton.vue'
 import {
   authorKind, correctionPrefill, draftToLines, entryId, decisionPrefill, isRatable, muteGroups,
-  muteCategoryLabel, USER_AUTHOR, CORRECTION_AUTHOR, type LabLogEntry, type Vote,
+  muteCategoryLabel, visibleEntries as computeVisibleEntries,
+  USER_AUTHOR, CORRECTION_AUTHOR, type LabLogEntry, type Vote,
 } from '../utils/labLog'
 
 const pm = useProjectMetaStore()
@@ -34,6 +36,7 @@ const tuning = ref<Record<string, Vote>>({})   // entryId → tuning vote (confi
 const mutes = ref<string[]>([])                // muted digest categories (config, NOT the log)
 const pageCategories = ref<string[]>([])       // module-page digest categories (mute chips: Pages group)
 const operationCategories = ref<string[]>([])  // operation digest categories (mute chips: Operations group)
+const dismissed = ref<string[]>([])            // hidden entry ids (config sidecar, NOT the log — append-only)
 const mode = computed(() => settings.labLogMode)
 // AI observer (in-app assistant, on-demand only). State lives in the observer STORE (survives this
 // v-if'd panel closing); the panel just drives the "Ask Claude" pass + shows its activity.
@@ -83,6 +86,9 @@ const observerTokens = computed(() => {
 // two mute groups: all module pages, and a general Operations group (orphaned mutes fold into it)
 const muteGroupsView = computed(() => muteGroups(pageCategories.value, operationCategories.value, mutes.value))
 const voteOf = (e: LabLogEntry): Vote | undefined => tuning.value[entryId(e.raw)]
+// entries shown in the panel: hidden (dismissed) ids filtered out. The log FILE still contains them —
+// hide is view-only (a config sidecar), so the append-only methodology record is preserved.
+const visibleEntries = computed(() => computeVisibleEntries(entries.value, dismissed.value))
 
 async function load() {
   error.value = ''
@@ -97,6 +103,7 @@ async function load() {
     mutes.value = body.mutes ?? []
     pageCategories.value = body.pageCategories ?? []
     operationCategories.value = body.operationCategories ?? []
+    dismissed.value = body.dismissed ?? []
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
     entries.value = []
@@ -222,6 +229,23 @@ async function tune(entry: LabLogEntry, vote: Vote) {
     })
     if (!r.ok) throw new Error((await r.json()).error ?? `HTTP ${r.status}`)
     tuning.value = (await r.json()).tuning ?? {}
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+// Hide an entry from the panel. The lab-log FILE is never edited (append-only); this writes the id to
+// a config sidecar and filters it out of the view. Two-click armed via ConfirmDeleteButton.
+async function dismissEntry(entry: LabLogEntry) {
+  if (!projectUid.value) return
+  const id = entryId(entry.raw)
+  try {
+    const r = await fetch('/api/lablog/dismiss', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid: projectUid.value, id, dismissed: true }),
+    })
+    if (!r.ok) throw new Error((await r.json()).error ?? `HTTP ${r.status}`)
+    dismissed.value = (await r.json()).dismissed ?? dismissed.value
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
   }
@@ -379,11 +403,11 @@ async function toggleMute(category: string) {
     <div class="ll-list">
       <div v-if="loading" class="ll-empty">Loading…</div>
       <div v-else-if="!projectUid" class="ll-empty">No project open.</div>
-      <div v-else-if="!entries.length" class="ll-empty">
+      <div v-else-if="!visibleEntries.length" class="ll-empty">
         No entries yet. The first note you save appears here.
       </div>
       <template v-else>
-        <div v-for="(e, i) in entries" :key="e.raw + i" class="ll-entry" :class="'k-' + authorKind(e.author)">
+        <div v-for="(e, i) in visibleEntries" :key="e.raw + i" class="ll-entry" :class="'k-' + authorKind(e.author)">
           <div class="ll-entry-head">
             <span class="ll-author">{{ e.author }}</span>
             <span class="ll-date">{{ e.date }}</span>
@@ -400,6 +424,10 @@ async function toggleMute(category: string) {
               </template>
               <button v-else class="ll-link" v-tooltip.top="'Add a correction (never edits the original)'"
                       @click="startCorrection(e)">correct</button>
+              <!-- Hide this entry (view-only — the log file is append-only, never edited). The ONE
+                   app-wide delete affordance: single button, arm on first click, hide on second. -->
+              <ConfirmDeleteButton title="Hide this entry (view only — the log file is kept)"
+                                   armed-title="Click again to hide" @confirm="dismissEntry(e)" />
             </span>
           </div>
           <ul class="ll-lines">

--- a/frontend/src/utils/labLog.test.ts
+++ b/frontend/src/utils/labLog.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   authorKind, correctionPrefill, draftToLines, unseenClaudeCount,
-  entryId, decisionPrefill, isRatable, muteGroups, muteCategoryLabel,
+  entryId, decisionPrefill, isRatable, muteGroups, muteCategoryLabel, visibleEntries,
   type LabLogEntry,
 } from './labLog'
 
@@ -64,6 +64,20 @@ describe('labLog.muteCategoryLabel', () => {
   it('handles empty / missing input', () => {
     expect(muteCategoryLabel('')).toBe('')
     expect(muteCategoryLabel(undefined as any)).toBe('')
+  })
+})
+
+describe('labLog.visibleEntries', () => {
+  it('filters out entries whose id is dismissed, keeps the rest', () => {
+    const a = entry('Cecelia', 'raw-a'), b = entry('User', 'raw-b'), c = entry('Claude', 'raw-c')
+    const out = visibleEntries([a, b, c], [entryId(b.raw)])
+    expect(out).toEqual([a, c])          // b dropped
+  })
+  it('returns all entries when nothing dismissed; handles empty/missing', () => {
+    const a = entry('User', 'raw-a')
+    expect(visibleEntries([a], [])).toEqual([a])
+    expect(visibleEntries([a], undefined as any)).toEqual([a])
+    expect(visibleEntries(undefined as any, [])).toEqual([])
   })
 })
 

--- a/frontend/src/utils/labLog.ts
+++ b/frontend/src/utils/labLog.ts
@@ -40,6 +40,13 @@ export function entryId(raw: string): string {
   return (h >>> 0).toString(16).padStart(8, '0')
 }
 
+/** Entries the panel should show: those whose `entryId` is NOT in the dismissed (hidden) list. Hiding
+ *  is view-only — the lab-log file keeps every entry (append-only); this just filters the panel. */
+export function visibleEntries(entries: LabLogEntry[], dismissed: string[]): LabLogEntry[] {
+  const hidden = new Set(dismissed ?? [])
+  return (entries ?? []).filter(e => !hidden.has(entryId(e.raw)))
+}
+
 /** Notes-mode decision-assessment prefill: a verdict + reference the user completes with the why. */
 export function decisionPrefill(entry: Pick<LabLogEntry, 'date' | 'author'>, vote: Vote): string {
   return `${vote === 'up' ? '👍' : '👎'} re ${entry.date} [${entry.author}]: `


### PR DESCRIPTION
## Lab log: hide entries + digest flagged-count

### Hide / dismiss an entry (append-only preserved)
A per-entry hide button using the canonical **`ConfirmDeleteButton`** (single button, arm on first click → hide on second — same as every other delete in the app). The lab-log **file is never edited** — the entry id goes to a `settings/lab-log-dismissed.json` sidecar (same mechanism as mutes/tuning) and the panel filters it out. So the append-only methodology record stays intact; un-hide by removing the id.

- Backend: `read_dismissed` / `set_dismissed!` + `POST /api/lablog/dismiss` + `dismissed` in the `/api/lablog` read payload.
- Frontend: pure `visibleEntries(entries, dismissed)` filter (unit-tested).

### Digest: how many images were flagged
`[Cecelia]` activity lines now say **"qcProbe on 7 images — 2 flagged"** — the count of images that banked a `warn` QC finding — instead of only leading with ⚠️ (which just meant "≥1"). Also drops the redundant **"(N images)"** parenthetical for >2 images (names are still shown for ≤2).

### Test-leak fix
The lab-log-context severity test created a second project (`projS`) but never `rm`'d it, leaking a `labctx-sev-*` project into the dev projects dir **on every package-test run**. Now cleaned up.

### Tests
Package **1175**, frontend **15**, API lab-log **36/36**, typecheck clean.

> ⚠️ Requires a **backend restart** — `/api/lablog/dismiss` + the `dismissed` payload live in `api/src` (not Revise-tracked); the hide button 404s until you restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
