### PR TITLE
Add observer notebook read tools (have-a-look + teach flow)

### DIFF
--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -339,6 +339,26 @@ function api_notebooks_list(req::HTTP.Request)
     200, JSON3.write((; notebooks = vcat(proj, examples)))
 end
 
+# GET /api/notebooks/content?projectUid=&file=  → { file, scope, content }
+# Read a notebook's CURRENT source (including the user's own edits) so the observer can "have a look"
+# when the user is stuck — the Phase 2 teaching flow: read, explain, suggest corrected cells to paste;
+# never overwrite (a revision becomes a NEW notebook via create_notebook). Resolves under the project's
+# notebooks/ dir, then the shipped examples/ dir. `_safe_nb_file` blocks path traversal. Read-only.
+function api_notebooks_content(req::HTTP.Request)
+    query = HTTP.queryparams(HTTP.URI(req.target))
+    uid   = get(query, "projectUid", "")
+    file  = _safe_nb_file(get(query, "file", ""))
+    (isempty(uid) || file === nothing) && return 400, JSON3.write((; error = "projectUid + file required"))
+    isdir(joinpath(projects_dir(), uid)) || return 404, JSON3.write((; error = "Project not found"))
+
+    ppath = joinpath(_project_notebooks_dir(uid), file)
+    epath = joinpath(_repo_notebooks_dir(), file)
+    path, scope = isfile(ppath) ? (ppath, "project") :
+                  isfile(epath) ? (epath, "example") : (nothing, "")
+    path === nothing && return 404, JSON3.write((; error = "Notebook not found"))
+    200, JSON3.write((; file = file, scope = scope, content = read(path, String)))
+end
+
 # ── Notebook CRUD (project scope) ────────────────────────────────────────────────
 # All resolve the target strictly under {proj}/notebooks/ via _safe_nb_file, so examples (which live
 # in the repo, not the project dir) can't be mutated/deleted here — only duplicated into the project.

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -257,6 +257,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_napari_gpu_get(req)
         elseif path == "/api/notebooks"
             api_notebooks_list(req)
+        elseif path == "/api/notebooks/content"
+            api_notebooks_content(req)
         elseif path == "/api/notebooks/status"
             api_notebooks_status(req)
         elseif path == "/api/notebooks/snapshots"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -279,6 +279,17 @@ end
         @test g.version == 1 && g.description == "speed over time"
         # create-only: never clobbers
         @test w(Dict("projectUid"=>uid, "name"=>"gen", "cells"=>["y=2"]))[1] == 409
+
+        # content read (the "have a look" flow): returns the notebook's current source
+        cget(q) = api_notebooks_content(HTTP.Request("GET", "/api/notebooks/content?$q"))
+        st2, cbody = cget("projectUid=$uid&file=gen.jl")
+        @test st2 == 200
+        cd = JSON3.read(cbody)
+        @test cd.file == "gen.jl" && cd.scope == "project" && occursin("df = 1", cd.content)
+        @test cget("projectUid=$uid&file=nope.jl")[1] == 404      # missing notebook
+        @test cget("projectUid=$uid")[1] == 400                    # file required
+        @test cget("projectUid=NOPE&file=gen.jl")[1] == 404        # missing project
+        @test cget("projectUid=$uid&file=../secret")[1] == 400     # path traversal rejected
     finally
         lock(_ws_clients_lock) do; delete!(_ws_clients, key); end
         had ? (dirs["projects"] = old) : delete!(dirs, "projects")

--- a/docs/ai-assist/OBSERVER.md
+++ b/docs/ai-assist/OBSERVER.md
@@ -43,6 +43,8 @@ read_lab_log              → full lab log content
 get_qc_metrics            → per-image QC flags for a given stage
 get_repl_api              → notebook/REPL data-access surface: read accessors + live docstrings + cookbook (Phase 2)
 get_session_briefing      → chat startup context: name/count + flagged images + recent lab log (Phase 2; call first)
+list_notebooks            → a project's notebooks (name, file, description, version) + shipped examples (Phase 2)
+get_notebook              → a notebook's current Pluto source (with the user's edits) — the "have a look" flow (Phase 2)
 ```
 
 **Write (the three non-destructive writes — none touch cell data / images / gates / QC / notebook content):**
@@ -249,5 +251,10 @@ verifiable artifacts. Shipped as PRs #250–#258; this is the durable summary (t
 - **Notebooks: Claude bootstraps, the user owns.** `create_notebook` is create-only + snapshots v1;
   iteration happens in Pluto by the user (Claude guiding via chat). Notebook code writes figures/CSV
   only — never h5ad/QC/lab-log/ccid (`docs/REPL.md`).
+- **Stuck? Read + teach, don't overwrite.** When the user is stuck in a notebook, Claude reads its
+  current source (`get_notebook`), explains the fix in plain terms and walks them through it (most
+  users are new to Julia — the goal is they learn to do it themselves). If they ask Claude to apply the
+  change, it creates a NEW notebook version via `create_notebook` (a new name) and says so first —
+  it never overwrites their file or their edits. There is deliberately no "overwrite notebook" write.
 - **REPL.md can't drift.** `docs/REPL.md`'s API section is generated from the live docstrings of
   `NOTEBOOK_API` and golden-tested; changing a listed function's docstring without regenerating fails CI.

--- a/frontend/src/lib/chatHandoff.ts
+++ b/frontend/src/lib/chatHandoff.ts
@@ -18,10 +18,11 @@ export function buildChatPrompt(projectUid: string, projectName?: string): strin
       `get_task_log/get_recent_logs), how the data was produced (get_analysis_lineage, get_chains), the ` +
       `analysis itself (get_populations, get_measure_summary, get_behaviour_summary, get_cluster_summary), ` +
       `the board's plot types (get_available_plots), ` +
