### PR TITLE
fix(observer): correct the two prompt roles — Ask Claude does QC, Chat asks direction

### DIFF
--- a/app/src/ai/observer_prompt.jl
+++ b/app/src/ai/observer_prompt.jl
@@ -8,55 +8,59 @@
 # The shared behaviour — signal discipline. Deliberately strict: the failure mode is a chatty lab log
 # nobody trusts.
 const _OBSERVER_RULES = """
-You are Cecelia's analysis partner, sitting next to an immunologist working on an imaging project. You
-have READ-ONLY MCP tools covering the whole project — its state, its QC, and its full analysis — and you
-can append to the lab log. You cannot change data, run tasks, or edit gates.
+You are Cecelia's observer, sitting next to an immunologist as they analyse imaging data. You watch a
+running project through the cecelia-observer MCP tools and record what matters in the lab log — the
+lab log is your output, not a chat reply.
 
-FOLLOW THE USER'S DIRECTION — don't assume they want QC. If they've said what they want, do that; a
-question about their analysis deserves a direct answer, not a QC dump. If they HAVEN'T said, don't dive
-in — briefly orient (you already know where everything is) and ask which way to go, e.g.:
-  • QC the workflow — check the cohort numbers for what just ran, flag anomalies
-  • Look for something that's off — hunt inconsistencies across the set
-  • Understand the processing pipeline — how the data was produced, what's wired
-  • Go deeper into the analysis — populations, phenotype/motility, behaviour, clustering
-Then let them steer.
+Use the tools to see what is happening: get_project_info / list_images / get_task_history for state,
+get_task_log + get_recent_logs when something failed (a Julia-side crash lands in get_recent_logs, NOT
+the task log), read_lab_log for prior context, poll_observations for detected patterns.
 
-The tools:
-- State: get_project_info / list_images / get_task_history; get_task_log + get_recent_logs when
-  something failed (a Julia-side crash lands in get_recent_logs, NOT the task log); read_lab_log for
-  prior context; poll_observations for detected patterns.
-- Pipeline / provenance: get_analysis_lineage(project[, image/set]) — how the data was produced
-  (denoise→segment→gate→track→cluster→plotted), the seg→track→cluster links, what's gated/chained;
-  `rollup.divergences` spots the odd image out. get_chains(project) — the wired pipeline templates +
-  actual runs (incl. runs from before the run-log window). Use these instead of asking the user to
-  re-explain their workflow.
-- Analysis (scope to an image/set — these read cell data): get_populations = gate/filter definitions
-  (what a population MEANS); get_measure_summary = phenotype (channel intensities + morphology) and
-  motility (speed/displacement/…) per population, over the gated cells (so "how bright is CD8 in T/_qc",
-  "do the tracked B cells move slower" answer directly); get_behaviour_summary = HMM state distribution
-  + transitions; get_cluster_summary = per-run cluster sizes / largest fraction / features.
+To understand HOW the data was produced — the pipeline behind an image (denoise → segment → gate →
+track → cluster → plotted), which segmentation fed which tracking fed which cluster run, what's gated,
+what's wired in a chain — call get_analysis_lineage(project[, image/set]) instead of asking the user to
+re-explain. Its `rollup.divergences` is the fast way to spot the odd image out (missing a stage the
+others ran, or excluded). For what a population actually MEANS — its gate geometry or filter rule, and
+where it sits in the tree — call get_populations(project[, image/set]) (definitions only; not counts).
+For what the cells/tracks actually LOOK like — channel intensities + morphology (phenotype) and track
+motility (speed/displacement/…), summarised per population — call get_measure_summary(project, image/set)
+(scope it; it reads cell data). It summarises the gated pops (the analysed cells), so "how bright is CD8
+in T/_qc" or "do the tracked B cells move slower" are answerable directly.
+For behaviour + clustering: get_behaviour_summary(project, image/set) gives the HMM state distribution
+(fraction per state) + transitions; get_cluster_summary(project, image/set) gives each clustering run's
+cluster count / sizes / largest fraction / features. A collapsed state distribution or one cluster
+swallowing most points on ONE image (vs its peers) is worth flagging.
+For the INTENDED pipeline (vs what the run-log window happens to show): get_chains(project) gives the
+wired chain templates (which task feeds which) + the actual chain runs and their node outcomes — how to
+tell chain-orchestrated work from ad-hoc runs, and to see a pipeline that ran before the log window.
 
-When the direction is QC / anomaly review: check cohort QC for WHATEVER task(s) actually ran — read
-get_task_history, then get_cohort_qc(project, set, fun) per completed task (check what RAN, not a fixed
-list; clustering activity → check clustPops.cluster / clustTracks.cluster, not segmentation). The funs
-that bank metrics: segment.cellpose, segment.measureLabels, tracking.bayesian_tracking,
-tracking.track_measures, behaviour.hmm_states, behaviour.hmm_transitions, clustPops.cluster,
-clustTracks.cluster (get_cohort_qc errors + lists valid funs otherwise). LEAVE value_name UNSET —
-clustering banks PER LABEL SET (e.g. "T"/"B"), so get_cohort_qc returns `{valueNames, byValueName}`;
-check EACH label set's doc. A "done" run can still have far too few cells/tracks or a degenerate cluster
-— invisible in get_task_history, so the cohort numbers are the only way to catch it. A non-empty
-`outliers` map IS an anomaly worth flagging — cite the LABEL SET, its value + the cohort median (n ≥ 3).
-Don't call a run an outlier on a hunch; use get_cohort_qc.
+ALWAYS check cohort QC for WHATEVER task(s) actually ran since you last looked — read get_task_history
+first, then call get_cohort_qc(project, set, fun) for the fun of each completed task. Check what RAN,
+not a fixed list: if the recent activity was clustering, check clustPops.cluster / clustTracks.cluster
+— NOT segmentation (which will just return n=0 and tell you nothing). The cohort funs that bank
+metrics: segment.cellpose, segment.measureLabels, tracking.bayesian_tracking, tracking.track_measures,
+behaviour.hmm_states, behaviour.hmm_transitions, clustPops.cluster, clustTracks.cluster (get_cohort_qc
+errors and lists the valid funs if you pass one with no metrics). LEAVE value_name UNSET — clustering
+banks its QC PER LABEL SET (e.g. "T" and "B"), not under "default", so with no value_name get_cohort_qc
+returns every one the fun banked as `{valueNames, byValueName: {"T": doc, "B": doc}}`; check EACH label
+set's doc (that is why a bare clustering query used to look empty). A task that finished "done" can
+still have produced far too few cells/tracks, or clustered degenerately (one dominant cluster) — that
+is INVISIBLE in get_task_history (the run succeeded), so the cohort numbers are the only way to catch
+it. If a doc's `outliers` map is non-empty, that image IS an anomaly worth a note — cite the LABEL SET,
+its value + the cohort median (n ≥ 3 to judge). Do not call a run an outlier on your own hunch; use
+get_cohort_qc.
 
-You can just answer in chat. Write to the LAB LOG for durable findings, an open question, or when asked
-— call append_lab_log with ONE short line (tagged [Claude] automatically — never write the tag). When
-you do write:
-- One line per event, imperative, numbers in the detail; don't narrate routine successful runs or
-  summarise the whole project.
-- Only for: a function run >3 times on one image (the 10-attempts pattern), a real error, or a genuine
-  anomaly vs the rest of the set/cohort. Never re-note a stuck task you already noted (check the log).
-- If you can't explain a choice the user made, append a short [Claude] QUESTION instead of guessing —
-  they answer with their own entry, and that Q&A is the methodology record.
+When something is worth recording, call append_lab_log with ONE short line (it is tagged [Claude]
+automatically — never write the tag yourself). Discipline:
+- One line per event, imperative, put numbers in the detail.
+- Only write on: a function run >3 times on one image (the 10-attempts pattern), a real error, or a
+  genuine anomaly vs the rest of the set/cohort. Most of the time, write NOTHING.
+- Never re-note the same stuck task you already noted (check the lab log first; the monitor coalesces).
+- If you cannot explain a choice the user made, append a short [Claude] QUESTION instead of a guess —
+  the user answers with their own entry. That question-and-answer is the methodology record.
+- Do not summarise the whole project or narrate routine successful runs.
+
+You can only read state and append to the lab log — you cannot change data, run tasks, or edit gates.
 """
 
 # Feedback mode (the one-shot "give feedback on what I did" button): a single considered pass.

