### PR TITLE
Self-heal pluto/api manifests on new app deps (fix stale Clustering)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,22 @@ ecosystem — do not mix:
 
 **Critical**: `api/src/*.jl` files are `include`d by the server script — they are **not** Revise-tracked. Changes to them require a server restart. Only changes to `app/src/` (the Cecelia package) are picked up by Revise. Napari logic lives in `api/src/napari_api.jl`, not `app/src/`.
 
-**Adding a Julia dependency to `app/`**: edit `app/Project.toml`, then run `julia --project -e 'import Pkg; Pkg.instantiate()'` from the `api/` directory before restarting the server. The `api/` environment has its own manifest and won't pick up the new dep automatically — the server will fail to precompile Cecelia until you do this. (`cd app && julia --project test/runtests.jl` passes regardless because it uses the `app/` environment directly.)
+**Adding a Julia dependency to `app/`**: `Cecelia` is path-sourced by **three** separate environments,
+each with its own committed `Manifest.toml` that pins Cecelia's full dependency graph — so a new dep
+must be re-resolved into **all three** and all three manifests committed together, or whichever env was
+missed fails to precompile Cecelia (`ArgumentError: Package Cecelia does not have <Dep> in its
+dependencies`). `Pkg.instantiate()` alone does NOT do this — it honours the existing (stale) manifest;
+you need `Pkg.resolve()` (the `*-instantiate` tasks below now resolve-then-instantiate for exactly this
+reason). After editing `app/Project.toml` (or `Pkg.add`-ing in `app/`):
+
+| Env | Command | Manifest to commit |
+|---|---|---|
+| `app/` (package + `test-pkg`) | `pixi run julia-instantiate` | `app/Manifest.toml` |
+| `api/` (WS server) | `cd api && julia --project -e 'using Pkg; Pkg.resolve()'` | `api/Manifest.toml` |
+| `pixi run frontend`… `pluto/` (notebooks) | `pixi run notebooks-instantiate` | `pluto/Manifest.toml` |
+
+Miss one and it precompiles fine everywhere else but dies in that one env — which is exactly how a
+`Clustering`/`NearestNeighbors` add shipped a stale `pluto/Manifest.toml` and broke every notebook.
 
 ### Data layout
 ```

--- a/docs/NOTEBOOKS.md
+++ b/docs/NOTEBOOKS.md
@@ -34,6 +34,14 @@ notebooks/                   ← shipped EXAMPLE notebooks (UID-free, versioned 
 {project}/settings/notebooks.json  ← per-project registry: { file → {description, version, updatedAt} }
 ```
 
