### PR TITLE
Cohort check: detailed lab-log entry + amber button (no toasts)

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -1037,16 +1037,20 @@ function api_qc_cohort_check(body_bytes::Vector{UInt8})
     catch e
         return 404, JSON3.write((; error = sprint(showerror, e)))
     end
-    # Cecelia authors a lab-log summary ONLY for docs that flagged (an all-clear would be noise; the
-    # toast covers that). Best-effort — a lab-log hiccup never fails the check. Author "Cecelia — …" so
-    # the append route treats it as a Cecelia digest (no observer re-broadcast).
+    # Cecelia authors a "Cohort check" lab-log entry ONLY for docs that flagged (an all-clear would be
+    # noise). This is the cross-image analysis — image NAMES, the metric, its value vs the cohort median
+    # — the durable record the amber button points at (no toast). Best-effort; a lab-log hiccup never
+    # fails the check. Author "Cecelia — …" so the append route treats it as a Cecelia entry.
+    name_by = Dict(img.uid => img.name for img in images(set))
+    name_of(uid) = get(name_by, string(uid), string(uid))
     log_flagged(docs) = begin
         flagged = [d for d in docs if d isa AbstractDict && Cecelia.cohort_has_outliers(d)]
         isempty(flagged) && return
         try
             proj = load_project(project_uid)
             for d in flagged
-                Cecelia.append_lab_log!(proj, "Cecelia — Cohort QC", Cecelia.cohort_qc_summary_lines(d))
+                Cecelia.append_lab_log!(proj, "Cecelia — Cohort check",
+                                        Cecelia.cohort_qc_summary_lines(d; name_of = name_of))
             end
         catch e
             @warn "cohort check: lab-log append failed" exception = e

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -751,6 +751,11 @@ end
         @test haskey(JSON3.read(bc), :byValueName)
         _check((; projectUid = proj.uid, setUid = s.uid, funName = "clustTracks.cluster"))
         @test isfile(joinpath(tmp, proj.uid, "1", s.uid, "qc", "cohort", "clustTracks.cluster", "B.json"))
+        # the cross-image detail lands in the lab log under a "[Cecelia — Cohort check]" entry, by image
+        # NAME (i1), with the label set and value-vs-median — not just a bare count
+        ll = JSON3.read(api_lablog_read(HTTP.Request("GET", "/api/lablog?projectUid=$(proj.uid)"))[2]).content
+        @test occursin("Cohort check", ll) && occursin("clustTracks.cluster (B)", ll)
+        @test occursin("i1 — nTracks", ll) && occursin("cohort median", ll)   # image NAME + detail
     finally
         had ? (dirs["projects"] = old) : delete!(dirs, "projects")
         rm(tmp; recursive = true, force = true)

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -203,7 +203,9 @@ function cohort_has_outliers(doc::AbstractDict)
         values(get(doc, "metrics", Dict())))
 end
 
-function cohort_qc_summary_lines(doc::AbstractDict)
+# `name_of(uid)` resolves an image uid → its human name (default: the uid) so the lab-log lines read
+# with image NAMES, not opaque uids — the caller (the check route) passes the set's uid→name map.
+function cohort_qc_summary_lines(doc::AbstractDict; name_of = identity)
     fun = string(get(doc, "funName", "?")); n = get(doc, "nIncluded", 0)
     vn  = string(get(doc, "valueName", ""))
     # name the label set when it isn't the default, so per-label-set cohorts (clustTracks.cluster on
@@ -215,7 +217,7 @@ function cohort_qc_summary_lines(doc::AbstractDict)
         med = get(m, "median", nothing)
         for (uid, e) in get(m, "outliers", Dict())
             val = (e isa AbstractDict) ? get(e, "value", nothing) : nothing
-            push!(outs, "  $(uid) — $(mk) $(val) (cohort median $(med))")
+            push!(outs, "  $(name_of(string(uid))) — $(mk) $(val) (cohort median $(med))")
         end
     end
     isempty(outs) ?

--- a/frontend/src/components/CohortCheckButton.vue
+++ b/frontend/src/components/CohortCheckButton.vue
@@ -1,37 +1,38 @@
 <script setup lang="ts">
 // "Check cohort consistency" — runs cohort QC for the module's stage fun_names over the current set
-// (POST /api/qc/cohort/check, which persists per-image outlier findings + a [Cecelia] lab-log line).
-// Shown only for modules that bank cohort metrics (cohortFunsFor). Feedback is a toast; the durable
-// record is the lab log. See docs/todo/QC_OBSERVER_PLAN.md (A3) + the toast convention in INVENTORY.md.
+// (POST /api/qc/cohort/check, which persists per-image outlier findings + a [Cecelia — Cohort check]
+// lab-log entry with the cross-image detail). Shown only for modules that bank cohort metrics
+// (cohortFunsFor). NO toast — the durable, detailed record is the lab log; the button just goes AMBER
+// when the last run flagged something, pointing the user there. See docs/todo/QC_OBSERVER_PLAN.md (A3).
 import { computed, ref } from 'vue'
