### PR TITLE
Notebook MCP: real versioning (revise_notebook) + short descriptions

### DIFF
--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -294,6 +294,11 @@ function _safe_nb_file(name)::Union{String,Nothing}
     n
 end
 
+# Descriptions are a one-line label shown in the notebook table — cap so a verbose generator (e.g.
+# Claude via the MCP) can't bloat the row. Applied wherever a description is stored.
+const _NB_DESC_MAX = 120
+_cap_desc(s::AbstractString)::String = (t = strip(String(s)); length(t) > _NB_DESC_MAX ? String(first(t, _NB_DESC_MAX)) : String(t))
+
 _reg_desc(e) = String(get(e, "description", ""))
 # `current` = which snapshot version the LIVE notebook currently reflects (0 = never snapshotted).
 # This is what the UI shows, so a restore to v3 reads back as "v3" (not a monotonic counter).
@@ -380,7 +385,7 @@ function api_notebooks_create(body_bytes::Vector{UInt8})
     cp(template, dest)
 
     reg = _read_registry(uid)
-    reg[file] = Dict{String,Any}("description" => String(get(body, :description, "")),
+    reg[file] = Dict{String,Any}("description" => _cap_desc(String(get(body, :description, ""))),
                                  "current" => 0, "updatedAt" => string(Dates.now()))
     _write_registry!(uid, reg)
     200, JSON3.write((; ok = true, file = file))
@@ -470,7 +475,7 @@ function api_notebooks_write(body_bytes::Vector{UInt8})
     open(dest, "w") do io; write(io, _pluto_notebook_source(collect(cells))); end
 
     reg = _read_registry(uid)
-    reg[file] = Dict{String,Any}("description" => String(get(body, :description, "")),
+    reg[file] = Dict{String,Any}("description" => _cap_desc(String(get(body, :description, ""))),
                                  "current" => 0, "updatedAt" => string(Dates.now()))
     _write_registry!(uid, reg)
     # snapshot v1 — an immediate restore point before the user starts editing in Pluto
@@ -490,11 +495,44 @@ function api_notebooks_describe(body_bytes::Vector{UInt8})
 
     reg = _read_registry(uid)
     e = get(reg, file, Dict{String,Any}("current" => 0))
-    e["description"] = String(get(body, :description, ""))
+    e["description"] = _cap_desc(String(get(body, :description, "")))
     e["updatedAt"]   = string(Dates.now())
     reg[file] = e
     _write_registry!(uid, reg)
     200, JSON3.write((; ok = true))
+end
+
+# POST /api/notebooks/revise  { projectUid, file, cells, description? }  → { ok, file, snapshotVersion }
+# A safe in-place revision: SNAPSHOT the current notebook first (freezing whatever is live — including
+# the user's un-snapshotted edits — as a restorable version), THEN overwrite it with the new cells.
+# This is how a notebook gets a new version from the MCP — never a "<name>-v2" copy. 404 if the file
+# doesn't exist (use /write to create a new one). See docs/NOTEBOOKS.md → Versioning.
+function api_notebooks_revise(body_bytes::Vector{UInt8})
+    body = JSON3.read(String(body_bytes))
+    uid  = String(get(body, :projectUid, ""))
+    isempty(uid) && return 400, JSON3.write((; error = "projectUid required"))
+    isdir(joinpath(projects_dir(), uid)) || return 404, JSON3.write((; error = "Project not found"))
+    file = _safe_nb_file(get(body, :file, ""))
+    file === nothing && return 400, JSON3.write((; error = "Invalid notebook name"))
+    cells = get(body, :cells, nothing)
+    (cells === nothing || isempty(cells)) && return 400, JSON3.write((; error = "cells required (a non-empty list of Julia cell sources)"))
+    dir  = _project_notebooks_dir(uid)
+    dest = joinpath(dir, file)
+    isfile(dest) || return 409, JSON3.write((; error = "Notebook not found: $file (use create for a new one; revise is for existing)"))
+
+    # freeze the current live state first, then overwrite — nothing is lost (restorable via History)
+    snap = api_notebooks_snapshot(Vector{UInt8}(JSON3.write((; projectUid = uid, file = file))))
+    open(dest, "w") do io; write(io, _pluto_notebook_source(collect(cells))); end
+
+    reg = _read_registry(uid)
+    e = get(reg, file, Dict{String,Any}("current" => 0))
+    haskey(body, :description) && (e["description"] = _cap_desc(String(get(body, :description, ""))))
+    e["updatedAt"] = string(Dates.now())
+    reg[file] = e
+    _write_registry!(uid, reg)
+    broadcast_ws(Dict{String,Any}("type" => "notebooks_changed", "projectUid" => uid, "file" => file))
+    v = try JSON3.read(snap[2]).version catch; nothing end
+    200, JSON3.write((; ok = true, file = file, snapshotVersion = v))
 end
 
 # POST /api/notebooks/delete  { projectUid, file }  → { ok }

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -388,6 +388,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_notebooks_delete(body_bytes)
         elseif path == "/api/notebooks/duplicate"
             api_notebooks_duplicate(body_bytes)
+        elseif path == "/api/notebooks/revise"
+            api_notebooks_revise(body_bytes)
         elseif path == "/api/notebooks/snapshot"
             api_notebooks_snapshot(body_bytes)
         elseif path == "/api/notebooks/restore"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -237,6 +237,22 @@ end
         @test JSON3.read(_post(api_notebooks_duplicate, Dict("projectUid"=>uid,"file"=>"nb1.jl","scope"=>"project"))[2]).file == "nb1-copy.jl"
         @test find("nb1-copy.jl") !== nothing
 
+        # revise: SNAPSHOTS the current notebook (freezes it) then overwrites its cells — a real new
+        # version, not a "-v2" copy. 409 if the file is absent; 400 without cells.
+        let before = length(snaps())
+            r = JSON3.read(_post(api_notebooks_revise, Dict("projectUid"=>uid, "file"=>"nb1.jl",
+                                  "cells"=>["using Cecelia", "df = 1 + 1"], "description"=>"revised"))[2])
+            @test r.ok == true
+            @test length(snaps()) == before + 1                 # pre-revision state was frozen as a version
+            @test find("nb1.jl").description == "revised"
+        end
+        @test _post(api_notebooks_revise, Dict("projectUid"=>uid, "file"=>"nope.jl", "cells"=>["x"]))[1] == 409  # must exist
+        @test _post(api_notebooks_revise, Dict("projectUid"=>uid, "file"=>"nb1.jl"))[1] == 400                   # cells required
+
+        # description cap: a long blurb is truncated at _NB_DESC_MAX (create/describe/write/revise all cap)
+        @test _post(api_notebooks_create, Dict("projectUid"=>uid, "name"=>"nbcap", "description"=>repeat("x", 300)))[1] == 200
+        @test length(find("nbcap.jl").description) == _NB_DESC_MAX
+
         # delete — pass force=true so this is deterministic regardless of whether a Pluto server is
         # running locally. The guard 409s on a live server without force (a dev machine with the
         # notebook server up would otherwise fail this + the two asserts below); force is what the

--- a/docs/NOTEBOOKS.md
+++ b/docs/NOTEBOOKS.md
@@ -106,6 +106,13 @@ is self-contained/runnable), registers it, and snapshots v1. **Create-only** (40
 non-destructive. The user then opens it in the Notebooks page and edits/owns it in Pluto. Backed by
 the `create_notebook` MCP tool; the code-generation guidance for Claude lives in `docs/REPL.md`.
 
+To **change an existing** notebook, the observer uses `POST /api/notebooks/revise` (MCP tool
+`revise_notebook`): it **snapshots the current notebook first** (freezing whatever is live — including
+the user's un-snapshotted edits — as a restorable version) then overwrites its cells. That's the
+versioned-revision path — the observer never makes a `<name>-v2` copy, and nothing is lost (History →
+Restore brings the prior version back). Descriptions (create/describe/revise) are capped to one short
+line (`_NB_DESC_MAX`).
+
 ## Sysimage (why the first plot isn't slow)
 
 Makie compiles plotting code on first use (~20 s cold). A PackageCompiler sysimage bakes that in
@@ -152,6 +159,7 @@ Routes:
 | `POST /api/notebooks/create` | new notebook from the template |
 | `POST /api/notebooks/describe` | set a notebook's description |
 | `POST /api/notebooks/duplicate` | copy a project/example notebook into the project |
+| `POST /api/notebooks/revise` | new version of an existing notebook: snapshot then overwrite cells (the MCP's versioned-revision path) |
 | `POST /api/notebooks/delete` | delete a project notebook |
 | `POST /api/notebooks/snapshot` | freeze a version |
 | `GET  /api/notebooks/snapshots?projectUid=&file=` | list a notebook's snapshots |

--- a/docs/REPL.md
+++ b/docs/REPL.md
@@ -175,8 +175,12 @@ cells to paste) → once happy, they run it without you.
   above**: pool in one `pop_df` call rather than looping+`vcat`, and confirm pop paths/column names
   via `get_populations` / `get_measure_summary` instead of a candidate-list guesser. Plot with
   AlgebraOfGraphics + CairoMakie; export with `CSV.write`. Obey the **write rules above** (figures/CSV only).
-- **Create-only**: a name that already exists returns 409 — it never overwrites a notebook the user
-  may have edited. Pick a new name, or suggest cell edits for them to apply in Pluto.
+- **`description`** is ONE short line (a title-ish phrase shown in the notebook table), not a paragraph
+  — it's capped server-side. Reword later with `set_notebook_description`.
+- **Create vs revise**: `create_notebook` is create-only (409 on an existing name). To CHANGE an
+  existing notebook, use **`revise_notebook`** — it snapshots the current one (a restorable version on
+  the Notebooks page) then updates it in place. That's the real versioning; **never make a `<name>-v2`
+  copy**. For a brand-new notebook, `create_notebook` with a new name.
 - Suggest first, create on the user's ask — don't spam notebooks.
 
 ---

--- a/docs/ai-assist/OBSERVER.md
+++ b/docs/ai-assist/OBSERVER.md
@@ -51,6 +51,7 @@ get_notebook              → a notebook's current Pluto source (with the user's
 ```
 append_lab_log            → append a dated [Claude] entry. Append-only, never edits existing content.
 create_notebook           → create a Pluto notebook from cells (Phase 2). Create-only (409 on existing); the user edits/owns it.
+revise_notebook           → new version of an EXISTING notebook: snapshots it (restorable) then overwrites its cells. Real versioning, not a "-v2" copy.
 set_notebook_description  → reword a notebook's one-line description (registry sidecar). Description text only; cells untouched.
 ```
 
@@ -234,7 +235,9 @@ verifiable artifacts. Shipped as PRs #250–#258; this is the durable summary (t
 - **REPL knowledge (`get_repl_api` + `docs/REPL.md`)** — the notebook-safe accessor allow-list
   (`NOTEBOOK_API`) with live docstrings; a golden test keeps REPL.md from drifting.
 - **`create_notebook`** — generates a runnable Pluto notebook from cells (`/api/notebooks/write`).
-  `set_notebook_description` rewords its blurb afterwards (`/api/notebooks/describe`, description text only).
+  **`revise_notebook`** makes a new version of an existing one (`/api/notebooks/revise` — snapshots then
+  overwrites; real versioning, not a `-v2` copy). `set_notebook_description` rewords its blurb afterwards
+  (`/api/notebooks/describe`, description text only).
 - **`get_available_plots`** — the board's plot types, for viz suggestions.
 - **In-app overview** — `ClaudeOverviewDialog` (`?` in the lab-log toolbar): a brief how-to.
 
@@ -251,10 +254,11 @@ verifiable artifacts. Shipped as PRs #250–#258; this is the durable summary (t
 - **Notebooks: Claude bootstraps, the user owns.** `create_notebook` is create-only + snapshots v1;
   iteration happens in Pluto by the user (Claude guiding via chat). Notebook code writes figures/CSV
   only — never h5ad/QC/lab-log/ccid (`docs/REPL.md`).
-- **Stuck? Read + teach, don't overwrite.** When the user is stuck in a notebook, Claude reads its
-  current source (`get_notebook`), explains the fix in plain terms and walks them through it (most
-  users are new to Julia — the goal is they learn to do it themselves). If they ask Claude to apply the
-  change, it creates a NEW notebook version via `create_notebook` (a new name) and says so first —
-  it never overwrites their file or their edits. There is deliberately no "overwrite notebook" write.
+- **Stuck? Read + teach, then version.** When the user is stuck in a notebook, Claude reads its current
+  source (`get_notebook`), explains the fix in plain terms and walks them through it (most users are new
+  to Julia — the goal is they learn to do it themselves). If they ask Claude to apply the change, it
+  calls **`revise_notebook`**, which snapshots the current notebook (a restorable version) then updates
+  it in place — real versioning, not a `<name>-v2` copy — and says so first. Nothing is lost: the
+  pre-revision state is always snapshotted, so there is no *unrecoverable* overwrite.
 - **REPL.md can't drift.** `docs/REPL.md`'s API section is generated from the live docstrings of
   `NOTEBOOK_API` and golden-tested; changing a listed function's docstring without regenerating fails CI.

--- a/frontend/src/lib/chatHandoff.ts
+++ b/frontend/src/lib/chatHandoff.ts
@@ -20,9 +20,10 @@ export function buildChatPrompt(projectUid: string, projectName?: string): strin
       `the board's plot types (get_available_plots), ` +
       `cross-set QC (get_cohort_qc), the lab log (read_lab_log), the notebook/REPL data-access ` +
       `surface (get_repl_api), and the notebooks themselves (list_notebooks, get_notebook — so you can ` +
-      `read one I'm stuck in and walk me through the fix). They are read-only except three non-destructive ` +
+      `read one I'm stuck in and walk me through the fix). They are read-only except four recoverable ` +
       `actions, taken only when I ask: appending to the lab log (append_lab_log), creating a Pluto notebook ` +
-      `(create_notebook), and rewording a notebook's description (set_notebook_description).`,
+      `(create_notebook), making a new version of one (revise_notebook — it snapshots first, so nothing is ` +
+      `lost), and rewording a notebook's description (set_notebook_description).`,
     ``,
     `Don't dive in yet. Call get_session_briefing first to get oriented — it returns the project name + ` +
       `image count, which images are flagged (QC), and recent lab-log entries. Open with what stands out ` +

--- a/mcp/cecelia_mcp/client.py
+++ b/mcp/cecelia_mcp/client.py
@@ -3,11 +3,14 @@
 Every request goes through an explicit ALLOW-LIST of (method, path) pairs. That list IS the
 observer's no-mutation guarantee: the only non-GET routes permitted are ``POST /api/lablog/append``
 (append-only), ``POST /api/notebooks/write`` (create-only — 409 on an existing name, so it never
-overwrites), and ``POST /api/notebooks/describe`` (edits ONLY a notebook's own description string in
-the registry sidecar — not its cells, not analysis data). All three are non-destructive to project &
-analysis data: no allow-listed route can touch cell data, images, gates, QC, or a notebook's content.
-Any attempt to call a route not on the list raises ``DisallowedRoute`` — so if a future tool ever
-wires in a mutating route it fails loudly in tests rather than silently mutating a project.
+overwrites), ``POST /api/notebooks/describe`` (edits ONLY a notebook's own description string in the
+registry sidecar — not its cells), and ``POST /api/notebooks/revise`` (which SNAPSHOTS the current
+notebook first — a restorable version — then overwrites its cells; it's how a notebook gets a new
+version, never a "-v2" copy). All four are recoverable / non-destructive to project & analysis data:
+no allow-listed route can touch cell data, images, gates, or QC, and revise can't lose a notebook's
+content (the pre-revision state is always snapshotted). Any attempt to call a route not on the list
+raises ``DisallowedRoute`` — so if a future tool ever wires in a truly destructive route it fails
+loudly in tests rather than silently mutating a project.
 
 Uses only the Python standard library (urllib) so this module — and its tests — carry no third-party
 dependency; the ``mcp`` SDK is needed only by ``server.py`` which wires these calls into tools.
@@ -46,9 +49,10 @@ ALLOWED_ROUTES = frozenset(
         ("GET", "/api/lablog"),
         ("GET", "/api/notebooks"),         # list a project's notebooks (file, description, version)
         ("GET", "/api/notebooks/content"),  # read a notebook's current source (the "have a look" flow)
-        ("POST", "/api/lablog/append"),  # write 1/3 — append-only, server-guarded
-        ("POST", "/api/notebooks/write"),  # write 2/3 — create-only (409 on existing); serialises cells to a Pluto notebook
-        ("POST", "/api/notebooks/describe"),  # write 3/3 — edits ONLY a notebook's description string (registry sidecar); not its content
+        ("POST", "/api/lablog/append"),  # write 1/4 — append-only, server-guarded
+        ("POST", "/api/notebooks/write"),  # write 2/4 — create-only (409 on existing); serialises cells to a Pluto notebook
+        ("POST", "/api/notebooks/describe"),  # write 3/4 — edits ONLY a notebook's description string (registry sidecar); not its content
+        ("POST", "/api/notebooks/revise"),  # write 4/4 — SNAPSHOTS the current notebook (restorable), then overwrites its cells (real versioning, no "-v2" copies)
     }
 )
 
@@ -260,4 +264,15 @@ class CeceliaClient:
             "POST",
             "/api/notebooks/describe",
             body={"projectUid": project_uid, "file": file, "description": description},
+        )
+
+    def revise_notebook(self, project_uid: str, file: str, cells: list[str], description: str = ""):
+        # New version of an EXISTING notebook: the server snapshots the current one (restorable via the
+        # Notebooks page History) then overwrites its cells — real versioning, not a "-v2" copy. `file`
+        # is the existing notebook's filename (bare name works; server appends .jl). 409 if it doesn't
+        # exist (use create_notebook for a new one). `description` optional — only updates it if given.
+        return self._request(
+            "POST",
+            "/api/notebooks/revise",
+            body={"projectUid": project_uid, "file": file, "cells": cells, "description": description},
         )

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -390,27 +390,48 @@ def create_notebook(project_uid: str, name: str, cells: list[str], description: 
     `CSV.write` export. The env-activation cell is prepended automatically, so DON'T include it; your
     first cell is typically `using Cecelia, DataFrames, AlgebraOfGraphics, CairoMakie, CSV`.
 
-    CREATE-ONLY: 409 if `name` already exists — never overwrites (pick a new name). After creating, tell
-    the user it's ready in the **Notebooks page** — an open page auto-refreshes; if theirs was already
-    open and doesn't show it, they can hit refresh. They open it, edit/iterate in Pluto (you can guide
-    them + suggest corrected cells to paste), and once happy they run it without you. One of only three
-    writes; non-destructive. Suggest, then create on the user's ask — don't spam notebooks. To reword
-    its description afterwards, use set_notebook_description (don't recreate).
+    `description` = ONE short line (a title-ish phrase shown in the notebook table), NOT a paragraph —
+    e.g. "T/B-cell speed over time". It's capped server-side; keep it tight.
 
-    REVISIONS: when the user asks you to change an existing notebook, read it with get_notebook, then
-    create a NEW version here under a new name (e.g. "<name>-v2") — never overwrite theirs. Say so
-    first: "I'll make a new notebook version." Prefer teaching them the edit over doing it for them."""
+    CREATE-ONLY: 409 if `name` already exists — never overwrites (pick a new name, or use
+    revise_notebook to make a new version of an existing one). After creating, tell the user it's ready
+    in the **Notebooks page** — an open page auto-refreshes; if theirs was already open and doesn't show
+    it, they can hit refresh. They open it, edit/iterate in Pluto (you can guide them + suggest corrected
+    cells to paste), and once happy they run it without you. Non-destructive. Suggest, then create on the
+    user's ask — don't spam notebooks. To reword its description afterwards, use set_notebook_description.
+
+    REVISIONS: when the user asks you to change an EXISTING notebook, read it with get_notebook, then
+    call revise_notebook — do NOT create a "<name>-v2" copy. revise_notebook snapshots the current
+    notebook (a restorable version on the Notebooks page) then updates it in place, so it uses the real
+    versioning and nothing is lost. Say so first: "I'll make a new version." Prefer teaching them the
+    edit over doing it for them."""
     return _client.create_notebook(project_uid, name, cells, description)
 
 
 @mcp.tool()
 def set_notebook_description(project_uid: str, file: str, description: str) -> dict:
-    """Update a notebook's one-line description (shown in the Notebooks page). Use this to reword the
-    blurb after create_notebook — e.g. the user asks to make it briefer — instead of recreating the
-    notebook. Edits ONLY the description string in the registry sidecar; the notebook's cells are
-    untouched. `file` is the notebook filename create_notebook returned (e.g. "speed.jl"); a bare name
-    works too. 404 if it doesn't exist. One of only three writes; non-destructive."""
+    """Update a notebook's description — ONE short line (title-ish, not a paragraph; capped server-side).
+    Shown in the Notebooks page. Use this to reword the blurb after create_notebook — e.g. the user asks
+    to make it briefer — instead of recreating the notebook. Edits ONLY the description string in the
+    registry sidecar; the notebook's cells are untouched. `file` is the notebook filename create_notebook
+    returned (e.g. "speed.jl"); a bare name works too. 404 if it doesn't exist. Non-destructive."""
     return _client.set_notebook_description(project_uid, file, description)
+
+
+@mcp.tool()
+def revise_notebook(project_uid: str, file: str, cells: list[str], description: str = "") -> dict:
+    """Make a NEW VERSION of an EXISTING notebook — the correct way to change one the user already has.
+    The server SNAPSHOTS the current notebook first (a restorable version, visible under History on the
+    Notebooks page) then overwrites its cells, so it uses the real versioning and nothing is lost. Do
+    NOT create a "<name>-v2" copy — that bypasses versioning and clutters the list.
+
+    Flow: read the current notebook with get_notebook, tell the user "I'll make a new version", then call
+    this with the full new `cells` (same rules as create_notebook — env-activation cell is prepended;
+    figures/CSV only). `file` is the existing notebook's filename (bare name works; .jl appended). 409 if
+    it doesn't exist — use create_notebook for a brand-new one. `description` optional (one short line,
+    capped) — only changes it if you pass a non-empty value. Non-destructive: the pre-revision state is
+    always snapshotted, so the user can Restore it."""
+    return _client.revise_notebook(project_uid, file, cells, description)
 
 
 @mcp.tool()

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -44,16 +44,28 @@ class ClientTest(unittest.TestCase):
         with self.assertRaises(DisallowedRoute):
             self.c._request("GET", "/api/gating/save")
 
-    def test_writes_are_only_the_three_non_destructive_routes(self):
+    def test_writes_are_only_the_four_recoverable_routes(self):
         # The no-mutation guarantee: the only non-GET routes are lab-log append (append-only), notebook
-        # write (create-only), and notebook describe (description text only). None can edit/delete cell
-        # data, images, gates, QC, or a notebook's content.
+        # write (create-only), notebook describe (description text only), and notebook revise (snapshots
+        # first, so it's recoverable). None can edit/delete cell data, images, gates, or QC.
         writes = sorted((m, p) for (m, p) in ALLOWED_ROUTES if m != "GET")
         self.assertEqual(writes, [
             ("POST", "/api/lablog/append"),
             ("POST", "/api/notebooks/describe"),
+            ("POST", "/api/notebooks/revise"),
             ("POST", "/api/notebooks/write"),
         ])
+
+    def test_revise_notebook_posts_cells(self):
+        with _patch_urlopen({"ok": True, "file": "speed.jl", "snapshotVersion": 2}) as u:
+            self.c.revise_notebook("p", "speed.jl", ["using Cecelia", "df = 2"], description="d2")
+        req = u.call_args[0][0]
+        self.assertEqual(req.method, "POST")
+        self.assertTrue(req.full_url.endswith("/api/notebooks/revise"))
+        self.assertEqual(
+            json.loads(req.data.decode()),
+            {"projectUid": "p", "file": "speed.jl", "cells": ["using Cecelia", "df = 2"], "description": "d2"},
+        )
 
     def test_create_notebook_posts_cells(self):
         with _patch_urlopen({"ok": True, "file": "speed.jl"}) as u:

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -26,7 +26,7 @@ class ServerToolRegistrationTest(unittest.TestCase):
             "get_measure_summary", "get_behaviour_summary", "get_cluster_summary",
             "get_chains", "get_cohort_qc", "get_repl_api", "get_session_briefing",
             "get_recent_logs", "read_lab_log", "append_lab_log", "create_notebook",
-            "set_notebook_description", "list_notebooks", "get_notebook",
+            "set_notebook_description", "revise_notebook", "list_notebooks", "get_notebook",
         ):
             self.assertIn(tool, self.names)
 


