### PR TITLE
Record task params in the run log (Observer Phase 2 tuning trail)

### DIFF
--- a/app/src/run_log.jl
+++ b/app/src/run_log.jl
@@ -1,14 +1,22 @@
-# Per-image RUN LOG — an append-only record of which task functions ran on an image and when, so the
-# UI can show a provenance history ("ran segment.cellpose on 2026-07-11", …). No params are stored here
-# (the last-run params live in the task config); this is just fun + value_name + timestamp. Stored as a
-# sidecar `{1/uid}/runlog.json` (a JSON array), mirroring the QC sidecars. The scheduler appends an
-# entry when a task finishes successfully (:done); see tasks/scheduler.jl. Capped to the most recent
-# RUN_LOG_CAP entries so it can't grow unbounded.
+# Per-image RUN LOG — an append-only record of which task functions ran on an image, with what params,
+# and when, so the UI can show a provenance history ("ran segment.cellpose on 2026-07-11", …) and the
+# AI observer can see the *tuning trail* — which param sets were tried across re-runs. Each entry is
+# {fun, valueName, status, params, at}; `params` is the sanitised task params (internal `_…` keys and
+# the redundant `valueName` dropped — see `_run_log_params`). Stored as a sidecar `{1/uid}/runlog.json`
+# (a JSON array), mirroring the QC sidecars. The scheduler appends an entry when a task finishes
+# (:done or :failed); see tasks/scheduler.jl. Capped to the most recent RUN_LOG_CAP entries.
+#
+# IMPORTANT — this is a TRAIL, not a param↔outcome correlation. QC-at-the-time is deliberately NOT
+# snapshotted here: a re-run overwrites the h5ad, so a superseded run's metrics are gone, and real
+# projects produce only a few confounded re-runs (the user nudges params *because* the last result was
+# off) — not a fittable dataset. Readers (incl. Claude) must treat `params` as "what was tried", never
+# as a relationship to extrapolate from. See docs/todo/OBSERVER_PHASE2_PLAN.md §1 + the tier-3 note.
 const RUN_LOG_CAP = 200
 
 run_log_path(img::CciaImage) = joinpath(img._dir, "runlog.json")
 
-# the run log as a Vector of Dicts ({fun, valueName, at}), oldest→newest; [] when none.
+# the run log as a Vector of Dicts ({fun, valueName, status, params, at}), oldest→newest; [] when none.
+# Legacy entries may lack `status`/`params`; readers treat missing status as "done" and missing params as {}.
 function read_run_log(img::CciaImage)::Vector{Any}
     p = run_log_path(img)
     isfile(p) || return Any[]
@@ -19,15 +27,30 @@ function read_run_log(img::CciaImage)::Vector{Any}
     end
 end
 
-# append one {fun, valueName, status, at} entry (ISO-ish local timestamp) and persist; returns the new
-# log. `status` is "done" (success) or "failed" — recording failures too so the run history (and the
-# AI observer reading it) can see repeated failures, not just successes. Legacy entries lack `status`;
-# readers should treat a missing status as "done".
+# Sanitise task params for the run-log trail: drop internal keys (any leading-underscore key, e.g. the
+# injected `_task_id`) and the redundant `valueName` (already its own field). Keeps the real tuning
+# knobs. Returns a String-keyed Dict; `nothing`/empty → an empty Dict (so entries are shape-stable).
+function _run_log_params(params)::Dict{String,Any}
+    out = Dict{String,Any}()
+    params === nothing && return out
+    for (k, v) in params
+        ks = string(k)
+        (startswith(ks, "_") || ks == "valueName") && continue
+        out[ks] = v
+    end
+    out
+end
+
+# append one {fun, valueName, status, params, at} entry (ISO-ish local timestamp) and persist; returns
+# the new log. `status` is "done" (success) or "failed" — recording failures too so the run history
+# (and the AI observer reading it) can see repeated failures, not just successes. `params` is the raw
+# task params (sanitised via `_run_log_params`); pass `nothing` (default) when there are none.
 function append_run_log!(img::CciaImage, fun_name::AbstractString, value_name::AbstractString = "",
-                         status::AbstractString = "done")
+                         status::AbstractString = "done", params = nothing)
     entries = read_run_log(img)
     push!(entries, Dict{String,Any}(
         "fun" => string(fun_name), "valueName" => string(value_name), "status" => string(status),
+        "params" => _run_log_params(params),
         "at" => Dates.format(Dates.now(), "yyyy-mm-ddTHH:MM:SS")))
     length(entries) > RUN_LOG_CAP && (entries = entries[(end - RUN_LOG_CAP + 1):end])
     open(run_log_path(img), "w") do io

