### PR TITLE
Fix flaky notebook delete test when a Pluto server is running

### DIFF
--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -226,9 +226,12 @@ end
         @test JSON3.read(_post(api_notebooks_duplicate, Dict("projectUid"=>uid,"file"=>"nb1.jl","scope"=>"project"))[2]).file == "nb1-copy.jl"
         @test find("nb1-copy.jl") !== nothing
 
-        # delete (server not running in tests → guard doesn't require force)
+        # delete — pass force=true so this is deterministic regardless of whether a Pluto server is
+        # running locally. The guard 409s on a live server without force (a dev machine with the
+        # notebook server up would otherwise fail this + the two asserts below); force is what the
+        # UI's confirm supplies anyway.
         @test !isempty(snaps())    # nb1 has snapshots on disk before delete
-        @test _post(api_notebooks_delete, Dict("projectUid"=>uid,"file"=>"nb1.jl"))[1] == 200
+        @test _post(api_notebooks_delete, Dict("projectUid"=>uid,"file"=>"nb1.jl","force"=>true))[1] == 200
         @test find("nb1.jl") === nothing
         @test isempty(snaps())     # delete also removes the notebook's snapshot history
 


### PR DESCRIPTION
## Problem

The `API: notebooks registry + versioning` testset failed **across sessions on a dev machine** (but passed in CI). The delete block called `api_notebooks_delete` without `force`:

```julia
@test _post(api_notebooks_delete, Dict("projectUid"=>uid,"file"=>"nb1.jl"))[1] == 200
```

The delete guard returns **409** whenever a Pluto notebook server is alive on :7660 (it can re-create an open notebook's file after deletion). So on any machine with `pixi run notebooks` / a survivor server running, delete returned 409 → that assert failed, and the two follow-ups (notebook gone, snapshots gone) cascaded. CI has no server running, so it never caught it. The test's inline "server not running in tests" assumption simply doesn't hold locally.

## Fix

Pass `force=true` (exactly what the UI's delete-confirm supplies) so the delete is deterministic regardless of whether a Pluto server happens to be up. Verified: the testset now passes 30/30 with the server alive (403 on :7660).

## Note

This drops coverage of the 409-guard-when-server-running path — that behaviour is environment-coupled (`_notebook_server_alive()` does a real HTTP probe) and can't be asserted deterministically without stubbing. The guard itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
