### PR TITLE
docs: community-health files (CITATION, CHANGELOG, CONTRIBUTING, issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks for taking the time to report a bug. Cecelia Pineapple is early
+        software and has not yet been widely tested, so detailed reports are
+        genuinely useful. Please search existing issues first to avoid duplicates.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: |
+        Steps to reproduce:
+        1. ...
+        2. ...
+
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Cecelia version
+      description: Release tag, or `git` commit if you built from source.
+      placeholder: "v0.1.0-rc8"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install?
+      options:
+        - Installer script (install.sh / install.ps1)
+        - Built from source
+        - Other (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: >-
+        Paste any error messages, stack traces, or relevant console output.
+        This will be automatically formatted as code, so no backticks needed.
+      render: shell
+  - type: textarea
+    id: data-context
+    attributes:
+      label: Data context (optional)
+      description: >-
+        Image type / modality, size, number of channels or timepoints — anything
+        about the data that might be relevant. Do **not** upload sensitive or
+        unpublished imaging data.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: FAQ — why it's built this way
+    url: https://github.com/schienstockd/cecelia/blob/main/FAQ.md
+    about: Design rationale and answers to common questions. Please check here first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks for the suggestion. Please check the
+        [FAQ](https://github.com/schienstockd/cecelia/blob/main/FAQ.md) and
+        existing issues first — some design choices are deliberate and explained there.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do that's currently hard or impossible?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've thought about (optional).
+  - type: textarea
+    id: context
+    attributes:
+      label: Scientific / workflow context
+      description: >-
+        How does this fit your analysis workflow? Knowing the science behind the
+        request helps prioritise it (optional).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,149 @@
+# Changelog
+
+All notable changes to Cecelia Pineapple are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the project is pre-1.0, minor versions may contain breaking changes.
+
+Cecelia Pineapple is a ground-up reimplementation of the original R/Shiny
+[Cecelia](https://github.com/schienstockd/cecelia-legacy) in a Julia + Python + Vue
+stack. Per-tag notes are also on the
+[GitHub releases](https://github.com/schienstockd/cecelia/releases) page.
+
+## [Unreleased]
+
+_Changes on `main` that have not yet been tagged in a release._
+
+## [0.1.0-rc8] — 2026-07-16
+
+### Added
+- **Legacy migration**: import original R/Shiny Cecelia projects (images +
+  segmentation + tracking).
+- **First-launch setup wizard** + onboarding; **system-wide install scope** and
+  in-app update surfacing.
+- **Per-project lab log** — backend, routes, and Vue panel: auto-generated
+  `[Cecelia]` activity digests, mute-by-category, reactions on entries, and
+  GUI diagnostics that flag a stale backend or napari bridge.
+- **MCP observer server** — read-only Claude access to a running project
+  (Phase 1, Slice A).
+- **napari 3D crop** — draw a box, preview, save as a new image.
+- **Animation module** — keyframe render engine + timeline editor, batch
+  movies (one mp4 per image), clean-capture publication stills, vector scale
+  bar and timestamp.
+- `INVENTORY.md` + a discovery-first rule; raw-datapoint CSV export, duplicate
+  boards, and per-image stat units on the analysis board.
+
+### Changed
+- Plots aligned with the original R/ggplot look (UMAP, heatmap, palette).
+- Consolidated zarr/OME image readers into one path; ImageJ TIFF metadata read
+  via `ome_xml_utils`.
+- Track/cluster populations render in their own colour under colour-by.
+
+### Fixed
+- Installer now expands a leading `~` in `CECELIA_HOME`.
+- README config path; PDF/CSV export waits for plots to render (no fixed sleep).
+
+## [0.1.0-rc7] — 2026-07-14
+
+### Changed
+- Fetch bioformats2raw at install time instead of bundling it — slims the
+  release download.
+
+## [0.1.0-rc6] — 2026-07-13
+
+### Added
+- **Population summary** — count / % specs, distribution charts, per-popType
+  backbones (gated and tracked populations).
+- **Analysis board** view-snapshot atom (zoom-to-source, sidecar board images,
+  autosave); per-slot titles for PDF captions.
+- Cluster UMAP **faceting**, colour-by population or image attribute, and
+  **run-global cluster pops** pooled across co-clustered segmentations.
+- Generic `ConfirmDeleteButton` and `TeleportPopover`; napari animation movie
+  recorder; extracted `cecelia.utils.napari_utils` layer helpers.
+- Frontend typecheck script + CI gate (`vue-tsc -b`).
+
+### Changed
+- **Gating overhaul**: 2D raster gating (dropped WebGL), multi-segmentation
+  napari pops with autoscale, FlowJo-style dot plot, copy-strategy-to-images.
+- Nav sidebar regrouped by pipeline stage; Settings moved to the footer.
+
+### Fixed
+- Gates re-project on scale change; freshly-drawn gates show immediately;
+  morphology axes auto-linearise.
+- Numerous plot/export fixes (square gate dots on PDF, heatmap left margin,
+  canvas placement under zoom transforms).
+- Dev supervisor: worktree switch relaunches the frontend; free a port by
+  killing only the listening process; tear down Vite children on Ctrl-C.
+
+## [0.1.0-rc5] — 2026-07-02
+
+### Added
+- **Universal Analysis canvas** (`/analysis`) — tabbed multi-board layout,
+  gating-strategy plot, filmstrip, PDF/CSV export.
+- One plot-hosting mechanism across surfaces with unified hi-res export; cluster
+  UMAP, heatmap, and HMM plots on the board; read-only cluster manager.
+
+### Changed
+- Migrated theming to `@primeuix/themes` (`@primevue/themes` deprecated).
+
+### Fixed
+- Honour `yMin`/`yMax` on count/proportion charts; keep gate name labels
+  on-canvas; CI bumped off the deprecated Node 20 runtime.
+
+## [0.1.0-rc4] — 2026-07-01
+
+### Added
+- **Clustering** — Leiden cell + track clustering (`clust` / `trackclust` pop
+  types), UMAP endpoint and module pages, cluster population manager, a generic
+  interactive-plot canvas (UMAP + heatmap), and cluster HMM behaviour plots.
+- **`LICENSE` (GPL-3.0-or-later)** + third-party acknowledgements.
+- `run_py` launcher; collapsible left nav + right function/tasks panel; CI +
+  Release status badges.
+
+### Changed
+- Route all Python spawns through `run_py` (drop inline spawn + `sys.path`);
+  standardise Python runner filenames; move the update control to Settings.
+- Removed the unused `PythonCall` dependency.
+
+### Fixed
+- macOS-arm64 install (cvxopt source build) + full cross-platform CI; installer
+  404 while only prereleases exist; restore `ome-types`; several API/napari
+  robustness fixes (missing `labelProps`, single-timepoint overlay, name coercion).
+
+## [0.1.0-rc3] — 2026-06-30
+
+### Added
+- Bundle **bioformats2raw + Java** for out-of-the-box image import; per-OS README
+  guidance for the projects folder / `custom.toml`.
+
+### Fixed
+- Use `read_idle_timeout` (`readtimeout` deprecated in HTTP.jl) in the updater.
+
+## [0.1.0-rc2] — 2026-06-30
+
+### Added
+- **In-app update** — check + staged-apply-on-restart.
+
+### Fixed
+- README links point at the `cecelia-legacy` R/Shiny source.
+
+## [0.1.0-rc1] — 2026-06-30
+
+### Added
+- **Initial release** — Cecelia ported to a Julia + Python + Vue stack: the core
+  pipeline (image import, segmentation, tracking, gating, population management,
+  behavioural track measures), headless-runnable `Cecelia.jl`, and the Vue
+  frontend.
+- **Bootstrap installer** + release workflow (`release.yml`); CI smoke-test
+  workflow; README + docs.
+
+[Unreleased]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc8...HEAD
+[0.1.0-rc8]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc7...v0.1.0-rc8
+[0.1.0-rc7]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc6...v0.1.0-rc7
+[0.1.0-rc6]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc5...v0.1.0-rc6
+[0.1.0-rc5]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc4...v0.1.0-rc5
+[0.1.0-rc4]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc3...v0.1.0-rc4
+[0.1.0-rc3]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc2...v0.1.0-rc3
+[0.1.0-rc2]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc1...v0.1.0-rc2
+[0.1.0-rc1]: https://github.com/schienstockd/cecelia/releases/tag/v0.1.0-rc1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,51 @@
+cff-version: 1.2.0
+message: >-
+  If you use Cecelia Pineapple in your research, please cite both the software
+  (this record) and the original Cecelia paper (see preferred-citation).
+title: "Cecelia Pineapple"
+abstract: >-
+  A Julia package with a graphical interface for cellular image cytometry —
+  import, segmentation, tracking, gating, behavioural analysis, and clustering
+  of multiplexed and live-cell microscopy data. A ground-up reimplementation of
+  the original R/Shiny Cecelia in a Julia + Python + Vue stack.
+type: software
+authors:
+  - given-names: Dominik
+    family-names: Schienstock
+    orcid: "https://orcid.org/0000-0001-8440-0009"
+    affiliation: "Garvan Institute of Medical Research"
+license: GPL-3.0-or-later
+repository-code: "https://github.com/schienstockd/cecelia"
+url: "https://github.com/schienstockd/cecelia"
+version: 0.1.0-rc8
+date-released: 2026-07-16
+keywords:
+  - microscopy
+  - image-analysis
+  - cell-tracking
+  - cytometry
+  - segmentation
+  - napari
+  - julia
+  - bioinformatics
+preferred-citation:
+  type: article
+  title: "Cecelia: a multifunctional image analysis toolbox for decoding spatial cellular interactions and behaviour"
+  authors:
+    - given-names: Dominik
+      family-names: Schienstock
+      orcid: "https://orcid.org/0000-0001-8440-0009"
+    - given-names: Jyh Liang
+      family-names: Hor
+    - given-names: Sapna
+      family-names: Devi
+    - given-names: Scott N.
+      family-names: Mueller
+      orcid: "https://orcid.org/0000-0002-3838-3989"
+  journal: "Nature Communications"
+  year: 2025
+  month: 2
+  volume: 16
+  issue: 1
+  article-number: 1931
+  doi: 10.1038/s41467-025-57193-y

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to Cecelia Pineapple
+
+Thanks for your interest. Cecelia Pineapple is early software and is primarily
+maintained by its author, [Dominik Schienstock](https://orcid.org/0000-0001-8440-0009).
+Contributions — bug reports, fixes, and ideas — are welcome. Please read this
+first.
+
+## Before you start
+
+- **Questions / usage help** → check the [FAQ](FAQ.md) first.
+- **Bugs and features** → use the [issue templates](https://github.com/schienstockd/cecelia/issues/new/choose).
+- **Larger changes** → open an issue to discuss the design *before* writing code,
+  so effort isn't wasted on something that doesn't fit the architecture.
+
+## Architecture is non-negotiable
+
+The layer boundaries are deliberate and enforced: analysis logic lives only in
+the headless `Cecelia.jl` package — never in the API or the Vue frontend — and
+there is no fourth language. Read [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+and [`CLAUDE.md`](CLAUDE.md) before proposing structural changes. Departures from
+the ported R behaviour should be deliberate and documented, not incidental.
+
+## Development workflow
+
+The full workflow — branching, commits, PRs, and releases — is documented in
+[`docs/DEV.md`](docs/DEV.md). In short:
+
+- Branch off the latest `main` with a conventional prefix (`feat/`, `fix/`,
+  `docs/`, `chore/`, `refactor/`). **Never commit or push to `main` directly** —
+  everything lands via a pull request.
+- Keep a branch scoped to one logical change.
+- **Every change ships with tests and docs.** The package must stay verifiable
+  headlessly from the Julia REPL, without the GUI.
+
+## Running the tests
+
+Tests run per layer via Pixi (all of these run in CI):
+
+```sh
+pixi run test-pkg       # Cecelia.jl package (headless)
+pixi run test-api       # Julia API adapters
+pixi run test-frontend  # frontend logic (Vitest)
+pixi run test-py        # Python analysis env
+pixi run test-mcp       # MCP observer client
+```
+
+See [`docs/INSTALL.md`](docs/INSTALL.md) for the developer environment setup.
+
+## A note on AI-assisted development
+
+This project was built almost entirely with an AI assistant under human
+direction — see [*How this software was built*](README.md#how-this-software-was-built).
+That transparency expectation applies to contributions too: AI-assisted PRs are
+fine, but you are responsible for the correctness of what you submit, and
+scientific/visual claims must be validated by a human, not asserted by a model.
+
+## License
+
+By contributing, you agree that your contributions are licensed under
+[GPL-3.0-or-later](LICENSE), the license of this project.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -65,10 +65,28 @@ someone else installs it.
 1. CI matrix green on `main` (all three OSes).
 2. Decide the version (heartbeat patch vs substantial minor; `-rcN` if you'll soak before announcing).
 3. Draft release notes (features / fixes / infra since the last tag — `git log <lasttag>..HEAD`).
-4. Tag off `main` and push (`release.yml` builds + publishes). Hyphenated tag = prerelease.
-5. If it's a demo/onboarding/external build: verify the published artifact **installs clean** on a
+   The same log feeds **`CHANGELOG.md`**: rename its `[Unreleased]` block to the new version + date
+   and paste the notes in (see snippet below). Don't hand-maintain `[Unreleased]` between releases —
+   it's generated here, so it can't silently drift from what actually shipped.
+4. Bump the `version:` + `date-released:` in **`CITATION.cff`** to this tag.
+5. Tag off `main` and push (`release.yml` builds + publishes). Hyphenated tag = prerelease.
+6. If it's a demo/onboarding/external build: verify the published artifact **installs clean** on a
    fresh machine + the target dataset before relying on it.
-6. Only at a coarse boundary: add a MILESTONES entry (append-only).
+7. Only at a coarse boundary: add a MILESTONES entry (append-only).
+
+### Regenerating the CHANGELOG section
+
+The `CHANGELOG.md` `[Unreleased]` block is filled in *at release time* from the commit log, so it
+never has to be maintained by hand between tags. Grab the one-liners since the last tag:
+
+```sh
+git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
+```
+
+Rename `## [Unreleased]` to `## [<version>] — <YYYY-MM-DD>`, drop the grouped notes under it
+(Added / Changed / Fixed), add a fresh empty `## [Unreleased]` above it, and update the compare
+links at the bottom of the file. This is the same content as the GitHub Release — the CHANGELOG is
+just its offline-readable, in-repo mirror.
 
 ## Overdue check
 


### PR DESCRIPTION
## What

Adds the standard open-source / academic repo-hygiene files that were missing, plus the discovery topics (applied live, outside this PR).

| File | Purpose |
|---|---|
| `CITATION.cff` | Machine-readable citation — GitHub renders a **Cite this repository** button. Cites the software + `preferred-citation` → the Nat Comms 2025 paper (real ORCID + full author list from Crossref). |
| `CHANGELOG.md` | Keep a Changelog format, **v0.1.0-rc1..rc8**, grouped Added/Changed/Fixed from the tag-to-tag commit log. |
| `CONTRIBUTING.md` | Short — points at `docs/DEV.md` + `docs/ARCHITECTURE.md`, lists the `pixi run test-*` commands, carries the AI-disclaimer-applies-to-contributions note. |
| `.github/ISSUE_TEMPLATE/` | Bug report + feature request **forms** (version / OS / install-method / logs), plus a FAQ contact link. |
| `docs/RELEASING.md` | Checklist steps: regenerate the CHANGELOG section + bump `CITATION.cff` version at each tag. |

## Decisions

- **No `CODE_OF_CONDUCT.md`** — dropped rather than publish a contact email for a solo, early project. Easy to add later.
- **No GitHub Discussions** — feature is disabled, so all "questions" routes point at the FAQ instead (no dead links).
- **CHANGELOG is generate-at-release**, not hand-maintained between tags — the `[Unreleased]` block is filled from `git log` at tag time (documented in `docs/RELEASING.md`), so it can't silently drift.
- `FAQ.md` already existed — untouched.

## Notes / caveats

- CHANGELOG rc summaries are thematic (hand-curated from the commit log), not one-line-per-commit for the big drops (rc4 clustering, rc6 gating, rc8 legacy migration / lab log / animation / MCP).
- `CITATION.cff` `version:` is pinned to `v0.1.0-rc8` and must be bumped per release — now a step in `docs/RELEASING.md`.
- Repo **topics** (`julia`, `microscopy`, `image-analysis`, `napari`, `cell-tracking`, `cytometry`, `segmentation`, `bioinformatics`) were applied directly to the repo settings; they are not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
