### PR TITLE
mcp: keep a notebook's description when revising without one

### DIFF
--- a/mcp/cecelia_mcp/client.py
+++ b/mcp/cecelia_mcp/client.py
@@ -270,9 +270,10 @@ class CeceliaClient:
         # New version of an EXISTING notebook: the server snapshots the current one (restorable via the
         # Notebooks page History) then overwrites its cells — real versioning, not a "-v2" copy. `file`
         # is the existing notebook's filename (bare name works; server appends .jl). 409 if it doesn't
-        # exist (use create_notebook for a new one). `description` optional — only updates it if given.
-        return self._request(
-            "POST",
-            "/api/notebooks/revise",
-            body={"projectUid": project_uid, "file": file, "cells": cells, "description": description},
-        )
+        # exist (use create_notebook for a new one). `description` optional — OMITTED from the body when
+        # empty so the server keeps the notebook's existing description (it updates only when the key is
+        # present; sending "" would blank it, which is why a revised notebook lost its description).
+        body = {"projectUid": project_uid, "file": file, "cells": cells}
+        if description:
+            body["description"] = description
+        return self._request("POST", "/api/notebooks/revise", body=body)

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -67,6 +67,17 @@ class ClientTest(unittest.TestCase):
             {"projectUid": "p", "file": "speed.jl", "cells": ["using Cecelia", "df = 2"], "description": "d2"},
         )
 
+    def test_revise_notebook_omits_empty_description(self):
+        # An empty description must NOT be sent — else the server (which updates the description only when
+        # the key is present) would blank the notebook's existing description on a plain re-version.
+        with _patch_urlopen({"ok": True, "file": "speed.jl", "snapshotVersion": 3}) as u:
+            self.c.revise_notebook("p", "speed.jl", ["using Cecelia", "df = 3"])
+        req = u.call_args[0][0]
+        self.assertEqual(
+            json.loads(req.data.decode()),
+            {"projectUid": "p", "file": "speed.jl", "cells": ["using Cecelia", "df = 3"]},
+        )
+
     def test_create_notebook_posts_cells(self):
         with _patch_urlopen({"ok": True, "file": "speed.jl"}) as u:
             self.c.create_notebook("p", "speed", ["using Cecelia", "df = 1"], description="d")


### PR DESCRIPTION
## Problem

Revising a notebook via the MCP (`revise_notebook`) with no description **blanked** the notebook's existing description (the Notebooks table showed "Add a description…" on the new version).

## Cause

The Julia handler updates the description only when the key is present:

```julia
# api/src/notebooks_api.jl (revise)
haskey(body, :description) && (e["description"] = _cap_desc(String(get(body, :description, ""))))
```

But the MCP client **always** sent `description`, defaulting to `""` — so `haskey` was always true and a plain re-version overwrote the stored description with empty. The client's own comment even claimed "only updates it if given," which it didn't honor.

## Fix

`mcp/cecelia_mcp/client.py` — `revise_notebook` now **omits** `description` from the body when empty, so the server keeps the existing one; a non-empty description still updates it. Matches the server's presence-based contract (no Julia change needed — the server was already correct). Added a client test asserting the empty case sends no `description` key.

`pixi run test-mcp`: 51/51 pass.

## Reservations

- The **running** MCP server has the old client code — this takes effect after the MCP server restarts (`pixi run mcp`). Until then, `revise` still blanks; `set_notebook_description` restores it.
- **Not retroactive**: notebooks already blanked keep their empty description — reset via the Notebooks page field or `set_notebook_description`.
- No Julia-side hardening: the `/revise` endpoint is still permissive to any client that explicitly sends `""` (would blank). The MCP is its only caller, so the client fix is sufficient; a server-side "treat empty as no-change" guard could be added later if another caller appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
