### PR TITLE
Filter populations: add/edit/delete on any obs measure (Decision 15)

### DIFF
--- a/api/src/gating_api.jl
+++ b/api/src/gating_api.jl
@@ -673,6 +673,7 @@ function api_gating_pop_add(body_bytes::Vector{UInt8})
                      filter_fun     = flt === nothing ? nothing : get(flt, "fun", nothing),
                      filter_values  = flt === nothing ? nothing : get(flt, "values", nothing),
                      filter_default_all = flt === nothing ? false : Bool(get(flt, "default_all", false)),
+                     filter_conditions = flt === nothing ? nothing : get(flt, "conditions", nothing),
                      is_track = Bool(get(body, "is_track", false)))
         catch e
             return _gerr(400, sprint(showerror, e))
@@ -725,6 +726,14 @@ function api_gating_pop_update(body_bytes::Vector{UInt8})
             haskey(flt, "fun")         && (p.filter_fun = get(flt, "fun", nothing))
             haskey(flt, "values")      && (p.filter_values = get(flt, "values", nothing))
             haskey(flt, "default_all") && (p.filter_default_all = Bool(get(flt, "default_all", false)))
+            # compound filter (Decision 15): replace the AND-ed conditions, mirroring conditions[1] onto
+            # the single fields (same contract as add_pop!). `conditions: []`/null clears back to single.
+            if haskey(flt, "conditions")
+                conds = Cecelia._normalise_conditions(get(flt, "conditions", nothing))
+                p.filter_conditions = conds
+                conds === nothing || (p.filter_measure = conds[1].measure;
+                                      p.filter_fun = conds[1].fun; p.filter_values = conds[1].values)
+            end
         end
         200, JSON3.write((; tree = _persist_and_broadcast!(m, img, body, vn, pt)))
     end

--- a/app/src/gating/gating_engine.jl
+++ b/app/src/gating/gating_engine.jl
@@ -40,6 +40,7 @@ function _needed_columns(m::PopulationMap)::Vector{String}
             push!(cols, p.gate.x_channel, p.gate.y_channel)
         end
         p.filter_measure !== nothing && push!(cols, p.filter_measure)
+        p.filter_conditions === nothing || append!(cols, (c.measure for c in p.filter_conditions))
     end
     unique(cols)
 end
@@ -72,6 +73,18 @@ function recompute!(m::PopulationMap, fetch_cols::Function)
             (p.gate.x_channel in cols && p.gate.y_channel in cols) ?
                 parent_mask .& inside(p.gate, df[!, p.gate.x_channel], df[!, p.gate.y_channel]) :
                 _missing_col_mask(n, path, string(p.gate.x_channel, " / ", p.gate.y_channel))
+        elseif p.filter_conditions !== nothing
+            # compound filter (Decision 15): AND every condition's mask. A missing column degrades the
+            # WHOLE pop to empty + a warning (same rationale as the single-filter case below), never a 500.
+            cmask = trues(n)
+            for c in p.filter_conditions
+                if c.measure in cols
+                    cmask .&= _filter_mask(df[!, c.measure], c.fun, c.values, false)
+                else
+                    cmask = _missing_col_mask(n, path, String(c.measure)); break
+                end
+            end
+            parent_mask .& cmask
         elseif p.filter_measure !== nothing
             # A filter's column can legitimately be absent from THIS frame — e.g. a cluster pop
             # (`clusters.{suffix}`) evaluated against a segmentation that didn't take part in that

--- a/app/src/gating/population_manager.jl
+++ b/app/src/gating/population_manager.jl
@@ -54,6 +54,11 @@ mutable struct Population
     filter_fun::Union{String,Nothing}      # gt|gte|lt|lte|eq|neq|in
     filter_values::Any
     filter_default_all::Bool
+    # compound filter (Decision 15): a list of AND-ed conditions, each `(; measure, fun, values)`.
+    # `nothing` → the single filter_measure/fun/values above (back-compat: existing sidecars). When set
+    # (non-empty), it is the source of truth and the single fields mirror conditions[1] for readers that
+    # only look at one. Lets a user-defined filter pop combine e.g. CD4>0.5 AND speed>5 in ONE pop.
+    filter_conditions::Union{Vector,Nothing}
     is_track::Bool
     # explicit-label membership: when set, this pop's cells ARE these label IDs (∩ parent),
     # bypassing gate/filter. Used by the transient napari selection (docs/POPULATION.md) so a
@@ -93,12 +98,27 @@ descendants(m::PopulationMap, path::AbstractString) =
 """Paths in parent-before-child order (stable by depth)."""
 topo_order(m::PopulationMap) = sort(m.order; by = p -> count(==('/'), p), alg = MergeSort)
 
