### PR TITLE
Fix pixi run stop hanging: use ss instead of lsof on Linux

### DIFF
--- a/app/src/tasks/scheduler.jl
+++ b/app/src/tasks/scheduler.jl
@@ -203,18 +203,35 @@ end
 # guarantee a clean app shutdown even for a child we only ADOPTED or that outlived a crash (no process
 # handle to `kill`) — napari :7655, notebooks :7660 — mirroring `pixi run stop`. There is no libuv API
 # for port→pid, so we shell out per-OS; this is the one sanctioned place, alongside `_kill_tree`.
+# Extract listener PIDs from `ss -tlnpH` output (the `users:(("name",pid=NNN,fd=..))` field), deduped
+# (a listener shows once for IPv4 and once for IPv6). Pure/unit-tested — the rest of
+# _kill_listeners_on_port shells out and kills, which isn't.
+_listener_pids_from_ss(raw::AbstractString) =
+    unique(parse(Int, m.captures[1]) for m in eachmatch(r"pid=(\d+)", raw))
+
 function _kill_listeners_on_port(port::Integer)
     pids = Int[]
     try
-        out = Sys.iswindows() ?
-            readchomp(`powershell -NoProfile -Command "(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).OwningProcess"`) :
-            # -sTCP:LISTEN keeps this to the LISTENING process (as the docstring promises + the Windows
-            # `-State Listen` above): plain `lsof -ti tcp:$port` also returns clients CONNECTED to the
-            # port, so we'd kill them too. Exits non-zero (throws) when nothing is listening → caught.
-            readchomp(`lsof -ti tcp:$port -sTCP:LISTEN`)
-        for line in split(out, '\n'; keepempty=false)
-            p = tryparse(Int, strip(line))
-            isnothing(p) || push!(pids, p)
+        # All three keep to the LISTENING process (docstring promise): plain `lsof -ti tcp:$port` (or
+        # ss without -l) also returns clients CONNECTED to the port, so we'd kill them too (e.g. the
+        # browser on :5173). Each shell-out exits non-zero / throws when nothing listens → caught.
+        if Sys.iswindows()
+            out = readchomp(`powershell -NoProfile -Command "(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).OwningProcess"`)
+            for line in split(out, '\n'; keepempty=false)
+                p = tryparse(Int, strip(line))
+                isnothing(p) || push!(pids, p)
+            end
+        elseif Sys.islinux()
+            # `ss` reads /proc/net/tcp* directly; unlike lsof it does NOT walk each process's
+            # /proc/<pid>/fd table, so a process wedged in D (uninterruptible) sleep can't hang it
+            # (lsof does — it stalled `pixi run stop`; see pixi.toml's linux-64 stop tasks).
+            append!(pids, _listener_pids_from_ss(readchomp(`ss -tlnpH $("sport = :$port")`)))
+        else   # macOS: no ss; lsof is fine here (the D-state /proc walk hang is Linux-specific).
+            out = readchomp(`lsof -ti tcp:$port -sTCP:LISTEN`)
+            for line in split(out, '\n'; keepempty=false)
+                p = tryparse(Int, strip(line))
+                isnothing(p) || push!(pids, p)
+            end
         end
     catch; end
     for p in unique(pids)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -5073,4 +5073,14 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         end
     end
 
+    @testset "ss listener PID parse (_kill_listeners_on_port, Linux)" begin
+        # Real `ss -tlnpH` lines: a listener appears once for IPv4 and once for IPv6 → one PID.
+        raw = "LISTEN 0 128 127.0.0.1:8080 0.0.0.0:* users:((\"julia\",pid=1044704,fd=24))\n" *
+              "LISTEN 0 128 [::1]:8080 [::]:* users:((\"julia\",pid=1044704,fd=25))"
+        @test Cecelia._listener_pids_from_ss(raw) == [1044704]
+        @test isempty(Cecelia._listener_pids_from_ss(""))                # nothing listening
+        two = "users:((\"a\",pid=10,fd=1))\nusers:((\"b\",pid=22,fd=3))"
+        @test Cecelia._listener_pids_from_ss(two) == [10, 22]            # distinct PIDs kept, in order
+    end
+
 end

--- a/pixi.toml
+++ b/pixi.toml
@@ -152,6 +152,9 @@ julia-instantiate = "julia --project=app -e 'using Pkg; Pkg.instantiate()'"
 # -sTCP:LISTEN restricts to the LISTENING server; without it lsof also returns clients CONNECTED to the
 # port — the browser on :5173 (page + Vite HMR socket) — so `kill` would crash Firefox/Chrome. Mirrors
 # the win-64 branch's `-State Listen`.
