### PR TITLE
docs: phenotype in observer plan + module-building checklist

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -14,6 +14,22 @@ This document is the authoritative how-to for adding a new analysis function (ta
 
 ---
 
+## Checklist — adding a task (go through every box)
+
+This doc has grown; use this as the run-list. Details for each are in the numbered sections.
+
+- [ ] **Two co-located files, same base name** — `.jl` (struct + `_run_task`) + `.json` (param spec). §1, §3
+- [ ] **Register** in `task_registry.jl` — `_spec_path` overload + `"category.myTask"` in `_fun_name_map`. §4
+- [ ] **`resource_pool`** in the JSON. §3
+- [ ] **Bank QC** — `write_qc` with an objective `metrics` count + a `warn` finding for the bad case, under the task's **`value_name`/`outputValueName`** (NOT hardcoded `"default"` — per label set, so cohort works). §1 → *QC*
+- [ ] **Cohort metrics** — add the keys to `COHORT_METRICS` (built-in) or call `register_cohort_metrics!` (custom). §1 → *QC*
+- [ ] **Observer summary layer** — does this task produce analysable data (measures / pops / clusters / behaviour / **phenotype** / lineage) the AI observer should see? If so, extend the read-only summary route + MCP tool (or add a field), per [`docs/todo/OBSERVER_DATA_ACCESS_PLAN.md`](todo/OBSERVER_DATA_ACCESS_PLAN.md). Don't let a new data type land with the observer blind to it.
+- [ ] **Tests** — dispatch + a bad-param `ParamValidationError`, and a QC finding unit test. §7
+- [ ] **Module page + route + nav** if it needs its own page. §7–§9
+- [ ] **Persist every user-settable option** (no bare `ref()`). §7 → *RULE*
+
+---
+
 ## 1. Julia task handler
 
 Create two co-located files under `app/src/tasks/<category>/`:

--- a/docs/todo/OBSERVER_DATA_ACCESS_PLAN.md
+++ b/docs/todo/OBSERVER_DATA_ACCESS_PLAN.md
@@ -12,6 +12,12 @@ repeatedly hit this wall (reconstructing track counts from clustering inputs bec
 **Goal:** give it as much *decision-useful* information as feasible, **summary-level only** — never
 raw 100 MB tables — plus a synthesized **lineage** so it understands *how* the data was produced.
 
+**Coverage — not just tracking.** Live/tracking projects are the current focus, but many users have
+**static images** where the signal is **phenotype** — per-cell channel intensities + morphology — with
+no tracks at all. Phenotype is a first-class summary target (see `get_measure_summary`), equal to
+motility. **Spatial** / neighbourhood analysis is a future stage (not yet ported) — leave a slot for it,
+don't build it.
+
 ## Locked decisions
 
 1. **Lineage-first.** Build `get_analysis_lineage` (Slice A) before the richer per-stage numbers —
@@ -28,6 +34,10 @@ raw 100 MB tables — plus a synthesized **lineage** so it understands *how* the
    in `mcp/cecelia_mcp/server.py`.
 5. **Two layers, one arc.** Layer 1 = the lineage story; Layer 2 = per-stage summaries. Boards +
    chains feed both.
+6. **New modules wire this layer.** When a module that produces analysable data lands, extending the
+   observer summary layer (a thin route + MCP tool, or a new field on an existing one) is PART of the
+   module — not an afterthought — so the observer never silently goes blind on a new data type. Codified
+   as a checklist in [`docs/MODULES.md`](../MODULES.md) (the module-building doc).
 
 ## Layer 1 — lineage (Slice A)
 
@@ -56,11 +66,12 @@ Each = a read-only `/api` route + an MCP tool returning aggregates (+ caps):
 | Tool | Slice | Returns (summary only) |
 |---|---|---|
 | `get_populations` | B | pop tree: names, type (gate/clust/track), **gate defs** (channels/measures + gate kind), **membership counts** (n cells/tracks per pop) |
-| `get_measure_summary` | C | per pop/image: median + quantiles + n for speed / displacement / track-length (+ key cell measures) |
+| `get_measure_summary` | C | per pop/image: median + quantiles + n. **Phenotype** (per-cell channel intensities + morphology) for static images, **and** track motility (speed / displacement / track-length) for live. Static projects have no tracks — phenotype is their whole signal. |
 | `get_behaviour_summary` | D | HMM state distribution (fraction per state), n transitions / distinct |
 | `get_cluster_summary` | D | n clusters, sizes, largestFrac, feature list, per label set |
 | `get_analysis_boards` | E | what plots exist (type, data source, pops/measures plotted) |
 | `get_chains` | E | whiteboard chain templates (which tasks wired) |
+| *(spatial)* | *future* | neighbourhood / proximity summaries — **not yet ported**; leave the slot, don't build |
 
 ## Build slices (each shippable)
 


### PR DESCRIPTION
Two doc updates gating the observer-data-access build (#10):

- **`OBSERVER_DATA_ACCESS_PLAN.md`** — the plan was tracking-centric; now it covers **static-image projects** where the signal is **phenotype** (per-cell channel intensities + morphology, first-class alongside motility), marks **spatial** as a future/unported slot, and adds the principle that **new modules wire the observer summary layer** as part of the module.
- **`MODULES.md`** — the module-building doc has grown, so add a **checklist** an agent can go through when adding a task: two co-located files, register, `resource_pool`, **QC under the run value_name (not hardcoded "default")**, `COHORT_METRICS`/`register_cohort_metrics!`, the **observer summary layer**, tests, page/route, persist options.

Docs-only. Closes the module-checklist task; preps #10 Slice A (lineage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