+# Normalise a compound-filter spec (Decision 15): `nothing` | a list of `{measure, fun, values}`
+# (dicts, from JSON, or NamedTuples) → `Vector{NamedTuple}` of `(; measure, fun, values)`, dropping
+# entries missing a measure/fun. Empty → `nothing` (treated as no compound filter).
+function _normalise_conditions(conds)
+    conds === nothing && return nothing
+    out = NamedTuple[]
+    for c in conds
+        gc(k) = c isa AbstractDict ? get(c, k, get(c, Symbol(k), nothing)) : getproperty(c, Symbol(k))
+        mz = gc("measure"); fz = gc("fun")
+        (mz === nothing || fz === nothing) && continue
+        push!(out, (; measure = String(mz), fun = String(fz), values = gc("values")))
+    end
+    isempty(out) ? nothing : out
+end
+
 # ── Mutations ────────────────────────────────────────────────────────────────────
 function add_pop!(m::PopulationMap, name::AbstractString;
                   parent::AbstractString=ROOT, gate::Union{Gate,Nothing}=nothing,
                   colour::AbstractString="#ffffff", show::Bool=true,
                   filter_measure=nothing, filter_fun=nothing, filter_values=nothing,
-                  filter_default_all::Bool=false, is_track::Bool=false,
+                  filter_default_all::Bool=false, filter_conditions=nothing, is_track::Bool=false,
                   explicit_labels=nothing, transient::Bool=false,
                   reserved_ok::Bool=false)::String
     # `_`-prefixed names are reserved for derived populations (e.g. _tracked); only the derived
@@ -110,11 +130,16 @@ function add_pop!(m::PopulationMap, name::AbstractString;
     (parent == ROOT || has_pop(m, parent)) || error("add_pop!: parent not found: $parent")
     path = pop_path(parent, name)
     has_pop(m, path) && error("add_pop!: population already exists: $path")
+    conds = _normalise_conditions(filter_conditions)
+    # when compound, mirror the single fields onto conditions[1] so single-field readers still work.
+    if conds !== nothing
+        filter_measure = conds[1].measure; filter_fun = conds[1].fun; filter_values = conds[1].values
+    end
     m.pops[path] = Population(String(name), path, parent, String(colour), show,
                               m.pop_type, m.value_name, gate,
                               filter_measure === nothing ? nothing : String(filter_measure),
                               filter_fun === nothing ? nothing : String(filter_fun),
-                              filter_values, filter_default_all, is_track,
+                              filter_values, filter_default_all, conds, is_track,
                               explicit_labels === nothing ? nothing : collect(explicit_labels), transient)
     push!(m.order, path)
     _invalidate!(m)
@@ -182,6 +207,10 @@ function _node_dict(m::PopulationMap, path::AbstractString; include_transient::B
     if p.filter_measure !== nothing
         d["filter"] = Dict{String,Any}("measure" => p.filter_measure, "fun" => p.filter_fun,
                                        "values" => p.filter_values, "default_all" => p.filter_default_all)
+        # compound filter (Decision 15): emit the AND-ed conditions so a multi-condition pop round-trips.
+        p.filter_conditions === nothing ||
+            (d["filter"]["conditions"] = [Dict{String,Any}("measure" => c.measure, "fun" => c.fun,
+                                                           "values" => c.values) for c in p.filter_conditions])
     end
     p.is_track && (d["is_track"] = true)
     p.transient && (d["transient"] = true)
@@ -218,6 +247,7 @@ function _add_node!(m::PopulationMap, node::AbstractDict, parent::AbstractString
                     filter_fun     = flt === nothing ? nothing : get(flt, "fun", get(flt, :fun, nothing)),
                     filter_values  = flt === nothing ? nothing : get(flt, "values", get(flt, :values, nothing)),
                     filter_default_all = flt === nothing ? false : Bool(get(flt, "default_all", get(flt, :default_all, false))),
+                    filter_conditions = flt === nothing ? nothing : get(flt, "conditions", get(flt, :conditions, nothing)),
                     is_track = Bool(g("is_track", false)))
     for child in g("children", [])
         _add_node!(m, child, path)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2985,6 +2985,33 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
               Set(["A/TumourZone", "B/TumourZone"])
     end
 
+    @testset "compound filter populations (Decision 15 — AND-ed conditions)" begin
+        # a user-defined filter pop combining two obs conditions in ONE pop: CD4>0.5 AND speed>5
+        m = PopulationMap(pop_type="flow", value_name="B")
+        add_pop!(m, "CD4hi_fast"; colour="#8b5cf6", filter_conditions=[
+            Dict("measure" => "live.cell.cd4",   "fun" => "gt", "values" => 0.5),
+            Dict("measure" => "live.cell.speed", "fun" => "gt", "values" => 5)])
+        fetch = _ -> DataFrame("label" => [1, 2, 3, 4],
+                               "live.cell.cd4"   => [0.9, 0.9, 0.1, 0.6],
+                               "live.cell.speed" => [10,  2,   10,  7])
+        recompute!(m, fetch)
+        @test Set(cells_in_pop(m, "/CD4hi_fast")) == Set([1, 4])   # BOTH hold: (0.9,10) and (0.6,7)
+
+        # single fields mirror conditions[1] so single-field readers still work
+        p = pop_at(m, "/CD4hi_fast")
+        @test p.filter_measure == "live.cell.cd4" && p.filter_fun == "gt" && length(p.filter_conditions) == 2
+
+        # round-trip through to_tree/from_tree preserves the conditions + membership
+        m2 = from_tree(to_tree(m)); recompute!(m2, fetch)
+        @test Set(cells_in_pop(m2, "/CD4hi_fast")) == Set([1, 4])
+        @test length(pop_at(m2, "/CD4hi_fast").filter_conditions) == 2
+
+        # a missing condition column → the whole pop degrades to empty (warns), never crashes
+        fetch1 = _ -> DataFrame("label" => [1, 2], "live.cell.cd4" => [0.9, 0.1])   # speed absent
+        @test_logs (:warn, r"live\.cell\.speed") match_mode=:any recompute!(m, fetch1)
+        @test isempty(cells_in_pop(m, "/CD4hi_fast"))
+    end
+
     @testset "recompute! — a missing filter/gate column degrades to empty (no crash)" begin
         # A cluster pop whose `clusters.{suffix}` column isn't in the fetched frame — e.g. evaluated
         # against a segmentation that didn't take part in that run, so `fetch_cols` silently dropped it

--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -123,6 +123,16 @@ cluster column), never written into the H5AD; only the *definition* (which IDs) 
 evaluates over the cell table (`:cell`), `trackclust` over `track_props` (`:track`, with
 expand-to-cells for `:cell`) — exactly mirroring `flow` and `track` respectively.
 
+**User-defined filter populations (compound).** The same stored-filter-pop mechanism is exposed to the
+user for ANY obs/var measure via the PopulationManager "New filter population" form: name + parent +
+colour + N conditions. Multiple conditions are stored on one `Population` as `filter_conditions` — a
+list of AND-ed `(; measure, fun, values)` — with `conditions[1]` mirrored onto the single
+`filter_measure/fun/values` for back-compat (absent `filter_conditions` = the plain single filter;
+existing sidecars keep working). `recompute!` ANDs each condition; a missing column degrades the whole
+pop to empty + a warning, never a crash. Created/edited via `pop/add`·`pop/update` `filter.conditions`.
+Filter pops are badged in the manager to distinguish them from hand-drawn gates — one manager, not two
+(SPATIAL_REGIONS_PLAN Decision 15).
+
 Clustering is **set-scope**, so a cluster pop is written **set-wide**: the same filter pop lands in
 every clustered image's sidecar (the filter is image-independent and cluster IDs are comparable
 across the run). Membership of a run is recorded as `partOf` (the clustered uIDs) in the

