### PR TITLE
Explicit centroid axis names (centroid_x/_y/_z, centroid_t)

### DIFF
--- a/api/src/gating_api.jl
+++ b/api/src/gating_api.jl
@@ -337,7 +337,10 @@ function api_gating_channels(req::HTTP.Request)
         channelNameVersions = versions,
         obsColumns = col_names(lp; data_type = :obs),   # per-cell obs measures (live.cell.*, hmm.state, …) for labelPropsColsSelection
         trackColourColumns = trackColourColumns,         # track-level clusters.* — colour-by broadcasts to cells
-        temporalColumns = temporal_columns(lp),          # obsm temporal col(s) (e.g. "t") — groupable for the per-timepoint QC view
+        # spatial/temporal centroid axes (obsm) — offered as gating scatter axes you can visualise AND
+        # gate on (like the old R flow frame). Read/gate-eval already materialise them via as_df.
+        spatialColumns = centroid_columns(lp; order = [:x, :y, :z]),   # centroid_x/_y[/_z], present axes
+        temporalColumns = temporal_columns(lp),          # ["centroid_t"] — groupable + a gateable time axis
         clusterSuffixes = _cluster_suffixes(col_names(lp; data_type = :obs)),   # clust runs in the cell table
         clusterFeatures = _clust_features(img_label_props_path(img, vn)),
         clusterMembers  = _clust_members(img_label_props_path(img, vn)),        # uIDs clustered together (partOf)

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -20,7 +20,7 @@ export save!
 export load_project, init_object
 export create_project!, add_image!, add_set!, images, image_by_uid, sets
 export delete_image!, delete_set!
-export img_filepath, img_zero_dir, img_physical_sizes, image_included
+export img_filepath, img_zero_dir, img_physical_sizes, physical_size_for_axis, image_included
 export img_label_props_dir, img_label_props_path, img_track_props_path, img_value_names, img_has_value_name
 export read_module_fun_params, write_module_fun_params!
 export TRACK_PROPS_SUFFIX, is_reserved_value_name
@@ -43,7 +43,7 @@ export with_transaction
 export LabelProps, label_props, as_df, as_matrix, add_obs, drop_obs, write_categorical_obs, n_obs
 export select_cols, view_cols, view_channel_cols, view_centroid_cols, view_label_col
 export filter_rows, sort_by, rename_channels!
-export col_names, channel_columns, centroid_columns, temporal_columns
+export col_names, channel_columns, centroid_columns, temporal_columns, axis_of
 export obsm, obsm_keys
 
 # ── Gating engine: transforms, gates, density ─────────────────────────────────

--- a/app/src/label_props.jl
+++ b/app/src/label_props.jl
@@ -90,7 +90,9 @@ const view_cols = select_cols
 """Add the per-channel intensity columns to the selection."""
 view_channel_cols(lp::LabelProps) = _add_cols!(lp, channel_columns(lp))
 
-"""Add centroid columns (optionally ordered, e.g. order=["x","y","z"])."""
+"""Add the centroid columns to the selection — the explicit spatial axes (`centroid_x`/`_y`/`_z`,
+present only) plus the temporal `centroid_t`. `order` selects the spatial axes BY AXIS
+(`order=[:x,:y,:z]`), never positionally."""
 view_centroid_cols(lp::LabelProps; order=nothing) =
     _add_cols!(lp, vcat(centroid_columns(lp; order=order), temporal_columns(lp)))
 
@@ -230,24 +232,50 @@ function _channel_label(varname::String, chans::Vector{String})
     isnothing(m[:prefix]) ? chans[idx + 1] : "$(m[:prefix])_$(chans[idx + 1])"
 end
 
-"""Spatial centroid column names from `uns/spatial_cols` (skimage order: z?, y, x),
-optionally restricted to `order` length. Mirrors the Python `LabelPropsView.centroid_columns`."""
-function centroid_columns(lp::LabelProps; order=nothing)::Vector{String}
-    _with_h5(lp.path, "r") do fid
-        cols = haskey(fid, "uns/spatial_cols") ? _as_strings(read(fid["uns/spatial_cols"])) : String[]
-        if !isnothing(order)
-            want = ["centroid-$(i)" for i in 0:(length(order)-1)]   # array-order names
-            cols = filter(c -> c in cols, want)
-        end
-        return cols
+# Centroids are stored in obsm and labelled explicitly: `centroid_x`/`centroid_y`/`centroid_z` (present
+# axes only) in `uns/spatial_cols`, and `centroid_t` in `uns/temporal_cols`. Names are written explicitly
+# at measurement time and by the migration (docs/todo/CENTROID_AXES_PLAN.md); the reader takes them
+# verbatim — there is NO positional `centroid-N` fallback (run the migration on pre-existing data).
+# Every consumer selects by axis name, never by position (the celltrackR x,y,z-vs-skimage z,y,x mismatch
+# makes positional reads a silent 2D bug). `axis_of` is the one place that parses an axis from a name.
+axis_of(col::AbstractString)::Symbol = Symbol(match(r"^centroid_([xyzt])$", col)[1])
+
+_read_uns_strings(fid, key) = haskey(fid, key) ? _as_strings(read(fid[key])) : String[]
+
+# `centroid-N` (skimage's positional names) and a bare `t` are NOT acceptable anywhere — measurement
+# and the migration write explicit axis names. Fail loudly the moment a stale/un-migrated file is read,
+# rather than silently mis-mapping axes (docs/todo/CENTROID_AXES_PLAN.md).
+function _check_centroid_names(names::Vector{String}, kind::Symbol)::Vector{String}
+    pat = kind === :spatial ? r"^centroid_[xyz]$" : r"^centroid_t$"
+    for n in names
+        occursin(pat, n) || error(
+            "LabelProps: non-explicit $kind centroid name '$n' — expected " *
+            (kind === :spatial ? "centroid_x/_y/_z" : "centroid_t") *
+            ". This file predates the centroid-axis rename; run the migration " *
+            "(docs/todo/CENTROID_AXES_PLAN.md).")
     end
+    names
+end
+_spatial_uns(fid)  = _check_centroid_names(_read_uns_strings(fid, "uns/spatial_cols"), :spatial)
+_temporal_uns(fid) = _check_centroid_names(_read_uns_strings(fid, "uns/temporal_cols"), :temporal)
+
+"""Spatial centroid column names (`centroid_x`/`_y`/`_z`, present axes only, verbatim from
+`uns/spatial_cols`). `order` selects BY AXIS — `order=[:x,:y,:z]` returns the present axes in that
+order (z dropped for 2D), never a positional slice. Mirrors the old R `LabelPropsView.centroid_columns`.
+Errors on a pre-migration `centroid-N` file."""
+function centroid_columns(lp::LabelProps; order=nothing)::Vector{String}
+    cols = _with_h5(lp.path, "r") do fid
+        _spatial_uns(fid)
+    end
+    isnothing(order) && return cols
+    want = ["centroid_$(lowercase(string(a)))" for a in order]
+    filter(in(cols), want)
 end
 
-"""Temporal column names from `uns/temporal_cols` (e.g. `["t"]`; empty for non-timecourse).
-Mirrors the Python `LabelPropsView.temporal_columns`."""
+"""Temporal column name (`["centroid_t"]`; empty for non-timecourse) — verbatim from `uns/temporal_cols`."""
 function temporal_columns(lp::LabelProps)::Vector{String}
     _with_h5(lp.path, "r") do fid
-        haskey(fid, "uns/temporal_cols") ? _as_strings(read(fid["uns/temporal_cols"])) : String[]
+        _temporal_uns(fid)
     end
 end
 
