### PR TITLE
Gating: default all centroid_* axes to linear

### DIFF
--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -39,7 +39,11 @@ const g = useGatingStore()
 // track properties → linear by default; flow intensities → logicle (FlowJo) — same rule as GatePlotPanel
 const defaultTransform: Kind = g.popType === 'track' ? 'linear' : 'logicle'
 const channels = computed<string[]>({ get: () => props.ui.channels ?? [], set: v => { props.ui.channels = v } })
-const transform = computed<Kind>({ get: () => props.ui.xt ?? defaultTransform, set: v => { props.ui.xt = v } })
+// centroid/spatial axes are raw coordinates → linear (same rule as GatePlotPanel). Pairs share ONE
+// transform across all selected channels, so default to linear only when EVERY channel is a linear axis.
+const pairsDefaultTransform = computed<Kind>(() =>
+  channels.value.length > 0 && channels.value.every(c => g.isLinearAxis(c)) ? 'linear' : defaultTransform)
+const transform = computed<Kind>({ get: () => props.ui.xt ?? pairsDefaultTransform.value, set: v => { props.ui.xt = v } })
 // ≥1 tile's transform was auto-linearised (measure range too small) → amber the control + explain
 const coerced = ref(false)
 const renderMode = computed<RenderMode>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -48,8 +48,8 @@ const TRANSFORMS: Kind[] = ['linear', 'log', 'asinh', 'logicle']
 // track properties (motility, per-track aggregates) are plain continuous values → linear by
 // default; flow intensities default to logicle (FlowJo). User can switch either per axis.
 const defaultTransform: Kind = g.popType === 'track' ? 'linear' : 'logicle'
-// spatial/temporal centroid axes are raw coordinates → linear by default (never logicle).
-const axisDefaultTransform = (col: string): Kind => g.isSpatialAxis(col) ? 'linear' : defaultTransform
+// spatial/temporal + centroid axes are raw coordinates → linear by default (never logicle).
+const axisDefaultTransform = (col: string): Kind => g.isLinearAxis(col) ? 'linear' : defaultTransform
 // axis config reads/writes the persisted `ui` bag (owned by GatingPlots) so it survives remount.
 const xChan = computed({ get: () => props.ui.x ?? '', set: v => { props.ui.x = v } })
 const yChan = computed({ get: () => props.ui.y ?? '', set: v => { props.ui.y = v } })

--- a/frontend/src/stores/gating.ts
+++ b/frontend/src/stores/gating.ts
@@ -5,6 +5,7 @@ import { useProjectMetaStore } from './projectMeta'
 import { useProjectStore } from './project'
 import { useSettingsStore } from './settings'
 import { clusterMeasure } from '../utils/clusterMeasure'
+import { isCentroidAxis } from '../utils/gatingAxes'
 
 // Derived populations (e.g. `_tracked`, future clustering pops) own a reserved namespace:
 // leaf names beginning with `_`. Hand-drawn gates may not use that prefix — mirrors the backend
@@ -121,6 +122,10 @@ export const useGatingStore = defineStore('gating', () => {
   // spatial + temporal centroid axes, offered together as a "Spatial / Time" group in the axis pickers
   const spatialAxes = computed(() => [...spatialColumns.value, ...temporalColumns.value])
   const isSpatialAxis = (col: string) => spatialAxes.value.includes(col)
+  // columns that should default to a LINEAR transform in the gate axis pickers: raw coordinates
+  // (spatial/temporal axes + any centroid column, matched by name via isCentroidAxis so it holds even
+  // for data that doesn't list centroids in spatial_cols) are positions, never logicle.
+  const isLinearAxis = (col: string) => isSpatialAxis(col) || isCentroidAxis(col)
 
   const flat = computed(() => flatten(tree.value))
   // transient pops (e.g. the napari cell selection) — auto-highlighted on the plots
@@ -332,7 +337,7 @@ export const useGatingStore = defineStore('gating', () => {
 
   return {
     imageUid, valueName, popType, mirrorUids, tree, columns, obsColumns, channels, channelNames, valueNames,
-    spatialColumns, temporalColumns, spatialAxes, isSpatialAxis,
+    spatialColumns, temporalColumns, spatialAxes, isSpatialAxis, isLinearAxis,
     cellMeasures, trackAggregates, stats, popVersion, flat,
     transientPaths, napariZMode, napariZWindow,
     projectUid, napariSetUid, colLabel, selectImage, fetchChannels, fetchPopmap, fetchStats,

--- a/frontend/src/utils/gatingAxes.test.ts
+++ b/frontend/src/utils/gatingAxes.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { isCentroidAxis } from './gatingAxes'
+
+describe('isCentroidAxis', () => {
+  it('matches every centroid coordinate column', () => {
+    for (const c of ['centroid_x', 'centroid_y', 'centroid_z', 'centroid_t', 'Centroid_X'])
+      expect(isCentroidAxis(c)).toBe(true)
+  })
+
+  it('does not match ordinary feature columns', () => {
+    for (const c of ['area', 'intensity_mean', 'live.cell.speed', 'eccentricity', 'centroids', 'x_centroid'])
+      expect(isCentroidAxis(c)).toBe(false)
+  })
+})

--- a/frontend/src/utils/gatingAxes.ts
+++ b/frontend/src/utils/gatingAxes.ts
@@ -1,0 +1,7 @@
+// Axis-classification helpers for the gate axis pickers. Pure (name-based) so they hold regardless of
+// whether the .h5ad lists centroids in `uns/spatial_cols` (legacy/partially-migrated data surfaces
+// them as ordinary features). Kept out of the store SFC so they are unit-testable.
+
+// A centroid coordinate column: centroid_x / centroid_y / centroid_z / centroid_t (and any centroid_*).
+// These are raw positions → they should default to a LINEAR transform, never logicle.
+export const isCentroidAxis = (col: string): boolean => /^centroid_/i.test(col)


### PR DESCRIPTION
## Problem

Gating on `centroid_z` showed a **linear** transform, but `centroid_x` / `centroid_y` stayed **logicle**.

## Cause

There was never a `centroid_z` special-case. The intended rule is "spatial/temporal axes default to linear" (`axisDefaultTransform` → `isSpatialAxis`), which depends on the axes being listed in the file's `uns/spatial_cols`. When they aren't (legacy / partially-migrated data), the centroids surface as ordinary features and default to logicle — and only `centroid_z` then flips to linear via the **backend range-collapse auto-linearise** (z has a tiny extent; x/y span the whole image, so they don't collapse). Hence the asymmetry.

## Fix

Make the linear-by-default rule match any `centroid_*` column **by name**, so it holds regardless of migration state:

- `isCentroidAxis` (`utils/gatingAxes.ts`, unit-tested): `/^centroid_/i`.
- gating store: `isLinearAxis = isSpatialAxis || isCentroidAxis`.
- `GatePlotPanel`: `axisDefaultTransform` uses `isLinearAxis`.
- `GatePairsPanel`: pairs share one transform, so it defaults to linear only when **every** selected channel is a linear axis (previously it never applied the spatial override at all).

Only sets the **default** (`?? ` fallback) — a persisted per-axis transform is untouched. Frontend tests 275 pass; `vue-tsc -b` clean.

## Reservations

- Not clicked through in a browser (typecheck + unit test + full vitest cover the logic).
- Applies to fresh axis picks; an already-saved gate plot keeps its persisted transform.
- Mixed centroid + intensity channels in a pairs panel default to logicle (one shared transform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