--- a/docs/todo/SPATIAL_REGIONS_PLAN.md
+++ b/docs/todo/SPATIAL_REGIONS_PLAN.md
@@ -290,6 +290,12 @@ per-poptype `PopulationManager` (reused CRUD: `pop/add`·`update`·`delete`), an
   reference not gospel"; kept measure-agnostic (`> 0` is just the flag case).
 LAST priority (task #10). See CD8→aggregate→CD69 workflow: chain composes parent∩child, no muddle.
 
+**BUILT** (branch feat/filter-pop-gui): `Population.filter_conditions` (AND-ed, back-compat) + recompute!
+eval + to_tree/from_tree round-trip; `pop/add`·`pop/update` accept `filter.conditions`; gating store
+`addFilterPop`/`updateFilterPop` + `obsColumns`; PopulationManager "New filter population" form (name,
+parent, colour, N conditions on any obs/var measure) + a filter badge distinguishing filter pops from
+hand-drawn gates. Pure form logic in `utils/filterPopForm.ts`. Julia 1478, vitest 268.
+
 ### Decision 16 — Spatial Analysis plots: CytoMAP parity for the Gerner lab
 
 Dominik: "take CytoMAP as inspiration; provide at least similar plots for Gerner people." The Spatial

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -22,6 +22,7 @@ import { useSettingsStore } from '../../stores/settings'
 import PopulationPanelShell from './PopulationPanelShell.vue'
 import ConfirmDeleteButton from '../ConfirmDeleteButton.vue'
 import TeleportPopover from '../TeleportPopover.vue'
+import { parseFilterValues, filterSummary } from '../../utils/filterPopForm'
 import { PALETTES, type VisProps } from '../../plots/plot'
 import { clusterMeasure, isClusterPopType } from '../../utils/clusterMeasure'
 
@@ -151,6 +152,37 @@ async function addClusterPopulation() {
   const n = visiblePops.value.length
   await g.addClusterPop(`Population ${n + 1}`, props.suffix, POP_PALETTE[n % POP_PALETTE.length])
 }
+
+// ── Filter-population form (Decision 15): define a pop by an AND-ed filter on ANY obs measure, for the
+// current popType. Reuses pop/add (compound `conditions`). Aligned with the old populationUI.R dialog,
+// modernised — colour is user-picked (not random) and it's the same Population underneath (badged, not
+// a separate manager). ──
+interface FpCond { measure: string; fun: string; values: string }
+const FILTER_FUNS = ['gt', 'gte', 'lt', 'lte', 'eq', 'neq', 'in']
+const showFilterForm = ref(false)
+const fpName = ref('')
+const fpParent = ref('root')
+const fpColour = ref(POP_PALETTE[0])
+const fpConds = ref<FpCond[]>([{ measure: '', fun: 'gt', values: '' }])
+// measures: per-cell obs (regions/clusters/aggregate/hmm/speed…) + gateable var columns (intensities)
+const filterMeasures = computed(() => [...new Set([...g.obsColumns, ...g.columns])].sort())
+const parentOptions = computed(() => ['root', ...visiblePops.value.map(p => p.path)])
+
+function addFpCond() { fpConds.value.push({ measure: filterMeasures.value[0] ?? '', fun: 'gt', values: '' }) }
+function removeFpCond(i: number) { fpConds.value.splice(i, 1) }
+
+async function submitFilterPop() {
+  const name = fpName.value.trim()
+  const conds = fpConds.value.filter(c => c.measure)
+    .map(c => ({ measure: c.measure, fun: c.fun, values: parseFilterValues(c.fun, c.values) }))
+  if (!name || !conds.length) return
+  await g.addFilterPop(name, fpParent.value, fpColour.value, conds)
+  fpName.value = ''; fpConds.value = [{ measure: '', fun: 'gt', values: '' }]; showFilterForm.value = false
+}
+
+// a hand-drawn gate vs a declarative filter pop (badge in the list)
+const isFilterPop = (p: FlatPop) => !!p.filter && !p.gate
+const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
 </script>
 
 <template>
@@ -163,6 +195,43 @@ async function addClusterPopulation() {
                 v-tooltip.bottom="'Create a population, then tick cluster IDs into it'">
           <i class="pi pi-plus" /> Add population
         </button>
+      </div>
+
+      <!-- filter-population form (Decision 15): a pop defined by an AND-ed filter on any obs measure -->
+      <div v-if="!readonly && !clusterMode" class="pm-add">
+        <button class="pm-add-btn" @click="showFilterForm = !showFilterForm"
+                v-tooltip.bottom="'Define a population by filtering on obs measures (region, cluster, aggregate, intensity, speed…)'">
+          <i class="pi pi-filter" /> New filter population
+        </button>
+      </div>
+      <div v-if="showFilterForm && !readonly && !clusterMode" class="pm-ff">
+        <div class="pm-ff-head">
+          <input v-model="fpName" class="pm-ff-name" placeholder="Population name" />
+          <input v-model="fpColour" type="color" class="pm-ff-colour" v-tooltip.top="'Colour'" />
+        </div>
+        <label class="pm-ff-row">Under
+          <select v-model="fpParent">
+            <option v-for="o in parentOptions" :key="o" :value="o">{{ o === 'root' ? '(all cells)' : o }}</option>
+          </select>
+        </label>
+        <div v-for="(c, i) in fpConds" :key="i" class="pm-ff-cond">
+          <select v-model="c.measure" class="pm-ff-measure">
+            <option value="" disabled>measure…</option>
+            <option v-for="m in filterMeasures" :key="m" :value="m">{{ g.colLabel(m) }}</option>
+          </select>
+          <select v-model="c.fun" class="pm-ff-fun">
+            <option v-for="f in FILTER_FUNS" :key="f" :value="f">{{ f }}</option>
+          </select>
+          <input v-model="c.values" class="pm-ff-vals" :placeholder="c.fun === 'in' ? 'a, b, c' : 'value'" />
+          <button v-if="fpConds.length > 1" class="pm-icon" @click="removeFpCond(i)" v-tooltip.left="'Remove condition'">
+            <i class="pi pi-times" />
+          </button>
+        </div>
+        <div class="pm-ff-actions">
+          <button class="pm-ff-cond-add" @click="addFpCond"><i class="pi pi-plus" /> AND condition</button>
+          <button class="pm-add-btn" :disabled="!fpName.trim() || !fpConds.some(c => c.measure)"
+                  @click="submitFilterPop">Create</button>
+        </div>
       </div>
 
       <div v-if="!visiblePops.length" class="pm-empty">
@@ -183,6 +252,10 @@ async function addClusterPopulation() {
                 @dblclick.stop="!readonly && !p.transient && beginRename(p)">{{ p.name }}</span>
           <input v-else class="pm-rename" v-model="editName" autofocus
                  @keyup.enter="commitRename(p)" @blur="commitRename(p)" @click.stop />
+
+          <!-- distinguish a declarative filter pop from a hand-drawn gate; tooltip shows the predicate -->
+          <i v-if="isFilterPop(p)" class="pi pi-filter pm-filter-badge"
+             v-tooltip.top="popFilterSummary(p)" />
 
           <span class="pm-stat" v-tooltip.left="'cells · % of parent'">
             {{ g.stats[p.path]?.count ?? '–' }}
@@ -336,6 +409,25 @@ async function addClusterPopulation() {
   border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-2);
   color: var(--cc-text); cursor: pointer; }
 .pm-add-btn:hover { border-color: #7c3aed; color: #c4b5fd; }
+.pm-add-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+/* filter-population form (Decision 15) */
+.pm-ff { display: flex; flex-direction: column; gap: 5px; padding: 6px 8px; border-bottom: 1px solid var(--cc-border);
+  background: var(--cc-surface-1); }
+.pm-ff-head { display: flex; gap: 5px; align-items: center; }
+.pm-ff-name { flex: 1; font-size: 11px; padding: 3px 6px; border: 1px solid var(--cc-border); border-radius: 4px;
+  background: var(--cc-surface-2); color: var(--cc-text); }
+.pm-ff-colour { width: 24px; height: 24px; padding: 0; border: 1px solid var(--cc-border); border-radius: 4px;
+  background: none; cursor: pointer; }
+.pm-ff-row, .pm-ff-cond { display: flex; gap: 4px; align-items: center; font-size: 11px; color: var(--cc-text-dim); }
+.pm-ff-cond select, .pm-ff-row select, .pm-ff-vals { font-size: 11px; padding: 2px 4px; border: 1px solid var(--cc-border);
+  border-radius: 3px; background: var(--cc-surface-2); color: var(--cc-text); }
+.pm-ff-measure { flex: 1; min-width: 0; }
+.pm-ff-fun { width: 48px; }
+.pm-ff-vals { width: 64px; }
+.pm-ff-actions { display: flex; justify-content: space-between; align-items: center; }
+.pm-ff-cond-add { background: none; border: none; color: var(--cc-text-dim); font-size: 11px; cursor: pointer; padding: 2px; }
+.pm-ff-cond-add:hover { color: var(--cc-text); }
+.pm-filter-badge { font-size: 10px; color: #8b5cf6; margin-left: 2px; opacity: 0.8; }
 .pm-clusters { display: flex; flex-wrap: wrap; gap: 3px; padding: 2px 8px 6px; border-bottom: 1px solid var(--cc-border); }
 .pm-chip { min-width: 1.4rem; height: 1.4rem; padding: 0 4px; font-size: 11px; line-height: 1;
   border: 1px solid var(--cc-border); border-radius: 3px; background: var(--cc-surface-1);

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -160,6 +160,7 @@ async function addClusterPopulation() {
 interface FpCond { measure: string; fun: string; values: string }
 const FILTER_FUNS = ['gt', 'gte', 'lt', 'lte', 'eq', 'neq', 'in']
 const showFilterForm = ref(false)
+const fpEditPath = ref<string | null>(null)   // null → creating; a path → editing that filter pop
 const fpName = ref('')
 const fpParent = ref('root')
 const fpColour = ref(POP_PALETTE[0])
@@ -171,13 +172,40 @@ const parentOptions = computed(() => ['root', ...visiblePops.value.map(p => p.pa
 function addFpCond() { fpConds.value.push({ measure: filterMeasures.value[0] ?? '', fun: 'gt', values: '' }) }
 function removeFpCond(i: number) { fpConds.value.splice(i, 1) }
 
+function resetFilterForm() {
+  fpEditPath.value = null; fpName.value = ''; fpParent.value = 'root'
+  fpColour.value = POP_PALETTE[0]; fpConds.value = [{ measure: '', fun: 'gt', values: '' }]
+}
+function openCreateFilter() { resetFilterForm(); showFilterForm.value = true }
+// EDIT reuses the same form (nothing special about editing): pre-fill from the pop's stored filter.
+function beginEditFilter(p: FlatPop) {
+  const f = p.filter
+  const conds = f?.conditions?.length ? f.conditions
+    : (f ? [{ measure: f.measure, fun: f.fun, values: f.values }] : [])
+  fpEditPath.value = p.path; fpName.value = p.name; fpParent.value = p.parent; fpColour.value = p.colour
+  fpConds.value = conds.length
+    ? conds.map(c => ({ measure: String(c.measure ?? ''), fun: String(c.fun ?? 'gt'),
+        values: Array.isArray(c.values) ? c.values.join(', ') : (c.values == null ? '' : String(c.values)) }))
+    : [{ measure: '', fun: 'gt', values: '' }]
+  showFilterForm.value = true
+}
+
 async function submitFilterPop() {
   const name = fpName.value.trim()
   const conds = fpConds.value.filter(c => c.measure)
     .map(c => ({ measure: c.measure, fun: c.fun, values: parseFilterValues(c.fun, c.values) }))
-  if (!name || !conds.length) return
-  await g.addFilterPop(name, fpParent.value, fpColour.value, conds)
-  fpName.value = ''; fpConds.value = [{ measure: '', fun: 'gt', values: '' }]; showFilterForm.value = false
+  if (!conds.length) return
+  if (fpEditPath.value) {
+    const path = fpEditPath.value
+    const cur = visiblePops.value.find(p => p.path === path)
+    await g.updateFilterPop(path, conds)                                   // conditions
+    if (cur && cur.colour !== fpColour.value) await g.updatePop(path, { colour: fpColour.value })  // colour
+    if (name && cur && name !== cur.name && !isReservedPopName(name)) await g.renamePop(path, name) // rename LAST (path changes)
+  } else {
+    if (!name) return
+    await g.addFilterPop(name, fpParent.value, fpColour.value, conds)
+  }
+  resetFilterForm(); showFilterForm.value = false
 }
 
 // a hand-drawn gate vs a declarative filter pop (badge in the list)
@@ -197,20 +225,22 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
         </button>
       </div>
 
-      <!-- filter-population form (Decision 15): a pop defined by an AND-ed filter on any obs measure -->
+      <!-- filter-population form (Decision 15): a pop defined by an AND-ed filter on any obs measure.
+           Same form creates AND edits (fpEditPath) — editing is not a special path. -->
       <div v-if="!readonly && !clusterMode" class="pm-add">
-        <button class="pm-add-btn" @click="showFilterForm = !showFilterForm"
+        <button class="pm-add-btn" @click="showFilterForm ? (showFilterForm = false) : openCreateFilter()"
                 v-tooltip.bottom="'Define a population by filtering on obs measures (region, cluster, aggregate, intensity, speed…)'">
           <i class="pi pi-filter" /> New filter population
         </button>
       </div>
       <div v-if="showFilterForm && !readonly && !clusterMode" class="pm-ff">
+        <div class="pm-ff-title">{{ fpEditPath ? 'Edit filter population' : 'New filter population' }}</div>
         <div class="pm-ff-head">
           <input v-model="fpName" class="pm-ff-name" placeholder="Population name" />
           <input v-model="fpColour" type="color" class="pm-ff-colour" v-tooltip.top="'Colour'" />
         </div>
         <label class="pm-ff-row">Under
-          <select v-model="fpParent">
+          <select v-model="fpParent" :disabled="!!fpEditPath" v-tooltip.top="fpEditPath ? 'Parent is fixed when editing — delete & recreate to move' : ''">
             <option v-for="o in parentOptions" :key="o" :value="o">{{ o === 'root' ? '(all cells)' : o }}</option>
           </select>
         </label>
@@ -229,8 +259,10 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
         </div>
         <div class="pm-ff-actions">
           <button class="pm-ff-cond-add" @click="addFpCond"><i class="pi pi-plus" /> AND condition</button>
+          <span class="pm-ff-spacer" />
+          <button class="pm-ff-cancel" @click="showFilterForm = false; resetFilterForm()">Cancel</button>
           <button class="pm-add-btn" :disabled="!fpName.trim() || !fpConds.some(c => c.measure)"
-                  @click="submitFilterPop">Create</button>
+                  @click="submitFilterPop">{{ fpEditPath ? 'Save' : 'Create' }}</button>
         </div>
       </div>
 
@@ -253,8 +285,12 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
           <input v-else class="pm-rename" v-model="editName" autofocus
                  @keyup.enter="commitRename(p)" @blur="commitRename(p)" @click.stop />
 
-          <!-- distinguish a declarative filter pop from a hand-drawn gate; tooltip shows the predicate -->
-          <i v-if="isFilterPop(p)" class="pi pi-filter pm-filter-badge"
+          <!-- filter pops are badged (vs hand-drawn gates); the badge is the EDIT affordance (click →
+               open the same form pre-filled). Read-only surfaces show a static badge. Tooltip = predicate. -->
+          <button v-if="isFilterPop(p) && !readonly && !p.transient" type="button"
+                  class="pm-icon pm-filter-badge" v-tooltip.top="`Edit: ${popFilterSummary(p)}`"
+                  @click.stop="beginEditFilter(p)"><i class="pi pi-filter" /></button>
+          <i v-else-if="isFilterPop(p)" class="pi pi-filter pm-filter-badge"
              v-tooltip.top="popFilterSummary(p)" />
 
           <span class="pm-stat" v-tooltip.left="'cells · % of parent'">
@@ -427,7 +463,13 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
 .pm-ff-actions { display: flex; justify-content: space-between; align-items: center; }
 .pm-ff-cond-add { background: none; border: none; color: var(--cc-text-dim); font-size: 11px; cursor: pointer; padding: 2px; }
 .pm-ff-cond-add:hover { color: var(--cc-text); }
+.pm-ff-title { font-size: 11px; font-weight: 600; color: var(--cc-text); }
+.pm-ff-spacer { flex: 1; }
+.pm-ff-cancel { background: none; border: none; color: var(--cc-text-dim); font-size: 11px; cursor: pointer; padding: 4px 6px; }
+.pm-ff-cancel:hover { color: var(--cc-text); }
 .pm-filter-badge { font-size: 10px; color: #8b5cf6; margin-left: 2px; opacity: 0.8; }
+button.pm-filter-badge { border: none; background: none; cursor: pointer; padding: 2px; }
+button.pm-filter-badge:hover { opacity: 1; }
 .pm-clusters { display: flex; flex-wrap: wrap; gap: 3px; padding: 2px 8px 6px; border-bottom: 1px solid var(--cc-border); }
 .pm-chip { min-width: 1.4rem; height: 1.4rem; padding: 0 4px; font-size: 11px; line-height: 1;
   border: 1px solid var(--cc-border); border-radius: 3px; background: var(--cc-surface-1);

--- a/frontend/src/stores/gating.ts
+++ b/frontend/src/stores/gating.ts
@@ -102,6 +102,7 @@ export const useGatingStore = defineStore('gating', () => {
 
   const tree      = ref<PopTree>({ value_name: 'default', pop_type: 'flow', populations: [] })
   const columns   = ref<string[]>([])           // gateable feature columns (raw var names)
+  const obsColumns = ref<string[]>([])          // per-cell obs measures (regions.*/clusters.*/hmm.*/is.aggregate/speed…) — filter-pop measures
   const channels  = ref<string[]>([])           // intensity columns, e.g. mean_intensity_0 (ordered)
   const channelNames = ref<string[]>([])         // display names aligned to `channels`
   const valueNames = ref<string[]>([])
@@ -196,8 +197,10 @@ export const useGatingStore = defineStore('gating', () => {
       const res = await fetch(`/api/gating/channels?${_params()}`)
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const d = await res.json() as { columns: string[]; channels?: string[]; channelNames?: string[]
-        valueNames: string[]; valueName?: string; cellMeasures?: string[]; trackAggregates?: string[] }
+        valueNames: string[]; valueName?: string; cellMeasures?: string[]; trackAggregates?: string[]
+        obsColumns?: string[] }
       columns.value = d.columns ?? []
+      obsColumns.value = d.obsColumns ?? []
       // track gating returns no intensity channels — `columns` are the (motility) track axes; flow
       // returns intensity channels + display names. cellMeasures/trackAggregates are track-only.
       channels.value = d.channels ?? []
@@ -319,7 +322,7 @@ export const useGatingStore = defineStore('gating', () => {
   const clearNapariSelection = () => _napari('/api/napari/stop-selection', true)
 
   return {
-    imageUid, valueName, popType, mirrorUids, tree, columns, channels, channelNames, valueNames,
+    imageUid, valueName, popType, mirrorUids, tree, columns, obsColumns, channels, channelNames, valueNames,
     cellMeasures, trackAggregates, stats, popVersion, flat,
     transientPaths, napariZMode, napariZWindow,
     projectUid, napariSetUid, colLabel, selectImage, fetchChannels, fetchPopmap, fetchStats,

--- a/frontend/src/stores/gating.ts
+++ b/frontend/src/stores/gating.ts
@@ -25,10 +25,15 @@ export interface GateSpec {
   x_min?: number; x_max?: number; y_min?: number; y_max?: number
   vertices?: [number, number][]
 }
+// one AND-ed condition of a compound filter (Decision 15)
+export interface FilterCondition { measure: string; fun: string; values: unknown }
+// a filter spec: the single measure/fun/values (back-compat) plus optional AND-ed `conditions`
+export interface FilterSpec { measure: string; fun: string; values: unknown; default_all: boolean; conditions?: FilterCondition[] }
+
 export interface PopNode {
   name: string; colour: string; show: boolean
   gate?: GateSpec
-  filter?: { measure: string; fun: string; values: unknown; default_all: boolean }
+  filter?: FilterSpec
   is_track?: boolean
   transient?: boolean              // ephemeral (napari cell selection) — not persisted
   membership_sig?: string          // explicit-label pops (napari selection): hash of label set
@@ -40,7 +45,7 @@ export interface PopTree { value_name: string; pop_type: string; populations: Po
 export interface FlatPop {
   path: string; name: string; parent: string; colour: string; show: boolean
   depth: number; gate?: GateSpec; transient?: boolean
-  filter?: { measure: string; fun: string; values: unknown; default_all: boolean }  // cluster pops
+  filter?: FilterSpec  // cluster / region / user-defined filter pops
 }
 
 function flatten(tree: PopTree): FlatPop[] {
@@ -244,6 +249,16 @@ export const useGatingStore = defineStore('gating', () => {
   const addClusterPop = (name: string, suffix: string, colour: string) =>
     _post('/api/gating/pop/add', { name, colour,
       filter: { measure: clusterMeasure(popType.value, suffix), fun: 'in', values: [], default_all: false } })
+  // user-defined filter population (Decision 15): a compound AND-ed filter on any obs measures, under a
+  // chosen parent, for the current popType. The backend mirrors conditions[1] onto the single fields.
+  const addFilterPop = (name: string, parent: string, colour: string, conditions: FilterCondition[]) =>
+    _post('/api/gating/pop/add', { name, parent, colour,
+      filter: { conditions, measure: conditions[0]?.measure, fun: conditions[0]?.fun,
+                values: conditions[0]?.values, default_all: false } })
+  // rewrite a filter pop's conditions (edit) — mirror onto single fields as add does.
+  const updateFilterPop = (path: string, conditions: FilterCondition[]) =>
+    _post('/api/gating/pop/update', { path,
+      filter: { conditions, measure: conditions[0]?.measure, fun: conditions[0]?.fun, values: conditions[0]?.values } })
   const setGate    = (path: string, gate: GateSpec) => _post('/api/gating/pop/set-gate', { path, gate })
   const deletePop  = (path: string)                  => _post('/api/gating/pop/delete', { path })
   const renamePop  = (path: string, newName: string) => _post('/api/gating/pop/rename', { path, newName })
@@ -308,7 +323,7 @@ export const useGatingStore = defineStore('gating', () => {
     cellMeasures, trackAggregates, stats, popVersion, flat,
     transientPaths, napariZMode, napariZWindow,
     projectUid, napariSetUid, colLabel, selectImage, fetchChannels, fetchPopmap, fetchStats,
-    addPop, addClusterPop, setGate, deletePop, renamePop, updatePop, applyBroadcast,
+    addPop, addClusterPop, addFilterPop, updateFilterPop, setGate, deletePop, renamePop, updatePop, applyBroadcast,
     refreshNapariPops, refreshNapari, startCellSelection, clearNapariSelection, updateSelectionScope,
   }
 })

--- a/frontend/src/utils/filterPopForm.test.ts
+++ b/frontend/src/utils/filterPopForm.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { parseFilterValues, filterSummary } from './filterPopForm'
+
+describe('parseFilterValues', () => {
+  it('single fun → one coerced value', () => {
+    expect(parseFilterValues('gt', '0.5')).toBe(0.5)
+    expect(parseFilterValues('gt', ' 5 ')).toBe(5)
+    expect(parseFilterValues('eq', 'mac')).toBe('mac')   // non-numeric kept as string
+    expect(parseFilterValues('gt', '')).toBe('')
+  })
+  it('in → comma-separated list, coerced per token', () => {
+    expect(parseFilterValues('in', '1, 2, 3')).toEqual([1, 2, 3])
+    expect(parseFilterValues('in', 'a, b')).toEqual(['a', 'b'])
+    expect(parseFilterValues('in', '0,1')).toEqual([0, 1])
+  })
+})
+
+describe('filterSummary', () => {
+  const label = (m: string) => m.replace('live.cell.', '')
+  it('formats a single-condition filter', () => {
+    expect(filterSummary({ measure: 'live.cell.cd4', fun: 'gt', values: 0.5 }, label)).toBe('cd4 gt 0.5')
+  })
+  it('formats compound AND-ed conditions', () => {
+    const f = { conditions: [
+      { measure: 'live.cell.cd4', fun: 'gt', values: 0.5 },
+      { measure: 'live.cell.speed', fun: 'gt', values: 5 },
+    ] }
+    expect(filterSummary(f, label)).toBe('cd4 gt 0.5  AND  speed gt 5')
+  })
+  it('joins list values with commas', () => {
+    expect(filterSummary({ measure: 'regions.default', fun: 'in', values: [0, 2] }, label))
+      .toBe('regions.default in 0,2')
+  })
+  it('empty filter → empty string', () => {
+    expect(filterSummary(undefined, label)).toBe('')
+  })
+})

--- a/frontend/src/utils/filterPopForm.ts
+++ b/frontend/src/utils/filterPopForm.ts
@@ -1,0 +1,31 @@
+// Pure helpers for the filter-population form (PopulationManager, Decision 15). Logic lives here
+// (not the SFC) so the value parsing + predicate formatting are unit-tested (docs/DEV.md).
+
+export interface FilterCond { measure: string; fun: string; values: unknown }
+
+// Parse the values box for a condition. `in` → comma-separated list; every other fun → a single
+// value. Each token is coerced to a number when it parses cleanly, else kept as a string (so
+// categorical filters like region IDs or hmm.state labels work either way).
+export function parseFilterValues(fun: string, raw: string): unknown {
+  const toNum = (s: string) => {
+    const n = Number(s)
+    return s !== '' && Number.isFinite(n) ? n : s
+  }
+  const parts = raw.split(',').map(s => s.trim()).filter(s => s.length)
+  return fun === 'in' ? parts.map(toNum) : (parts.length ? toNum(parts[0]) : '')
+}
+
+// One-line human summary of a filter pop's predicate (for the list badge tooltip): the single
+// measure/fun/values, or the AND-ed compound conditions. `label` maps a raw measure to its display name.
+export function filterSummary(
+  filter: { measure?: string; fun?: string; values?: unknown; conditions?: FilterCond[] } | undefined,
+  label: (m: string) => string,
+): string {
+  if (!filter) return ''
+  const conds = filter.conditions?.length
+    ? filter.conditions
+    : [{ measure: filter.measure ?? '', fun: filter.fun ?? '', values: filter.values }]
+  const one = (c: FilterCond) =>
+    `${label(c.measure)} ${c.fun} ${Array.isArray(c.values) ? c.values.join(',') : c.values}`
+  return conds.filter(c => c.measure).map(one).join('  AND  ')
+}


### PR DESCRIPTION
Adds user-defined **filter populations** — the modernised, unified version of the old
`populationUI.R` "Create Filter Populations" dialog (SPATIAL_REGIONS_PLAN.md Decision 15).

## Design: one manager, not two
A filter pop is just a `Population` (same per-poptype sidecar, same `pop_df`, same rename/colour/delete
paths) — so it lives in the existing PopulationManager, not a separate manager. It's badged (ƒ) to
distinguish it from a hand-drawn gate. Works for ANY poptype and filters on ANY obs/var measure
(region / cluster / aggregate / hmm / intensity / speed …).

## Full add / edit / delete
- **Add** — "New filter population" form: name, parent, colour, and N AND-ed conditions
  (measure / fun / values).
- **Edit** — click the ƒ badge → the same form, pre-filled → Save. (Parent is fixed when editing;
  moving a pop is structural.)
- **Delete** — the standard row delete button.

## Backend (compound filter, back-compatible)
- `Population.filter_conditions`: a list of AND-ed `(; measure, fun, values)`. `nothing` → the plain
  single filter (existing sidecars untouched); when set it's the source of truth and mirrors
  `conditions[1]` onto the single fields for single-field readers. `recompute!` ANDs each condition; a
  missing column degrades the whole pop to empty + a warning, never a crash. Round-trips through
  `to_tree`/`from_tree`.
- `pop/add` + `pop/update` accept `filter.conditions`; gating store `addFilterPop`/`updateFilterPop`
  + `obsColumns`. Pure form logic in `utils/filterPopForm.ts`.

## Tests
Julia 1478 · vitest 268 · test-api green · typecheck clean.

## Not verified / caveats
- **Not clicked through in-app** — form layout, the (unfiltered) measure dropdown, and the
  click-badge-to-edit interaction need review.
- The measure dropdown lists ALL obs+var measures unfiltered (could grow long on rich datasets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
