### PR TITLE
Add set_notebook_description observer write tool

### DIFF
--- a/docs/ai-assist/OBSERVER.md
+++ b/docs/ai-assist/OBSERVER.md
@@ -45,10 +45,11 @@ get_repl_api              → notebook/REPL data-access surface: read accessors 
 get_session_briefing      → chat startup context: name/count + flagged images + recent lab log (Phase 2; call first)
 ```
 
-**Write (additive only — the two non-destructive writes):**
+**Write (the three non-destructive writes — none touch cell data / images / gates / QC / notebook content):**
 ```
 append_lab_log            → append a dated [Claude] entry. Append-only, never edits existing content.
 create_notebook           → create a Pluto notebook from cells (Phase 2). Create-only (409 on existing); the user edits/owns it.
+set_notebook_description  → reword a notebook's one-line description (registry sidecar). Description text only; cells untouched.
 ```
 
 **Write (Phase 2 — deferred):**
@@ -231,13 +232,16 @@ verifiable artifacts. Shipped as PRs #250–#258; this is the durable summary (t
 - **REPL knowledge (`get_repl_api` + `docs/REPL.md`)** — the notebook-safe accessor allow-list
   (`NOTEBOOK_API`) with live docstrings; a golden test keeps REPL.md from drifting.
 - **`create_notebook`** — generates a runnable Pluto notebook from cells (`/api/notebooks/write`).
+  `set_notebook_description` rewords its blurb afterwards (`/api/notebooks/describe`, description text only).
 - **`get_available_plots`** — the board's plot types, for viz suggestions.
 - **In-app overview** — `ClaudeOverviewDialog` (`?` in the lab-log toolbar): a brief how-to.
 
 **Durable boundaries (why, so they aren't relitigated)**
-- **Two additive writes only.** The MCP allow-list permits exactly `POST /api/lablog/append`
-  (append-only) and `POST /api/notebooks/write` (create-only, 409 on existing). Neither edits/deletes;
-  the invariant test asserts the set. No task-run, gate, h5ad, or config write.
+- **Three non-destructive writes only.** The MCP allow-list permits exactly `POST /api/lablog/append`
+  (append-only), `POST /api/notebooks/write` (create-only, 409 on existing), and `POST
+  /api/notebooks/describe` (a notebook's description string only — not its cells). None touch cell
+  data, images, gates, QC, or notebook content; the invariant test asserts the exact set. No task-run,
+  gate, h5ad, or config write.
 - **Param suggestions are current-state, not a correlation.** The run log stores params but QC is NOT
   snapshotted per run, so there is no fittable params→outcome curve — Claude cites what was tried + the
   valid range and suggests a direction; it does not predict. A per-run QC snapshot was considered and

--- a/frontend/src/lib/chatHandoff.ts
+++ b/frontend/src/lib/chatHandoff.ts
@@ -19,8 +19,9 @@ export function buildChatPrompt(projectUid: string, projectName?: string): strin
       `analysis itself (get_populations, get_measure_summary, get_behaviour_summary, get_cluster_summary), ` +
       `the board's plot types (get_available_plots), ` +
       `cross-set QC (get_cohort_qc), the lab log (read_lab_log), and the notebook/REPL data-access ` +
-      `surface (get_repl_api). They are read-only except two additive actions, taken only when I ask: ` +
-      `appending to the lab log (append_lab_log) and creating a Pluto notebook (create_notebook).`,
+      `surface (get_repl_api). They are read-only except three non-destructive actions, taken only when ` +
+      `I ask: appending to the lab log (append_lab_log), creating a Pluto notebook (create_notebook), and ` +
+      `rewording a notebook's description (set_notebook_description).`,
     ``,
     `Don't dive in yet. Call get_session_briefing first to get oriented — it returns the project name + ` +
       `image count, which images are flagged (QC), and recent lab-log entries. Open with what stands out ` +

--- a/mcp/cecelia_mcp/client.py
+++ b/mcp/cecelia_mcp/client.py
@@ -2,10 +2,12 @@
 
 Every request goes through an explicit ALLOW-LIST of (method, path) pairs. That list IS the
 observer's no-mutation guarantee: the only non-GET routes permitted are ``POST /api/lablog/append``
