### PR TITLE
Gating: transform follows the axis (re-derive on axis/channel change)

### DIFF
--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -38,11 +38,15 @@ const g = useGatingStore()
 
 // track properties → linear by default; flow intensities → logicle (FlowJo) — same rule as GatePlotPanel
 const defaultTransform: Kind = g.popType === 'track' ? 'linear' : 'logicle'
-const channels = computed<string[]>({ get: () => props.ui.channels ?? [], set: v => { props.ui.channels = v } })
 // centroid/spatial axes are raw coordinates → linear (same rule as GatePlotPanel). Pairs share ONE
-// transform across all selected channels, so default to linear only when EVERY channel is a linear axis.
-const pairsDefaultTransform = computed<Kind>(() =>
-  channels.value.length > 0 && channels.value.every(c => g.isLinearAxis(c)) ? 'linear' : defaultTransform)
+// transform across all selected channels, so it's linear only when EVERY selected channel is a linear axis.
+const pairsDefault = (chs: string[]): Kind =>
+  chs.length > 0 && chs.every(c => g.isLinearAxis(c)) ? 'linear' : defaultTransform
+// Changing the channel selection re-derives the shared transform (FlowJo-style: transform follows the
+// parameters) — else a once-set transform sticks when the selection changes to/from centroid axes. Only
+// fires on user picks via the multiselect's v-model; a restored bag sets ui.channels directly.
+const channels = computed<string[]>({ get: () => props.ui.channels ?? [], set: v => { props.ui.channels = v; props.ui.xt = pairsDefault(v) } })
+const pairsDefaultTransform = computed<Kind>(() => pairsDefault(channels.value))
 const transform = computed<Kind>({ get: () => props.ui.xt ?? pairsDefaultTransform.value, set: v => { props.ui.xt = v } })
 // ≥1 tile's transform was auto-linearised (measure range too small) → amber the control + explain
 const coerced = ref(false)

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -51,8 +51,13 @@ const defaultTransform: Kind = g.popType === 'track' ? 'linear' : 'logicle'
 // spatial/temporal + centroid axes are raw coordinates → linear by default (never logicle).
 const axisDefaultTransform = (col: string): Kind => g.isLinearAxis(col) ? 'linear' : defaultTransform
 // axis config reads/writes the persisted `ui` bag (owned by GatingPlots) so it survives remount.
-const xChan = computed({ get: () => props.ui.x ?? '', set: v => { props.ui.x = v } })
-const yChan = computed({ get: () => props.ui.y ?? '', set: v => { props.ui.y = v } })
+// Picking a NEW axis re-derives its transform (linear for spatial/centroid, logicle for flow) — the
+// transform follows the parameter, FlowJo-style. Without this a once-set transform sticks across axis
+// changes (e.g. logicle stays when you switch back to centroid_x). Only fires on user picks via the
+// axis <select>'s v-model setter; loading a saved gate mutates ui.x/ui.xt directly (GatingPlots
+// openPop), so a gate keeps the transform it was drawn in.
+const xChan = computed({ get: () => props.ui.x ?? '', set: v => { props.ui.x = v; props.ui.xt = axisDefaultTransform(v) } })
+const yChan = computed({ get: () => props.ui.y ?? '', set: v => { props.ui.y = v; props.ui.yt = axisDefaultTransform(v) } })
 const xt = computed<Kind>({ get: () => props.ui.xt ?? axisDefaultTransform(xChan.value), set: v => { props.ui.xt = v } })
 const yt = computed<Kind>({ get: () => props.ui.yt ?? axisDefaultTransform(yChan.value), set: v => { props.ui.yt = v } })
 const renderMode = computed<RenderMode>({ get: () => props.ui.renderMode ?? 'points', set: v => { props.ui.renderMode = v } })


### PR DESCRIPTION
## Problem

Even after #286, a centroid axis could still show **logicle**: pick `centroid_x` → linear (good), switch to another column and set logicle, switch **back** to `centroid_x` → it stayed logicle. Changing an axis never re-derived its transform, so once `ui.xt` held a concrete value it stuck across axis changes.

## Cause

The axis `<select>` (`v-model="xChan"`) set `ui.x` but left `ui.xt` untouched. #284/#286's `ui.xt ?? axisDefaultTransform(col)` default only fires while `ui.xt` is `undefined` — a real value (from a prior pick or persisted state) shadows it. So the linear-by-default rule was reachable only for a never-yet-set panel, not the normal "change the axis" flow.

## Fix

The transform now **follows the parameter** (FlowJo-style): picking a new axis re-derives its transform from the existing classifier.

- `GatePlotPanel`: `xChan`/`yChan` setters set `ui.xt`/`ui.yt = axisDefaultTransform(v)` (linear for spatial/centroid via `isLinearAxis`, logicle for flow).
- `GatePairsPanel`: the shared transform is linear only when **every** selected channel is a linear axis; extracted that rule into one `pairsDefault(chs)` helper (no duplicated rule) and the `channels` setter re-derives `ui.xt` on selection change.

Reuses the single `isLinearAxis` classifier — **no new mechanism**; the backend range-collapse auto-linearise is untouched. Fires only on user picks via the `v-model` setters; loading a saved gate mutates `ui.x`/`ui.xt` directly (GatingPlots `openPop`), so a saved gate keeps the transform it was drawn in.

`vue-tsc -b` clean; 275/275 vitest pass.

## Reservations

- Not clicked through in a browser (typecheck + unit tests only).
- Intended behaviour change: a manual transform override is discarded when you change that axis / the pairs selection.
- A panel already sitting on a centroid axis with a stored logicle won't self-correct until the axis is re-picked (the setter only fires on a pick).
- No new automated test: setter one-liners in the components; the `isLinearAxis`/`isCentroidAxis` classifier is already unit-tested, and the frontend rule is pure-logic-only (no component mounting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
