### PR TITLE
fix(lab log): refresh the panel on external (Chat-to-Claude) appends

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -1497,6 +1497,11 @@ function api_lablog_append(body_bytes::Vector{UInt8})
                 "summary" => join(lines, " ")))
         end
     end
+    # Panel-reload signal for EVERY append (any author) — an external Chat-to-Claude session appends
+    # straight through this route with no frontend action, so without this the open lab-log panel stays
+    # stale until the user closes+reopens it. Distinct from `lab_log_entry_added` above (that's the MCP
+    # observer's user-only, anti-loop notification); the frontend just reloads, so there's no loop.
+    broadcast_ws(Dict{String,Any}("type" => "lab_log_updated", "projectUid" => project_uid))
     200, JSON3.write((; ok=true, block, entries=parse_lab_log(read_lab_log(proj))))
 end
 

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -602,20 +602,30 @@ end
                     Dict("projectUid"=>uid, "values"=>Dict(img.uid=>Dict("included"=>false))))[1] == 200
         @test isempty(filter(x -> x.type == "image_note_added", drain()))
 
-        # ── lab_log_entry_added fires for USER entries only (not [Claude]/[Cecelia]) ──
+        # ── lab_log_entry_added fires for USER entries only (anti-loop); lab_log_updated (the panel-
+        # reload signal) fires for EVERY append so an external Chat-to-Claude append still refreshes ──
         drain()
         @test _post(api_lablog_append, Dict("projectUid"=>uid, "author"=>"User", "lines"=>["switched to diam 30"]))[1] == 200
-        let f = filter(x -> x.type == "lab_log_entry_added", drain())
-            @test length(f) == 1 && occursin("diam 30", f[1].summary) && f[1].projectUid == uid
+        let f = drain()
+            ea = filter(x -> x.type == "lab_log_entry_added", f)
+            @test length(ea) == 1 && occursin("diam 30", ea[1].summary) && ea[1].projectUid == uid
+            @test length(filter(x -> x.type == "lab_log_updated" && x.projectUid == uid, f)) == 1
         end
-        # the observer's own [Claude] append must NOT re-broadcast (would loop)
+        # the observer's own [Claude] append must NOT re-broadcast entry_added (would loop) — but it
+        # STILL emits lab_log_updated so an open panel reloads (the external-append bug fix)
         drain()
         @test _post(api_lablog_append, Dict("projectUid"=>uid, "author"=>"Claude", "lines"=>["noted"]))[1] == 200
-        @test isempty(filter(x -> x.type == "lab_log_entry_added", drain()))
-        # [Cecelia] auto-digests are not user decisions → no broadcast
+        let f = drain()
+            @test isempty(filter(x -> x.type == "lab_log_entry_added", f))
+            @test length(filter(x -> x.type == "lab_log_updated", f)) == 1
+        end
+        # [Cecelia] auto-digests: no entry_added either, but still a panel reload
         drain()
         @test _post(api_lablog_append, Dict("projectUid"=>uid, "author"=>"Cecelia", "lines"=>["digest"]))[1] == 200
-        @test isempty(filter(x -> x.type == "lab_log_entry_added", drain()))
+        let f = drain()
+            @test isempty(filter(x -> x.type == "lab_log_entry_added", f))
+            @test length(filter(x -> x.type == "lab_log_updated", f)) == 1
+        end
     finally
         lock(_ws_clients_lock) do; delete!(_ws_clients, key); end
         had ? (dirs["projects"] = old) : delete!(dirs, "projects")

--- a/frontend/src/stores/ws.ts
+++ b/frontend/src/stores/ws.ts
@@ -5,6 +5,7 @@ import { useTaskStore } from './tasks'
 import { useProjectStore } from './project'
 import { useProjectMetaStore } from './projectMeta'
 import { useTaskDefsStore } from './taskDefs'
+import { useLabCaptureStore } from './labCapture'
 
 export type WsStatus = 'connecting' | 'connected' | 'disconnected' | 'error'
 
@@ -76,6 +77,14 @@ export const useWsStore = defineStore('ws', () => {
       if (type === 'server:log') {
         const level = (data.level === 'error' || data.level === 'warn') ? data.level : 'info'
         useLogStore().push(level as any, String(data.message ?? ''), { source: 'server' })
+      }
+
+      // a lab-log entry was appended by ANY path (incl. an external Chat-to-Claude MCP session) — reload
+      // an open panel if it's for the current project. Reuses notifyAppended() (bumps the tick the panel
+      // watches). Covers the case the frontend didn't initiate the append, so it has no other signal.
+      if (type === 'lab_log_updated') {
+        const puid = String(data.projectUid ?? '')
+        if (puid && puid === useProjectMetaStore().current?.uid) useLabCaptureStore().notifyAppended()
       }
 
       if (type === 'task:progress') {


### PR DESCRIPTION
## What

An external **Chat-to-Claude** session appends straight through `/api/lablog/append` via the cecelia-observer MCP, with no frontend action — so the open lab-log panel stayed stale until the user closed and reopened it. (The in-app Ask Claude and Cecelia-digest paths reload via their own frontend ticks; the external path had no signal.)

The existing append broadcast (`lab_log_entry_added`) is deliberately **user-only** — it feeds the MCP observer, and a `[Claude]` re-broadcast would loop it. So this adds a **separate `lab_log_updated` frame emitted on every append (any author)**, purely as a panel-reload signal. The frontend just reloads — no write-back, so no loop. `ws.ts` reloads an open panel (via the existing `notifyAppended()`) when the event is for the current project.

## Why it's safe

- Distinct event from `lab_log_entry_added`, which stays user-only (the anti-loop observer notification is unchanged).
- The panel reload is idempotent (`load()` re-fetches the current project's log); in-app appends now double-signal (their own tick + this) — harmless.

## Tests

`pixi run test-api` — the observer-broadcasts testset now asserts `lab_log_updated` fires for **user / Claude / Cecelia** appends while `lab_log_entry_added` stays user-only. `pixi run test-frontend` (236) + `vue-tsc` clean.

## Reservation

The `ws.ts` handler is verified by typecheck + unit tests, not a live socket round-trip — but this is the exact flow you hit (Chat-to-Claude append not showing until close/reopen), so it's directly checkable in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
