### PR TITLE
fix(import): stage all OIR companions + don't freeze the GUI during staging

### DIFF
--- a/app/src/tasks/importImages/omezarr.jl
+++ b/app/src/tasks/importImages/omezarr.jl
@@ -450,12 +450,17 @@ end
 #  2. Require the companion suffix to be `_` + EXACTLY five digits, so a sibling image like
 #     `Img_processed.oir` / `Img_v2.oir` isn't mistaken for a companion of `Img.oir`.
 function _companion_files(names::AbstractVector{<:AbstractString}, main::AbstractString)
-    stem = first(splitext(main))
-    ext  = last(splitext(main))
+    stem   = first(splitext(main))       # main name WITHOUT extension, e.g. "…-res_0001"
+    prefix = stem * "_"
     filter(names) do n
         n == main && return true
-        startswith(n, stem * "_") &&
-            occursin(r"^_[0-9]{5}$", chop(n; head = length(stem), tail = length(ext)))
+        # Olympus OIR companions are `<main-stem>_<digits>` and are typically EXTENSIONLESS, e.g.
+        # `…-res_0001.oir` (main) + `…-res_0001_00001`, `…-res_0001_00002`, … . So match a numeric
+        # run after `<stem>_` (with an optional extension), not a fixed 5-digit + same-extension shape
+        # — the earlier rule matched none of these, so only the main file staged and bioformats saw a
+        # fraction of the timepoints. Literal stem prefix still avoids grabbing a sibling `…-res_0002`.
+        startswith(n, prefix) || return false
+        occursin(r"^[0-9]+(\.[^.]+)?$", chop(n; head = length(prefix), tail = 0))
     end
 end
 
