### PR TITLE
Fix UMAP facet ghost circles to follow point size + opacity sliders

### DIFF
--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -227,9 +227,8 @@ function paintDots(c: CanvasRenderingContext2D, w: number, h: number) {
       const cell = facetCell(fi, fs.length, w, h)
       // GHOST: the whole cloud in faint grey behind each facet, so the UMAP shape stays legible and
       // facets are comparable (you see where this facet's points sit within the full embedding).
-      c.globalAlpha = 0.6; c.fillStyle = ghostColour()
-      for (let i = 0; i < n; i++) { const [px, py] = mapRect(pts[2 * i], pts[2 * i + 1], cell); dot(c, px, py, 1) }
-      c.globalAlpha = alpha
+      c.globalAlpha = alpha; c.fillStyle = ghostColour()
+      for (let i = 0; i < n; i++) { const [px, py] = mapRect(pts[2 * i], pts[2 * i + 1], cell); dot(c, px, py, dotR.value) }
       paintInto(c, fs[fi].idx, i => mapRect(pts[2 * i], pts[2 * i + 1], cell))
     }
   }
@@ -549,7 +548,7 @@ function exportSvg(): string {
       const cell = facetCell(fi, fs.length, S, S)
       const ghost: [number, number][] = []
       for (let i = 0; i < n; i++) ghost.push(mapRect(pts[2 * i], pts[2 * i + 1], cell))
-      body += svgCircles(ghost, { fill: ghostLight, opacity: 0.6, r: 1, label: 'ghost' })
+      body += svgCircles(ghost, { fill: ghostLight, opacity: alpha, r, label: 'ghost' })
       const groups: number[][] = pal.map(() => [])
       for (const i of fs[fi].idx) { const g = groups[cats[i]]; if (g) g.push(i) }
       for (let gi = 0; gi < pal.length; gi++) {


### PR DESCRIPTION
## Problem

In the faceted UMAP, the pop-manager **point-size** and **point-opacity** sliders had no effect on the faded "ghost" backdrop — the full-cloud grey circles drawn behind each facet for context. They resized/faded only the foreground points.

## Cause

The ghost was drawn with hardcoded values: radius `1` and opacity `0.6`, ignoring `dotR` (`vis.pointSize`) and `dotAlpha` (`vis.pointOpacity`). Present in both render paths.

## Fix

`frontend/src/components/plots/UmapView.vue` — ghost circles now use `dotR` / `alpha` like the foreground, in both:
- the canvas paint (`paintDots`, faceting branch)
- the SVG export (`exportSvg`, faceting branch)

The existing redraw watch on `pointSize`/`pointOpacity` already repaints on slider change.

## Notes / reservations

- Not clicked through in a browser; it's a literal swap of hardcoded constants for existing computed values (no extractable pure logic to unit-test).
- The ghost's opacity now tracks the point opacity exactly (still the faint grey `ghostColour`, so it stays a distinct backdrop). At high opacity the backdrop is denser than the old fixed 0.6 — this is the requested behaviour. Can scale it (`alpha * 0.6`) if a proportionally fainter ghost is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