--- a/app/src/tasks/scheduler.jl
+++ b/app/src/tasks/scheduler.jl
@@ -306,7 +306,7 @@ function _execute_job!(job::TaskJob)
             fn = _fun_name_from_task(job.task)
             vn = string(get(job.params, "valueName", ""))
             for tgt in (isnothing(job.imgs) ? [job.img] : job.imgs)
-                append_run_log!(tgt, fn, vn, string(final))
+                append_run_log!(tgt, fn, vn, string(final), job.params)
             end
         catch e
             @warn "run-log append failed" task_id = job.id exception = e

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -291,6 +291,25 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         @test length(capped) == Cecelia.RUN_LOG_CAP
         @test capped[end]["fun"] == "x.$(Cecelia.RUN_LOG_CAP + 10)"   # newest kept
 
+        # params trail: entry carries the sanitised task params; internal `_…` keys and the redundant
+        # `valueName` are dropped, real tuning knobs kept (Observer Phase 2 §1 — see OBSERVER_PHASE2_PLAN).
+        img2 = add_image!(s; name="img-2", meta=Dict{String,Any}("ori_path" => "/tmp/fake2.tif"))
+        append_run_log!(img2, "tracking.bayesian_tracking", "default", "done",
+                        Dict{String,Any}("search_radius" => 5.0, "max_lost" => 3,
+                                         "valueName" => "default", "_task_id" => "abc123"))
+        e = read_run_log(img2)[end]
+        @test e["params"]["search_radius"] == 5.0
+        @test e["params"]["max_lost"] == 3
+        @test !haskey(e["params"], "valueName")    # redundant with its own field
+        @test !haskey(e["params"], "_task_id")      # internal, dropped
+        # default (no params) → shape-stable empty dict, and it survives reload
+        append_run_log!(img2, "behaviour.hmm")
+        @test read_run_log(img2)[end]["params"] == Dict{String,Any}()
+        @test read_run_log(init_object(proj.uid, img2.uid))[end-1]["params"]["search_radius"] == 5.0
+        # sanitiser handles nothing/empty directly
+        @test Cecelia._run_log_params(nothing) == Dict{String,Any}()
+        @test Cecelia._run_log_params(Dict("_x" => 1, "keep" => 2)) == Dict{String,Any}("keep" => 2)
+
         rm(proj.root; recursive=true)
     end
 

