### PR TITLE
refactor(observer): shared summary scaffold + artifact-aware rollup

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -1041,30 +1041,11 @@ function api_qc_cohort_runs(req::HTTP.Request)
     200, JSON3.write((; funName = fun_name, runs = runs))
 end
 
-# GET /api/analysis/lineage?projectUid[&imageUid][&setUid] — the synthesized analysis lineage: per
-# image the ordered pipeline steps + segmentation/track/cluster/gating links, plus project chains,
-# board tabs and a set-level roll-up. READ-ONLY, summary-level (see analysis_lineage / Slice A of
-# OBSERVER_DATA_ACCESS_PLAN). Lets the observer understand HOW the data was produced without the user
-# re-explaining the workflow each session.
-function api_analysis_lineage(req::HTTP.Request)
-    q = HTTP.queryparams(HTTP.URI(req.target))
-    project_uid = get(q, "projectUid", "")
-    isempty(project_uid) && return 400, JSON3.write((; error = "projectUid required"))
-    proj = try load_project(project_uid) catch e
-        return 404, JSON3.write((; error = sprint(showerror, e)))
-    end
-    lin = try
-        analysis_lineage(proj; image_uid = get(q, "imageUid", ""), set_uid = get(q, "setUid", ""))
-    catch e
-        return 500, JSON3.write((; error = sprint(showerror, e)))
-    end
-    200, JSON3.write(lin)
-end
-
-# GET /api/analysis/populations?projectUid[&imageUid][&setUid] — per-image population DEFINITIONS
-# (tree + gate/filter specs), the detail behind the lineage's gatedPops. READ-ONLY, cheap (sidecar
-# read only; membership counts are Slice C). See populations_summary / OBSERVER_DATA_ACCESS_PLAN.
-function api_analysis_populations(req::HTTP.Request)
+# Shared GET handler for the observer's project-scoped summary routes (analysis/*): parse projectUid +
+# optional image/set scope, load the project (404), run `build(proj, image_uid, set_uid)` (500), return
+# JSON. Each route is then a one-liner over its builder — the same consolidation as the Julia
+# `observer_image_summary` scaffold and the MCP `_analysis_summary` client helper.
+function _observer_summary_route(req::HTTP.Request, build::Function)
     q = HTTP.queryparams(HTTP.URI(req.target))
     project_uid = get(q, "projectUid", "")
     isempty(project_uid) && return 400, JSON3.write((; error = "projectUid required"))
@@ -1072,12 +1053,21 @@ function api_analysis_populations(req::HTTP.Request)
         return 404, JSON3.write((; error = sprint(showerror, e)))
     end
     out = try
-        populations_summary(proj; image_uid = get(q, "imageUid", ""), set_uid = get(q, "setUid", ""))
+        build(proj, get(q, "imageUid", ""), get(q, "setUid", ""))
     catch e
         return 500, JSON3.write((; error = sprint(showerror, e)))
     end
     200, JSON3.write(out)
 end
+
+# GET /api/analysis/lineage — synthesized pipeline (steps + seg/track/cluster/gating links, chains,
+# boards, rollup). GET /api/analysis/populations — the gate/filter DEFINITIONS behind lineage's
+# gatedPops. Both READ-ONLY, summary-level. See analysis_lineage / populations_summary and Slices A/B
+# of OBSERVER_DATA_ACCESS_PLAN.
+api_analysis_lineage(req::HTTP.Request) =
+    _observer_summary_route(req, (p, i, s) -> analysis_lineage(p; image_uid = i, set_uid = s))
+api_analysis_populations(req::HTTP.Request) =
+    _observer_summary_route(req, (p, i, s) -> populations_summary(p; image_uid = i, set_uid = s))
 
 # POST /api/qc/cohort/check — the explicit "Check cohort consistency" action: recompute AND persist
 # (set sidecar + per-image `cohort.{fun}` findings so outliers surface on the image). Body:

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -166,6 +166,7 @@ include("napari.jl")
 include("ai/observer_prompt.jl")
 include("ai/agent_runner.jl")
 include("ai/observer_session.jl")
+include("ai/observer_summary.jl")
 include("ai/lineage.jl")
 include("ai/populations.jl")
 export analysis_lineage, populations_summary

--- a/app/src/ai/lineage.jl
+++ b/app/src/ai/lineage.jl
@@ -71,7 +71,7 @@ end
 function _image_lineage(img::CciaImage)
     segs    = sort(img_value_names(img))                                      # segmentations (label_props keys), stable order
     tracked = String[v for v in segs if isfile(img_track_props_path(img, v))]  # those with a __tracks table