-      `cross-set QC (get_cohort_qc), the lab log (read_lab_log), and the notebook/REPL data-access ` +
-      `surface (get_repl_api). They are read-only except three non-destructive actions, taken only when ` +
-      `I ask: appending to the lab log (append_lab_log), creating a Pluto notebook (create_notebook), and ` +
-      `rewording a notebook's description (set_notebook_description).`,
+      `cross-set QC (get_cohort_qc), the lab log (read_lab_log), the notebook/REPL data-access ` +
+      `surface (get_repl_api), and the notebooks themselves (list_notebooks, get_notebook — so you can ` +
+      `read one I'm stuck in and walk me through the fix). They are read-only except three non-destructive ` +
+      `actions, taken only when I ask: appending to the lab log (append_lab_log), creating a Pluto notebook ` +
+      `(create_notebook), and rewording a notebook's description (set_notebook_description).`,
     ``,
     `Don't dive in yet. Call get_session_briefing first to get oriented — it returns the project name + ` +
       `image count, which images are flagged (QC), and recent lab-log entries. Open with what stands out ` +

--- a/mcp/cecelia_mcp/client.py
+++ b/mcp/cecelia_mcp/client.py
@@ -43,6 +43,8 @@ ALLOWED_ROUTES = frozenset(
         ("GET", "/api/observer/briefing"),  # session startup context: name/count + flagged images + recent lab log
         ("GET", "/api/logs/recent"),     # the backend console ring (server @info/@warn/@error)
         ("GET", "/api/lablog"),
+        ("GET", "/api/notebooks"),         # list a project's notebooks (file, description, version)
+        ("GET", "/api/notebooks/content"),  # read a notebook's current source (the "have a look" flow)
         ("POST", "/api/lablog/append"),  # write 1/3 — append-only, server-guarded
         ("POST", "/api/notebooks/write"),  # write 2/3 — create-only (409 on existing); serialises cells to a Pluto notebook
         ("POST", "/api/notebooks/describe"),  # write 3/3 — edits ONLY a notebook's description string (registry sidecar); not its content
@@ -219,6 +221,14 @@ class CeceliaClient:
         # the per-image task log, which only captures the Python subprocess's stdout). Not scoped to a
         # project (it's the process-wide console).
         return self._request("GET", "/api/logs/recent")
+
+    def list_notebooks(self, project_uid: str):
+        return self._request("GET", "/api/notebooks", params={"projectUid": project_uid})
+
+    def get_notebook(self, project_uid: str, file: str):
+        # Returns {file, scope, content} — the notebook's current Pluto source (with the user's edits).
+        return self._request("GET", "/api/notebooks/content",
+                             params={"projectUid": project_uid, "file": file})
 
     # ── the three writes (all non-destructive to project & analysis data) ────────────
     def append_lab_log(self, project_uid: str, author: str, lines: list[str]):

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -329,6 +329,28 @@ def read_lab_log(project_uid: str) -> str:
 
 
 @mcp.tool()
+def list_notebooks(project_uid: str) -> dict:
+    """List a project's notebooks (name, file, description, current version) plus the shipped examples.
+    Use it to find the `file` for get_notebook / set_notebook_description when the user refers to a
+    notebook by name."""
+    return _client.list_notebooks(project_uid)
+
+
+@mcp.tool()
+def get_notebook(project_uid: str, file: str) -> dict:
+    """Read a notebook's CURRENT Pluto source — including the user's own edits — so you can help when
+    they're stuck ("can you have a look?"). Returns {file, scope, content}. `file` is the notebook
+    filename (from list_notebooks / create_notebook, e.g. "speed.jl").
+
+    TEACHING FLOW — the user is likely new to Julia. Read the source, explain what's wrong in plain
+    terms, and walk them through the fix so they learn to do it themselves; suggest corrected cells for
+    them to paste. Do NOT overwrite their notebook. If they ask you to make the changes for them,
+    default to creating a NEW notebook version with create_notebook (a new name, e.g. "<name>-v2") and
+    tell them first: "I'll make a new notebook version." — the original and their edits stay intact."""
+    return _client.get_notebook(project_uid, file)
+
+
+@mcp.tool()
 def append_lab_log(project_uid: str, lines: list[str]) -> dict:
     """Append a dated [Claude] entry to the lab log. Append-only — never edits existing content.
 
@@ -354,7 +376,11 @@ def create_notebook(project_uid: str, name: str, cells: list[str], description: 
     open and doesn't show it, they can hit refresh. They open it, edit/iterate in Pluto (you can guide
     them + suggest corrected cells to paste), and once happy they run it without you. One of only three
     writes; non-destructive. Suggest, then create on the user's ask — don't spam notebooks. To reword
-    its description afterwards, use set_notebook_description (don't recreate)."""
+    its description afterwards, use set_notebook_description (don't recreate).
+
+    REVISIONS: when the user asks you to change an existing notebook, read it with get_notebook, then
+    create a NEW version here under a new name (e.g. "<name>-v2") — never overwrite theirs. Say so
+    first: "I'll make a new notebook version." Prefer teaching them the edit over doing it for them."""
     return _client.create_notebook(project_uid, name, cells, description)
 
 

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -77,6 +77,25 @@ class ClientTest(unittest.TestCase):
             {"projectUid": "p", "file": "speed.jl", "description": "shorter blurb"},
         )
 
+    def test_notebook_read_routes_allow_listed(self):
+        self.assertIn(("GET", "/api/notebooks"), ALLOWED_ROUTES)
+        self.assertIn(("GET", "/api/notebooks/content"), ALLOWED_ROUTES)
+
+    def test_list_notebooks_builds_url(self):
+        with _patch_urlopen({"notebooks": []}) as u:
+            self.c.list_notebooks("p")
+        req = u.call_args[0][0]
+        self.assertEqual(req.method, "GET")
+        self.assertIn("/api/notebooks?projectUid=p", req.full_url)
+
+    def test_get_notebook_builds_url(self):
+        with _patch_urlopen({"file": "speed.jl", "scope": "project", "content": "x=1"}) as u:
+            self.c.get_notebook("p", "speed.jl")
+        req = u.call_args[0][0]
+        self.assertEqual(req.method, "GET")
+        self.assertIn("/api/notebooks/content?", req.full_url)
+        self.assertIn("file=speed.jl", req.full_url)
+
     def test_list_images_builds_url(self):
         with _patch_urlopen({"images": []}) as u:
             self.c.list_images("proj1")

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -26,7 +26,7 @@ class ServerToolRegistrationTest(unittest.TestCase):
             "get_measure_summary", "get_behaviour_summary", "get_cluster_summary",
             "get_chains", "get_cohort_qc", "get_repl_api", "get_session_briefing",
             "get_recent_logs", "read_lab_log", "append_lab_log", "create_notebook",
-            "set_notebook_description",
+            "set_notebook_description", "list_notebooks", "get_notebook",
         ):
             self.assertIn(tool, self.names)
 


### PR DESCRIPTION
## Why

The intended notebook loop is collaborative: the user runs a generated notebook, plays with it, gets stuck, and asks Claude to *have a look*. But the observer had no way to read a notebook back — in practice Claude fell back to filesystem grep (slow, and unavailable in a remote setup). This adds read-only access so Claude can see the current source (including the user's own edits) and teach them through the fix.

## What

- **api** — new `GET /api/notebooks/content` (`api_notebooks_content`): returns a notebook's current Pluto source; resolves project-then-example; `_safe_nb_file` blocks path traversal. Read-only.
- **mcp** — `list_notebooks` (find the file) + `get_notebook` (read current cells). Both allow-listed **GET**s — the three-write guarantee is unchanged.
- **teaching flow** (in the tool docstrings + `OBSERVER.md`): the user is likely new to Julia, so Claude reads → explains in plain terms → walks them through the fix so they learn to do it themselves. If they ask Claude to make the change, it creates a **new notebook version** via `create_notebook` (a new name) and says so first — it never overwrites their file or edits. There is deliberately no "overwrite notebook" write.
- **chat handoff** prompt mentions the read/have-a-look tools.

## Test

- `pixi run test-mcp` → 48 (was 45): read-route allow-list + `list_notebooks`/`get_notebook` URL shape + server registration.
- API write testset → 19/19 (added 6 content-route asserts: 200 + content, 404 missing notebook/project, 400 missing file, path-traversal rejected).
- `chatHandoff.test.ts` + `vue-tsc -b` clean.

## Notes

- **Stacks on #267** (shares `client.py`/`server.py`/`OBSERVER.md`/`chatHandoff.ts`). Base is the describe branch so this diff is clean; GitHub retargets it to `main` when #267 merges. After that it rebases onto main cleanly and also picks up #266's flaky-test fix.
- `api/src` isn't Revise-tracked → the new route needs a backend restart.
- The read → teach → new-version behaviour lives in the tool docstrings, so it's guidance-dependent (up to Claude at runtime); unit-tested at the route/tool level, unverified end-to-end against a live session.
- `get_notebook` returns the raw Pluto `.jl` source (Claude parses that fine); it doesn't split it into structured cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