-(append-only) and ``POST /api/notebooks/write`` (create-only — 409 on an existing name, so it never
-overwrites). Both are ADDITIVE / non-destructive: no allow-listed route can edit or delete project
-data. Any attempt to call a route not on the list raises ``DisallowedRoute`` — so if a future tool
-ever wires in a mutating route it fails loudly in tests rather than silently mutating a project.
+(append-only), ``POST /api/notebooks/write`` (create-only — 409 on an existing name, so it never
+overwrites), and ``POST /api/notebooks/describe`` (edits ONLY a notebook's own description string in
+the registry sidecar — not its cells, not analysis data). All three are non-destructive to project &
+analysis data: no allow-listed route can touch cell data, images, gates, QC, or a notebook's content.
+Any attempt to call a route not on the list raises ``DisallowedRoute`` — so if a future tool ever
+wires in a mutating route it fails loudly in tests rather than silently mutating a project.
 
 Uses only the Python standard library (urllib) so this module — and its tests — carry no third-party
 dependency; the ``mcp`` SDK is needed only by ``server.py`` which wires these calls into tools.
@@ -19,9 +21,8 @@ import urllib.request
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8080"
 
-# (method, path) → the ONLY routes the observer may ever call. Read-only except the append route.
-# Keep this in sync with the backing routes in api/src/routes.jl; the test asserts append is the
-# sole write.
+# (method, path) → the ONLY routes the observer may ever call. Read-only except the three writes below.
+# Keep this in sync with the backing routes in api/src/routes.jl; the test pins the exact write set.
 ALLOWED_ROUTES = frozenset(
     {
         ("GET", "/api/projects"),
@@ -42,8 +43,9 @@ ALLOWED_ROUTES = frozenset(
         ("GET", "/api/observer/briefing"),  # session startup context: name/count + flagged images + recent lab log
         ("GET", "/api/logs/recent"),     # the backend console ring (server @info/@warn/@error)
         ("GET", "/api/lablog"),
-        ("POST", "/api/lablog/append"),  # write 1/2 — append-only, server-guarded
-        ("POST", "/api/notebooks/write"),  # write 2/2 — create-only (409 on existing); serialises cells to a Pluto notebook
+        ("POST", "/api/lablog/append"),  # write 1/3 — append-only, server-guarded
+        ("POST", "/api/notebooks/write"),  # write 2/3 — create-only (409 on existing); serialises cells to a Pluto notebook
+        ("POST", "/api/notebooks/describe"),  # write 3/3 — edits ONLY a notebook's description string (registry sidecar); not its content
     }
 )
 
@@ -218,7 +220,7 @@ class CeceliaClient:
         # project (it's the process-wide console).
         return self._request("GET", "/api/logs/recent")
 
-    # ── the two writes (both additive / non-destructive) ─────────────────────────────
+    # ── the three writes (all non-destructive to project & analysis data) ────────────
     def append_lab_log(self, project_uid: str, author: str, lines: list[str]):
         return self._request(
             "POST",
@@ -233,4 +235,14 @@ class CeceliaClient:
             "POST",
             "/api/notebooks/write",
             body={"projectUid": project_uid, "name": name, "cells": cells, "description": description},
+        )
+
+    def set_notebook_description(self, project_uid: str, file: str, description: str):
+        # Edits ONLY the notebook's description text in the registry sidecar — never its cells. `file`
+        # is the notebook filename as returned by create_notebook (e.g. "speed.jl"); a bare name works
+        # too (the server appends .jl). 404 if the notebook doesn't exist.
+        return self._request(
+            "POST",
+            "/api/notebooks/describe",
+            body={"projectUid": project_uid, "file": file, "description": description},
         )

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -332,8 +332,8 @@ def read_lab_log(project_uid: str) -> str:
 def append_lab_log(project_uid: str, lines: list[str]) -> dict:
     """Append a dated [Claude] entry to the lab log. Append-only — never edits existing content.
 
-    `lines` is one or more markdown lines. One of only two writes the observer can make (the other is
-    create_notebook); both are additive.
+    `lines` is one or more markdown lines. One of only three writes the observer can make (the others
+    are create_notebook and set_notebook_description); all are non-destructive to project data.
     """
     return _client.append_lab_log(project_uid, CLAUDE_AUTHOR, lines)
 
@@ -352,9 +352,20 @@ def create_notebook(project_uid: str, name: str, cells: list[str], description: 
     CREATE-ONLY: 409 if `name` already exists — never overwrites (pick a new name). After creating, tell
     the user it's ready in the **Notebooks page** — an open page auto-refreshes; if theirs was already
     open and doesn't show it, they can hit refresh. They open it, edit/iterate in Pluto (you can guide
-    them + suggest corrected cells to paste), and once happy they run it without you. One of only two
-    writes; additive. Suggest, then create on the user's ask — don't spam notebooks."""
+    them + suggest corrected cells to paste), and once happy they run it without you. One of only three
+    writes; non-destructive. Suggest, then create on the user's ask — don't spam notebooks. To reword
+    its description afterwards, use set_notebook_description (don't recreate)."""
     return _client.create_notebook(project_uid, name, cells, description)
+
+
+@mcp.tool()
+def set_notebook_description(project_uid: str, file: str, description: str) -> dict:
+    """Update a notebook's one-line description (shown in the Notebooks page). Use this to reword the
+    blurb after create_notebook — e.g. the user asks to make it briefer — instead of recreating the
+    notebook. Edits ONLY the description string in the registry sidecar; the notebook's cells are
+    untouched. `file` is the notebook filename create_notebook returned (e.g. "speed.jl"); a bare name
+    works too. 404 if it doesn't exist. One of only three writes; non-destructive."""
+    return _client.set_notebook_description(project_uid, file, description)
 
 
 @mcp.tool()

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -44,11 +44,16 @@ class ClientTest(unittest.TestCase):
         with self.assertRaises(DisallowedRoute):
             self.c._request("GET", "/api/gating/save")
 
-    def test_writes_are_only_the_two_additive_routes(self):
-        # The no-mutation guarantee: the only non-GET routes are lab-log append (append-only) and
-        # notebook write (create-only). Both additive; nothing can edit/delete project data.
+    def test_writes_are_only_the_three_non_destructive_routes(self):
+        # The no-mutation guarantee: the only non-GET routes are lab-log append (append-only), notebook
+        # write (create-only), and notebook describe (description text only). None can edit/delete cell
+        # data, images, gates, QC, or a notebook's content.
         writes = sorted((m, p) for (m, p) in ALLOWED_ROUTES if m != "GET")
-        self.assertEqual(writes, [("POST", "/api/lablog/append"), ("POST", "/api/notebooks/write")])
+        self.assertEqual(writes, [
+            ("POST", "/api/lablog/append"),
+            ("POST", "/api/notebooks/describe"),
+            ("POST", "/api/notebooks/write"),
+        ])
 
     def test_create_notebook_posts_cells(self):
         with _patch_urlopen({"ok": True, "file": "speed.jl"}) as u:
@@ -59,6 +64,17 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(
             json.loads(req.data.decode()),
             {"projectUid": "p", "name": "speed", "cells": ["using Cecelia", "df = 1"], "description": "d"},
+        )
+
+    def test_set_notebook_description_posts(self):
+        with _patch_urlopen({"ok": True}) as u:
+            self.c.set_notebook_description("p", "speed.jl", "shorter blurb")
+        req = u.call_args[0][0]
+        self.assertEqual(req.method, "POST")
+        self.assertTrue(req.full_url.endswith("/api/notebooks/describe"))
+        self.assertEqual(
+            json.loads(req.data.decode()),
+            {"projectUid": "p", "file": "speed.jl", "description": "shorter blurb"},
         )
 
     def test_list_images_builds_url(self):

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -26,6 +26,7 @@ class ServerToolRegistrationTest(unittest.TestCase):
             "get_measure_summary", "get_behaviour_summary", "get_cluster_summary",
             "get_chains", "get_cohort_qc", "get_repl_api", "get_session_briefing",
             "get_recent_logs", "read_lab_log", "append_lab_log", "create_notebook",
+            "set_notebook_description",
         ):
             self.assertIn(tool, self.names)
 


