### PR TITLE
Tidy Claude overview "Try asking" examples

### DIFF
--- a/frontend/src/components/ClaudeOverviewDialog.vue
+++ b/frontend/src/components/ClaudeOverviewDialog.vue
@@ -39,7 +39,9 @@ defineEmits<{ (e: 'close'): void }>()
     <!-- example prompts to try -->
     <div class="co-examples">
       <span class="co-examples-label">Try asking</span>
-      <span v-for="(ex, i) in CLAUDE_EXAMPLES" :key="i" class="co-chip">{{ ex }}</span>
+      <div class="co-chips">
+        <span v-for="(ex, i) in CLAUDE_EXAMPLES" :key="i" class="co-chip">{{ ex }}</span>
+      </div>
     </div>
   </BaseModal>
 </template>
@@ -65,8 +67,9 @@ defineEmits<{ (e: 'close'): void }>()
 .co-cell.tone-muted { opacity: 0.85; }
 .co-cell.tone-muted .co-cell-head { color: var(--cc-text-dim); }
 
-.co-examples { margin-top: 14px; display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
-.co-examples-label { font-size: 0.78rem; color: var(--cc-text-dim); margin-right: 2px; }
+.co-examples { margin-top: 14px; }
+.co-examples-label { display: block; font-size: 0.78rem; color: var(--cc-text-dim); margin-bottom: 6px; }
+.co-chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .co-chip {
   font-size: 0.78rem; color: var(--cc-text); background: var(--cc-surface-2);
   border: 1px solid var(--cc-border); border-radius: 999px; padding: 3px 10px;

--- a/frontend/src/lib/claudeOverview.ts
+++ b/frontend/src/lib/claudeOverview.ts
@@ -81,8 +81,9 @@ export const CLAUDE_CAPABILITIES: CapabilityGroup[] = [
 ]
 
 // Copyable one-liners that show the range — from QC to a notebook.
+// Keep them short and uniform so they read as a clean row of chips.
 export const CLAUDE_EXAMPLES: string[] = [
   'Why is this image off?',
-  'How do I plot the behaviour differences?',
-  'Build me a notebook for cell speed over time.',
+  'Plot the behaviour differences',
+  'Build a cell-speed notebook',
 ]


### PR DESCRIPTION
## What

Cleans up the "Try asking" example chips in the Claude overview dialog (`ClaudeOverviewDialog`).

- **Shorter, uniform examples** so they read as one tidy row rather than one long chip wrapping onto its own line:
  - "How do I plot the behaviour differences?" → "Plot the behaviour differences"
  - "Build me a notebook for cell speed over time." → "Build a cell-speed notebook"
  - "Why is this image off?" kept (already short).
- **"Try asking" label on its own line**, with the chips wrapping as a group in a `.co-chips` flex row beneath it — so the label no longer shares a row with the first two chips while the third wraps awkwardly.

Presentational only; no logic or data-model change.

## Test

- `vue-tsc -b` clean
- `claudeOverview.test.ts` passes (3/3)

## Reservation

Rendered result is typecheck- and unit-verified but not eyeballed in a browser — worth a quick look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