--- a/docs/todo/OBSERVER_PHASE2_PLAN.md
+++ b/docs/todo/OBSERVER_PHASE2_PLAN.md
@@ -1,0 +1,129 @@
+# Observer Phase 2 — Actionable suggestions, notebook generation, session entry
+
+Parked plan. Builds on the working observer data-access foundation (Slices A–E, see
+`docs/ai-assist/OBSERVER.md` and `OBSERVER_DATA_ACCESS_PLAN.md`). Source brief:
+`docs/prompts/phase2-observer-prompt.md` — this doc is the **corrected, locked** version
+of it. Read both; where they disagree, this doc wins (the brief was written without the
+real REPL interface).
+
+**Core principle (unchanged):** Cecelia works without Claude. Everything here is
+Claude-*optional*. Cecelia's own QC/cohort/reporting functions stand alone; Claude adds
+suggestions, notebooks, and a guided session entry on top.
+
+---
+
+## Ground-truth corrections to the brief (verified against the code)
+
+The brief was written before the real interface was checked. These are wrong in it and
+right here:
+
+| Brief says | Reality |
+|---|---|
+| `pop_dt(...)` | `pop_df(img, pop_type, pops; value_name=…)` |
+| `get_image(project; uid)` / `get_images(project; set_uid)` | `images(proj)` / `images(set)` / `sets(proj)`; **no image-by-uid helper** — filter by `.uid` (we add a tiny `image(proj; uid=)` convenience) |
+| `track_measures(img; value_name=)` as a read accessor | `track_measures` is a **task** (`TrackMeasures`). Track data reads via `track_props` / `track_cell_measures` / `is_tracked` and `pop_df` |
+| "Chat to Claude launches a session; pass a startup payload / `_build_claude_cmd`" | It **copies a starter prompt to the clipboard** (`buildChatPrompt` → clipboard in `LabLogPanel.vue`). No launch command exists. Context is delivered by a tool the pasted prompt calls, not an injected payload |
+| "Reuse the project versioning system for notebooks" | Notebooks **already have** their own snapshot/registry versioning (`.snapshots/<name>@v<N>.jl` + `notebooks.json`, see `docs/NOTEBOOKS.md`). Reuse **that**, not project-state versioning |
+| "Read param JSON at `inputDefinitions/`" | Real specs are the co-located task `<name>.json`, already served by `api_task_definitions` (`GET /api/tasks/definitions`). Reuse that route |
+| "Parameter history per image from the run log" | **The run log stores no params** (`append_run_log!` = fun/valueName/status/at only). Current last-used params come from `read_module_fun_params`. Historical param↔outcome correlation is **not** available — see §1 boundary |
+
+Already true (no work needed): `append_lab_log` MCP tool exists; observer analysis tools
+(lineage/populations/measures/behaviour/clusters/chains/cohort-QC) exist; Pluto engine +
+notebooks exist.
+
+---
+
+## Locked decisions
+
+1. **How Claude knows the REPL — introspection-backed doc, drift-guarded by a test.**
+   - One curated `const NOTEBOOK_API::Vector{Symbol}` in the package = the notebook-safe
+     read-accessor allow-list (`load_project`, `images`, `sets`, `image`, `pop_df`,
+     `label_props`, `select_cols`/`view_*`/`as_df`, `track_props`, `track_cell_measures`,
+     `is_tracked`, `img_value_names`, `plot_summary_data`, …).
+   - An introspection fn `repl_api_reference()` reads the **live package** for each symbol:
+     exported? + `Base.Docs.doc` docstring + `methods()` signatures → structured entries.
+   - `docs/REPL.md` = human cookbook (the `|>` chain idiom, pop_type/value_name model, the
+     **notebook write rules**) **plus** a generated `<!-- BEGIN GENERATED API -->…<!-- END -->`
+     section produced from `repl_api_reference()`.
+   - **Drift guard (the "wire it in"):** a `test-pkg` golden test regenerates that section
+     and asserts it equals what's committed. Change a documented signature without updating
+     `REPL.md` → CI red. There is a `pixi run gen-repl-doc` (or a Julia script) to regenerate.
+   - Claude reads `REPL.md` as an MCP **resource** (`get_repl_api` tool returns the same
+     structured reference for programmatic use). Per-project structure (actual value_names /
+     pops / columns) keeps coming from the existing `populations_summary`/`measure_summary`.
+
+2. **Session context = `get_session_briefing` MCP tool**, not an injected payload. The
+   clipboard prompt (`buildChatPrompt`) tells Claude to call it first. Returns: project
+   name + image count, images currently at 🟡/🔴, recent lab-log entries (last 7 days).
+   Small, live, no launch mechanism needed.
+
+3. **§1 param suggestions are IN scope, bounded honestly.** Claude cites the *current*
+   param value (`read_module_fun_params`) + valid range (task JSON via `get_module_params`)
+   + current QC/cohort outcome, and suggests a direction. It does **not** claim historical
+   "params X → outcome Y" correlation — the run log doesn't store params, so that regression
+   isn't buildable without new per-run snapshotting (explicitly deferred, noted in the tool
+   docstring). Suggestions land as `[Claude]` 🟡 lab-log entries framed "suggestion, not
+   instruction". Read-only; user approves any actual re-run.
+
+4. **Notebook writes are figures + CSV only.** Never `.h5ad`, qc store, lab log, ccid.json.
+   Enforced by convention in `REPL.md` + the notebook generation guidance; notebooks use
+   `using Cecelia` only (no raw HDF5/zarr, no `sys.path`).
+
+5. **No new launch mechanism, no GUI plot creation** (brief §7 stays deferred — Pluto is the
+   safe write path). No automatic param adjustment. No cross-project learning.
+
+---
+
+## Build order
+
+Foundation first (everything leans on the REPL layer), then the features, panel last.
+
+1. **REPL knowledge foundation** — `NOTEBOOK_API` const + `repl_api_reference()` +
+   `docs/REPL.md` (cookbook + generated section) + golden test + MCP resource/`get_repl_api`
+   tool + a tiny `image(proj; uid=)` convenience. *(app/ + mcp/ + docs/ + test-pkg)*
+2. **`get_module_params` MCP tool** — expose the existing task-definition specs (valid
+   ranges/defaults/types) to Claude. Route already exists; add the allow-list entry + client
+   method + server tool. *(mcp/ + allow-list; possibly a thin `/api` shim if the current one
+   isn't shaped for it)*
+3. **§1 param suggestions** — `read_module_fun_params` exposure (current params per fun/image)
+   + the suggestion pattern documented in the observer prompt so Claude produces range-valid,
+   QC-anchored 🟡 suggestions. *(mcp/ + app/ accessor exposure + observer_prompt.jl)*
+4. **`get_session_briefing` MCP tool** + `buildChatPrompt` update to call it first.
+   *(mcp/ + frontend/ chatHandoff.ts + test-frontend)*
+5. **Notebook generation guidance** — document the collaborator-request→notebook workflow so
+   Claude generates a correct `using Cecelia` Pluto notebook via the existing notebooks
+   registry/snapshot system; verify the generated patterns run. *(docs/ + mcp/ prompt; leans
+   on `docs/NOTEBOOKS.md`)*
+6. **`get_available_plots` MCP tool** — from the existing plot JSON specs (name/module/data
+   needs/scope modes). *(mcp/ + allow-list + a `/api/plots/available` read if not already
+   served)*
+7. **In-app Claude overview panel** — static reference panel (what Claude can see / suggest /
+   create / cannot do / can write). Verified against real capabilities. *(frontend/)*
+
+Each step ships with its tests (`test-pkg`/`test-api`/`test-mcp`/`test-frontend`) and doc
+updates (`docs/ai-assist/OBSERVER.md`, `mcp/README.md`, `docs/API.md`, `docs/NOTEBOOKS.md`)
+in the same change. Land as focused PRs, not one mega-PR.
+
+---
+
+## Boundaries / non-goals
+
+- No historical param↔QC regression (run log has no params). §1 is current-state only.
+- No writes outside notebook figures/CSV and lab-log `[Claude]` entries.
+- No task auto-run; Claude suggests, user approves.
+- No GUI-canvas plot creation (deferred; Pluto is the write path).
+- No cross-project learning; stay within the current project.
+
+---
+
+## Verification (from the brief, kept)
+
+- `get_repl_api`/`REPL.md` reflect the real exports; the golden test fails on undocumented
+  signature drift.
+- Chat-to-Claude opens with context loaded (Claude calls `get_session_briefing`) — user
+  doesn't re-explain.
+- Claude suggests a range-valid param value for a flagged image, citing current value + QC.
+- "Make a notebook for this" → a `using Cecelia` Pluto notebook via the existing snapshot
+  versioning; runs clean, produces figure/CSV, touches no data store.
+- `get_available_plots` returns the plot-type list Claude uses to suggest a visualization.
+- The overview panel accurately describes real capabilities.


### PR DESCRIPTION
## What

The per-image run log recorded only `fun`/`valueName`/`status`/timestamp. This adds the **sanitised task params** to each entry, so the AI observer (and the UI) can see the *tuning trail* — which param sets were tried across re-runs — as the grounding for parameter suggestions (Observer Phase 2, §1).

## Changes

- **`app/src/run_log.jl`** — `append_run_log!` gains an optional `params` arg; new `_run_log_params` sanitiser drops internal `_…` keys and the redundant `valueName`, keeping the real knobs. Entry shape is now `{fun, valueName, status, params, at}`. Header comment rewritten.
- **`app/src/tasks/scheduler.jl`** — passes `job.params` at the one call site (both `:done` and `:failed`).
- **`app/test/runtests.jl`** — Run-log testset extended: params captured, `_task_id`/`valueName` stripped, empty-default shape-stable, survives reload, sanitiser unit-checked. **1254 pass**, exit 0.
- **`docs/todo/OBSERVER_PHASE2_PLAN.md`** — the parked epic plan (context; corrects the source brief's fictional REPL and locks the Phase 2 decisions).

## Deliberately a trail, not a correlation

QC-at-the-time is **not** snapshotted: a re-run overwrites the h5ad (a superseded run's metrics are gone), and real projects produce only a few *confounded* re-runs (users nudge params *because* the last result was off) — not a fittable dataset. Readers (incl. Claude) must treat `params` as "what was tried", never as a relationship to extrapolate from. The deferred tier-3 param+QC snapshot is noted in the plan.

## Notes / limitations

- **Capture-only.** Params surface in `get_image_info`'s per-image `runLog` now; the aggregated `get_task_history` and the Claude-facing "trail, don't extrapolate" framing land with §1.
- **No retroactive data** — legacy `runlog.json` entries lack `params` (treated as `{}`); only runs from merge onward get the trail.
- Not exercised end-to-end through a live GUI task run (tests hit `append_run_log!` directly); the scheduler change is a one-line pass-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