@@ -466,19 +471,41 @@ per-read network latency (bioformats does many small random seeks); a bulk seque
 throughput-bound and far faster — this automates the manual copy-to-tmp workaround. See
 docs/todo/IMPORT_RESCALE_PLAN.md.
 """
+# Copy one file in chunks, yielding between blocks. Julia's `cp` is a single NON-yielding blocking
+# call (`jl_fs_sendfile`); when the pool worker running it is scheduled onto the event-loop thread, a
+# multi-GB copy freezes the WS server (and the whole GUI) until it finishes. A chunked loop with an
+# explicit `yield()` keeps the scheduler/event loop responsive, and lets us report progress.
+function _copy_file_yielding(src::AbstractString, dst::AbstractString;
+                             chunk::Int = 8 * 1024 * 1024, on_bytes::Function = _ -> nothing)
+    buf = Vector{UInt8}(undef, chunk)
+    open(src, "r") do s
+        open(dst, "w") do d
+            while !eof(s)
+                n = readbytes!(s, buf, chunk)
+                write(d, view(buf, 1:n))
+                on_bytes(n)
+                yield()   # let the WS event loop + other tasks run between chunks
+            end
+        end
+    end
+end
+
 function _stage_source!(src_path::AbstractString, stage_dir::AbstractString;
-                        on_log::Function = _ -> nothing)
+                        on_log::Function = _ -> nothing, on_progress::Function = (_, _) -> nothing)
     src_dir = dirname(src_path)
     files   = _companion_files(readdir(src_dir), basename(src_path))
     isempty(files) && (files = [basename(src_path)])
     mkpath(stage_dir)
-    total = 0
-    on_log("[INFO] Staging $(length(files)) source file(s) to local scratch …")
+
+    grand_total = sum(f -> filesize(joinpath(src_dir, f)), files; init = 0)
+    on_log("[INFO] Staging $(length(files)) source file(s), $(round(grand_total / 1e9; digits = 1)) GB, to local scratch …")
+
+    copied = 0
     for f in files
-        cp(joinpath(src_dir, f), joinpath(stage_dir, f); force = true)
-        total += filesize(joinpath(stage_dir, f))
+        _copy_file_yielding(joinpath(src_dir, f), joinpath(stage_dir, f);
+                            on_bytes = n -> (copied += n; grand_total > 0 && on_progress(copied, grand_total)))
     end
-    on_log("[INFO] Staged $(length(files)) file(s) ($(round(total / 1e9; digits = 1)) GB).")
+    on_log("[INFO] Staged $(length(files)) file(s) ($(round(copied / 1e9; digits = 1)) GB).")
     joinpath(stage_dir, basename(src_path))
 end
 
@@ -537,7 +564,7 @@ function _run_task(task::ImportOmezarr, img::CciaImage, params::Dict{String,Any}
     eff_src     = src_path
     if stage_local
         try
-            eff_src = _stage_source!(src_path, stage_dir; on_log = on_log)
+            eff_src = _stage_source!(src_path, stage_dir; on_log = on_log, on_progress = on_progress)
         catch e
             on_log("[ERROR] Failed to stage source locally: $e")
             rm(stage_dir; recursive = true, force = true)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -4520,18 +4520,36 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         end
 
         @testset "OIR companion-file staging" begin
-            # main .oir + its _000nn parts; a sibling image (Img2) and a non-numbered sibling
-            # (Img_processed — the exact case the old R version's loose pattern got wrong) must NOT be grabbed
+            # REAL Olympus naming: the registered file already ends in _NNNN.oir and companions are
+            # EXTENSIONLESS <mainstem>_00001, _00002, … (this is what shipped broken — only the main
+            # matched, so bioformats saw a fraction of the timepoints).
+            real = ["M1a-res_0001.oir", "M1a-res_0001_00001", "M1a-res_0001_00002", "M1a-res_0001_00045",
+                    "M1a-res_0002.oir",           # a DIFFERENT acquisition — must NOT be grabbed
+                    "M1a-res_0001_notes.txt"]     # non-numeric sibling — excluded
+            @test Set(Cecelia._companion_files(real, "M1a-res_0001.oir")) ==
+                  Set(["M1a-res_0001.oir", "M1a-res_0001_00001", "M1a-res_0001_00002", "M1a-res_0001_00045"])
+
+            # extensioned companions (Img.oir + Img_00001.oir …); sibling Img2 / non-numbered excluded
             names = ["Img.oir", "Img_00001.oir", "Img_00002.oir",
                      "Img2.oir", "Img_processed.oir", "Other.oir", "notes.txt"]
             @test Set(Cecelia._companion_files(names, "Img.oir")) ==
                   Set(["Img.oir", "Img_00001.oir", "Img_00002.oir"])
-            # regex metacharacters in the stem (their `basal+NECA` bug): literal match, no injection
-            plus = ["basal+NECA.oir", "basal+NECA_00001.oir", "basal+NECB.oir"]
+            # regex metacharacters in the stem (the `basal+NECA` bug): literal match, no injection
+            plus = ["basal+NECA.oir", "basal+NECA_00001", "basal+NECB.oir"]
             @test Set(Cecelia._companion_files(plus, "basal+NECA.oir")) ==
-                  Set(["basal+NECA.oir", "basal+NECA_00001.oir"])
+                  Set(["basal+NECA.oir", "basal+NECA_00001"])
             # single self-contained file → just itself
             @test Cecelia._companion_files(["a.tif", "b.tif"], "a.tif") == ["a.tif"]
+
+            # chunked yielding copy is byte-identical (incl. a size that isn't a chunk multiple)
+            src = tempname(); dst = tempname()
+            data = rand(UInt8, 3 * 1024 * 1024 + 777)
+            write(src, data)
+            copied = Ref(0)
+            Cecelia._copy_file_yielding(src, dst; chunk = 1024 * 1024, on_bytes = n -> (copied[] += n))
+            @test read(dst) == data
+            @test copied[] == length(data)
+            rm(src; force = true); rm(dst; force = true)
         end
 
         @testset "rescale (16→8-bit) findings" begin

--- a/docs/todo/IMPORT_RESCALE_PLAN.md
+++ b/docs/todo/IMPORT_RESCALE_PLAN.md
@@ -58,13 +58,21 @@ bioformats2raw at the local copy, delete after the source read finishes. Indepen
 
 **Why it's needed (not a nicety):** a multi-file format like Olympus OIR is read with many small
 random seeks; over SMB each seek is a network round-trip, so the read is latency-bound and glacial.
-A bulk `cp` of the whole set is one sequential, throughput-bound transfer — the same copy-to-tmp
-trick done by hand, now automated. No bioformats flag changes its access pattern; staging is the fix.
-`_companion_files` (ported from the old R `prepFilelistToSync` in `cciaHelpers.R`) matches the main
-file + `_<5 digits>` parts by LITERAL stem prefix; bioformats auto-discovers them once co-located. Two
-lessons carried over from that code's comments: (1) match the stem literally, never interpolated into
-a regex — a filename with metacharacters (`basal+NECA`) breaks an interpolated `"<stem>_[0-9]+"`;
-(2) require exactly 5 trailing digits so a sibling like `Img_processed.oir`/`Img2.oir` isn't grabbed.
+Copying the whole set locally first is one sequential, throughput-bound transfer — the copy-to-tmp
+trick, automated. No bioformats flag changes its access pattern; staging is the fix.
+
+`_companion_files` matches the main file + its companions by LITERAL stem prefix (never interpolate
+the stem into a regex — `basal+NECA` would break it). **Real Olympus naming** (fixed 2026-07 after it
+shipped broken): the registered file already ends in `_NNNN.oir` and the companions are
+EXTENSIONLESS — `M1a-…-res_0001.oir` (main) + `M1a-…-res_0001_00001`, `_00002`, … . So the match is
+`<main-stem>_<digits>` (optional extension), NOT a fixed `_<5 digits><same-ext>`; the first version
+matched none of the extensionless parts, so only the main staged and bioformats saw ~4 of 181
+timepoints. The literal-stem prefix still excludes a sibling acquisition (`…-res_0002.oir`).
+
+**Non-blocking copy:** the copy is chunked with an explicit `yield()` per block (`_copy_file_yielding`),
+NOT Julia's `cp`. `cp` is a single non-yielding blocking call (`jl_fs_sendfile`); when the pool worker
+running it is scheduled onto the event-loop thread, a multi-GB copy froze the whole GUI until done.
+Chunking + yielding keeps the WS server responsive and reports staging progress via `on_progress`.
 
 **Peak disk:** with staging + 8-bit, the stage copy and the 16-bit transient briefly coexist during
 conversion (≈ 2× the source), plus the 8-bit output. The stage copy is deleted the moment


### PR DESCRIPTION
Two bugs in the import local-staging path (`stageLocal`), both hit on the lab's 44 GB Olympus OIR timelapses.

## 1. Truncated timepoints (e.g. u9rv3I: ~4 of 181)
The OIR companions are **extensionless** — `M1a-…-res_0001.oir` (the registered file) + `M1a-…-res_0001_00001`, `_00002`, … . `_companion_files` expected `<stem>_<5digits><same-ext>` and matched **none** of them → "Staging 1 source file(s)" → bioformats read only the main file → a fraction of the timepoints. Now matches `<main-stem>_<digits>` (optional extension) by literal-stem prefix (still excludes a sibling acquisition `…-res_0002.oir`).

## 2. GUI freeze during staging
Julia's `cp` is a single non-yielding blocking call (`jl_fs_sendfile`); when the pool worker running it is scheduled onto the event-loop thread, the whole WS server (and GUI) freezes until the multi-GB copy finishes. Replaced with a chunked copy that `yield()`s every 8 MB (`_copy_file_yielding`) — keeps the server responsive and reports staging progress on the bar.

## Tests
`_companion_files` against the real extensionless naming + extensioned companions + `basal+NECA` (regex-metachar stem) + sibling exclusion; a byte-identical chunked-copy check (incl. a non-chunk-multiple size). pkg 1421 / 0-fail. Docs: IMPORT_RESCALE_PLAN.

## Reservations
1. Not re-run live — both fixes are unit-tested, but I haven't re-imported the SMB file through the running app; the freeze fix's responsiveness is worth confirming live.
2. **Images already imported with staging on are truncated (main file only) and won't self-heal — re-import after this merges** to recover all timepoints.
3. Staging progress now moves the bar, then conversion resets it (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
