### PR TITLE
Cohort QC discovers value_names (per label set)

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -982,7 +982,7 @@ function api_qc_cohort(req::HTTP.Request)
     haskey(COHORT_METRICS, fun_name) ||
         return 400, JSON3.write((; error = "No cohort metrics for fun '$fun_name'",
                                    known = sort(collect(keys(COHORT_METRICS)))))
-    value_name = get(q, "valueName", VERSIONED_DEFAULT_VAL)
+    vn_param = get(q, "valueName", "")
     thr = something(tryparse(Float64, get(q, "threshold", "")), Cecelia._COHORT_MODZ_THRESHOLD)
     set = try
         obj = init_object(project_uid, set_uid)
@@ -993,8 +993,20 @@ function api_qc_cohort(req::HTTP.Request)
     end
     # READ-ONLY: compute + return, write nothing (a GET must be safe). The write path — set sidecar +
     # per-image cohort findings — is the explicit POST /api/qc/cohort/check below.
+    # No valueName → discover every value_name this fun banked and return per-value_name cohorts (a
+    # `byValueName` map): clustering banks per label set (T/B), segment/tracking under "default", so a
+    # caller that doesn't know the suffix still gets all cohorts. An explicit valueName returns just that
+    # one cohort (single doc, backward-compatible).
+    if isempty(vn_param)
+        byval = try
+            cohort_qc_for_all(set, fun_name; threshold = thr)
+        catch e
+            return 500, JSON3.write((; error = sprint(showerror, e)))
+        end
+        return 200, JSON3.write((; funName = fun_name, valueNames = sort(collect(keys(byval))), byValueName = byval))
+    end
     doc = try
-        cohort_qc_for(set, fun_name, value_name; threshold = thr)
+        cohort_qc_for(set, fun_name, vn_param; threshold = thr)
     catch e
         return 500, JSON3.write((; error = sprint(showerror, e)))
     end
@@ -1015,7 +1027,7 @@ function api_qc_cohort_check(body_bytes::Vector{UInt8})
     haskey(COHORT_METRICS, fun_name) ||
         return 400, JSON3.write((; error = "No cohort metrics for fun '$fun_name'",
                                    known = sort(collect(keys(COHORT_METRICS)))))
-    value_name = String(get(body, :valueName, VERSIONED_DEFAULT_VAL))
+    vn_param = String(get(body, :valueName, ""))
     tv  = get(body, :threshold, nothing)
     thr = tv isa Real ? Float64(tv) : Cecelia._COHORT_MODZ_THRESHOLD
     set = try
@@ -1025,22 +1037,37 @@ function api_qc_cohort_check(body_bytes::Vector{UInt8})
     catch e
         return 404, JSON3.write((; error = sprint(showerror, e)))
     end
-    doc = try
-        cohort_qc_for!(set, fun_name, value_name; threshold = thr)
-    catch e
-        return 500, JSON3.write((; error = sprint(showerror, e)))
-    end
-    # Cecelia authors a lab-log summary ONLY when something flagged (an all-clear would be noise; the
-    # toast covers that). Best-effort — a lab-log hiccup never fails the check. Author "Cecelia — …"
-    # so the append route treats it as a Cecelia digest (no observer re-broadcast).
-    if Cecelia.cohort_has_outliers(doc)
+    # Cecelia authors a lab-log summary ONLY for docs that flagged (an all-clear would be noise; the
+    # toast covers that). Best-effort — a lab-log hiccup never fails the check. Author "Cecelia — …" so
+    # the append route treats it as a Cecelia digest (no observer re-broadcast).
+    log_flagged(docs) = begin
+        flagged = [d for d in docs if d isa AbstractDict && Cecelia.cohort_has_outliers(d)]
+        isempty(flagged) && return
         try
             proj = load_project(project_uid)
-            Cecelia.append_lab_log!(proj, "Cecelia — Cohort QC", Cecelia.cohort_qc_summary_lines(doc))
+            for d in flagged
+                Cecelia.append_lab_log!(proj, "Cecelia — Cohort QC", Cecelia.cohort_qc_summary_lines(d))
+            end
         catch e
             @warn "cohort check: lab-log append failed" exception = e
         end
     end