@@ -268,18 +296,19 @@ function as_df(lp::LabelProps; include_x::Bool=lp.include_x, include_obs::Bool=l
         n_var = length(var_names)
         var_idx = Dict(v => i for (i, v) in enumerate(var_names))
 
-        # centroid name → (group, position)
-        cent_map = Dict{String,Tuple{String,Int}}()
-        if haskey(fid, "uns/spatial_cols")
-            for (i, c) in enumerate(_as_strings(read(fid["uns/spatial_cols"])))
-                cent_map[c] = ("spatial", i)
-            end
-        end
-        if haskey(fid, "uns/temporal_cols")
-            for (i, c) in enumerate(_as_strings(read(fid["uns/temporal_cols"])))
-                cent_map[c] = ("temporal", i)
-            end
-        end
+        # centroid name → (group, position, ndim). Map BOTH the on-disk name and its explicit
+        # `centroid_{axis}` alias to the same obsm column, so a consumer can select "centroid_x" even
+        # on a legacy file that stores "centroid-0" (normalisation lives in _explicit_*_names). This is
+        # the legacy bridge that lets the code deploy before the data migration (CENTROID_AXES_PLAN.md).
+        # Guard on read: a file carrying `centroid-N`/bare-`t` is rejected outright (errors), so those
+        # names can NEVER reach a returned DataFrame. Convert the file first (CENTROID_AXES_PLAN.md).
+        cent_map = Dict{String,Tuple{String,Int,Int}}()
+        raw_spatial  = _spatial_uns(fid)
+        raw_temporal = _temporal_uns(fid)
+        n_sp = length(raw_spatial); n_tp = length(raw_temporal)
+        for (i, c) in enumerate(raw_spatial);  cent_map[c] = ("spatial", i, n_sp);  end
+        for (i, c) in enumerate(raw_temporal); cent_map[c] = ("temporal", i, n_tp); end
+        all_centroid_cols = vcat(raw_spatial, raw_temporal)   # set returned when no explicit selection
         obs_cols = haskey(HDF5.attrs(fid["obs"]), "column-order") ?
                    _as_strings(HDF5.read_attribute(fid["obs"], "column-order")) : String[]
 
@@ -287,7 +316,7 @@ function as_df(lp::LabelProps; include_x::Bool=lp.include_x, include_obs::Bool=l
         local var_cols::Vector{String}, cent_cols::Vector{String}, ocols::Vector{String}
         if isnothing(lp.sel_cols)
             var_cols  = include_x ? var_names : String[]
-            cent_cols = collect(keys(cent_map))
+            cent_cols = all_centroid_cols
             ocols     = include_obs ? obs_cols : String[]
         else
             sel = lp.sel_cols
@@ -318,9 +347,7 @@ function as_df(lp::LabelProps; include_x::Bool=lp.include_x, include_obs::Bool=l
 
         # centroid columns (from obsm)
         for c in cent_cols
-            grp, pos = cent_map[c]
-            n_dim = grp == "spatial" ? length(filter(p -> p[2][1] == "spatial", collect(cent_map))) :
-                                       length(filter(p -> p[2][1] == "temporal", collect(cent_map)))
+            grp, pos, n_dim = cent_map[c]
             col = _read_obsm_col(fid, grp, pos, n_obs, n_dim)
             df[!, c] = keep === Colon() ? col : col[keep]
         end

--- a/app/src/model/image.jl
+++ b/app/src/model/image.jl
@@ -238,6 +238,22 @@ function img_physical_sizes(img::CciaImage)::Tuple{Vector{Float64}, Float64}
     ([sz, sy, sx], ts)   # skimage order: z, y, x
 end
 
+"""
+    physical_size_for_axis(img_or_sizes, axis::Symbol) -> Float64
+
+Physical pixel size (µm/px) for ONE spatial axis (`:x`/`:y`/`:z`). Explicit per-axis lookup so a
+consumer maps a `centroid_{axis}` column to its resolution BY NAME, never by tail position — the fix
+for the silent 2D mis-scaling (docs/todo/CENTROID_AXES_PLAN.md). `img_or_sizes` is a `CciaImage` or the
+`[sz, sy, sx]` vector from `img_physical_sizes`. Absent metadata → 1.0 (pixel space)."""
+function physical_size_for_axis(sizes::AbstractVector{<:Real}, axis::Symbol)::Float64
+    axis === :z ? Float64(sizes[1]) :
+    axis === :y ? Float64(sizes[2]) :
+    axis === :x ? Float64(sizes[3]) :
+        error("physical_size_for_axis: axis must be :x/:y/:z (got :$axis)")
+end
+physical_size_for_axis(img::CciaImage, axis::Symbol)::Float64 =
+    physical_size_for_axis(first(img_physical_sizes(img)), axis)
+
 tryparse_f64(v::Real) = Float64(v)
 tryparse_f64(v::AbstractString) = tryparse(Float64, v)
 tryparse_f64(::Any) = nothing

--- a/app/src/tasks/spatialAnalysis/cellContacts.jl
+++ b/app/src/tasks/spatialAnalysis/cellContacts.jl
@@ -18,12 +18,11 @@ struct CellContacts <: CciaTask end
 # physical-scaled centroids (rows = points, cols = spatial dims) + labels for member labels of a seg
 function _scaled_centroids(img::CciaImage, vn::AbstractString, labels::AbstractVector{<:Integer})
     props = img_label_props_path(img, vn)
-    scols = centroid_columns(label_props(props))
+    scols = centroid_columns(label_props(props); order=[:x, :y, :z])   # explicit axes, present only
     cdf = label_props(props) |> view_centroid_cols |> filter_rows(collect(Int, labels)) |> as_df
     nrow(cdf) == 0 && return (zeros(Float64, 0, length(scols)), Int[])
-    (sizes, _) = img_physical_sizes(img)
-    scale = sizes[end - length(scols) + 1:end]
-    coords = hcat((Float64.(cdf[!, c]) .* scale[j] for (j, c) in enumerate(scols))...)
+    # each centroid column scaled by ITS OWN axis resolution (by name, never by position) — 2D-safe
+    coords = hcat((Float64.(cdf[!, c]) .* physical_size_for_axis(img, axis_of(c)) for c in scols)...)
     (coords, Int.(cdf.label))
 end
 

--- a/app/src/tasks/spatialAnalysis/detectAggregates.jl
+++ b/app/src/tasks/spatialAnalysis/detectAggregates.jl
@@ -51,14 +51,13 @@ function _run_task(::DetectAggregates, img::CciaImage, params::Dict{String,Any};
 
     props = img_label_props_path(img, value_name)
     lp    = label_props(props)
-    scols = centroid_columns(lp)                 # spatial (skimage z,y,x order)
+    scols = centroid_columns(lp; order=[:x, :y, :z])   # explicit axes, present only
     tcols = temporal_columns(lp)
     cdf   = label_props(props) |> view_centroid_cols |> filter_rows(labels) |> as_df
     nrow(cdf) == 0 && (on_log("[ERROR] detectAggregates: no centroids for the population"); return nothing)
 
-    (sizes, _) = img_physical_sizes(img)         # [sz, sy, sx]
-    scale = sizes[end - length(scols) + 1:end]
-    coords = hcat((Float64.(cdf[!, c]) .* scale[j] for (j, c) in enumerate(scols))...)
+    # each centroid column scaled by ITS OWN axis resolution (by name, never by position) — 2D-safe
+    coords = hcat((Float64.(cdf[!, c]) .* physical_size_for_axis(img, axis_of(c)) for c in scols)...)
     on_progress(2, 3)
 
     # DBSCAN — per timepoint for live (offset ids so they stay unique across t), else once

--- a/app/src/tasks/tracking/track_measures.jl
+++ b/app/src/tasks/tracking/track_measures.jl
@@ -191,18 +191,17 @@ function _load_tracks_with_labels(props_path::String,
     ("track_id" in col_names(lp; data_type=:obs)) ||
         error("TrackMeasures: no track_id column — run btrack first")
 
-    spatial_cols  = centroid_columns(lp)   # skimage order z?, y, x
+    spatial_cols  = centroid_columns(lp; order=[:x, :y, :z])   # explicit axes, present only, x,y,z order
     temporal_cols = temporal_columns(lp)
     isempty(temporal_cols) &&
         error("TrackMeasures: no temporal column — tracking needs a timecourse")
     t_col = first(temporal_cols)
-    n_sp  = length(spatial_cols)
 
     select_cols(lp, vcat(spatial_cols, temporal_cols, ["track_id"]))
     df = as_df(lp; include_x=false, include_obs=true)
 
-    # pixel_res is (z,y,x) skimage order; nD spatial axes are the LAST n_sp entries
-    res = pixel_res[max(1, length(pixel_res) - n_sp + 1):end]
+    # each centroid column scaled by ITS OWN axis resolution (by name, never by position) — 2D-safe
+    res = [physical_size_for_axis(pixel_res, axis_of(c)) for c in spatial_cols]
 
     _to_int(x) = x isa Integer ? Int(x) : Int(round(Float64(x)))
 
@@ -211,7 +210,7 @@ function _load_tracks_with_labels(props_path::String,
         tid = row.track_id
         (tid isa Number && !isnan(tid)) || continue          # untracked cells: NaN/missing
         t_phys = Float64(row[t_col]) * time_step
-        coords = [Float64(row[spatial_cols[k]]) * res[k] for k in 1:n_sp]
+        coords = [Float64(row[spatial_cols[k]]) * res[k] for k in eachindex(spatial_cols)]
         push!(get!(groups, Int(tid), []), (t_phys, coords, _to_int(row.label)))
     end
 

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2419,8 +2419,11 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test length(col_names(label_props(h5); data_type=:vars)) == 27
             @test channel_columns(label_props(h5)) ==
                   ["mean_intensity_0", "mean_intensity_1", "mean_intensity_2", "mean_intensity_3"]
-            @test centroid_columns(label_props(h5)) == ["centroid-0", "centroid-1", "centroid-2"]
-            @test temporal_columns(label_props(h5)) == ["t"]
+            @test centroid_columns(label_props(h5)) == ["centroid_z", "centroid_y", "centroid_x"]
+            @test temporal_columns(label_props(h5)) == ["centroid_t"]
+            # order= selects BY AXIS (present only), never positionally
+            @test centroid_columns(label_props(h5); order=[:x, :y, :z]) == ["centroid_x", "centroid_y", "centroid_z"]
+            @test centroid_columns(label_props(h5); order=[:x, :y]) == ["centroid_x", "centroid_y"]
 
             # full frame: label + 27 vars + 3 spatial + 1 temporal + 8 obs (track lineage +
             # live.cell.* from tracking.track_measures) = 40 cols, 1377 rows
@@ -2453,7 +2456,7 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
 
             # centroid + intensity selection
             @test Set(names(label_props(h5) |> select_cols(["mean_intensity_0"]) |> view_centroid_cols |> as_df)) ==
-                  Set(["label", "mean_intensity_0", "centroid-0", "centroid-1", "centroid-2", "t"])
+                  Set(["label", "mean_intensity_0", "centroid_z", "centroid_y", "centroid_x", "centroid_t"])
 
             # row filter by label
             d4 = label_props(h5) |> filter_rows([0, 1, 2]; by=:label) |> as_df
@@ -2571,7 +2574,7 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
                 "n_obs":          int(len(v.labels())),
                 "labels5":        [int(x) for x in df["label"].to_numpy()[:5]],
                 "mean_int0_5":    [float(x) for x in df["mean_intensity_0"].to_numpy()[:5]],
-                "centroid0_5":    [float(x) for x in cv["centroid-0"].to_numpy()[:5]],
+                "centroid0_5":    [float(x) for x in cv["centroid_z"].to_numpy()[:5]],
             }))
             """
             # python/ on PYTHONPATH so `import cecelia.utils...` resolves (matches run_py's PYTHONPATH).
@@ -2591,7 +2594,7 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test dj.label[1:5] == collect(Int, py.labels5)
             @test dj[1:5, "mean_intensity_0"] ≈ Float64.(py.mean_int0_5)
             cj = label_props(h5) |> view_centroid_cols |> sort_by("label") |> as_df
-            @test cj[1:5, "centroid-0"] ≈ Float64.(py.centroid0_5)
+            @test cj[1:5, "centroid_z"] ≈ Float64.(py.centroid0_5)
         end
     end
 
@@ -3656,14 +3659,14 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
             @test whole["series"][1]["value"] == Float64(nrow(all))
 
             # count per timepoint (group_by the temporal column) → counts partition the total.
-            byT = plot_summary_data(img, "labels", String[], "count"; value_name="B", group_by="t")
-            @test byT["groupBy"] == "t"
+            byT = plot_summary_data(img, "labels", String[], "count"; value_name="B", group_by="centroid_t")
+            @test byT["groupBy"] == "centroid_t"
             @test length(byT["series"]) > 1
             @test sum(s["value"] for s in byT["series"]) == Float64(nrow(all))
 
             # a morphology distribution over labels, per timepoint
             area = plot_summary_data(img, "labels", String[], "boxplot"; value_name="B",
-                                     measure="area", group_by="t")
+                                     measure="area", group_by="centroid_t")
             @test area["measure"] == "area"
             @test length(area["series"]) == length(byT["series"])
 

--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -21,8 +21,17 @@ Each measured label set produces one AnnData file:
 | `X` | Float32 feature matrix (cells × features). Contains all morphology and intensity columns. |
 | `obsm["spatial"]` | Float32 `(n_cells, n_spatial_dims)` — centroid coordinates in array order (Z, Y, X for 3D; Y, X for 2D). |
 | `obsm["temporal"]` | Float32 `(n_cells, 1)` — timepoint index (0-based). Present only for timecourse images. |
-| `uns["spatial_cols"]` | List of feature names that appear in `obsm["spatial"]` (e.g. `["centroid-0","centroid-1","centroid-2"]`). |
-| `uns["temporal_cols"]` | List of feature names that appear in `obsm["temporal"]` (always `["t"]`). |
+| `uns["spatial_cols"]` | Explicit axis names for `obsm["spatial"]` columns — `["centroid_z","centroid_y","centroid_x"]` (3D) or `["centroid_y","centroid_x"]` (2D). NOT skimage's positional `centroid-N` (see below). |
+| `uns["temporal_cols"]` | Name for `obsm["temporal"]` (always `["centroid_t"]`). |
+
+> **Centroid axis names are explicit and read by name, never by position.** Columns are
+> `centroid_x`/`centroid_y`/`centroid_z` (present axes only) + `centroid_t` — matching the old R
+> convention. Consumers select the axis they want via `centroid_columns(lp; order=[:x,:y,:z])` and map
+> physical resolution per axis (`physical_size_for_axis(img, axis_of(col))`); the positional
+> `centroid-N` names skimage produces are renamed at measurement time and are **rejected on read**
+> (the reader errors — run the converter, see `docs/todo/CENTROID_AXES_PLAN.md`). This avoids the
+> silent 2D mis-scaling that trailing-position alignment invites (celltrackR wants x,y,z; skimage
+> stores z,y,x).
 | `uns["intensity_measure"]` | `"mean"` or `"median"` — which statistic was used for channel intensities. |
 
 ### Companion per-track table — `{value_name}__tracks.h5ad`
@@ -81,7 +90,7 @@ The Leiden clustering tasks write their result back through the `LabelProps` wri
 | `aspect_ratio` | minor / major axis |
 | `perimeter_to_area` | Compactness proxy |
 | `oblate` | Circularity: 4π·area / perimeter² |
-| `centroid-0`, `centroid-1` | Y, X centroids |
+| `centroid_y`, `centroid_x` | Y, X centroids (lifted to `obsm["spatial"]`, not in `X`) |
 | `bbox-0` … `bbox-3` | Bounding box rows/columns |
 
 **Morphology (3D basic)**
@@ -95,7 +104,7 @@ The Leiden clustering tasks write their result back through the `LabelProps` wri
 | `euler_number` | Topological Euler number |
 | `feret_diameter_max` | Maximum Feret diameter |
 | `major_axis_length`, `interm_axis_length`, `minor_axis_length` | Derived from inertia tensor eigenvalues |
-| `centroid-0` … `centroid-2` | Z, Y, X centroids |
+| `centroid_z`, `centroid_y`, `centroid_x` | Z, Y, X centroids (lifted to `obsm["spatial"]`, not in `X`) |
 | `bbox-0` … `bbox-5` | Bounding box |
 
 **Morphology (3D extended, `extendedMeasures=true`)**
@@ -207,7 +216,7 @@ a human (it is not a *dispatch* ambiguity — `Bool` and `LabelProps` are disjoi
 one); use the lambda form: `… |> v -> rename_channels!(v, !raw_channel_names)`.
 
 Output is a `DataFrame` with a `label` column (obs `_index`, parsed to `Int`), plus the selected
-var columns, centroid columns (`centroid-0..2`, `t`), and obs columns. The reader dispatches on
+var columns, centroid columns (`centroid_x`/`_y`/`_z`, `centroid_t`), and obs columns. The reader dispatches on
 the AnnData `encoding-type` attribute: dense `array` + `string`/`string-array` (+ `categorical`
 for obs) are handled; sparse (`csr/csc`) raises rather than misreads.
 

--- a/docs/REPL.md
+++ b/docs/REPL.md
@@ -309,7 +309,9 @@ Add the per-channel intensity columns to the selection.
 
 ### `view_centroid_cols`
 
-Add centroid columns (optionally ordered, e.g. order=["x","y","z"]).
+Add the centroid columns to the selection — the explicit spatial axes (`centroid_x`/`_y`/`_z`,
+present only) plus the temporal `centroid_t`. `order` selects the spatial axes BY AXIS
+(`order=[:x,:y,:z]`), never positionally.
 
 ### `filter_rows`
 
@@ -333,8 +335,10 @@ Per-channel intensity var names (e.g. `mean_intensity_0`). Renamed to channel na
 
 ### `centroid_columns`
 
-Spatial centroid column names from `uns/spatial_cols` (skimage order: z?, y, x),
-optionally restricted to `order` length. Mirrors the Python `LabelPropsView.centroid_columns`.
+Spatial centroid column names (`centroid_x`/`_y`/`_z`, present axes only, verbatim from
+`uns/spatial_cols`). `order` selects BY AXIS — `order=[:x,:y,:z]` returns the present axes in that
+order (z dropped for 2D), never a positional slice. Mirrors the old R `LabelPropsView.centroid_columns`.
+Errors on a pre-migration `centroid-N` file.
 
 ### `col_names`
 

--- a/docs/todo/CENTROID_AXES_PLAN.md
+++ b/docs/todo/CENTROID_AXES_PLAN.md
@@ -1,0 +1,156 @@
+# Centroid axes: explicit `centroid_x/_y/_z/_t` everywhere (rename + read + gate)
+
+**Status:** planned, not started. Branch `feat/centroid-axes`.
+
+## Problem
+
+Segmentation measurement stores centroids in `obsm['spatial']` labelled with skimage's raw
+positional names `centroid-0/1/2` (z,y,x order) and time in `obsm['temporal']` labelled `t`. Two
+faults follow:
+
+1. **Positional reading is a latent 2D bug.** Every spatial/tracking consumer maps the centroid
+   columns onto a physical-resolution vector (or a z/y/x split) by *trailing-position alignment* —
+   it assumes "3 cols = z,y,x, 2 cols = y,x" and zips against the tail of `[sz,sy,sx]`. All current
+   project images happen to be 3D, so it's never bitten — but a 2D image would silently produce
+   wrong track speeds / distances / neighbour graphs. celltrackR in the old R version proved the
+   danger: it wants coordinates in **x,y,z** order, the *opposite* of skimage's z,y,x, and it
+   assembled them **by explicit column name** (`cciaImage.R:914-920`:
+   `which(colnames == "centroid_x")` …). Explicit-by-name is the only correct contract.
+2. **Opaque names + no gating parity.** `centroid-0` doesn't say which axis it is; `t` is
+   over-generic. And the gating plots don't expose the spatial/temporal axes at all — in R you could
+   *visualise* `centroid_x` vs `centroid_y` on a gating scatter and *gate* on spatial position
+   (`createFlowFrame.R` put the whole label-props table, centroids included, into the flow frame;
+   `flowPlotManager.R` special-cased spatial scatters). Also: the cookbook Claude reads had a wrong
+   example (`centroid_t`), so a Claude-generated notebook copied a nonexistent column and crashed —
+   the trigger for this work.
+
+The fix everyone already expects (Claude, the R version, intuition): name the columns
+`centroid_x`, `centroid_y`, `centroid_z`, `centroid_t`, and make **every** consumer select by axis.
+
+## Locked decisions
+
+1. **Canonical on-disk names** (the labels in `uns/spatial_cols` / `uns/temporal_cols`):
+   - `centroid_x`, `centroid_y`, always present.
+   - `centroid_z` — present only for 3D.
+   - `centroid_t` — present only for a timecourse.
+2. **Keep the `obsm` structure.** Only the `uns` *labels* change; `obsm['spatial']`/`['temporal']`
+   matrices stay (still skimage z,y,x column order internally). We are relabelling, not restructuring.
+   Not flattening centroids back into flat obs columns (that abandons the deliberate obsm layout).
+3. **Keystone: `centroid_columns(order=…)` is the explicit-axis selector; no consumer touches
+   positions; `centroid-N` is a hard error.** Following the old R `LabelPropsView.centroid_columns`
+   (reference, not gospel): the `order` arg selects **by axis name** — `order=[:x,:y,:z]` → the present
+   `centroid_{axis}` columns in that order (z dropped for 2D), *not* a positional `centroid-N` slice.
+   A consumer that needs coordinates writes `centroid_columns(lp; order=[:x,:y,:z])` and gets explicit,
+   correctly-ordered, present-only axes; `axis_of("centroid_x")==:x` + `physical_size_for_axis(img,:x)`
+   map each column to its resolution — never by tail position. **NO legacy bridge, NO fallback.**
+   **Strict:** `as_df` validates the centroid names on **every** read (both langs), so a file carrying
+   `centroid-N`/bare-`t` is rejected outright — those names can never reach a returned DataFrame, even
+   via a non-centroid read. The remedy is the converter (decision 6), not silent normalisation. The
+   positional `spatial_cols[k]` / `sp[:,0]=z` pattern is deleted everywhere. One home for the axis
+   convention (per the divergent-reimplementation rule); the skimage `centroid-N`→axis mapping exists
+   ONLY in the writer/converter namer (`skimage_centroid_axis_names`), never on the read path.
+4. **Physical resolution maps by axis name, never by position.** `centroid_x → PhysicalSizeX`, etc.,
+   via a helper (`physical_size_for_axis(img, :x)` or a `Dict`), replacing every
+   `res = phys[end-n+1:end]` tail-slice.
+5. **Gating exposes spatial + temporal axes** for both visualise and gate. The obsm read path and
+   gate-eval already handle named centroid columns (verified: `as_df` materialises any
+   `uns/spatial_cols`/`temporal_cols` name; the gate-eval and plotdata fetches use the same
+   `select_cols → as_df` chain). So this is publish-the-columns + UI, not data plumbing. Port R plot
+   behaviour: when both axes are `centroid_x`/`centroid_y`, **fixed aspect ratio + reversed Y**;
+   default transform **linear** (not logicle) for spatial/temporal axes.
+6. **Generic h5ad converter** (idempotent, dry-runnable) over `projects_dir()/**/labelProps/*.h5ad`.
+   Handles *any* prior format so it also covers anyone who used the old R version: (a) Pineapple
+   `centroid-N` labels in `uns/spatial_cols` + `t` → explicit names (via `skimage_centroid_axis_names`);
+   (b) old-R flat `centroid_x/_y/_z/_t` var columns → lifted into `obsm` with explicit `uns` (generalise
+   `legacy_migrate`). This is the remedy the read-time guard points at. Dominik runs it; we don't touch
+   his files.
+
+## Blast radius (from discovery — file:line)
+
+### Canonical readers (define the contract; become the accessor's home)
+- `app/src/label_props.jl` — `centroid_columns`/`temporal_columns` (name-agnostic), `as_df` `cent_map`
+  (name→matrix-offset, fine). **`centroid_columns(; order=)` L239 hardcodes `centroid-N`** — the
+  positional `order=` filter; drop it (no caller passes `order=`).
+- `python/cecelia/utils/label_props_utils.py` — `centroid_columns`/`temporal_columns` L43-47, `as_df`
+  L100-107 (positional against the matrix, authoritative — fine).
+
+### Positional consumers — MUST switch to explicit axis (the correctness fix)
+Physical-resolution / coordinate-order sensitive (all trailing-align today):
+- `app/src/tasks/tracking/track_measures.jl` L194-214 — `coords = row[spatial_cols[k]] * res[k]`.
+- `app/src/tasks/spatialAnalysis/detectAggregates.jl` L54-67 — `scols[j] ↔ scale[j]`; `tcols[1]`.
+- `app/src/tasks/spatialAnalysis/cellContacts.jl` L21-26 — `scols[j] ↔ scale[j]`.
+- `python/cecelia/tasks/spatialAnalysis/cell_neighbours_run.py` L52-64 — `phys[-n:]` tail align.
+- `python/cecelia/utils/spatial_utils.py` L112-123 — `phys[-len(ccols):]`; `tcols[0]`.
+- `python/cecelia/utils/tracking_utils.py` L113-135 — positional z/y/x split + hardcoded `"t"` (L104,
+  L115, L122); builds the btrack `(x,y,z,t)` frame.
+- `napari/napari_bridge.py` L395-423 `_centroid_matrix` (`zip(spatial_axes, centroid_cols)`), L523-557
+  `_tracks_matrix` (hardcoded `"t"` display-axis).
+- `app/src/tasks/tracking/track_measures.jl` L195 + `hmm_states.jl:38` + `detectAggregates.jl:55`
+  temporal-first assumptions.
+
+### Producer + migration (mint the names)
+- `python/cecelia/utils/measure_utils.py` `_to_anndata` L357-379 (+ `morph_df['t']` L132) — write
+  `centroid_{axis}` + `centroid_t` into `uns`.
+- `python/cecelia/tasks/importImages/legacy_migrate.py` L122-130 — already knows the explicit source
+  names; stop collapsing to `centroid-N`/`t`, emit the explicit names.
+
+### Gating exposure
+- `api/src/gating_api.jl` `api_gating_channels` flow/live branch L333-349 — add `spatialColumns =
+  centroid_columns(lp)`; `temporalColumns` already served (L340). No change to gate-eval
+  (`gating_engine.jl:35,55`), `gates.jl`, or plotdata (`gating_api.jl:151`) — obsm read already works.
+- `frontend/src/stores/gating.ts` L194-221 — read `spatialColumns` + the already-served
+  `temporalColumns` (currently dropped); export them.
+- `frontend/src/modules/gate/GatePlotPanel.vue` (X/Y selects L333/339, default-axis L276-279, default
+  transform L49-54) + `GatePairsPanel.vue` (checklist L146, `syncChannels` L84-89) — add a spatial/
+  time `<optgroup>`, accept spatial cols as valid persisted axes, default their transform to linear,
+  fixed-aspect + reversed-Y when both axes are `centroid_x`/`centroid_y`.
+
+### Docs
+- `docs/DATAMODEL.md` L22-25, L84, L98 (centroid tables), `docs/POPULATION.md` L344, `docs/REPL.md`
+  L105 (the wrong `centroid_t` example — becomes correct after rename), `docs/TRACKING.md`,
+  `label_props.jl` + `tracking_utils.py` docstrings.
+
+## Phases
+
+**Phase 0 — accessor contract (foundation) — DONE (both langs).** `centroid_columns(order=…)` is the
+R-style explicit-axis selector (verbatim `uns` names + order-by-axis); `temporal_columns` verbatim;
+`axis_of` parses an axis from a name; `_check_centroid_names` fails loudly on `centroid-N`/bare-`t` on
+every read (accessors + `as_df`); the skimage→axis namer lives writer-side only
+(`skimage_centroid_axis_names`, Python). Python helper unit-check passing; Julia to be run via
+`test-pkg` with Phase 3. *(`physical_size_for_axis` lands in Phase 3 with the readers.)*
+
+**Phase 1 — writer + legacy migrate.** `measure_utils._to_anndata` and `legacy_migrate` emit
+`centroid_x/_y/_z` + `centroid_t`. Python unit tests: 2D and 3D produce the right `uns` names.
+
+**Phase 2 — generic converter + fixtures.** A dry-runnable, idempotent converter over
+`projects_dir()/**/labelProps/*.h5ad` (excl. `*__tracks.h5ad`) handling both prior formats (decision
+6), via anndata (sanctioned structural edit, like `legacy_migrate`). Convert the committed test fixture
+and update the Julia/Python assertions (`runtests.jl:2422-2456`, `:2565-2569`). Dominik runs it on his
+data.
+
+**Phase 3 — explicit-axis readers (all spatial + tracking modules).** Rewrite every Section-B/C
+consumer to select by axis via the Phase-0 accessor and map resolution by axis name. Covers
+track_measures, detectAggregates, cellContacts, cell_neighbours, spatial_utils, tracking_utils,
+napari bridge. Add a **2D** test path so the positional bug can't regress.
+
+**Phase 4 — gating spatial/temporal axes — core DONE.** Backend serves `spatialColumns`
+(`centroid_columns(order=[:x,:y,:z])`) + `temporalColumns` (`["centroid_t"]`). Store carries them +
+`spatialAxes`/`isSpatialAxis`. `GatePlotPanel` X/Y pickers get a "Spatial / Time" optgroup, spatial
+axes default to the **linear** transform (`axisDefaultTransform`), and persisted spatial axes are
+accepted as valid (`ensureChannels`). `GatePairsPanel` checklist + `syncChannels` include them too.
+Gate-eval + plotdata need no change (obsm read already works). **Deferred (cosmetic):** the R
+fixed-aspect-ratio + reversed-Y for a `centroid_x`×`centroid_y` scatter — touches the regl-scatterplot
+renderer; capability (visualise + gate on spatial axes) works without it.
+
+**Phase 5 — docs.** Update DATAMODEL/POPULATION/REPL/TRACKING + docstrings; regenerate the REPL.md
+generated API section (`Cecelia.write_repl_doc()`); the golden test guards it.
+
+## Reservations / risks
+- The migration mutates every existing label-props h5ad — cheap `uns`-label rewrite, but back up
+  first; dry-run shows every change; idempotent.
+- Tracking / spatial / napari code paths can't be exercised fully headless — lean on the Phase-0/1/3
+  unit tests (incl. the 2D case) + a live check.
+- **No legacy fallback (by design):** reads of a pre-migration `centroid-N` file **fail** rather than
+  degrade — so the converter MUST be run when adopting this change, or existing projects won't read.
+  The fail-fast message names the converter. This is the deliberate "centroid-N not acceptable
+  anywhere" contract, not an oversight.

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -82,11 +82,13 @@ function clearChannels() { channels.value = [] }
 // returns a new array each time → would loop). Flow → intensity channels; track → gateable columns.
 function syncChannels() {
   const defaults = g.channels.length ? g.channels : g.columns
-  const next = reconcileChannels(channels.value, g.columns, defaults)
+  // spatial/temporal centroid axes are selectable too (kept out of the defaults — opt-in per user)
+  const valid = [...g.columns, ...g.spatialAxes]
+  const next = reconcileChannels(channels.value, valid, defaults)
   const changed = next.length !== channels.value.length || next.some((c, i) => c !== channels.value[i])
   if (changed) channels.value = next
 }
-watch([() => g.columns, () => g.imageUid, () => g.valueName], syncChannels, { immediate: true })
+watch([() => g.columns, () => g.spatialAxes, () => g.imageUid, () => g.valueName], syncChannels, { immediate: true })
 
 // ── heavy-matrix warning ────────────────────────────────────────────────────────────────────────
 // N×N grows fast, and every off-diagonal pair fetches the population's cells. Warn (before loading)
@@ -143,7 +145,7 @@ function exportAs(kind: string) {
                 <button class="chan-clear" :disabled="!channels.length" @click="clearChannels">clear</button>
               </div>
               <div class="chan-list">
-                <label v-for="c in g.columns" :key="c" class="chan-item"
+                <label v-for="c in [...g.columns, ...g.spatialAxes]" :key="c" class="chan-item"
                        :class="{ disabled: !channels.includes(c) && atCap }">
                   <input type="checkbox" :checked="channels.includes(c)"
                          :disabled="!channels.includes(c) && atCap" @change="toggleChannel(c)" />

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -47,11 +47,13 @@ const TRANSFORMS: Kind[] = ['linear', 'log', 'asinh', 'logicle']
 // track properties (motility, per-track aggregates) are plain continuous values → linear by
 // default; flow intensities default to logicle (FlowJo). User can switch either per axis.
 const defaultTransform: Kind = g.popType === 'track' ? 'linear' : 'logicle'
+// spatial/temporal centroid axes are raw coordinates → linear by default (never logicle).
+const axisDefaultTransform = (col: string): Kind => g.isSpatialAxis(col) ? 'linear' : defaultTransform
 // axis config reads/writes the persisted `ui` bag (owned by GatingPlots) so it survives remount.
 const xChan = computed({ get: () => props.ui.x ?? '', set: v => { props.ui.x = v } })
 const yChan = computed({ get: () => props.ui.y ?? '', set: v => { props.ui.y = v } })
-const xt = computed<Kind>({ get: () => props.ui.xt ?? defaultTransform, set: v => { props.ui.xt = v } })
-const yt = computed<Kind>({ get: () => props.ui.yt ?? defaultTransform, set: v => { props.ui.yt = v } })
+const xt = computed<Kind>({ get: () => props.ui.xt ?? axisDefaultTransform(xChan.value), set: v => { props.ui.xt = v } })
+const yt = computed<Kind>({ get: () => props.ui.yt ?? axisDefaultTransform(yChan.value), set: v => { props.ui.yt = v } })
 const renderMode = computed<RenderMode>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })
 // displayed population is owned by GatingPlots (per-panel) so the manager can highlight it
 const parent = computed({ get: () => props.parent, set: v => emit('update:parent', v) })
@@ -275,8 +277,10 @@ function buildCsv(): string {
 function ensureChannels() {
   const cols = g.columns
   if (!cols.length) return
-  if (!cols.includes(xChan.value)) xChan.value = g.channels[(props.index * 2) % Math.max(1, g.channels.length)] ?? cols[0]
-  if (!cols.includes(yChan.value)) yChan.value = g.channels[(props.index * 2 + 1) % Math.max(1, g.channels.length)] ?? cols[Math.min(1, cols.length - 1)]
+  // spatial/temporal axes are valid selections too — don't reset a persisted centroid_x/… axis
+  const valid = [...cols, ...g.spatialAxes]
+  if (!valid.includes(xChan.value)) xChan.value = g.channels[(props.index * 2) % Math.max(1, g.channels.length)] ?? cols[0]
+  if (!valid.includes(yChan.value)) yChan.value = g.channels[(props.index * 2 + 1) % Math.max(1, g.channels.length)] ?? cols[Math.min(1, cols.length - 1)]
 }
 // store readiness (channels/image/segmentation): pick default axes then load. `immediate` so the
 // first appearance fetches whether the store became ready BEFORE this panel mounted (values already
@@ -330,13 +334,23 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
       <!-- axis (X, Y) + displayed population — one row each, stacked so they don't wrap awkwardly -->
       <div class="panel-ctrl">
         <label class="ax-row"><span class="ax-lbl">X</span>
-          <select class="ax-chan" v-model="xChan"><option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option></select>
+          <select class="ax-chan" v-model="xChan">
+            <option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option>
+            <optgroup v-if="g.spatialAxes.length" label="Spatial / Time">
+              <option v-for="c in g.spatialAxes" :key="c" :value="c">{{ g.colLabel(c) }}</option>
+            </optgroup>
+          </select>
           <select class="tsel" :class="{ 'tsel-amber': xCoerced }" v-model="xtSel" v-tooltip.bottom="'Axis transform'">
             <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
           <i v-if="xCoerced" class="pi pi-exclamation-triangle ax-warn"
              v-tooltip.bottom="`${g.colLabel(xChan)}’s range is too small for ${xt} — shown linear`" /></label>
         <label class="ax-row"><span class="ax-lbl">Y</span>
-          <select class="ax-chan" v-model="yChan"><option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option></select>
+          <select class="ax-chan" v-model="yChan">
+            <option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option>
+            <optgroup v-if="g.spatialAxes.length" label="Spatial / Time">
+              <option v-for="c in g.spatialAxes" :key="c" :value="c">{{ g.colLabel(c) }}</option>
+            </optgroup>
+          </select>
           <select class="tsel" :class="{ 'tsel-amber': yCoerced }" v-model="ytSel" v-tooltip.bottom="'Axis transform'">
             <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
           <i v-if="yCoerced" class="pi pi-exclamation-triangle ax-warn"

--- a/frontend/src/stores/gating.ts
+++ b/frontend/src/stores/gating.ts
@@ -105,6 +105,9 @@ export const useGatingStore = defineStore('gating', () => {
   const obsColumns = ref<string[]>([])          // per-cell obs measures (regions.*/clusters.*/hmm.*/is.aggregate/speed…) — filter-pop measures
   const channels  = ref<string[]>([])           // intensity columns, e.g. mean_intensity_0 (ordered)
   const channelNames = ref<string[]>([])         // display names aligned to `channels`
+  // spatial/temporal centroid axes (obsm) — gateable + visualisable scatter axes (centroid_x/_y/_z, centroid_t)
+  const spatialColumns  = ref<string[]>([])
+  const temporalColumns = ref<string[]>([])
   const valueNames = ref<string[]>([])
   // track gating only (popType==='track'): cell measures aggregatable into per-track properties,
   // and the aggregate suffixes — the client builds an axis `{measure}.{agg}` (server inverts it).
@@ -114,6 +117,10 @@ export const useGatingStore = defineStore('gating', () => {
   // per-population membership version — bumped when a pop's (or an ancestor's) gate changes.
   // Panels watch the version of their displayed pop to refresh points smoothly (no full reload).
   const popVersion = ref<Record<string, number>>({})
+
+  // spatial + temporal centroid axes, offered together as a "Spatial / Time" group in the axis pickers
+  const spatialAxes = computed(() => [...spatialColumns.value, ...temporalColumns.value])
+  const isSpatialAxis = (col: string) => spatialAxes.value.includes(col)
 
   const flat = computed(() => flatten(tree.value))
   // transient pops (e.g. the napari cell selection) — auto-highlighted on the plots
@@ -198,9 +205,11 @@ export const useGatingStore = defineStore('gating', () => {
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const d = await res.json() as { columns: string[]; channels?: string[]; channelNames?: string[]
         valueNames: string[]; valueName?: string; cellMeasures?: string[]; trackAggregates?: string[]
-        obsColumns?: string[] }
+        obsColumns?: string[]; spatialColumns?: string[]; temporalColumns?: string[] }
       columns.value = d.columns ?? []
       obsColumns.value = d.obsColumns ?? []
+      spatialColumns.value = d.spatialColumns ?? []
+      temporalColumns.value = d.temporalColumns ?? []
       // track gating returns no intensity channels — `columns` are the (motility) track axes; flow
       // returns intensity channels + display names. cellMeasures/trackAggregates are track-only.
       channels.value = d.channels ?? []
@@ -323,6 +332,7 @@ export const useGatingStore = defineStore('gating', () => {
 
   return {
     imageUid, valueName, popType, mirrorUids, tree, columns, obsColumns, channels, channelNames, valueNames,
+    spatialColumns, temporalColumns, spatialAxes, isSpatialAxis,
     cellMeasures, trackAggregates, stats, popVersion, flat,
     transientPaths, napariZMode, napariZWindow,
     projectUid, napariSetUid, colLabel, selectImage, fetchChannels, fetchPopmap, fetchStats,

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -394,27 +394,27 @@ class NapariState:
 
     def _centroid_matrix(self, value_name: str):
         """Return (labels, C, axes): per-cell centroid coordinates as an (n, n_display_dim)
-        array in display-axis order, read once from the H5AD and cached. Maps the H5AD's
-        `centroid-i` (skimage z,y,x order) + temporal `t` onto the image's display axes."""
+        array in display-axis order, read once from the H5AD and cached. Maps the H5AD's explicit
+        `centroid_{x,y,z}` + `centroid_t` columns onto the image's display axes BY NAME."""
         if value_name in self._centroid_cache:
             return self._centroid_cache[value_name]
         from cecelia.utils.label_props_utils import LabelPropsView
         path = os.path.join(self._task_dir, "labelProps", f"{value_name}.h5ad")
         view = LabelPropsView(path)
-        centroid_cols = view.centroid_columns()
-        temporal_cols = view.temporal_columns()
+        centroid_cols = view.centroid_columns()       # explicit centroid_x/_y/_z (present axes)
+        temporal_cols = view.temporal_columns()        # ['centroid_t'] or []
         df = view.only_centroid_cols().as_df()
         view.close()
 
         labels = df["label"].to_numpy().astype(int)
         display_axes = self._display_axes()
-        spatial_axes = [a for a in display_axes if a in ("z", "y", "x")]   # z,y,x order
-        temporal_axes = [a for a in display_axes if a == "t"]
+        # map each display axis to its centroid column BY NAME (never positionally) — 2D-safe
         axis_to_col = {}
-        for ax, col in zip(spatial_axes, centroid_cols):
-            axis_to_col[ax] = col
-        for ax, col in zip(temporal_axes, temporal_cols):
-            axis_to_col[ax] = col
+        for ax in display_axes:
+            if ax in ("z", "y", "x") and f"centroid_{ax}" in centroid_cols:
+                axis_to_col[ax] = f"centroid_{ax}"
+            elif ax == "t" and temporal_cols:
+                axis_to_col[ax] = temporal_cols[0]
         axes = [a for a in display_axes if a in axis_to_col]
         C = (df[[axis_to_col[a] for a in axes]].to_numpy(dtype=float)
              if axes else np.empty((len(df), 0)))

--- a/python/cecelia/tasks/importImages/convert_centroid_names.py
+++ b/python/cecelia/tasks/importImages/convert_centroid_names.py
@@ -1,0 +1,70 @@
+"""
+Convert existing label-props h5ad files to the explicit centroid-axis convention.
+
+Walks `<root>/**/labelProps/*.h5ad` and normalises each cell-level file to
+`centroid_x/_y/_z` + `centroid_t` (see `cecelia.utils.centroid_migrate.normalise_centroids` for the
+handled prior formats). Idempotent. **Dry-run by default** — pass `--apply` to write. This is the
+remedy for the strict read-time guard that rejects pre-migration `centroid-N` / `t` files
+(docs/todo/CENTROID_AXES_PLAN.md).
+
+    pixi run python -m cecelia.tasks.importImages.convert_centroid_names <projects_dir>           # dry-run
+    pixi run python -m cecelia.tasks.importImages.convert_centroid_names <projects_dir> --apply   # write
+
+Per-track feature tables (`*__tracks.h5ad`) carry no spatial/temporal obsm and are skipped.
+"""
+import argparse
+import glob
+import os
+import sys
+
+import anndata as ad
+
+from cecelia.utils.centroid_migrate import normalise_centroids
+
+
+def _labelprops_files(root):
+    # {proj}/1/{img}/labelProps/{value_name}.h5ad — exclude the per-track tables (no centroids there)
+    hits = glob.glob(os.path.join(root, "**", "labelProps", "*.h5ad"), recursive=True)
+    return sorted(f for f in hits if not f.endswith("__tracks.h5ad"))
+
+
+def convert_file(path, apply=False):
+    """Normalise one file. Returns the list of changes (empty ⇒ nothing to do). Writes only if `apply`."""
+    a = ad.read_h5ad(path)
+    a, changes = normalise_centroids(a)
+    if changes and apply:
+        a.write_h5ad(path)
+    return changes
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Convert label-props h5ad centroids to explicit axis names.")
+    ap.add_argument("root", help="projects directory to scan (e.g. ~/cecelia-pineapple/projects)")
+    ap.add_argument("--apply", action="store_true", help="write changes (default: dry-run, no writes)")
+    args = ap.parse_args(argv)
+
+    root = os.path.expanduser(args.root)
+    files = _labelprops_files(root)
+    print(f"Scanning {len(files)} label-props file(s) under {root}"
+          f"{'' if args.apply else '  [DRY-RUN — no writes; pass --apply to write]'}")
+
+    n_changed = 0
+    for f in files:
+        try:
+            changes = convert_file(f, apply=args.apply)
+        except Exception as e:                                   # noqa: BLE001 — report and continue
+            print(f"  !! {f}: ERROR {e}")
+            continue
+        if changes:
+            n_changed += 1
+            verb = "converted" if args.apply else "would convert"
+            print(f"  {verb}: {f}")
+            for c in changes:
+                print(f"      - {c}")
+
+    print(f"Done. {n_changed}/{len(files)} file(s) {'converted' if args.apply else 'need conversion'}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cecelia/tasks/importImages/legacy_migrate.py
+++ b/python/cecelia/tasks/importImages/legacy_migrate.py
@@ -105,6 +105,8 @@ def migrate_h5ad(src: str, dst: str) -> dict:
     import pandas as pd
     import anndata as ad
 
+    from cecelia.utils.centroid_migrate import normalise_centroids
+
     a = ad.read_h5ad(src)
     summary: dict = {"n_obs": int(a.n_obs)}
 
@@ -116,24 +118,10 @@ def migrate_h5ad(src: str, dst: str) -> dict:
     else:
         summary["index_set_from_label"] = False
 
-    # 2. centroids -> obsm, only if not already there
-    if "spatial" not in a.obsm:
-        var_names = list(map(str, a.var_names))
-        spatial_src = [c for c in ("centroid_z", "centroid_y", "centroid_x") if c in var_names]
-        temporal_src = [c for c in ("centroid_t", "t") if c in var_names]
-        if spatial_src:
-            X = a.to_df()
-            a.obsm["spatial"] = X[spatial_src].to_numpy(dtype=np.float32)
-            a.uns["spatial_cols"] = np.array([f"centroid-{i}" for i in range(len(spatial_src))], dtype=object)
-            if temporal_src:
-                a.obsm["temporal"] = X[temporal_src[:1]].to_numpy(dtype=np.float32)
-                a.uns["temporal_cols"] = np.array(["t"], dtype=object)
-            a = a[:, [c for c in var_names if c not in spatial_src + temporal_src]].copy()
-            summary["centroids_lifted"] = spatial_src + temporal_src
-        else:
-            summary["centroids_lifted"] = None
-    else:
-        summary["centroids_lifted"] = "already_obsm"
+    # 2. centroids -> explicit-obsm (lift flat R var columns, relabel any legacy names). ONE home for
+    #    the conversion, shared with the standalone converter (see centroid_migrate.normalise_centroids).
+    a, cent_changes = normalise_centroids(a)
+    summary["centroids_lifted"] = cent_changes or None
 
     # 3/4. drop excluded (HMM / clustering) obs columns; keep track_id + measures
     dropped = [c for c in a.obs.columns if _is_excluded(str(c))]

--- a/python/cecelia/tasks/spatialAnalysis/cell_neighbours_run.py
+++ b/python/cecelia/tasks/spatialAnalysis/cell_neighbours_run.py
@@ -23,7 +23,7 @@ import json
 import numpy as np
 
 # `cecelia.*` resolves via PYTHONPATH=python/, set by the Julia launcher (app/src/py_runner.jl::run_py).
-from cecelia.utils.label_props_utils import LabelPropsView
+from cecelia.utils.label_props_utils import LabelPropsView, axis_of, physical_size_for_axis
 import cecelia.utils.script_utils as script_utils
 import cecelia.utils.spatial_utils as spatial_utils
 
@@ -59,8 +59,9 @@ def run(params):
         return
 
     # ── scale pixel centroids → physical µm (the radius is in µm) ──
+    # each centroid column scaled by ITS OWN axis resolution (by name, never by position) — 2D-safe
     coords = df[ccols].to_numpy(dtype=np.float64)
-    scale = phys[-coords.shape[1]:]           # align to the number of spatial dims (drops z for 2D)
+    scale = np.array([physical_size_for_axis(phys, axis_of(c)) for c in ccols])
     coords = coords * scale.reshape(1, -1)
 
     import anndata as ad

--- a/python/cecelia/tests/test_centroid_migrate.py
+++ b/python/cecelia/tests/test_centroid_migrate.py
@@ -1,0 +1,100 @@
+"""Unit tests for the explicit centroid-axis convention: the writer namer, the generic converter
+(`centroid_migrate.normalise_centroids`), the fail-fast read guard, and the by-axis resolution helper.
+See docs/todo/CENTROID_AXES_PLAN.md."""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import pandas as pd
+import anndata as ad
+
+from cecelia.utils.centroid_migrate import normalise_centroids
+from cecelia.utils.label_props_utils import (
+    LabelPropsView, skimage_centroid_axis_names, axis_of, physical_size_for_axis,
+)
+
+
+def _legacy_obsm(n_spatial=3, temporal=True):
+    """A Pineapple file with skimage positional labels in uns (the pre-migration shape)."""
+    a = ad.AnnData(X=np.random.rand(4, 2).astype(np.float32),
+                   obs=pd.DataFrame(index=[str(i) for i in range(4)]),
+                   var=pd.DataFrame(index=["area", "vol"]))
+    a.obsm["spatial"] = np.random.rand(4, n_spatial).astype(np.float32)
+    a.uns["spatial_cols"] = np.array([f"centroid-{i}" for i in range(n_spatial)], dtype=object)
+    if temporal:
+        a.obsm["temporal"] = np.random.rand(4, 1).astype(np.float32)
+        a.uns["temporal_cols"] = np.array(["t"], dtype=object)
+    return a
+
+
+def _flat_var():
+    """An old-R file with flat centroid columns in var/X (no obsm)."""
+    return ad.AnnData(
+        X=np.random.rand(4, 5).astype(np.float32),
+        obs=pd.DataFrame(index=[str(i) for i in range(4)]),
+        var=pd.DataFrame(index=["area", "centroid_z", "centroid_y", "centroid_x", "centroid_t"]))
+
+
+class TestWriterNamer(unittest.TestCase):
+    def test_skimage_axis_names(self):
+        self.assertEqual(skimage_centroid_axis_names(3), ["centroid_z", "centroid_y", "centroid_x"])
+        self.assertEqual(skimage_centroid_axis_names(2), ["centroid_y", "centroid_x"])
+        self.assertEqual(skimage_centroid_axis_names(0), [])
+        with self.assertRaises(ValueError):
+            skimage_centroid_axis_names(4)
+
+
+class TestByAxisResolution(unittest.TestCase):
+    def test_physical_size_for_axis(self):
+        phys = [3.0, 0.5, 0.25]   # [sz, sy, sx]
+        self.assertEqual(physical_size_for_axis(phys, "z"), 3.0)
+        self.assertEqual(physical_size_for_axis(phys, "y"), 0.5)
+        self.assertEqual(physical_size_for_axis(phys, "x"), 0.25)
+        self.assertEqual(physical_size_for_axis(phys, axis_of("centroid_x")), 0.25)
+
+
+class TestNormaliseCentroids(unittest.TestCase):
+    def test_case_a_relabel_matrix_untouched(self):
+        a = _legacy_obsm(3)
+        mat = a.obsm["spatial"].copy()
+        a, changes = normalise_centroids(a)
+        self.assertEqual(list(a.uns["spatial_cols"]), ["centroid_z", "centroid_y", "centroid_x"])
+        self.assertEqual(list(a.uns["temporal_cols"]), ["centroid_t"])
+        np.testing.assert_array_equal(a.obsm["spatial"], mat)   # matrix values unchanged
+        self.assertTrue(changes)
+        # idempotent
+        _, again = normalise_centroids(a)
+        self.assertEqual(again, [])
+
+    def test_case_a_2d(self):
+        a, _ = normalise_centroids(_legacy_obsm(2, temporal=False))
+        self.assertEqual(list(a.uns["spatial_cols"]), ["centroid_y", "centroid_x"])
+
+    def test_case_b_flat_lifted(self):
+        a, changes = normalise_centroids(_flat_var())
+        self.assertIn("spatial", a.obsm)
+        self.assertEqual(list(a.uns["spatial_cols"]), ["centroid_z", "centroid_y", "centroid_x"])
+        self.assertEqual(list(a.uns["temporal_cols"]), ["centroid_t"])
+        self.assertNotIn("centroid_x", list(a.var_names))       # dropped from X
+        self.assertIn("area", list(a.var_names))                # feature kept
+        self.assertTrue(changes)
+
+
+class TestReadGuard(unittest.TestCase):
+    def test_reader_rejects_legacy_then_accepts_after_convert(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = os.path.join(tmp, "x.h5ad")
+            _legacy_obsm(3).write_h5ad(p)
+            # pre-conversion: any read that returns a centroid must fail
+            with self.assertRaises(ValueError):
+                LabelPropsView(p).view_centroid_cols().as_df()
+            # convert, then it reads with explicit names
+            a, _ = normalise_centroids(ad.read_h5ad(p)); a.write_h5ad(p)
+            df = LabelPropsView(p).view_centroid_cols().as_df()
+            for c in ("centroid_z", "centroid_y", "centroid_x", "centroid_t"):
+                self.assertIn(c, df.columns)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/cecelia/tests/test_legacy_migrate.py
+++ b/python/cecelia/tests/test_legacy_migrate.py
@@ -49,17 +49,17 @@ class TestMigrateH5ad(unittest.TestCase):
             self.assertEqual(list(out.obs_names), ["1", "2", "3"])      # index = label
             self.assertNotIn("label", out.obs.columns)
             self.assertIn("spatial", out.obsm)                          # centroids lifted
-            self.assertEqual(list(out.uns["spatial_cols"]), ["centroid-0", "centroid-1", "centroid-2"])
+            self.assertEqual(list(out.uns["spatial_cols"]), ["centroid_z", "centroid_y", "centroid_x"])
             self.assertIn("temporal", out.obsm)
-            self.assertEqual(list(out.uns["temporal_cols"]), ["t"])
+            self.assertEqual(list(out.uns["temporal_cols"]), ["centroid_t"])
             self.assertNotIn("centroid_z", list(out.var_names))         # removed from matrix
             self.assertIn("track_id", out.obs.columns)                  # tracking kept
             self.assertIn("live.cell.speed", out.obs.columns)
             self.assertNotIn("live.cell.hmm.state.movement", out.obs.columns)   # hmm dropped
             self.assertNotIn("live.cell.track.clusters.x", out.obs.columns)     # clust dropped
 
-    def test_already_obsm_left_untouched(self):
-        # legacy "newer" file: already has obsm spatial/temporal; migrate must NOT re-lift.
+    def test_legacy_obsm_names_relabelled(self):
+        # legacy "newer" file: already obsm, but skimage positional labels — matrix stays, uns relabels.
         with tempfile.TemporaryDirectory() as tmp:
             a = ad.AnnData(
                 X=np.array([[1.0], [2.0]], dtype=np.float32),
@@ -72,9 +72,11 @@ class TestMigrateH5ad(unittest.TestCase):
             summary = migrate_h5ad(_write(tmp, a), dst)
             out = ad.read_h5ad(dst)
 
-            self.assertEqual(summary["centroids_lifted"], "already_obsm")
             self.assertEqual(list(out.obs_names), ["7", "9"])           # index = label
-            self.assertEqual(out.obsm["spatial"].shape, (2, 3))         # untouched
+            self.assertEqual(out.obsm["spatial"].shape, (2, 3))         # matrix untouched
+            self.assertEqual(list(out.uns["spatial_cols"]),
+                             ["centroid_z", "centroid_y", "centroid_x"])   # relabelled to explicit
+            self.assertTrue(summary["centroids_lifted"])                # recorded the relabel
 
 
 if __name__ == "__main__":

--- a/python/cecelia/utils/centroid_migrate.py
+++ b/python/cecelia/utils/centroid_migrate.py
@@ -1,0 +1,64 @@
+"""
+Normalise a label-props AnnData to the explicit centroid-axis convention.
+
+ONE home for converting any prior centroid layout to the current one (`obsm['spatial']` labelled
+`centroid_x`/`_y`/`_z` in `uns['spatial_cols']`, `obsm['temporal']` labelled `centroid_t`). Two prior
+shapes are handled — see `docs/todo/CENTROID_AXES_PLAN.md`:
+
+  A. Pineapple with skimage's positional labels: `obsm['spatial']` present but `uns['spatial_cols']`
+     is `centroid-0..N` (and `uns['temporal_cols']` is `['t']`). Relabel only — the matrices are
+     unchanged (skimage z,y,x order → `centroid_z/_y/_x`).
+  B. Old R (or any pre-obsm) file with flat `centroid_x/_y/_z/_t` columns in `var`/`X`: lift them into
+     `obsm` with the explicit `uns` labels and drop them from `X` (same as `legacy_migrate`).
+
+Idempotent: a file already in the explicit-obsm form reports no changes. This is the remedy the strict
+read-time guard (`label_props_utils._check_centroid_names`) points at.
+"""
+import re
+
+import numpy as np
+
+from cecelia.utils.label_props_utils import skimage_centroid_axis_names
+
+_EXPLICIT_SPATIAL = re.compile(r"^centroid_[xyz]$")
+# flat R var names, in skimage z,y,x order so the lifted matrix column order matches the labels
+_FLAT_SPATIAL = ("centroid_z", "centroid_y", "centroid_x")
+_FLAT_TEMPORAL = ("centroid_t", "t")
+
+
+def normalise_centroids(adata):
+    """Mutate `adata` in place to the explicit-obsm centroid convention. Returns a list of human-readable
+    change descriptions (empty ⇒ already normalised). Returns the (possibly new) adata via the caller's
+    reference for case B, so callers use the returned object: ``adata, changes = normalise_centroids(a)``."""
+    changes = []
+
+    if "spatial" in adata.obsm:
+        # Case A — relabel positional/legacy names; the obsm matrix is untouched.
+        sc = [str(x) for x in adata.uns.get("spatial_cols", [])]
+        if sc and not all(_EXPLICIT_SPATIAL.match(x) for x in sc):
+            new = skimage_centroid_axis_names(len(sc))
+            adata.uns["spatial_cols"] = np.array(new, dtype=object)
+            changes.append(f"spatial_cols {sc} -> {new}")
+        if "temporal" in adata.obsm:
+            tc = [str(x) for x in adata.uns.get("temporal_cols", [])]
+            if tc and tc != ["centroid_t"]:
+                adata.uns["temporal_cols"] = np.array(["centroid_t"], dtype=object)
+                changes.append(f"temporal_cols {tc} -> ['centroid_t']")
+        return adata, changes
+
+    # Case B — flat centroid columns in var → lift into obsm (mirror of legacy_migrate's lift).
+    var_names = [str(v) for v in adata.var_names]
+    spatial_src = [c for c in _FLAT_SPATIAL if c in var_names]
+    temporal_src = [c for c in _FLAT_TEMPORAL if c in var_names]
+    if spatial_src:
+        X = adata.to_df()
+        adata.obsm["spatial"] = X[spatial_src].to_numpy(dtype=np.float32)
+        adata.uns["spatial_cols"] = np.array(spatial_src, dtype=object)
+        if temporal_src:
+            adata.obsm["temporal"] = X[temporal_src[:1]].to_numpy(dtype=np.float32)
+            adata.uns["temporal_cols"] = np.array(["centroid_t"], dtype=object)
+        keep = [c for c in var_names if c not in spatial_src + temporal_src]
+        adata = adata[:, keep].copy()
+        changes.append(f"lifted flat centroids {spatial_src + temporal_src} -> obsm")
+
+    return adata, changes

--- a/python/cecelia/utils/label_props_utils.py
+++ b/python/cecelia/utils/label_props_utils.py
@@ -9,14 +9,67 @@ bridge (centroid lookup for population overlays + spatial cell selection).
 
 H5AD layout (written by `measure_run.py`): `X` = feature matrix (var_names = feature cols);
 `obs.index` = integer cell label; `obsm['spatial']` + `uns['spatial_cols']` = centroids
-(`centroid-0..N`, skimage order: z?, y, x); `obsm['temporal']` + `uns['temporal_cols']` =
-time (`t`). Files are small (hundreds of KB), so a plain in-memory read is fine.
+(`centroid_x`/`_y`/`_z`, present axes only); `obsm['temporal']` + `uns['temporal_cols']` =
+time (`centroid_t`). Pre-migration files used skimage's positional `centroid-0..N` / `t`; those are NOT
+accepted — the reader fails loudly (run the generic converter). Files are small (hundreds of KB), so a
+plain in-memory read is fine.
 """
 import os
+import re
 
 import anndata as ad
 import numpy as np
 import pandas as pd
+
+# The ONE home for the centroid axis convention (mirror of app/src/label_props.jl; see
+# docs/todo/CENTROID_AXES_PLAN.md). Centroids are labelled explicitly centroid_x/_y/_z (present axes
+# only) in uns['spatial_cols'] + centroid_t in uns['temporal_cols']. Consumers select by axis, never by
+# position. `centroid-N` (skimage's positional names) / bare `t` are NOT acceptable anywhere: the reader
+# fails loudly on them (run the generic converter). `skimage_centroid_axis_names` is the writer/converter
+# namer that turns skimage's centroid-0..N (z,y,x order) into the explicit names.
+_SKIMAGE_SPATIAL_AXES = ("z", "y", "x")   # the trailing n are used for n spatial dims
+
+
+def skimage_centroid_axis_names(n_spatial):
+    """Explicit spatial names for `n_spatial` skimage centroid columns (`centroid-0..N`, z,y,x order):
+    3 -> [centroid_z, centroid_y, centroid_x]; 2 -> [centroid_y, centroid_x]. Writer/converter only."""
+    if n_spatial > len(_SKIMAGE_SPATIAL_AXES):
+        raise ValueError(f"{n_spatial} spatial dims > 3")
+    return [f"centroid_{a}" for a in _SKIMAGE_SPATIAL_AXES[-n_spatial:]] if n_spatial else []
+
+
+def _check_centroid_names(names, kind):
+    """Fail loudly if `names` are not the explicit axis form. `kind` is 'spatial' (centroid_x/_y/_z) or
+    'temporal' (centroid_t). Guards every read so a pre-migration `centroid-N`/`t` file can't silently
+    mis-map axes — run the generic converter (docs/todo/CENTROID_AXES_PLAN.md)."""
+    pat = r"^centroid_[xyz]$" if kind == "spatial" else r"^centroid_t$"
+    want = "centroid_x/_y/_z" if kind == "spatial" else "centroid_t"
+    for n in names:
+        if not re.match(pat, str(n)):
+            raise ValueError(
+                f"LabelPropsView: non-explicit {kind} centroid name '{n}' — expected {want}. "
+                "This file predates the centroid-axis rename; run the migration "
+                "(docs/todo/CENTROID_AXES_PLAN.md).")
+    return [str(n) for n in names]
+
+
+def axis_of(col):
+    """'centroid_x' -> 'x', etc."""
+    m = re.match(r"^centroid_([xyzt])$", str(col))
+    if not m:
+        raise ValueError(f"not a centroid axis column: {col}")
+    return m.group(1)
+
+
+def physical_size_for_axis(sizes_zyx, axis):
+    """Physical pixel size (µm/px) for one spatial axis ('x'/'y'/'z') given the `[sz, sy, sx]` vector
+    that Julia's `img_physical_sizes` produces (fixed z,y,x order). Mirror of the Julia
+    `physical_size_for_axis` — lets a consumer map a `centroid_{axis}` column to its resolution by name,
+    never by tail position (2D-safe)."""
+    idx = {"z": 0, "y": 1, "x": 2}.get(axis)
+    if idx is None:
+        raise ValueError(f"physical_size_for_axis: axis must be x/y/z (got {axis})")
+    return float(sizes_zyx[idx])
 
 
 class LabelPropsView:
@@ -40,11 +93,19 @@ class LabelPropsView:
         """Integer cell label IDs (the obs index)."""
         return self.adata.obs.index.astype(np.int64).to_numpy()
 
-    def centroid_columns(self) -> list:
-        return list(self.adata.uns.get("spatial_cols", []))
+    def centroid_columns(self, order=None) -> list:
+        """Explicit spatial centroid names (centroid_x/_y/_z, present axes only). ``order`` selects
+        BY AXIS — ``order=['x','y','z']`` returns present axes in that order (z dropped for 2D), never
+        a positional slice. Mirrors the old R ``LabelPropsView.centroid_columns``."""
+        cols = _check_centroid_names(self.adata.uns.get("spatial_cols", []), "spatial")
+        if order is None:
+            return cols
+        want = [f"centroid_{str(a).lower()}" for a in order]
+        return [c for c in want if c in cols]
 
     def temporal_columns(self) -> list:
-        return list(self.adata.uns.get("temporal_cols", []))
+        """Temporal column name (['centroid_t']; empty for non-timecourse)."""
+        return _check_centroid_names(self.adata.uns.get("temporal_cols", []), "temporal")
 
     def var_names(self) -> list:
         return list(self.adata.var_names)
@@ -82,6 +143,12 @@ class LabelPropsView:
     # ── materialise ───────────────────────────────────────────────────────────────
     def as_df(self) -> pd.DataFrame:
         a = self.adata
+        # strict: reject a stale centroid-N / bare-t file on ANY read, so those names can never reach a
+        # returned DataFrame — convert the file first (docs/todo/CENTROID_AXES_PLAN.md).
+        if "spatial" in a.obsm:
+            _check_centroid_names(a.uns.get("spatial_cols", []), "spatial")
+        if "temporal" in a.obsm:
+            _check_centroid_names(a.uns.get("temporal_cols", []), "temporal")
         labels = a.obs.index.astype(np.int64).to_numpy()
         data = {}
 
@@ -99,11 +166,11 @@ class LabelPropsView:
 
         if self._with_centroids and "spatial" in a.obsm:
             sp = np.asarray(a.obsm["spatial"])
-            for i, name in enumerate(self.centroid_columns()):
+            for i, name in enumerate(_check_centroid_names(a.uns.get("spatial_cols", []), "spatial")):
                 data[name] = sp[:, i]
             if "temporal" in a.obsm:
                 tp = np.asarray(a.obsm["temporal"])
-                for i, name in enumerate(self.temporal_columns()):
+                for i, name in enumerate(_check_centroid_names(a.uns.get("temporal_cols", []), "temporal")):
                     data[name] = tp[:, i]
 
         df = pd.DataFrame(data)

--- a/python/cecelia/utils/measure_utils.py
+++ b/python/cecelia/utils/measure_utils.py
@@ -24,6 +24,8 @@ import skimage.measure as skmeas
 import skimage.filters as skfilt
 import anndata as ad
 
+from cecelia.utils.label_props_utils import skimage_centroid_axis_names
+
 try:
     import trimesh as _trimesh
     _HAS_TRIMESH = True
@@ -355,15 +357,19 @@ class MeasureUtils:
     # ── AnnData output ────────────────────────────────────────────────────────
 
     def _to_anndata(self, df: pd.DataFrame, is_3d: bool, n_t: int) -> str:
-        spatial_cols   = [c for c in df.columns if c.startswith('centroid-')]
-        temporal_cols  = ['t'] if 't' in df.columns else []
+        # skimage names its centroid columns positionally (`centroid-0..N`, z,y,x order) — rename to
+        # explicit axis names on the way into obsm so `centroid-N` never lands on disk (the readers
+        # reject it; see docs/todo/CENTROID_AXES_PLAN.md). Sort by index to fix z,y,x order.
+        spatial_src   = sorted((c for c in df.columns if c.startswith('centroid-')),
+                               key=lambda c: int(c.split('-')[1]))
+        temporal_src  = ['t'] if 't' in df.columns else []
 
         # separate spatial/temporal into obsm; keep everything else in X
-        obsm_spatial  = df[spatial_cols].values.astype(np.float32) if spatial_cols  else None
-        obsm_temporal = df[temporal_cols].values.astype(np.float32) if temporal_cols else None
+        obsm_spatial  = df[spatial_src].values.astype(np.float32) if spatial_src  else None
+        obsm_temporal = df[temporal_src].values.astype(np.float32) if temporal_src else None
 
         feature_cols = [c for c in df.columns
-                        if c not in spatial_cols and c not in temporal_cols]
+                        if c not in spatial_src and c not in temporal_src]
         X = df[feature_cols].values.astype(np.float32)
 
         adata = ad.AnnData(
@@ -373,10 +379,10 @@ class MeasureUtils:
         )
         if obsm_spatial is not None:
             adata.obsm['spatial']  = obsm_spatial
-            adata.uns['spatial_cols'] = spatial_cols
+            adata.uns['spatial_cols'] = skimage_centroid_axis_names(len(spatial_src))  # centroid_z/_y/_x
         if obsm_temporal is not None:
             adata.obsm['temporal'] = obsm_temporal
-            adata.uns['temporal_cols'] = temporal_cols
+            adata.uns['temporal_cols'] = ['centroid_t']
         adata.uns['intensity_measure'] = self.intensity_measure
 
         out_dir = os.path.join(self.task_dir, 'labelProps')

--- a/python/cecelia/utils/spatial_utils.py
+++ b/python/cecelia/utils/spatial_utils.py
@@ -104,7 +104,7 @@ def build_pooled_image_graph(segs, phys_uid, method="delaunay", radius=30.0, n_n
     (behaviour regions). Falls back to a single pooled graph if no temporal column is present."""
     import anndata as ad
     import pandas as pd
-    from cecelia.utils.label_props_utils import LabelPropsView
+    from cecelia.utils.label_props_utils import LabelPropsView, axis_of, physical_size_for_axis
 
     phys = np.asarray(phys_uid, dtype=float)
     coords_list, code_list, obs_list, time_list = [], [], [], []
@@ -115,7 +115,9 @@ def build_pooled_image_graph(segs, phys_uid, method="delaunay", radius=30.0, n_n
             continue
         code_map = {int(l): int(c) for l, c in zip(seg["labels"], seg["popCodes"])}
         codes = np.array([code_map[int(l)] for l in d["label"]], dtype=np.int64)
-        coords = d[ccols].to_numpy(dtype=np.float64) * phys[-len(ccols):].reshape(1, -1)
+        # each centroid column scaled by ITS OWN axis resolution (by name, never by position) — 2D-safe
+        scale = np.array([physical_size_for_axis(phys, axis_of(c)) for c in ccols])
+        coords = d[ccols].to_numpy(dtype=np.float64) * scale.reshape(1, -1)
         coords_list.append(coords)
         code_list.append(codes)
         obs_list.append(pd.DataFrame({"valueName": seg["valueName"], "label": d["label"].to_numpy()}))

--- a/python/cecelia/utils/tracking_utils.py
+++ b/python/cecelia/utils/tracking_utils.py
@@ -8,8 +8,8 @@ same H5AD `obs`, following our AnnData convention (docs/DATAMODEL.md):
 
   - `obs.index`      = integer cell label (preserved; we align on it)
   - `X` / `var`      = feature matrix (preserved untouched)
-  - `obsm['spatial']` + `uns['spatial_cols']` = centroids (skimage `centroid-0..N` order)
-  - `obsm['temporal']` + `uns['temporal_cols']` = time (`t`)
+  - `obsm['spatial']` + `uns['spatial_cols']` = centroids (`centroid_x`/`_y`/`_z`, present axes)
+  - `obsm['temporal']` + `uns['temporal_cols']` = time (`centroid_t`)
 
 Track lineage is identity, not a measurement, so it goes into `obs` (NOT `X`):
 `track_id, track_parent, track_root, track_state, track_generation, cell_id`. Cells not in
@@ -110,27 +110,22 @@ class BayesianTrackingUtils:
 
     # ── centroids → btrack input frame (x, y, z, t, label_id) ──────────────────────
     def _centroids_from_view(self, view) -> pd.DataFrame:
-        spatial_cols  = view.centroid_columns()
-        temporal_cols = view.temporal_columns()
-        if "t" not in temporal_cols:
+        temporal_cols = view.temporal_columns()      # ['centroid_t'] or [] (guarded → explicit)
+        if not temporal_cols:
             raise SystemExit(
                 "[ERROR] No temporal axis in label props — tracking needs a timecourse "
                 f"segmentation (value_name='{self.value_name}')")
 
-        df = view.view_centroid_cols().as_df()    # centroid-0..N + t + label (label-filtered)
+        df = view.view_centroid_cols().as_df()    # centroid_x/_y[/_z] + centroid_t + label (label-filtered)
         labels = df["label"].to_numpy(dtype=np.int64)
-        t = df["t"].to_numpy(dtype=np.float64)
+        t = df[temporal_cols[0]].to_numpy(dtype=np.float64)
 
-        # spatial_cols are skimage centroid axes: 2D = (y, x); 3D = (z, y, x)
-        sp = df[spatial_cols].to_numpy(dtype=np.float64)
-        n_sp = sp.shape[1]
-        if n_sp >= 3:
-            z, y, x = sp[:, 0], sp[:, 1], sp[:, 2]
-        elif n_sp == 2:
-            z = np.zeros_like(labels, dtype=np.float64)
-            y, x = sp[:, 0], sp[:, 1]
-        else:
-            raise SystemExit(f"[ERROR] Unexpected spatial dimensionality: {n_sp}")
+        # select each axis BY NAME (never positionally) — z is absent for 2D; btrack still wants a z
+        # column, so fill zeros. (btrack's own frame schema is t,x,y,z,label_id.)
+        x = df["centroid_x"].to_numpy(dtype=np.float64)
+        y = df["centroid_y"].to_numpy(dtype=np.float64)
+        z = (df["centroid_z"].to_numpy(dtype=np.float64)
+             if "centroid_z" in df.columns else np.zeros_like(labels, dtype=np.float64))
 
         return pd.DataFrame({"t": t, "x": x, "y": y, "z": z, "label_id": labels})
 


### PR DESCRIPTION
## Why

Centroids were stored with skimage's positional labels — `centroid-0..N` (z,y,x order) + a bare `t` — and read **positionally** (`sizes[end-n+1:end]`, `sp[:,0]=z`). That's a silent 2D mis-scaling waiting to happen: celltrackR wants coordinates in x,y,z order, skimage stores z,y,x, and physical resolution is per-axis. All current projects are 3D so it never bit — but a 2D dataset would get wrong track speeds / distances / neighbour graphs. The old R version already used explicit `centroid_x/y/z/t` names and read them **by name**; the Pineapple port dropped that. This restores it.

## What

- **Explicit names everywhere:** `centroid_x`/`centroid_y`/`centroid_z` (present axes only) + `centroid_t`.
- **Read by axis, never by position.** `centroid_columns(order=[:x,:y,:z])` selects by axis; `axis_of` + `physical_size_for_axis` map each column to its resolution by name (both languages).
- **Strict guard:** `as_df` rejects any file still carrying `centroid-N` / bare-`t` — those names can never reach a DataFrame. No legacy fallback.
- **Writer** (`measure_utils`, `legacy_migrate`) mints explicit names.
- **Generic converter** (`normalise_centroids` + `convert_centroid_names` CLI, dry-run default) fixes both prior formats: Pineapple `centroid-N`-in-`uns`, and old-R flat `centroid_x` var columns → explicit obsm.
- **All spatial/tracking/napari consumers** rewritten to select coordinates + resolution by axis: `track_measures`, `detectAggregates`, `cellContacts`, `tracking_utils` (btrack frame), `cell_neighbours_run`, `spatial_utils`, napari `_centroid_matrix`.
- **Gating:** spatial/temporal centroid axes are now exposed to **visualise and gate on** (`spatialColumns`/`temporalColumns`, a "Spatial / Time" optgroup, linear default transform).

Design + phases: `docs/todo/CENTROID_AXES_PLAN.md`.

## Migration (required)

The strict guard means existing projects won't read until converted:

```
pixi run python -m cecelia.tasks.importImages.convert_centroid_names <projects_dir>           # dry-run
pixi run python -m cecelia.tasks.importImages.convert_centroid_names <projects_dir> --apply   # write
```

(A GUI "run patches" button in Settings is a planned follow-up PR.)

## Tests

`test-py` (102), `test-pkg` (incl. the **celltrackR golden 33/33** — the track-measure rewrite is numerically identical), `test-api`, and `vue-tsc` typecheck all green. New `test_centroid_migrate`; updated `test_legacy_migrate` + Julia fixture assertions; committed fixture migrated in place.

## Reservations

- Not run in the live app — gating on spatial position + centroid-axis plotdata are typecheck-clean but never clicked.
- No 2D dataset exercised end-to-end (btrack/squidpy/napari); the fix is unit-proven + the celltrackR golden passes on 3D.
- The shared test fixture was migrated in place, so `main`'s tests will fail until this merges.
- Deferred (cosmetic): R's fixed-aspect / reversed-Y for `centroid_x`×`centroid_y` scatters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
