### PR TITLE
Delete-project button in the projects table

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -679,6 +679,25 @@ function api_projects_rename(body_bytes::Vector{UInt8})
     200, JSON3.write((; ok=true, name))
 end
 
+# delete → permanently remove a project directory from disk. Body {uid}. The frontend guards against
+# deleting the currently-open project; this is the raw removal (the recent list is a scan of
+# projects_dir, so it refreshes automatically). Destructive + irreversible.
+function api_projects_delete(body_bytes::Vector{UInt8})
+    body = try JSON3.read(String(body_bytes)) catch
+        return 400, JSON3.write((; error="Invalid JSON body"))
+    end
+    uid = String(get(body, :uid, ""))
+    isempty(uid) && return 400, JSON3.write((; error="uid required"))
+    proj_dir = joinpath(projects_dir(), uid)
+    isdir(proj_dir) || return 404, JSON3.write((; error="Project not found"))
+    try
+        rm(proj_dir; recursive=true, force=true)
+    catch e
+        return 500, JSON3.write((; error="Failed to delete project: " * sprint(showerror, e)))
+    end
+    200, JSON3.write((; ok=true, uid))
+end
+
 # ── Set management ────────────────────────────────────────────────────────────
 
 function api_sets_create(body_bytes::Vector{UInt8})

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -296,6 +296,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_board_asset_copy(body_bytes)
         elseif path == "/api/projects/rename"
             api_projects_rename(body_bytes)
+        elseif path == "/api/projects/delete"
+            api_projects_delete(body_bytes)
         elseif path == "/api/sets/create"
             api_sets_create(body_bytes)
         elseif path == "/api/sets/delete"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -415,6 +415,28 @@ end
     end
 end
 
+@testset "API: project delete" begin
+    # Redirect projects_dir() → a temp dir so we never touch the real dev projects dir.
+    conf = cecelia_conf()
+    dirs = get!(conf, "dirs", Dict{String,Any}())
+    had  = haskey(dirs, "projects"); old = get(dirs, "projects", nothing)
+    tmp  = mktempdir(); dirs["projects"] = tmp
+    try
+        proj = create_project!(name="api-del", kind="static")
+        uid  = proj.uid
+        @test isdir(proj.root)
+
+        @test _post(api_projects_delete, Dict())[1] == 400                    # uid missing
+        @test _post(api_projects_delete, Dict("uid"=>"nope"))[1] == 404       # not found
+        st, body = _post(api_projects_delete, Dict("uid"=>uid))
+        @test st == 200 && JSON3.read(body).ok == true
+        @test !isdir(proj.root)                                               # gone from disk
+    finally
+        had ? (dirs["projects"] = old) : delete!(dirs, "projects")
+        rm(tmp; recursive=true, force=true)
+    end
+end
+
 @testset "API: task log + history" begin
     # Redirect projects_dir() → a temp dir so we never touch the real dev projects dir.
     conf = cecelia_conf()

--- a/frontend/src/components/ProjectPanel.vue
+++ b/frontend/src/components/ProjectPanel.vue
@@ -5,6 +5,7 @@
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
 import BaseModal from './BaseModal.vue'
+import ConfirmDeleteButton from './ConfirmDeleteButton.vue'
 import { useProjectMetaStore, type ProjectType } from '../stores/projectMeta'
 
 const emit = defineEmits<{ (e: 'close'): void }>()
@@ -42,6 +43,13 @@ async function openSelected() {
   if (!selectedUid.value) return
   const ok = await projectMeta.openProject(selectedUid.value)
   if (ok) emit('close')
+}
+
+// Permanently delete a project from disk (armed via ConfirmDeleteButton). Never offered for the
+// currently-open project. Clears the selection if the deleted one was selected.
+async function deleteProject(uid: string) {
+  await projectMeta.deleteProject(uid)
+  if (selectedUid.value === uid) selectedUid.value = projectMeta.recent[0]?.uid ?? null
 }
 
 onMounted(async () => {
@@ -119,6 +127,7 @@ const typeColour: Record<ProjectType, string> = {
               <th class="col-type">Type</th>
               <th class="col-path">Location</th>
               <th class="col-date">Last opened</th>
+              <th class="col-del" />
             </tr>
           </thead>
           <tbody>
@@ -153,6 +162,13 @@ const typeColour: Record<ProjectType, string> = {
                 {{ p.path.length > 40 ? '…' + p.path.slice(-38) : p.path }}
               </td>
               <td class="col-date dim">{{ formatDate(p.lastOpenedAt) }}</td>
+              <td class="col-del">
+                <!-- delete a project (not the open one) — canonical arm→confirm single button -->
+                <ConfirmDeleteButton v-if="projectMeta.current?.uid !== p.uid"
+                                     title="Delete this project from disk"
+                                     armed-title="Click again to permanently delete"
+                                     @confirm="deleteProject(p.uid)" />
+              </td>
             </tr>
           </tbody>
         </table>
@@ -295,6 +311,7 @@ const typeColour: Record<ProjectType, string> = {
 .col-type { width: 80px; }
 .col-path { flex: 1; }
 .col-date { width: 120px; }
+.col-del  { width: 34px; text-align: center; }
 
 .proj-row {
   border-bottom: 1px solid var(--cc-border);

--- a/frontend/src/stores/projectMeta.ts
+++ b/frontend/src/stores/projectMeta.ts
@@ -141,5 +141,25 @@ export const useProjectMetaStore = defineStore('projectMeta', () => {
     log.info('Project closed.', { source: 'project' })
   }
 
-  return { current, recent, projectsDir, loading, hasProject, fetchRecent, createProject, openProject, renameProject, closeProject }
+  // Permanently delete a project's directory from disk, then refresh the recent list (which is a scan
+  // of projects_dir). Guarded by the caller against deleting the currently-open project. Irreversible.
+  async function deleteProject(uid: string): Promise<boolean> {
+    try {
+      const res = await fetch('/api/projects/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uid }),
+      })
+      const body = await res.json().catch(() => ({})) as { error?: string }
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
+      await fetchRecent()
+      log.info('Project deleted.', { source: 'project' })
+      return true
+    } catch (e) {
+      log.error(`Failed to delete project: ${e instanceof Error ? e.message : String(e)}`, { source: 'project' })
+      return false
+    }
+  }
+
+  return { current, recent, projectsDir, loading, hasProject, fetchRecent, createProject, openProject, renameProject, deleteProject, closeProject }
 })


### PR DESCRIPTION
## Delete-project button in the projects table

Restores the R-version ability to delete a project from the projects manager. Each row in the recent-projects table gets a delete affordance using the canonical **`ConfirmDeleteButton`** (single button: arm on first click → permanently delete on second — the same arm-then-confirm pattern as every other delete in the app).

- **Backend:** `POST /api/projects/delete {uid}` → `rm` the project directory (guarded: 400 on missing uid, 404 if not found). The recent list is a scan of `projects_dir`, so it refreshes automatically.
- **Frontend:** `projectMeta.deleteProject(uid)` store action (deletes, then `fetchRecent`); `ProjectPanel.vue` adds a delete cell. **Hidden for the currently-open project** so you can't delete data out from under an open session.

### Tests
`API: project delete` (missing uid → 400, not-found → 404, delete → gone from disk). Typecheck clean.

> ⚠️ Destructive + irreversible (`rm -rf` the project dir) — mitigated by two-click arm→confirm and hiding it for the open project; there is no trash/undo.
> ⚠️ Requires a **backend restart** — the route lives in `api/src` (not Revise-tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