+    # No valueName → check EVERY value_name the fun banked (per label set); else just the one.
+    if isempty(vn_param)
+        byval = try
+            cohort_qc_for_all!(set, fun_name; threshold = thr)
+        catch e
+            return 500, JSON3.write((; error = sprint(showerror, e)))
+        end
+        log_flagged(collect(values(byval)))
+        return 200, JSON3.write((; funName = fun_name, valueNames = sort(collect(keys(byval))), byValueName = byval))
+    end
+    doc = try
+        cohort_qc_for!(set, fun_name, vn_param; threshold = thr)
+    catch e
+        return 500, JSON3.write((; error = sprint(showerror, e)))
+    end
+    log_flagged([doc])
     200, JSON3.write(doc)
 end
 

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -714,6 +714,12 @@ end
             write_qc(img, "segment.measureLabels", "default", Dict{String,Any}[];
                      metrics = Dict{String,Any}("nCells" => n))
         end
+        # clustering banks PER LABEL SET (T/B), not "default" — bank some so discovery has >1 value_name
+        for (i, img) in enumerate(images(s))
+            write_qc(img, "clustTracks.cluster", "T", Dict{String,Any}[]; metrics = Dict{String,Any}("nTracks" => 40))
+            write_qc(img, "clustTracks.cluster", "B", Dict{String,Any}[];
+                     metrics = Dict{String,Any}("nTracks" => i == 1 ? 9 : 23))   # i1 sparse in B
+        end
         base = "?projectUid=$(proj.uid)&setUid=$(s.uid)"
         sidecar = joinpath(tmp, proj.uid, "1", s.uid, "qc", "cohort",
                            "segment.measureLabels", "default.json")
@@ -721,18 +727,30 @@ end
         @test _qc("")[1] == 400                                              # missing params
         @test _qc("$base&funName=bad.fun")[1] == 400                         # not a metric producer
         @test _qc("?projectUid=$(proj.uid)&setUid=nope&funName=segment.measureLabels")[1] == 404
-        # GET happy path: aggregates the banked nCells — and is READ-ONLY (no sidecar written)
-        st, body = _qc("$base&funName=segment.measureLabels")
+        # GET with an explicit valueName → single doc; READ-ONLY (no sidecar)
+        st, body = _qc("$base&funName=segment.measureLabels&valueName=default")
         @test st == 200
         d = JSON3.read(body)
         @test d.nIncluded == 4 && d.metrics.nCells.n == 4
         @test d.metrics.nCells.mean == 801.25                               # (800+810+790+805)/4
         @test !isfile(sidecar)                                              # a GET must not write
-        # POST /check is the write path: persists the set sidecar
+        # GET with NO valueName → per-value_name map (byValueName). segment banks under "default"…
+        dv = JSON3.read(_qc("$base&funName=segment.measureLabels")[2])
+        @test collect(dv.valueNames) == ["default"] && dv.byValueName.default.nIncluded == 4
+        # …clustering under T and B — both discovered, the sparse i1 flags in B only
+        dc = JSON3.read(_qc("$base&funName=clustTracks.cluster")[2])
+        @test Set(String.(dc.valueNames)) == Set(["B", "T"])
+        i1 = images(s)[1].uid
+        @test haskey(dc.byValueName.B.metrics.nTracks.outliers, Symbol(i1))
+        @test isempty(dc.byValueName.T.metrics.nTracks.outliers)
+        # POST /check (no valueName) → checks every label set, persists each sidecar
         @test _check((;))[1] == 400                                          # missing params
         @test _check((; projectUid = proj.uid, setUid = s.uid, funName = "bad.fun"))[1] == 400
-        stc, _ = _check((; projectUid = proj.uid, setUid = s.uid, funName = "segment.measureLabels"))
+        stc, bc = _check((; projectUid = proj.uid, setUid = s.uid, funName = "segment.measureLabels"))
         @test stc == 200 && isfile(sidecar)
+        @test haskey(JSON3.read(bc), :byValueName)
+        _check((; projectUid = proj.uid, setUid = s.uid, funName = "clustTracks.cluster"))
+        @test isfile(joinpath(tmp, proj.uid, "1", s.uid, "qc", "cohort", "clustTracks.cluster", "B.json"))
     finally
         had ? (dirs["projects"] = old) : delete!(dirs, "projects")
         rm(tmp; recursive = true, force = true)

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -25,6 +25,7 @@ export read_module_fun_params, write_module_fun_params!
 export TRACK_PROPS_SUFFIX, is_reserved_value_name
 export write_qc, read_qc, read_all_qc, qc_finding, qc_canvas_expansion, qc_path, track_count_metrics
 export cohort_qc, cohort_qc!, cohort_qc_for, cohort_qc_for!, read_cohort_qc, read_all_cohort_qc, cohort_qc_path, COHORT_METRICS, register_cohort_metrics!
