### PR TITLE
chore: add .editorconfig + PR template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# https://editorconfig.org — consistent whitespace across editors.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+# Julia and Python — 4 spaces
+[*.{jl,py}]
+indent_size = 4
+
+# Frontend (Vue, TypeScript, JS) and structured config — 2 spaces
+[*.{vue,ts,js,mjs,cjs,json,yml,yaml,toml}]
+indent_size = 2
+
+# Markdown — keep trailing whitespace (two spaces = hard line break)
+[*.md]
+trim_trailing_whitespace = false
+
+# Makefiles require real tabs
+[Makefile]
+indent_style = tab

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+Keep it short. Delete sections that don't apply. The checklist mirrors the
+conventions in CLAUDE.md and docs/DEV.md — it's a reminder, not paperwork.
+-->
+
+## What & why
+
+<!-- One or two sentences: what changes, and the problem it solves. -->
+
+## Checklist
+
+- [ ] Scoped to one logical change (branch off latest `main`, conventional prefix).
+- [ ] Tests updated/added and passing (`pixi run test-pkg` / `test-api` / `test-frontend` / `test-py` / `test-mcp` as relevant).
+- [ ] Docs updated (the per-area doc in `docs/`, and `CLAUDE.md` if a convention changed).
+- [ ] **Discovery-first**: checked `INVENTORY.md` + grepped before adding anything cross-cutting; reused the canonical helper rather than rolling a new one. Updated `INVENTORY.md` if a new component was added.
+- [ ] No analysis logic leaked into the API or frontend (it lives in `Cecelia.jl`); no new language added.
+
+## Notes / caveats
+
+<!-- Known limitations, follow-ups, or anything a reviewer should scrutinise. -->


### PR DESCRIPTION
## What

The worthwhile subset of the remaining repo-hygiene suggestions.

| File | Purpose |
|---|---|
| `.editorconfig` | Whitespace consistency across editors — 4-space Julia/Python, 2-space frontend/config (Vue/TS/JSON/YAML/TOML), LF + final newline + trim trailing (except `.md`). Matches the repo's existing indentation; there's no prettier/eslint/JuliaFormatter config to conflict with. |
| `.github/PULL_REQUEST_TEMPLATE.md` | Short checklist mirroring `CLAUDE.md` / `docs/DEV.md` — scope, tests, docs, discovery-first + `INVENTORY.md`, package-boundary. A reminder, not paperwork; skippable on solo PRs. |

## Deliberately left out

- **`CODE_OF_CONDUCT.md`** — the Contributor Covenant needs a mandatory enforcement-contact email; same public-address issue we chose to avoid for a solo project.
- **`SECURITY.md`** — a localhost desktop analysis tool, not a network service; the file's main benefit is a repo *setting*, and it reintroduces the same public-email problem. Instead, **GitHub private vulnerability reporting was enabled** on the repo (no file, no published address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