-    (; uid = img.uid, name = img.name, included = image_included(img),
+    (; _observer_image_header(img)...,
        steps         = _run_log_steps(img),
        segmentations = segs,
        tracked       = tracked,
@@ -109,11 +109,25 @@ function _board_tabs(proj::CciaProject)
     names
 end
 
-# Set-level roll-up: the common pipeline (every stage anyone ran, in canonical order) and where images
-# diverge from it — an image missing a stage the others ran, or one that's excluded. Ties to #9.
+# The stages an image reached — from run-log steps UNION artifact evidence. A stage counts as present
+# if a dated step OR a produced artifact shows it (segmentations→segment, tracked→track, clusterRuns→
+# cluster, gatedPops→gate). This matters because the run log is a recent, capped window: a segmentation
+# or tracking that predates it leaves no step but its artifacts persist, so a step-only rollup would
+# false-flag "missing segment/track" on images that plainly have them.
+function _image_stages(e)
+    st = String[s.stage for s in e.steps]
+    isempty(e.segmentations) || push!(st, "segment")
+    isempty(e.tracked)       || push!(st, "track")
+    isempty(e.clusterRuns)   || push!(st, "cluster")
+    isempty(e.gatedPops)     || push!(st, "gate")
+    unique(st)
+end
+
+# Set-level roll-up: the common pipeline (every stage anyone reached, in canonical order) and where
+# images diverge from it — an image missing a stage the others reached, or one that's excluded. Ties to #9.
 function _lineage_rollup(entries::AbstractVector)
     isempty(entries) && return (; pipeline = String[], divergences = Any[])
-    seqs = Dict(e.uid => unique(String[s.stage for s in e.steps]) for e in entries)
+    seqs = Dict(e.uid => _image_stages(e) for e in entries)
     pipeline = _stage_order(unique(vcat(values(seqs)...)))
     divergences = Any[]
     for e in entries
@@ -122,18 +136,6 @@ function _lineage_rollup(entries::AbstractVector)
             push!(divergences, (; uid = e.uid, name = e.name, included = e.included, missingStages = miss))
     end
     (; pipeline = pipeline, divergences = divergences)
-end
-
-# The images a lineage call covers: one image, one set, or the whole project.
-function _lineage_images(proj::CciaProject, image_uid::AbstractString, set_uid::AbstractString)
-    if !isempty(image_uid)
-        i = findfirst(im -> im.uid == image_uid, images(proj))
-        return isnothing(i) ? CciaImage[] : [images(proj)[i]]
-    elseif !isempty(set_uid)
-        s = findfirst(st -> st.uid == set_uid, sets(proj))
-        return isnothing(s) ? CciaImage[] : images(sets(proj)[s])
-    end
-    images(proj)
 end
 
 """
@@ -145,10 +147,9 @@ project-level `chains` (wired templates) and `boards` (tab names) and a `rollup`
 divergences). Summary-level only (names/counts/order), read-only. See OBSERVER_DATA_ACCESS_PLAN.md.
 """
 function analysis_lineage(proj::CciaProject; image_uid::AbstractString = "", set_uid::AbstractString = "")
-    entries = [_image_lineage(img) for img in _lineage_images(proj, image_uid, set_uid)]
-    (; projectUid = proj.uid,
-       images  = entries,
-       chains  = _chain_summaries(proj),
-       boards  = _board_tabs(proj),
-       rollup  = _lineage_rollup(entries))
+    base = observer_image_summary(proj, _image_lineage; image_uid = image_uid, set_uid = set_uid)
+    (; base...,                                # projectUid, images
+       chains = _chain_summaries(proj),
+       boards = _board_tabs(proj),
+       rollup = _lineage_rollup(base.images))
 end

--- a/app/src/ai/observer_summary.jl
+++ b/app/src/ai/observer_summary.jl
@@ -1,0 +1,29 @@
+# Shared scaffold for the read-only observer's per-image summary tools (Slices A–E of
+# docs/todo/OBSERVER_DATA_ACCESS_PLAN.md). Every summary tool has the SAME shape: scope to one image,
+# one set, or the whole project, then map a per-image builder into `{projectUid, images: [...]}`. This
+# holds that shape once so each tool (lineage, populations, and the measure/behaviour/board slices to
+# come) is just its per-image builder — not another copy of the scope/scaffold plumbing. The matching
+# API-route and MCP-client scaffolds live in `api/src/routes.jl` (`_observer_summary_route`) and
+# `mcp/cecelia_mcp/client.py` (`_analysis_summary`).
+
+# The images a summary call covers: one image, one set, or (default) the whole project.
+function _observer_scope_images(proj::CciaProject, image_uid::AbstractString, set_uid::AbstractString)
+    if !isempty(image_uid)
+        i = findfirst(im -> im.uid == image_uid, images(proj))
+        return isnothing(i) ? CciaImage[] : [images(proj)[i]]
+    elseif !isempty(set_uid)
+        s = findfirst(st -> st.uid == set_uid, sets(proj))
+        return isnothing(s) ? CciaImage[] : images(sets(proj)[s])
+    end
+    images(proj)
+end
+
+# The identity header every per-image summary entry starts with, so builders don't each re-spell it.
+_observer_image_header(img::CciaImage) = (; uid = img.uid, name = img.name, included = image_included(img))
+
+# Map a per-image builder over the scope → `{projectUid, images}`. A tool that needs project-level
+# fields too (e.g. lineage's chains/boards/rollup) merges onto this base.
+observer_image_summary(proj::CciaProject, per_image::Function;
+                       image_uid::AbstractString = "", set_uid::AbstractString = "") =
+    (; projectUid = proj.uid,
+       images = [per_image(img) for img in _observer_scope_images(proj, image_uid, set_uid)])

--- a/app/src/ai/populations.jl
+++ b/app/src/ai/populations.jl
@@ -39,6 +39,12 @@ function _image_populations(img::CciaImage)
     (out, false)
 end
 
+# Per-image builder: the identity header + its population definitions (+ a cap flag).
+function _population_image(img::CciaImage)
+    pops, trunc = _image_populations(img)
+    (; _observer_image_header(img)..., populations = pops, truncated = trunc)
+end
+
 """
     populations_summary(proj; image_uid="", set_uid="") -> NamedTuple
 
@@ -46,12 +52,5 @@ Per image, the persisted population definitions (tree + gate/filter specs), scop
 or `set_uid` or the whole project. Definitions only — cheap, sidecar-read; membership counts are Slice
 C. See OBSERVER_DATA_ACCESS_PLAN.md.
 """
-function populations_summary(proj::CciaProject; image_uid::AbstractString = "", set_uid::AbstractString = "")
-    imgs = _lineage_images(proj, image_uid, set_uid)
-    (; projectUid = proj.uid,
-       images = [begin
-                     pops, trunc = _image_populations(img)
-                     (; uid = img.uid, name = img.name, included = image_included(img),
-                        populations = pops, truncated = trunc)
-                 end for img in imgs])
-end
+populations_summary(proj::CciaProject; image_uid::AbstractString = "", set_uid::AbstractString = "") =
+    observer_image_summary(proj, _population_image; image_uid = image_uid, set_uid = set_uid)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -4595,10 +4595,17 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test length(lin.chains) == 1 && lin.chains[1].name == "pipeline"
             @test Set(lin.chains[1].tasks) == Set(["segment.cellpose", "tracking.bayesian_tracking"])
             @test lin.boards == ["Behaviour", "Counts"]
-            # rollup: common pipeline in canonical order; i2 diverges (excluded + missing track/cluster)
-            @test lin.rollup.pipeline == ["import", "segment", "track", "cluster"]
+            # rollup: pipeline unions run-log steps AND artifact evidence, so i1's gated pop adds a
+            # "gate" stage even though gating isn't a task step. i2 diverges (excluded + missing the
+            # track/gate/cluster stages the others reached).
+            @test lin.rollup.pipeline == ["import", "segment", "track", "gate", "cluster"]
             dv = lin.rollup.divergences[findfirst(d -> d.uid == "i2", lin.rollup.divergences)]
-            @test dv.included == false && Set(dv.missingStages) == Set(["track", "cluster"])
+            @test dv.included == false && Set(dv.missingStages) == Set(["track", "gate", "cluster"])
+            # artifact-aware stages: a segmentation/track with NO run-log step still counts as reached
+            # (it predates the capped run-log window) — the fix for false "missing segment" divergences
+            noStep = (; uid = "x", name = "X", included = true, steps = NamedTuple[],
+                        segmentations = ["A"], tracked = ["A"], clusterRuns = Any[], gatedPops = Any[])
+            @test Set(Cecelia._image_stages(noStep)) == Set(["segment", "track"])
             # scoping: one image, one set, unknown → empty
             @test length(analysis_lineage(proj; image_uid = "i1").images) == 1
             @test length(analysis_lineage(proj; set_uid = "linS").images) == 2

--- a/docs/todo/OBSERVER_DATA_ACCESS_PLAN.md
+++ b/docs/todo/OBSERVER_DATA_ACCESS_PLAN.md
@@ -73,6 +73,19 @@ Each = a read-only `/api` route + an MCP tool returning aggregates (+ caps):
 | `get_chains` | E | whiteboard chain templates (which tasks wired) |
 | *(spatial)* | *future* | neighbourhood / proximity summaries — **not yet ported**; leave the slot, don't build |
 
+## Shared scaffold (reuse — do NOT re-duplicate per slice)
+
+Every summary tool has the same shape (scope to image/set/project → per-image map → `{projectUid,
+images}`), so that shape lives once at each layer; a new slice is just its **per-image builder + one
+MCP-tool docstring**, not another copy of the plumbing:
+
+- **Julia** — `observer_image_summary(proj, per_image_fn; image_uid, set_uid)` + `_observer_scope_images`
+  + `_observer_image_header` in `app/src/ai/observer_summary.jl`. (`analysis_lineage` merges project-level
+  chains/boards/rollup onto the base; `populations_summary` is just the scaffold.)
+- **API** — `_observer_summary_route(req, build)` in `api/src/routes.jl`; each route is one line.
+- **MCP client** — `CeceliaClient._analysis_summary(path, …)`; each method is one line. The MCP **tools**
+  stay separate (their rich docstrings are the model-facing interface).
+
 ## Build slices (each shippable)
 
 - **A — Lineage** (`get_analysis_lineage`). Highest value, lightest data. ✅ **DONE** — `app/src/ai/lineage.jl`

--- a/mcp/cecelia_mcp/client.py
+++ b/mcp/cecelia_mcp/client.py
@@ -121,19 +121,22 @@ class CeceliaClient:
             },
         )
 