+export cohort_value_names, cohort_qc_for_all, cohort_qc_for_all!
 export cohort_qc_summary_lines, cohort_has_outliers
 export read_run_log, append_run_log!, run_log_path
 export read_lab_log, append_lab_log!, parse_lab_log, lab_log_path, LAB_LOG_FILENAME

--- a/app/src/ai/observer_prompt.jl
+++ b/app/src/ai/observer_prompt.jl
@@ -22,11 +22,14 @@ not a fixed list: if the recent activity was clustering, check clustPops.cluster
 — NOT segmentation (which will just return n=0 and tell you nothing). The cohort funs that bank
 metrics: segment.cellpose, segment.measureLabels, tracking.bayesian_tracking, tracking.track_measures,
 behaviour.hmm_states, behaviour.hmm_transitions, clustPops.cluster, clustTracks.cluster (get_cohort_qc
-errors and lists the valid funs if you pass one with no metrics). A task that finished "done" can
+errors and lists the valid funs if you pass one with no metrics). LEAVE value_name UNSET — clustering
+banks its QC PER LABEL SET (e.g. "T" and "B"), not under "default", so with no value_name get_cohort_qc
+returns every one the fun banked as `{valueNames, byValueName: {"T": doc, "B": doc}}`; check EACH label
+set's doc (that is why a bare clustering query used to look empty). A task that finished "done" can
 still have produced far too few cells/tracks, or clustered degenerately (one dominant cluster) — that
 is INVISIBLE in get_task_history (the run succeeded), so the cohort numbers are the only way to catch