### PR DESCRIPTION
## Why

After `create_notebook`, a "make the description briefer" request had no tool behind it — Claude fell back to grepping the codebase, finding the registry JSON, and hand-editing it (this is what made a description reword take minutes). The `POST /api/notebooks/describe` route already exists and is tested; this just exposes it through the observer's MCP surface.

## Change

- **client** — allow-list `POST /api/notebooks/describe` (write 3/3) + `set_notebook_description(project_uid, file, description)`.
- **server** — new `set_notebook_description` tool; the `create_notebook` docstring now points at it for rewording.
- **guarantee reframed** — from "two additive writes" to "three non-destructive writes": describe edits **only** a notebook's description string in the registry sidecar — never its cells, never analysis data. None of the three writes can touch cell data, images, gates, QC, or notebook content. The invariant test pins the exact 3-route write set.
- **docs** — `OBSERVER.md` write surface + durable-boundary section; `chatHandoff.ts` handoff prompt.

## Test

`pixi run test-mcp` → 45 pass (was 44): updated the write-set invariant to the exact 3 routes, added a client POST-shape test, added the tool to the server-registration list. Frontend `chatHandoff.test.ts` + `vue-tsc -b` clean.

## Reservations

- **First allow-listed write that *edits* existing data** (a description string) rather than purely appending/creating — a small, deliberate loosening of the original "additive only" invariant. Still non-destructive to all project/analysis data and notebook content.
- Unit-tested only (tool registration + client POST shape); the route itself is already live/tested on main, but the end-to-end Claude flow is unverified.
- Needs an MCP server restart + session reconnect for Claude to see the new tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