+# These (lsof) tasks are the macOS default; Linux OVERRIDES them with `ss` below — lsof walks every
+# process's /proc/<pid>/fd table and hangs indefinitely on any process stuck in D (uninterruptible)
+# sleep (e.g. a filesystem-wide search wedged on a slow mount), which stalled `pixi run stop`.
 stop           = "kill $(lsof -ti tcp:8080 -sTCP:LISTEN) 2>/dev/null ; kill $(lsof -ti tcp:5173 -sTCP:LISTEN) 2>/dev/null ; kill $(lsof -ti tcp:7655 -sTCP:LISTEN) 2>/dev/null ; kill $(lsof -ti tcp:7660 -sTCP:LISTEN) 2>/dev/null ; echo 'stopped backend(8080)/frontend(5173)/napari(7655)/notebooks(7660)'"
 stop-backend   = "kill $(lsof -ti tcp:8080 -sTCP:LISTEN) 2>/dev/null ; echo 'stopped backend(8080)'"
 stop-napari    = "kill $(lsof -ti tcp:7655 -sTCP:LISTEN) 2>/dev/null ; echo 'stopped napari bridge(7655)'"
@@ -163,6 +166,17 @@ stop           = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPo
 stop-backend   = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 8080 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
 stop-napari    = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 7655 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
 stop-notebooks = "powershell -NoProfile -Command \"Get-NetTCPConnection -LocalPort 7660 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\""
+
+# Linux: kill by listening port via `ss` (iproute2) instead of lsof. `ss` reads /proc/net/tcp*
+# directly and does NOT walk each process's /proc/<pid>/fd table, so a process wedged in D state
+# can't hang it (lsof does — see the default tasks above). `-l` = listening sockets only (mirrors
+# lsof's -sTCP:LISTEN / the Windows -State Listen), so a browser client connected to :5173 is never
+# killed. Literal (single-quoted) TOML strings so the `\K` in the grep pattern isn't escape-mangled.
+[target.linux-64.tasks]
+stop           = 'kill $(ss -tlnpH "sport = :8080" | grep -oP "pid=\K[0-9]+" | sort -u) 2>/dev/null ; kill $(ss -tlnpH "sport = :5173" | grep -oP "pid=\K[0-9]+" | sort -u) 2>/dev/null ; kill $(ss -tlnpH "sport = :7655" | grep -oP "pid=\K[0-9]+" | sort -u) 2>/dev/null ; kill $(ss -tlnpH "sport = :7660" | grep -oP "pid=\K[0-9]+" | sort -u) 2>/dev/null ; echo "stopped backend(8080)/frontend(5173)/napari(7655)/notebooks(7660)"'
+stop-backend   = 'kill $(ss -tlnpH "sport = :8080" | grep -oP "pid=\K[0-9]+" | sort -u) 2>/dev/null ; echo "stopped backend(8080)"'
+stop-napari    = 'kill $(ss -tlnpH "sport = :7655" | grep -oP "pid=\K[0-9]+" | sort -u) 2>/dev/null ; echo "stopped napari bridge(7655)"'
+stop-notebooks = 'kill $(ss -tlnpH "sport = :7660" | grep -oP "pid=\K[0-9]+" | sort -u) 2>/dev/null ; echo "stopped notebooks(7660)"'
 
 # --- GPU acceleration (PARKED) ----------------------------------------------------------------
 # RAPIDS-based GPU clustering is CUDA-only (Linux/Windows + NVIDIA). When un-parked, add it as a


### PR DESCRIPTION
## Problem

`pixi run stop` (and the in-app restart/stop) hangs and has to be Ctrl+C'd. Root cause: `lsof` walks **every** process's `/proc/<pid>/fd` table, so it blocks indefinitely on any process stuck in **`D` (uninterruptible) sleep** — e.g. a filesystem-wide search (`bfs / -iname …`) wedged on a slow block read. `kill $(lsof …)` waits on the `$(…)` substitution forever, so the task never reaches its `echo`.

It "didn't use to" hang because it only manifests when a `D`-state process happens to exist; then every `lsof`-based stop stalls. Measured on the affected machine: `lsof` timed out >8s; `ss` returned the same listener PID in 0.04s.

## Fix

`ss` (iproute2) reads `/proc/net/tcp*` directly and never walks per-process fd tables, so a wedged process can't hang it. Applied **Linux-only** (macOS has no `ss`, and the `/proc`-walk hang is Linux-specific, so it keeps `lsof`; Windows already uses PowerShell):

- **`pixi.toml`** — new `[target.linux-64.tasks]` with `ss`-based `stop` / `stop-backend` / `stop-napari` / `stop-notebooks`. `-l` (listening sockets only) mirrors `lsof`'s `-sTCP:LISTEN` and the Windows `-State Listen`, so a browser client connected to `:5173` is never killed.
- **`app/src/tasks/scheduler.jl`** — `_kill_listeners_on_port` (the in-app restart/stop path, incl. `api_notebooks_restart`) had the identical latent hang; it now branches to `ss` on Linux via a pure `_listener_pids_from_ss` parser.

## Test

- `pixi run test-pkg` green, incl. a new unit test for `_listener_pids_from_ss` (dedups the IPv4+IPv6 listener rows → one PID; empty input → none).
- Hand-verified: `pixi.toml` parses; `ss -tlnpH "sport = :8080" | grep -oP "pid=\K[0-9]+"` returns the backend PID instantly.

## Notes

- `ss`/`grep -oP` are Linux-only — hence the `[target.linux-64.tasks]` scoping. Both are present on every real Linux desktop/CI.
- The shell `stop` tasks can't be unit-tested (they kill live servers); those were validated by hand. The Julia parser is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