-it. If the returned `outliers` map is non-empty, that image IS an anomaly worth a note — cite its
-value + the cohort median (n ≥ 3 to judge). Do not call a run an outlier on your own hunch; use
+it. If a doc's `outliers` map is non-empty, that image IS an anomaly worth a note — cite the LABEL SET,
+its value + the cohort median (n ≥ 3 to judge). Do not call a run an outlier on your own hunch; use
 get_cohort_qc.
 
 When something is worth recording, call append_lab_log with ONE short line (it is tagged [Claude]

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -205,6 +205,10 @@ end
 
 function cohort_qc_summary_lines(doc::AbstractDict)
     fun = string(get(doc, "funName", "?")); n = get(doc, "nIncluded", 0)
+    vn  = string(get(doc, "valueName", ""))
+    # name the label set when it isn't the default, so per-label-set cohorts (clustTracks.cluster on
+    # T vs B) read distinctly in the lab log
+    fun = (isempty(vn) || vn == VERSIONED_DEFAULT_VAL) ? fun : "$fun ($vn)"
     outs = String[]
     for (mk, m) in get(doc, "metrics", Dict())
         (m isa AbstractDict) || continue
@@ -238,6 +242,38 @@ cohort_qc_for!(set::CciaSet, fun_name::AbstractString,
                value_name::AbstractString = VERSIONED_DEFAULT_VAL;
                threshold::Real = _COHORT_MODZ_THRESHOLD) =
     cohort_qc!(set, fun_name, value_name, _cohort_keys(fun_name); threshold = threshold)
+
+# Value_names actually banked for a fun across the set's included images — the on-disk QC filenames
+# under each image's qc/{fun}/ dir. Different producers bank under different value_names (segment/
+# tracking under "default"; clustering per label set, e.g. "T"/"B"), so a cohort check must DISCOVER
+# them rather than assume "default" (which is why a plain `get_cohort_qc(fun)` on clustering returned
+# n=0). Sorted + distinct; empty if the fun banked nothing anywhere in the set.
+function cohort_value_names(set::CciaSet, fun_name::AbstractString)::Vector{String}
+    vns = Set{String}()
+    for img in filter(image_included, images(set))
+        fdir = qc_fun_dir(img, fun_name)
+        isdir(fdir) || continue
+        for f in readdir(fdir)
+            endswith(f, ".json") && push!(vns, f[1:end-5])
+        end
+    end
+    sort(collect(vns))
+end
+
+# READ-ONLY: cohort summary for EVERY value_name a fun banked across the set → {value_name => doc}.
+# How a caller that doesn't know the suffix (the observer, the in-app button) gets per-label-set
+# cohorts — T-cells and B-cells as SEPARATE cohorts, which is correct (same value_name compared across
+# images). Empty when the fun banked nothing anywhere in the set.
+cohort_qc_for_all(set::CciaSet, fun_name::AbstractString;
+                  threshold::Real = _COHORT_MODZ_THRESHOLD)::Dict{String,Any} =
+    Dict{String,Any}(vn => cohort_qc_for(set, fun_name, vn; threshold = threshold)
+                     for vn in cohort_value_names(set, fun_name))
+
+# PERSIST variant of the above (the "check" action): writes each value_name's sidecar + per-image findings.
+cohort_qc_for_all!(set::CciaSet, fun_name::AbstractString;
+                   threshold::Real = _COHORT_MODZ_THRESHOLD)::Dict{String,Any} =
+    Dict{String,Any}(vn => cohort_qc_for!(set, fun_name, vn; threshold = threshold)
+                     for vn in cohort_value_names(set, fun_name))
 
 read_cohort_qc(set::CciaSet, fun_name::AbstractString, value_name::AbstractString = VERSIONED_DEFAULT_VAL) =
     (p = cohort_qc_path(set, fun_name, value_name); isfile(p) ? JSON3.read(read(p, String)) : nothing)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -4449,6 +4449,35 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test_throws ErrorException cohort_qc_for!(set, "not.aTask", "default")
         end
 
+        @testset "cohort value_name discovery (per label set)" begin
+            set = CciaSet(; dir = mktempdir())
+            # clustering banks per label set: T-tracks tight, B-tracks with one sparse image (c=9)
+            for (uid, nT, nB) in [("a", 40, 22), ("b", 39, 24), ("c", 41, 9)]
+                img = CciaImage(; uid = uid, dir = mktempdir())
+                write_qc(img, "clustTracks.cluster", "T", Dict{String,Any}[];
+                         metrics = Dict{String,Any}("nTracks"=>nT, "nClusters"=>4, "largestClusterFrac"=>0.4))
+                write_qc(img, "clustTracks.cluster", "B", Dict{String,Any}[];
+                         metrics = Dict{String,Any}("nTracks"=>nB, "nClusters"=>3, "largestClusterFrac"=>0.5))
+                push!(set._images, img); push!(set.image_uids, uid)
+            end
+            # discovers the banked label sets (sorted), empty for a fun that banked nothing
+            @test cohort_value_names(set, "clustTracks.cluster") == ["B", "T"]
+            @test cohort_value_names(set, "segment.cellpose") == String[]
+            # per-value_name cohorts: T and B are SEPARATE cohorts
+            allc = cohort_qc_for_all(set, "clustTracks.cluster")
+            @test Set(keys(allc)) == Set(["B", "T"])
+            @test allc["T"]["valueName"] == "T" && allc["B"]["valueName"] == "B"
+            # the sparse B image (c) flags in the B cohort, not the T cohort
+            @test haskey(allc["B"]["metrics"]["nTracks"]["outliers"], "c")
+            @test !haskey(allc["T"]["metrics"]["nTracks"]["outliers"], "c")
+            @test !isfile(cohort_qc_path(set, "clustTracks.cluster", "B"))   # read-only wrote nothing
+            # persist variant writes each label set's sidecar
+            allw = cohort_qc_for_all!(set, "clustTracks.cluster")
+            @test isfile(cohort_qc_path(set, "clustTracks.cluster", "B"))
+            @test isfile(cohort_qc_path(set, "clustTracks.cluster", "T"))
+            @test occursin("(B)", join(cohort_qc_summary_lines(allw["B"])))   # label set named in the summary
+        end
+
         @testset "register_cohort_metrics! (custom-module opt-in)" begin
             fun = "customExamples.qcProbeTest"
             @test !haskey(COHORT_METRICS, fun)                       # unknown → cohort errors

--- a/frontend/src/lib/cohortCheck.ts
+++ b/frontend/src/lib/cohortCheck.ts
@@ -45,7 +45,13 @@ export async function runCohortCheck(projectUid: string, setUid: string,
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ projectUid, setUid, funName }),
       })
-      if (res.ok) docs.push(await res.json())
+      if (!res.ok) continue
+      const body = await res.json()
+      // No valueName sent → the server checks EVERY value_name the fun banked and returns a
+      // `byValueName` map (clustering is per label set T/B; segment/tracking under "default"). Fold each
+      // per-label-set cohort into the summary; a single-doc response (explicit valueName) is pushed as-is.
+      if (body?.byValueName) docs.push(...(Object.values(body.byValueName) as CohortDoc[]))
+      else docs.push(body)
     } catch { /* skip this fun; others still report */ }
   }
   return summariseCohortResult(docs)

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -77,7 +77,7 @@ def get_qc_metrics(project_uid: str, image_uid: str) -> dict:
 
 
 @mcp.tool()