### PR DESCRIPTION
Two fixes to how Claude (via the MCP observer) manages notebooks, found while testing the Chat-to-Claude flow.

## (a) Descriptions too long

Descriptions were unbounded, so Claude wrote paragraphs into a one-line table blurb. Now capped server-side on **every** writer (`create`/`write`/`describe`/`revise`, `_NB_DESC_MAX = 120`), and the MCP tool docstrings say "one short line."

## (b) `-v2` copies instead of versioning

Claude made `prep-stability-speed-over-time-v2` notebooks instead of using the Notebooks page's versioning — **because the `create_notebook` docstring literally told it to** (`"create a NEW version under a new name (e.g. <name>-v2)"`). Meanwhile the real versioning (snapshot/restore) was never exposed to the MCP.

Fix: new **`POST /api/notebooks/revise`** + MCP tool **`revise_notebook`**. It **snapshots the current notebook** (freezing whatever is live — including the user's un-snapshotted edits — as a restorable version) then overwrites its cells in place. Real versioning, nothing lost; History → Restore brings the prior version back. Rewrote the `create_notebook` / teaching-flow guidance to use it and **never** make a `-v2` copy.

This is the observer's **4th** write — reframed the no-mutation guarantee from "3 non-destructive" to "4 recoverable": revise can't lose content because it snapshots first.

## Pieces
- `api/src/notebooks_api.jl`: `api_notebooks_revise` (snapshot-then-overwrite; 409 if the notebook is absent, 400 without cells) + `_cap_desc` on all four description writers.
- MCP `client.py` (allow-list `/api/notebooks/revise`; `revise_notebook` method; header reframed 3→4 recoverable writes) + `server.py` (`revise_notebook` tool; `create_notebook`/`set_notebook_description` docstrings — length + point to revise, drop the `-v2` guidance).
- Tests: MCP write-set invariant → 4 + a revise post-shape test; API `revise` (snapshot bump, 409, 400) + description-cap test.
- Docs: `REPL.md`, `NOTEBOOKS.md`, `OBSERVER.md`, `chatHandoff.ts`.

## Tests
`test-api` (notebook registry/versioning + write suites green, incl. new revise + cap), `test-mcp` (50; new revise tests pass), `vue-tsc` typecheck clean.

## Reservations
- **Not exercised via a live MCP/Claude session** — backend + client + server + tests are green, but the actual "Claude calls revise_notebook" round-trip hasn't been run in the app.
- The description cap is a hard truncation (can cut mid-word) — acceptable for a label.
- `revise` always snapshots, even if cells are unchanged — a possible redundant version, deliberate (safety over tidiness).
- Doesn't fix the `pop_df` channel-name issue (separate PR next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
