### PR TITLE
Surface excluded images (observer + count note)

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -903,7 +903,8 @@ function api_images_list(req::HTTP.Request)
     sets = [(; uid=s.uid, name=s.name, imageCount=length(s.image_uids)) for s in proj._sets]
     imgs = Vector{Any}()
     for s in proj._sets, img in images(s)
-        push!(imgs, (; uid=img.uid, name=img.name, status=img.status, setUid=s.uid, setName=s.name))
+        push!(imgs, (; uid=img.uid, name=img.name, status=img.status,
+                       included=image_included(img), setUid=s.uid, setName=s.name))
     end
     200, JSON3.write((; projectUid=project_uid, name=proj.name, kind=proj.kind,
                         count=length(imgs), sets, images=imgs))

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -469,7 +469,15 @@ end
             names = [i.name for i in r.images]
             @test "img-1" in names && "img-2" in names
             @test all(i -> i.setName == "set-A", r.images)
+            @test all(i -> i.included == true, r.images)          # included surfaced (default true)
         end
+        # excluding an image surfaces as included:false (so the observer can see the silent member)
+        img1.included = false; save!(img1)
+        let r = JSON3.read(api_images_list(HTTP.Request("GET", "/api/images?projectUid=$uid"))[2])
+            byname = Dict(i.name => i for i in r.images)
+            @test byname["img-1"].included == false && byname["img-2"].included == true
+        end
+        img1.included = true; save!(img1)                          # restore for the rest of the testset
         @test api_images_list(HTTP.Request("GET", "/api/images"))[1] == 400          # projectUid missing
         @test api_images_list(HTTP.Request("GET", "/api/images?projectUid=nope"))[1] == 404
 

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -270,6 +270,12 @@ const visibleUids = computed<string[]>(() =>
               {{ activeSet.images.length }}
             </template>
             image{{ activeSet.images.length !== 1 ? 's' : '' }}
+            <!-- an excluded image is still a "done" set member — call it out so the count isn't silently
+                 over (excluded images drop out of analysis / cohort denominators). -->
+            <span v-if="excludedCount > 0" class="excluded-note"
+                  v-tooltip.top="`${excludedCount} image(s) excluded from analysis — not counted downstream`">
+              &nbsp;({{ excludedCount }} excluded)
+            </span>
             <template v-if="selectedUids.length">
               &nbsp;·&nbsp;{{ selectedUids.length }} selected
             </template>
@@ -481,6 +487,7 @@ const visibleUids = computed<string[]>(() =>
   align-items: center;
   gap: 0.4rem;
 }
+.excluded-note { color: var(--cc-sev-warn); }
 
 .filter-badge {
   font-size: 0.65rem;

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -32,12 +32,18 @@ mcp = FastMCP("cecelia-observer")
 
 @mcp.tool()
 def get_project_info(project_uid: str) -> dict:
-    """Project summary: name, kind, image count, its sets, and a per-status breakdown of images."""
+    """Project summary: name, kind, image count, its sets, a per-status breakdown, and `excludedCount`
+    — how many images are EXCLUDED (included:false). An excluded image is a silent member: it still
+    sits in the set as "done", so anything counting "images in the set" (cohort denominators, figures)
+    is over by that many. If excludedCount > 0, check list_images/get_image_notes for which and why."""
     data = _client.list_images(project_uid)
     statuses: dict[str, int] = {}
+    excluded = 0
     for img in data.get("images", []):
         s = img.get("status", "?")
         statuses[s] = statuses.get(s, 0) + 1
+        if img.get("included") is False:
+            excluded += 1
     return {
         "projectUid": project_uid,
         "name": data.get("name"),
@@ -45,12 +51,15 @@ def get_project_info(project_uid: str) -> dict:
         "imageCount": data.get("count"),
         "sets": data.get("sets"),
         "statusBreakdown": statuses,
+        "excludedCount": excluded,
     }
 
 
 @mcp.tool()
 def list_images(project_uid: str) -> list:
-    """Every image in the project: uid, name, processing status, and which set it belongs to."""
+    """Every image in the project: uid, name, processing status, which set it belongs to, and
+    `included` — false means EXCLUDED from analysis (a silent member; downstream/cohort counts should
+    drop it). An excluded image that is still "done" is intentional but easy to miss — see its note."""
     return _client.list_images(project_uid).get("images", [])
 
 


### PR DESCRIPTION
## Make excluded images visible

An excluded image (`included:false`, e.g. M1d "failed drift correction") still sits in the set as `done` — a **silent member**, so anything counting "images in the set" is quietly over by one. The observer couldn't even tell (it had to read the note). This surfaces exclusion on both fronts:

- **Backend:** `api_images_list` now returns `included` per image.
- **MCP:** `get_project_info` reports `excludedCount` (+ docstring explains the silent-member trap so a cohort/figure count isn't trusted blindly); `list_images` documents the `included` field.
- **UI:** the module image-count shows **"(N excluded)"** in amber when any are excluded, with a tooltip.

Cohort denominators already drop excluded images (`image_included` filter); this makes the exclusion *visible* rather than silent.

### Tests
API `list_images` asserts `included` true/false; MCP 32; typecheck clean.

> ⚠️ Backend restart for the `api/src` route (MCP picks it up on the next Ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