-def get_cohort_qc(project_uid: str, set_uid: str, fun_name: str, value_name: str = "default") -> dict:
+def get_cohort_qc(project_uid: str, set_uid: str, fun_name: str, value_name: str | None = None) -> dict:
     """Cohort QC for one task across a set's images — the way to spot an outlier run ("image 7 has 8×
     fewer cells than the cohort"). Aggregates the objective metric each task banks, over the set's
     INCLUDED images, into mean/SD + z-scored outliers.
@@ -94,14 +94,21 @@ def get_cohort_qc(project_uid: str, set_uid: str, fun_name: str, value_name: str
       - "behaviour.hmm_transitions"  → nTransitions, nDistinctTransitions
       - "clustPops.cluster"          → nCells, nClusters, largestClusterFrac
       - "clustTracks.cluster"        → nTracks, nClusters, largestClusterFrac
-    `value_name` is the output variant (default "default").
 
-    Returns {funName, valueName, nIncluded, metrics: {<key>: {n, median, mad, mean, sd, threshold,
+    **LEAVE value_name UNSET** unless you have a specific one. A task banks its QC under a value_name,
+    and different tasks use different ones: segment/tracking bank under "default", but CLUSTERING banks
+    PER LABEL SET (e.g. "T" and "B" — T-cells and B-cells). With no value_name, this returns every one
+    the fun actually banked, so you don't have to know the suffix:
+       {funName, valueNames: [...], byValueName: {"T": <doc>, "B": <doc>}}
+    (that is why a bare clustering query used to come back empty — it defaulted to "default", where
+    clustering banks nothing). Pass an explicit value_name only to get that single label set's <doc>.
+
+    Each <doc> is {funName, valueName, nIncluded, metrics: {<key>: {n, median, mad, mean, sd, threshold,
     outliers: {imageUid: {value, z|relDev}}}}}. Outliers use a robust modified z-score (median/MAD) —
     the entry carries `z` (that score); when the cohort has no spread (MAD 0, ≥half identical) it
     carries `relDev` (relative departure) instead. Either way a clear outlier flags even at n=3. An
-    `outliers` map with entries is the flag worth a note — name the image, its value, and the cohort
-    median (numbers in the detail). `n` < 3 ⇒ too few images to judge. Advisory; reads current data."""
+    `outliers` map with entries is the flag worth a note — name the image, the LABEL SET, its value, and
+    the cohort median (numbers in the detail). `n` < 3 ⇒ too few images to judge. Advisory; reads current data."""
     return _client.get_cohort_qc(project_uid, set_uid, fun_name, value_name)
 
 


### PR DESCRIPTION
## Cohort QC discovers value_names (per label set) instead of assuming "default"

Cohort QC compares one metric across a set under **one** `value_name` — but tasks bank under different ones: segmentation/tracking under `"default"`, **clustering per label set** (e.g. `T`, `B`). So `get_cohort_qc(fun)` defaulting to `"default"` returned **n=0** for clustering, and the observer missed cluster outliers unless it manually discovered the suffixes (as an external session had to).

### Change
- `cohort_value_names(set, fun)` — the value_names a fun *actually banked* across the set (scans the QC sidecars).
- `cohort_qc_for_all[!](set, fun)` — a cohort **per** value_name → `{value_name => doc}` (T-cells and B-cells stay separate cohorts, which is correct).
- **`GET`/`POST /api/qc/cohort` without `valueName`** now return `{funName, valueNames, byValueName}`; an explicit `valueName` still returns the single doc (backward-compatible).
- **MCP `get_cohort_qc`**: `value_name` optional — omit it to get every label set; docstring + observer prompt updated to say so (and why a bare clustering query used to look empty).
- Frontend `runCohortCheck` folds each label set's doc into the summary.
- The cohort lab-log summary now names the label set (e.g. `clustTracks.cluster (B): …`).

### Tests
Package **1185** (discovery + per-label-set outlier), API cohort **16/16** (`byValueName` GET/POST), MCP **32**, typecheck clean.

> ⚠️ **Response-shape change:** callers that omitted `valueName` expecting the old single "default" doc get `byValueName` now (internal consumers updated; explicit `valueName` unchanged).
> ⚠️ Requires a **backend restart** (route logic in `api/src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
