### PR TITLE
Gating: let the centroid linear-default actually fire (follow-up to #284)

### DIFF
--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -52,20 +52,23 @@ type GateKind = 'linear' | 'log' | 'asinh' | 'logicle'
 // A panel is either a single gate scatter (default, drawable) or a read-only channel-pairs matrix.
 // `channels` is the pairs plot's selected list; the single plot ignores it (and vice-versa for x/y).
 interface PlotState { kind: 'single' | 'pairs'; parent: string; hl: string[]; lineWidth: number; labels: boolean; fromZero: boolean
-  x: string; y: string; xt: GateKind; yt: GateKind; renderMode: 'points' | 'contour' | 'outliers'; channels: string[] }
+  x: string; y: string; xt?: GateKind; yt?: GateKind; renderMode: 'points' | 'contour' | 'outliers'; channels: string[] }
 const canvasRef = useTemplateRef<HTMLElement>('canvasRef')   // the visible viewport (zoom + fit measure it)
 const zoomRef = useTemplateRef<HTMLElement>('zoomRef')       // the scaled workspace (panels' offsetParent)
 // Per-image + segmentation: gating populations are per-value_name, so each (image, segmentation) keeps
 // its own plots/parents/highlights and the canvas rebinds when either the image or the segmentation
 // (g.valueName) changes.
 const ckey = computed(() => `gate:${props.popType}:${props.imageUid ?? 'none'}:${g.valueName}`)
-// track properties → linear by default; flow intensities → logicle (FlowJo). Channels (x/y) start
-// empty and the panel picks index-based defaults once the store's columns load (see ensureChannels).
-const defT: GateKind = props.popType === 'track' ? 'linear' : 'logicle'
+// Axis transforms (xt/yt) are intentionally LEFT UNSET here so the panels' own per-axis default
+// fires: GatePlotPanel/GatePairsPanel resolve `ui.xt ?? axisDefaultTransform(col)` (linear for
+// spatial/centroid axes via the store's isLinearAxis, logicle for flow intensities). That fallback
+// only runs while ui.xt is undefined — pre-seeding a concrete transform here would pin logicle and
+// silently defeat it. Channels (x/y) start empty; the panel picks index-based defaults once columns
+// load (see ensureChannels).
 const { panels, activeId, activePanel, shared, add, remove, arrangeGrid, arrangeCascade, contentBounds } =
   useCanvasPanels<PlotState>(zoomRef, () =>
     ({ kind: 'single', parent: 'root', hl: [], lineWidth: 1.5, labels: true, fromZero: true,
-       x: '', y: '', xt: defT, yt: defT, renderMode: 'points', channels: [] }), ckey)
+       x: '', y: '', renderMode: 'points', channels: [] }), ckey)
 // show/hide the floating population manager — persisted per canvas in the `shared` bag (default shown)
 const showManager = computed<boolean>({ get: () => (shared.value.showManager as boolean) ?? true, set: v => (shared.value.showManager = v) })
 


### PR DESCRIPTION
## Problem

After #284, centroid axes *still* came up **logicle** instead of **linear** in the gate plots. #284 fixed the classifier (`isSpatialAxis` → `isLinearAxis`, matching `centroid_*` by name) but the switch never fired.

## Cause

`axisDefaultTransform` is only consulted as a `??` fallback — `ui.xt ?? axisDefaultTransform(col)` in `GatePlotPanel`/`GatePairsPanel`. But the `PlotState` factory in `GatingPlots.vue` **pre-seeded** every panel with `xt: defT, yt: defT` (`defT = 'logicle'` for flow). So `ui.xt` was never `undefined`, the fallback never ran, and the per-axis default (including #284's centroid rule) was dead code. This pre-seed predates #284, so #284 was written against a fallback that was already short-circuited.

## Fix

Stop pre-seeding — make `xt`/`yt` optional in `PlotState` and leave them unset in the factory. Now `ui.xt` starts `undefined`, so the existing `?? axisDefaultTransform(col)` resolves the per-axis default (linear for spatial/centroid via `isLinearAxis`, logicle for flow intensities) and re-evaluates when the axis changes. A user's manual transform pick still writes a concrete `ui.xt` and stays pinned; loading a saved gate still sets its persisted transform explicitly.

**No new mechanism** — reuses #284's frontend default; the backend range-collapse auto-linearise (`autoLinear`/`effective_transform`) is untouched.

- `GatingPlots.vue`: `xt?`/`yt?` optional; drop `xt: defT, yt: defT` (and the now-unused `defT`).

`vue-tsc -b` clean; 275/275 vitest pass.

## Reservations

- Not clicked through in a browser (typecheck + unit tests only).
- **Existing persisted panels keep their stored `xt: 'logicle'`** — only newly added panels get the undefined→linear default. Verify with a *fresh* plot picking `centroid_x`; an old panel will still read logicle (matches #284's "fresh axis picks" scope).
- Manual transform override is now sticky across axis changes on that panel (intended per #284's "persisted per-axis transform is untouched").
- No new automated test: the fix is removing a default; the classifier is already unit-tested, and the pre-seed removal isn't testable under the pure-logic-only frontend test rule (no component mounting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