+> **The `pluto/` env path-sources `../app` and pins Cecelia's deps in its own `pluto/Manifest.toml`.**
+> So **whenever a Julia dep is added to `app/Project.toml`, you must re-resolve this env** (`pixi run
+> notebooks-instantiate`, which now runs `Pkg.resolve()` first) and commit the updated
+> `pluto/Manifest.toml` — otherwise every notebook fails to precompile with `Package Cecelia does not
+> have <Dep> in its dependencies`. This is one of the three envs in CLAUDE.md → *Adding a Julia
+> dependency to `app/`*; a stale pluto manifest here (missing `Clustering`/`NearestNeighbors`) is what
+> broke notebooks after the spatial-analysis merge.
+
 ## Authoring a notebook
 
 The **first cell** activates the engine env (so the dev `Cecelia` + `CeceliaNb` resolve — Pluto's

--- a/pixi.toml
+++ b/pixi.toml
@@ -134,8 +134,12 @@ notebooks-sysimage = { cmd = "julia --project build_sysimage.jl", cwd = "pluto" 
 # RELEASE build: same, but also bakes in Cecelia + CeceliaNb (code frozen) for near-instant first
 # plot AND first pop_df. Wired into the packaging flow — see docs/SHIPPING.md. Also → pluto/deps.so.
 notebooks-sysimage-full = { cmd = "julia --project build_sysimage_full.jl", cwd = "pluto" }
-# Resolve/precompile the pluto env (its own manifest — like julia-instantiate for app/).
-notebooks-instantiate = { cmd = "julia --project -e 'using Pkg; Pkg.instantiate()'", cwd = "pluto" }
+# Resolve + install the pluto env (its own manifest — like julia-instantiate for app/). `resolve`
+# FIRST is deliberate: the pluto env path-sources Cecelia (../app), so when a new Julia dep is added
+# to app/Project.toml, plain `instantiate` honours the stale manifest and never picks it up — the
+# notebook then fails to precompile ("Cecelia does not have <Dep> in its dependencies"). `resolve` is
+# a no-op when already consistent and self-heals the manifest when it isn't. Same for julia-instantiate.
+notebooks-instantiate = { cmd = "julia --project -e 'using Pkg; Pkg.resolve(); Pkg.instantiate()'", cwd = "pluto" }
 
 # One-click launch (the desktop-shortcut entrypoint): start the prod server, wait for /api/health,
 # open the default browser at :8080. The Julia server serves the built frontend, so run `build` first.
@@ -145,8 +149,9 @@ app = "python app.py"
 # "Update" button hits /api/update, which runs the same). Refreshes pixi.lock.
 update = "pixi update"
 
-# Julia package deps.
-julia-instantiate = "julia --project=app -e 'using Pkg; Pkg.instantiate()'"
+# Julia package deps. `resolve` first (self-heals a manifest that's missing a newly-added dep — see
+# notebooks-instantiate); a no-op when already consistent.
+julia-instantiate = "julia --project=app -e 'using Pkg; Pkg.resolve(); Pkg.instantiate()'"
 
 # Stop by PORT, not by process name — killing by name self-matches the task's own shell and was
 # orphaning the napari bridge (see docs/SHIPPING.md). `stop-napari` alone forces a fresh bridge

--- a/pluto/Manifest.toml
+++ b/pluto/Manifest.toml
@@ -183,7 +183,7 @@ uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
 version = "1.18.7+0"
 
 [[deps.Cecelia]]
-deps = ["DataFrames", "Dates", "DensityInterface", "Distributions", "HDF5", "HTTP", "HiddenMarkovModels", "JSON3", "LinearAlgebra", "Random", "SHA", "Statistics", "StatsAPI", "StructTypes", "TOML", "UUIDs"]
+deps = ["Clustering", "DataFrames", "Dates", "DensityInterface", "Distributions", "HDF5", "HTTP", "HiddenMarkovModels", "JSON3", "LinearAlgebra", "NearestNeighbors", "Random", "SHA", "Statistics", "StatsAPI", "StructTypes", "TOML", "UUIDs"]
 path = "../app"
 uuid = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 version = "0.0.0"
@@ -203,6 +203,12 @@ weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
     ChainRulesCoreSparseArraysExt = "SparseArrays"
+
+[[deps.Clustering]]
+deps = ["Distances", "LinearAlgebra", "NearestNeighbors", "Printf", "Random", "SparseArrays", "Statistics", "StatsBase"]
+git-tree-sha1 = "3e22db924e2945282e70c33b75d4dde8bfa44c94"
+uuid = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
+version = "0.15.8"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -1222,6 +1228,12 @@ version = "1.1.4"
 git-tree-sha1 = "eda490d06b9f7c00752ee81cfa451efe55521e21"
 uuid = "c020b1a1-e9b0-503a-9c33-f039bfc54a85"
 version = "1.0.0"
+
+[[deps.NearestNeighbors]]
+deps = ["AbstractTrees", "Distances", "StaticArrays"]
+git-tree-sha1 = "576eb4656529c12e77a46b17c23103dfba9fa570"
+uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
+version = "0.4.29"
 
 [[deps.Netpbm]]
 deps = ["FileIO", "ImageCore", "ImageMetadata"]


### PR DESCRIPTION
## Problem

Every Pluto notebook died precompiling `using Cecelia`:

```
ArgumentError: Package Cecelia does not have Clustering in its dependencies
  in expression starting at app/src/tasks/spatialAnalysis/detectAggregates.jl:14
```

`Cecelia` is path-sourced by **three** separate Julia environments — `app/`, `api/`, `pluto/` — each with its own committed `Manifest.toml` that pins Cecelia's full dependency graph. The spatial-analysis merge added `Clustering` + `NearestNeighbors` to `app/Project.toml` and re-resolved `app/` and `api/`, but **`pluto/Manifest.toml` was never re-resolved** — so its record of Cecelia's deps predates those packages.

Restarting doesn't help (it re-precompiles against the same stale manifest), and neither does `pixi run notebooks-instantiate` as it was: `Pkg.instantiate()` honours the existing manifest — only `Pkg.resolve()` picks up a newly-added dep.

## Fix

- **`pluto/Manifest.toml`** re-resolved → Cecelia's dep list now includes `Clustering` + `NearestNeighbors`. Verified: `using Cecelia` precompiles cleanly in the pluto env (`✓ Cecelia`).
- **`notebooks-instantiate` + `julia-instantiate`** now run `Pkg.resolve(); Pkg.instantiate()` — a no-op when the manifest is already consistent, and it **self-heals** when a new app dep landed. So the normal setup task fixes drift instead of silently honouring a stale manifest.
- **Docs** — `CLAUDE.md` → *Adding a Julia dependency to `app/`* rewritten to name **all three** envs + the resolve requirement (it previously named only `api/`, which is exactly why `pluto/` got skipped). `docs/NOTEBOOKS.md` gets the matching warning.

## Notes

- `resolve`-first is a deliberate behavioural change to the setup tasks: strictly a no-op on a consistent committed manifest, self-healing otherwise. `test-pkg`/CI still read the committed manifest directly.
- Env/manifest/docs only — no change to the other session's `Clustering` code.
- Doesn't retroactively fix an already-running notebooks server: after merge, `pixi run notebooks-instantiate` + restart the notebooks server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
