### PR TITLE
Fix create_notebook: wrap multi-statement cells in begin…end

### DIFF
--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -385,10 +385,29 @@ function _cell_uuid()::String
     string(h[1:8], "-", h[9:12], "-", h[13:16], "-", h[17:20], "-", h[21:32])
 end
 
+# Pluto allows only ONE top-level expression per cell — a cell with several statements fails to load
+# ("Multiple expressions in one cell"). Wrap any such cell in `begin … end` (Pluto's own remedy, and
+# what the activation cell already uses) so a generated notebook loads and runs as-is. A single
+# expression (incl. a `md"…"` block or a lone assignment) is left bare; code that doesn't parse is
+# left untouched — don't mask the caller's syntax error behind a wrapper. Pure/testable.
+function _wrap_multi_expr(code::AbstractString)::String
+    s = rstrip(String(code))
+    try
+        ex = Meta.parseall(s)   # → Expr(:toplevel, LineNumberNode, expr, …); comments already stripped
+        if ex isa Expr && ex.head === :toplevel &&
+           count(a -> !(a isa LineNumberNode), ex.args) > 1
+            return string("begin\n", s, "\nend")   # verbatim body — don't indent (would corrupt heredocs)
+        end
+    catch
+        # unparseable → leave as the caller wrote it
+    end
+    s
+end
+
 # Serialise a list of Julia cell sources into a valid Pluto notebook `.jl` (the format
 # notebook_template.jl uses: a header, one `# ╔═╡ <uuid>` marker per cell, then a `# ╔═╡ Cell order:`
 # block). The activation cell is prepended and pinned to the template's fixed id; caller cells get
-# fresh uuids. Pure — unit-tested in api/test.
+# fresh uuids. Each cell is normalised so multi-statement cells load in Pluto. Pure — unit-tested in api/test.
 function _pluto_notebook_source(cells::AbstractVector)::String
     all_cells = vcat(Any[_NB_ACTIVATION_CELL], collect(cells))
     ids  = String[]
@@ -396,7 +415,7 @@ function _pluto_notebook_source(cells::AbstractVector)::String
     for (i, code) in enumerate(all_cells)
         id = i == 1 ? "10000000-0000-0000-0000-000000000001" : _cell_uuid()
         push!(ids, id)
-        print(body, "# ╔═╡ ", id, "\n", rstrip(String(code)), "\n\n")
+        print(body, "# ╔═╡ ", id, "\n", _wrap_multi_expr(String(code)), "\n\n")
     end
     io = IOBuffer()
     print(io, "### A Pluto.jl notebook ###\n# v1.0.3\n\n")

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -250,6 +250,18 @@ end
     @test occursin("# ╔═╡ Cell order:", src)
     @test count("# ╠═", src) == 3                             # activation + 2 caller cells, listed once each
 
+    # Pluto is one-expression-per-cell: a multi-statement cell must be wrapped in begin…end so it
+    # loads (otherwise "Multiple expressions in one cell"). Single expressions stay bare.
+    @test _wrap_multi_expr("df = 1") == "df = 1"                          # single expr → untouched
+    @test _wrap_multi_expr("# just a comment") == "# just a comment"     # no expr → untouched
+    @test !occursin("begin", _wrap_multi_expr("plot(df.x, df.y)"))       # single call → bare
+    multi = _wrap_multi_expr("a = 1\nb = 2\na + b")
+    @test startswith(multi, "begin\n") && endswith(multi, "\nend")       # multi-statement → wrapped
+    @test occursin("a = 1\nb = 2\na + b", multi)                         # body preserved verbatim
+    @test _wrap_multi_expr("x = (\n  1 + 2)") == "x = (\n  1 + 2)"       # one expr spanning lines → bare
+    # end-to-end through the serialiser: a multi-statement caller cell comes out wrapped
+    @test occursin("begin\nusing Cecelia\ndf = pop_df", _pluto_notebook_source(["using Cecelia\ndf = pop_df(img, \"flow\", [\"/T\"])"]))
+
     conf = cecelia_conf(); dirs = get!(conf, "dirs", Dict{String,Any}())
     had  = haskey(dirs, "projects"); old = get(dirs, "projects", nothing)
     tmp  = mktempdir(); dirs["projects"] = tmp


### PR DESCRIPTION
## Problem

A notebook made with the `create_notebook` MCP tool failed to load in Pluto — **every cell** showed:

```
Multiple expressions in one cell
```

Pluto allows only **one top-level expression per cell**. The write serializer (`_pluto_notebook_source`) wrote each caller cell verbatim, so any cell with more than one statement (`a = …; b = …; plot(…)` — i.e. most generated cells) tripped the rule. The prepended activation cell worked only because it was already a `begin … end` block.

## Fix

`_pluto_notebook_source` now normalises each cell through `_wrap_multi_expr`: it parses the cell and, if it contains more than one top-level expression, wraps it in `begin … end` — Pluto's own remedy, identical to the in-app "Wrap all code in a begin … end block" button. A single expression (including a `md"…"` block or a lone assignment) is left bare; code that doesn't parse is left untouched so a genuine syntax error isn't hidden behind a wrapper.

## Test

Added 7 assertions to the write testset (`api/test/runtests.jl`): single expr untouched, comment-only untouched, single call bare, multi-statement wrapped with body preserved, a single expression spanning lines stays bare, and an end-to-end serialise of a multi-statement cell comes out wrapped.

## Notes

- `api/src` isn't Revise-tracked → takes effect after a backend restart, and only helps **newly** created notebooks (existing broken ones regenerate cleanly).
- Correctness-only: multi-statement cells now *run*, but as one `begin … end` block rather than several small reactive cells — finer granularity is a separate guidance tweak.
- 3 unrelated notebook-registry test failures seen locally are pre-existing and environment-only (a running Pluto server flips the delete-guard path); they pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