-    def get_analysis_lineage(self, project_uid: str, image_uid: str | None = None,
-                             set_uid: str | None = None):
+    # Shared caller for the observer's analysis/* summary routes — same (projectUid + optional
+    # image/set scope) contract for every slice, so each tool method is a one-liner over its path.
+    def _analysis_summary(self, path: str, project_uid: str,
+                          image_uid: str | None = None, set_uid: str | None = None):
         return self._request(
-            "GET", "/api/analysis/lineage",
+            "GET", path,
             {"projectUid": project_uid, "imageUid": image_uid, "setUid": set_uid},
         )
 
+    def get_analysis_lineage(self, project_uid: str, image_uid: str | None = None,
+                             set_uid: str | None = None):
+        return self._analysis_summary("/api/analysis/lineage", project_uid, image_uid, set_uid)
+
     def get_populations(self, project_uid: str, image_uid: str | None = None,
                         set_uid: str | None = None):
-        return self._request(
-            "GET", "/api/analysis/populations",
-            {"projectUid": project_uid, "imageUid": image_uid, "setUid": set_uid},
-        )
+        return self._analysis_summary("/api/analysis/populations", project_uid, image_uid, set_uid)
 
     def read_lab_log(self, project_uid: str):
         return self._request("GET", "/api/lablog", {"projectUid": project_uid})