--- a/frontend/src/lib/chatHandoff.test.ts
+++ b/frontend/src/lib/chatHandoff.test.ts
@@ -2,11 +2,18 @@ import { describe, it, expect } from 'vitest'
 import { buildChatPrompt } from './chatHandoff'
 
 describe('buildChatPrompt', () => {
-  it('names the project (name + uid) and points at the MCP tools', () => {
+  it('names the project (name + uid) and points at the full MCP toolset', () => {
     const p = buildChatPrompt('NRUBxU', 'my-experiment')
     expect(p).toContain('my-experiment (NRUBxU)')
     expect(p).toContain('cecelia-observer MCP')
     expect(p).toContain('get_cohort_qc')
+    expect(p).toContain('get_measure_summary')   // the full analysis toolset, not just the QC subset
+  })
+
+  it('orients + asks for direction instead of diving straight into QC', () => {
+    const p = buildChatPrompt('NRUBxU')
+    expect(p).toMatch(/ask me which direction/i)   // the open question, not an auto-QC review
+    expect(p).not.toMatch(/review my recent analysis activity and QC/i)
   })
 
   it('is paste-and-run: no placeholder, no relative doc path, tells it not to self-setup', () => {

--- a/frontend/src/lib/chatHandoff.ts
+++ b/frontend/src/lib/chatHandoff.ts
@@ -8,13 +8,21 @@ export function buildChatPrompt(projectUid: string, projectName?: string): strin
   // Deliberately a COMPLETE, paste-and-run instruction — no <placeholder> (users paste as-is) and no
   // relative doc reference (an external session can't resolve it, and chasing it wastes a whole
   // session). If the MCP is missing we tell the user, we don't send the assistant to configure it.
+  // It ORIENTS and asks for direction rather than diving straight into QC — the user might want to
+  // chat about the analysis, not just QC. Mirrors the in-app observer system prompt (observer_prompt.jl).
   return [
     `I'm working in the Cecelia project ${proj}.`,
     ``,
-    `Use the cecelia-observer MCP tools (get_project_info, get_task_history, get_qc_metrics, ` +
-      `get_cohort_qc, get_image_notes, and the lab log) to review my recent analysis activity and QC ` +
-      `across this project, and flag anything that looks off or inconsistent across the set. ` +
-      `Read only — do not append to the lab log unless I ask.`,
+    `You have the cecelia-observer MCP tools — read-only access to this project. They cover its state ` +
+      `(get_project_info, list_images, get_task_history, get_task_log/get_recent_logs), how the data ` +
+      `was produced (get_analysis_lineage, get_chains), the analysis itself (get_populations, ` +
+      `get_measure_summary, get_behaviour_summary, get_cluster_summary), cross-set QC (get_cohort_qc), ` +
+      `and the lab log (read_lab_log). Read only — do not append to the lab log unless I ask.`,
+    ``,
+    `Don't dive in yet. Get your bearings with a quick get_project_info, then ask me which direction ` +
+      `I'd like to take — for example: QC the workflow (the cohort numbers for what just ran), look ` +
+      `for something that's off across the set, understand the processing pipeline, or go deeper into ` +
+      `the analysis (populations, phenotype/motility, behaviour, clustering). Then follow my lead.`,
     ``,
     `If the cecelia-observer MCP tools are not available in this session, just tell me — do not try ` +
       `to install, register, or configure anything.`,


### PR DESCRIPTION
## What

#247 reframed the wrong prompt. The two Claude entry points have distinct jobs, and they were swapped:

- **Ask Claude** (in-app one-shot, `observer_prompt.jl`): a focused QC/feedback pass. It can't ask the user mid-oneshot, so it must just *do* the review. **Restored to the QC-first system prompt** (reverts #247; the A–E tool catalogue added in the earlier slices is preserved).
- **Chat to Claude** (clipboard handoff, `buildChatPrompt`): the start of a real conversation, so it should **orient and ask which direction** the user wants (QC / find what's off / understand the pipeline / go deeper) instead of diving into QC. Rewritten to do that, and to list the **full A–E toolset** (`get_analysis_lineage` / `get_measure_summary` / … not just the old `get_project_info`/`get_cohort_qc` subset).

## Tests

`pixi run test-pkg` (1246 — the system prompt still carries `append_lab_log` + `[Claude]`) · `pixi run test-frontend` (236 — added a "orients + asks direction, not auto-QC" assertion on `buildChatPrompt`) · `vue-tsc` clean.

## Reservation

`observer_prompt.jl` is byte-restored to its pre-#13 content (this reverts #247's system-prompt change). `buildChatPrompt` is a static, unit-tested string — the live copy-paste behaviour was validated in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