-import { useToast } from 'primevue/usetoast'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { cohortFunsFor } from '../lib/cohortStages'
 import { runCohortCheck } from '../lib/cohortCheck'
-import { SEVERITY } from '../lib/severity'
 
 // `funs` overrides the built-in COHORT_STAGES lookup — passed by pages whose cohort funs come from the
 // backend (custom modules: funNames ∩ COHORT_METRICS), so the button needs no hardcoded per-page entry.
 const props = defineProps<{ module?: string; setUid?: string; funs?: string[] }>()
-const toast = useToast()
 const projectMeta = useProjectMetaStore()
 const busy = ref(false)
+const foundWarnings = ref(false)   // last run flagged an outlier → amber + "see the lab log" tooltip
 
 const funs = computed(() => props.funs?.length ? props.funs : cohortFunsFor(props.module))
 const canCheck = computed(() => funs.value.length > 0 && !!props.setUid && !!projectMeta.current?.uid)
+const tip = computed(() => foundWarnings.value
+  ? 'Cohort check found warnings — check the lab log for details'
+  : 'Flag images whose output is an outlier vs the rest of the set')
 
 async function check() {
   const projectUid = projectMeta.current?.uid
   if (!projectUid || !props.setUid || busy.value) return
   busy.value = true
-  toast.add({ severity: 'info', summary: 'Cohort QC', detail: 'Checking cohort consistency…', life: 2000 })
   try {
     const r = await runCohortCheck(projectUid, props.setUid, funs.value)
-    // severity maps to the traffic-light scale; 'ok'→success, 'warn'→warn (PrimeVue severities)
-    toast.add({ severity: r.severity === 'ok' ? 'success' : 'warn',
-                summary: `${SEVERITY[r.severity].emoji} Cohort QC`, detail: r.message, life: 4000 })
-  } catch {
-    toast.add({ severity: 'error', summary: 'Cohort QC', detail: 'Check failed — see console.', life: 4000 })
+    // No toast: the cross-image detail is written to the [Cecelia — Cohort check] lab-log entry. The
+    // button turns amber when something flagged so the user knows to look there; clears when clean.
+    foundWarnings.value = r.severity === 'warn'
+  } catch (e) {
+    console.error('cohort check failed', e)
   } finally {
     busy.value = false
   }
@@ -39,9 +40,9 @@ async function check() {
 </script>
 
 <template>
-  <button v-if="canCheck" class="cohort-check-btn" :disabled="busy" @click="check"
-          v-tooltip.bottom="'Flag images whose output is an outlier vs the rest of the set'">
-    <i :class="['pi', busy ? 'pi-spin pi-spinner' : 'pi-chart-bar']" />
+  <button v-if="canCheck" class="cohort-check-btn" :class="{ warn: foundWarnings }" :disabled="busy"
+          @click="check" v-tooltip.bottom="tip">
+    <i :class="['pi', busy ? 'pi-spin pi-spinner' : (foundWarnings ? 'pi-exclamation-triangle' : 'pi-chart-bar')]" />
     {{ busy ? 'Checking…' : 'Check cohort' }}
   </button>
 </template>
@@ -55,4 +56,7 @@ async function check() {
 .cohort-check-btn:hover:not(:disabled) { border-color: var(--cc-accent); }
 .cohort-check-btn:disabled { opacity: 0.6; cursor: default; }
 .cohort-check-btn .pi { font-size: 0.72rem; }
+/* amber when the last check flagged an outlier — the cross-image detail is in the lab log */
+.cohort-check-btn.warn { color: var(--cc-sev-warn); border-color: var(--cc-sev-warn); background: rgba(250, 178, 25, 0.1); }
+.cohort-check-btn.warn:hover:not(:disabled) { border-color: var(--cc-sev-warn); }
 </style>

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -8,7 +8,6 @@ import { ref, computed, watch, nextTick } from 'vue'
 import { isAuthError, observerSetupReason } from '../utils/observerSetup'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
-import { useToast } from 'primevue/usetoast'
 import { useObserverStore } from '../stores/observer'
 import { useLabCaptureStore } from '../stores/labCapture'
 import { buildChatPrompt } from '../lib/chatHandoff'
@@ -42,10 +41,12 @@ const mode = computed(() => settings.labLogMode)
 // v-if'd panel closing); the panel just drives the "Ask Claude" pass + shows its activity.
 const observer = useObserverStore()
 const labCapture = useLabCaptureStore()
-const toast = useToast()
+const chatCopied = ref(false)              // brief "Prompt copied" state on the Chat-to-Claude button
+let chatCopiedTimer: ReturnType<typeof setTimeout> | null = null
 
 // Chat to Claude: copy a starter prompt (project context + MCP pointer) to the clipboard for a full
 // external session. Re-copies on each click. Works for any MCP assistant — no `claude` install needed.
+// No toast — the button flashes "Prompt copied" (colour + tooltip) for a couple of seconds instead.
 async function chatToClaude() {
   if (!projectUid.value) return
   const text = buildChatPrompt(projectUid.value, pm.current?.name)
@@ -56,8 +57,9 @@ async function chatToClaude() {
     ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0'
     document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta)
   }
-  toast.add({ severity: 'info', summary: 'Prompt copied',
-              detail: 'Paste it into Claude (or any MCP chat bot) to start.', life: 3500 })
+  chatCopied.value = true
+  if (chatCopiedTimer) clearTimeout(chatCopiedTimer)
+  chatCopiedTimer = setTimeout(() => { chatCopied.value = false }, 2500)
 }
 const observerAvailable = computed(() => observer.available)
 const observerBusy = computed(() => observer.busy)
@@ -316,9 +318,10 @@ async function toggleMute(category: string) {
       </select>
       <!-- Chat to Claude: hand off to a FULL external session (any MCP assistant), not the in-app
            one-shot. Copies a starter prompt; no `claude` install needed. -->
-      <button class="ll-capture" :disabled="!projectUid" @click="chatToClaude"
-              v-tooltip.top="'Copy a starter prompt to your clipboard — paste it into Claude Code (or any MCP assistant) for a full chat about this project'">
-        <i class="pi pi-comments" /> Chat to Claude
+      <button class="ll-capture" :class="{ copied: chatCopied }" :disabled="!projectUid" @click="chatToClaude"
+              v-tooltip.top="chatCopied ? 'Prompt copied — paste it into Claude (or any MCP chat bot)'
+                : 'Copy a starter prompt to your clipboard — paste it into Claude Code (or any MCP assistant) for a full chat about this project'">
+        <i :class="['pi', chatCopied ? 'pi-check' : 'pi-comments']" /> {{ chatCopied ? 'Copied' : 'Chat to Claude' }}
       </button>
       <span v-if="observerTokens" class="ll-tokens"
             v-tooltip.top="'Assistant token use for this observer session (real usage)'">{{ observerTokens }}</span>
@@ -475,6 +478,8 @@ async function toggleMute(category: string) {
   border-radius: 0.35rem; padding: 0.2rem 0.5rem; font-size: 0.7rem; cursor: pointer;
 }
 .ll-capture:hover:not(:disabled) { border-color: #8b949e; }
+/* brief "copied" flash on the Chat-to-Claude button (replaces the toast) */
+.ll-capture.copied { color: var(--cc-sev-ok); border-color: var(--cc-sev-ok); background: rgba(12, 163, 12, 0.1); }
 .ll-capture:disabled { opacity: 0.5; cursor: default; }
 .ll-auto { display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.7rem; color: var(--cc-text-dim); cursor: pointer; }
 .ll-model {


### PR DESCRIPTION
## Cohort check: detailed lab-log entry + amber button (no toasts)

Makes the "Check cohort" result carry the actual cross-image analysis, and replaces the out-of-context toast notifications with inline button feedback (matching the rest of the app).

### Cohort check → a real lab-log entry
The check now writes a distinct **`[Cecelia — Cohort check]`** entry with the cross-image detail — **image names** (not uids), the label set, and the value vs the cohort median — so it's visibly different from the per-task Cecelia digest (which reports each task's own QC). E.g. `clustTracks.cluster (B): 1 outlier … M3a — nTracks 9 (cohort median 23)`.

### Cohort button: amber, no toast
- No toast. While running it shows the spinner (like every other button).
- When the last run **flagged** an outlier, the button turns **amber** with a warning icon and the tooltip *"Cohort check found warnings — check the lab log for details."* Clears when a run comes back clean.

### Chat-to-Claude button: copied flash, no toast
- No toast. On click it briefly flashes green **"Copied"** (2.5 s) with a *"Prompt copied"* tooltip.

### Tests
Package **1185**, frontend **235**, API cohort **18/18** (asserts the lab-log entry has the image name + label set + median), typecheck clean.

> ⚠️ Requires a **backend restart** — cohort route logic is in `api/src`.
> Lab-log author string changed `Cecelia — Cohort QC` → `Cecelia — Cohort check` (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