### PR DESCRIPTION
## What

Two things, both prompted by the observer-summary work: **consolidate the shape** the per-image summary tools share (before slices C–E multiply it), and **fix the lineage rollup** using what a live observer session surfaced.

### Shared scaffold

`analysis_lineage` and `populations_summary` share the exact shape — scope to image/set/project → per-image map → `{projectUid, images}` — and the API routes / MCP client methods were near-identical copies. Consolidated at each layer so a new slice is just its per-image builder + one tool docstring:

- **Julia** — `app/src/ai/observer_summary.jl`: `observer_image_summary(proj, per_image_fn; scope)` + `_observer_scope_images` + `_observer_image_header`. `analysis_lineage`/`populations_summary` are now thin builders (lineage merges its project-level chains/boards/rollup onto the base).
- **API** — one `_observer_summary_route(req, build)`; both routes are one line each.
- **MCP client** — one `_analysis_summary(path, …)`; both methods one line. The MCP **tools** stay separate — their rich docstrings are the model-facing interface.

The plan documents the scaffold so C–E reuse it rather than re-duplicating.

### Artifact-aware rollup

From a live session: `rollup.divergences` keyed off run-log *steps* only, so a segmentation/tracking that predates the capped run-log window read as "missing segment/track" even though the image plainly has them (the observer had to explain it away). Now a stage counts as reached if a run-log **step** OR an **artifact** (`segmentations`/`tracked`/`clusterRuns`/`gatedPops`) shows it. This also surfaces gating as a first-class `gate` stage.

## Tests

`pixi run test-pkg` (1224, + a targeted `_image_stages` assertion), `pixi run test-api` (8 + 5), `pixi run test-mcp` (34). Behaviour-preserving except the intended rollup change.

## Reservations

- **Behaviour-preserving refactor** except the rollup — verified by the existing lineage/populations tests still passing; not re-run through a live MCP session.
- The rollup now shows `gate` as a first-class stage, so a project where some images are gated and others aren't will show `gate` divergences — correct/intended, just more visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
