### PR TITLE
fix(qc): don't create empty per-image cohort.* placeholders

### DIFF
--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -175,14 +175,19 @@ end
 # PERSIST: compute, then write the per-set summary sidecar AND per-image cohort findings — so an
 # outlier surfaces on the IMAGE (table indicator, whiteboard, lab log, MCP), not just in the sidecar.
 # Per-image findings go under the `cohort.{fun}` namespace so they never clobber the task's own `{fun}`
-# QC doc; EVERY included image is written (empty ⇒ clears a stale cohort warning, so a fixed cohort
-# un-flags). This is the explicit user/auto action (POST /api/qc/cohort/check), never a GET.
+# QC doc. Write an image ONLY when it has a finding, or to CLEAR an existing `cohort.{fun}` doc (a
+# fixed cohort un-flags) — never create a fresh empty placeholder on an image that never flagged
+# (that put an empty `cohort.{fun}.json` on every image on every check). This is the explicit
+# user/auto action (POST /api/qc/cohort/check), never a GET.
 function cohort_qc!(set::CciaSet, fun_name::AbstractString, value_name::AbstractString,
                     metric_keys::AbstractVector; threshold::Real = _COHORT_MODZ_THRESHOLD)
     doc, imgs, img_findings = _cohort_compute(set, fun_name, value_name, metric_keys; threshold)
     cohort_fun = "cohort." * string(fun_name)
     for img in imgs
-        write_qc(img, cohort_fun, value_name, img_findings[img.uid])
+        findings = img_findings[img.uid]
+        # skip empty placeholders: write only when there's a finding, or when clearing a prior doc
+        (isempty(findings) && !isfile(qc_path(img, cohort_fun, value_name))) && continue
+        write_qc(img, cohort_fun, value_name, findings)
     end
     path = cohort_qc_path(set, fun_name, value_name); mkpath(dirname(path))
     open(path, "w") do io; JSON3.write(io, doc); end

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -4436,16 +4436,24 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test isfile(cohort_qc_path(set, "segment.measureLabels", "default"))
             @test read_cohort_qc(set, "segment.measureLabels", "default")["nIncluded"] == 10
             @test haskey(read_all_cohort_qc(set), "segment.measureLabels/default")
-            # per-image write-back: the outlier (j) gets a cohort finding ON the image; a normal one
-            # (a) is written empty (no stale flag). Under the cohort.* namespace, merged by read_all_qc.
+            # per-image write-back: the outlier (j) gets a cohort finding ON the image. A normal image
+            # (a) is NOT written — no empty placeholder (that would put an empty cohort.* doc on every
+            # image on every check). Under the cohort.* namespace, merged by read_all_qc.
             byid = Dict(i.uid => i for i in set._images)
             fj = read_qc(byid["j"], "cohort.segment.measureLabels", "default")
             @test fj !== nothing && !isempty(fj["findings"])
             @test fj["findings"][1]["code"] == "cohort.nCells" && fj["findings"][1]["level"] == "warn"
             @test occursin("below", fj["findings"][1]["long"])         # 100 < median 800
-            fa = read_qc(byid["a"], "cohort.segment.measureLabels", "default")
-            @test fa !== nothing && isempty(fa["findings"])
+            @test read_qc(byid["a"], "cohort.segment.measureLabels", "default") === nothing
             @test haskey(read_all_qc(byid["j"]), "cohort.segment.measureLabels/default")
+            # clear-stale: bump the outlier back into range and re-check → j's prior cohort doc is
+            # CLEARED (written empty, un-flags), not left as a stale warning
+            byid["j"].included = true
+            write_qc(byid["j"], "segment.measureLabels", "default", Dict{String,Any}[];
+                     metrics = Dict{String,Any}("nCells" => 801))
+            cohort_qc_for!(set, "segment.measureLabels", "default")
+            fj2 = read_qc(byid["j"], "cohort.segment.measureLabels", "default")
+            @test fj2 !== nothing && isempty(fj2["findings"])          # existing doc cleared, not deleted
             # excluded images drop out of the cohort
             set._images[1].included = false                      # exclude one
             @test cohort_qc_for!(set, "segment.measureLabels", "default")["nIncluded"] == 9


### PR DESCRIPTION
## What

`cohort_qc!` wrote a `cohort.{fun}` doc on **every** included image on every check, so a normal (non-outlier) image accumulated an empty `cohort.{fun}.json` placeholder even when it never flagged and had no prior doc to clear (the "bank under default" noise from task #6).

Now an image is written only when it has a cohort finding, **or** to clear an existing `cohort.{fun}` doc — so a fixed cohort still un-flags. No behaviour change for outliers or for clearing stale warnings; only the empty-placeholder churn is gone.

## Why

Closes the last item from the QC/cohort arc: empty per-image placeholders made it look like a cohort was computed on images that had nothing comparable, and littered `qc/cohort.*/` on every image.

## Tests

`pixi run test-pkg` (1189 pass). Updated the cohort round-trip test (a normal image is no longer written) and added clear-stale coverage: a prior outlier's `cohort.*` doc is written empty on re-check when the metric returns to range.

## Reservation

Behaviour change to persisted on-disk `cohort.*` docs. Covered by the updated + new package tests, but not yet exercised against a live project's existing on-disk state (old empty placeholders from prior checks remain until their fun is re-checked; harmless — they read as "no findings").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
