### PR TITLE
notebooks: preserve cell ids on revise so an open notebook reloads live

### DIFF
--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -400,6 +400,9 @@ begin
     Pkg.activate(get(ENV, \"CECELIA_PLUTO_ENV\", joinpath(@__DIR__, \"..\", \"pluto\")))
 end"""
 
+# The activation cell's id is PINNED (matches notebook_template.jl) so it's stable across every write.
+const _NB_ACTIVATION_ID = "10000000-0000-0000-0000-000000000001"
+
 # A valid v4-UUID string for a Pluto cell id — built from Base rand/bytes2hex so we don't pull the
 # UUIDs stdlib into the api env. (Pluto parses cell ids as UUIDs, so they must be well-formed.)
 function _cell_uuid()::String
@@ -408,6 +411,24 @@ function _cell_uuid()::String
     b[9] = (b[9] & 0x3f) | 0x80   # variant 10xx
     h = bytes2hex(b)
     string(h[1:8], "-", h[9:12], "-", h[13:16], "-", h[17:20], "-", h[21:32])
+end
+
+# The content-cell ids currently in a notebook file, in body order, EXCLUDING the pinned activation id
+# — the ids to REUSE when re-serialising a revised notebook. Preserving them lets Pluto's
+# `auto_reload_from_file` reconcile the change in an OPEN notebook by matching cells on their id; a
+# fresh id for every cell reads as delete-all + add-all, which auto_reload can't merge in place, so the
+# open notebook goes stale (only a manual reload / server restart would then show the new version).
+# Matches only the `# ╔═╡ <uuid>` cell-definition markers (never the `# ╠═`/`# ╟─` Cell-order list).
+# Best-effort: a missing/garbled file → no ids → revise just falls back to fresh ids (old behaviour).
+function _content_cell_ids(path::AbstractString)::Vector{String}
+    isfile(path) || return String[]
+    ids = String[]
+    for ln in eachline(path)
+        m = match(r"^# ╔═╡ ([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$", ln)
+        (m === nothing || m.captures[1] == _NB_ACTIVATION_ID) && continue
+        push!(ids, String(m.captures[1]))
+    end
+    ids
 end
 
 # Pluto allows only ONE top-level expression per cell — a cell with several statements fails to load
@@ -431,14 +452,18 @@ end
 
 # Serialise a list of Julia cell sources into a valid Pluto notebook `.jl` (the format
 # notebook_template.jl uses: a header, one `# ╔═╡ <uuid>` marker per cell, then a `# ╔═╡ Cell order:`
-# block). The activation cell is prepended and pinned to the template's fixed id; caller cells get
-# fresh uuids. Each cell is normalised so multi-statement cells load in Pluto. Pure — unit-tested in api/test.
-function _pluto_notebook_source(cells::AbstractVector)::String
+# block). The activation cell is prepended and pinned to the fixed id. `reuse_ids` supplies the prior
+# version's content-cell ids (from `_content_cell_ids`): each is reused POSITIONALLY so a revise keeps
+# stable ids where the cells line up (letting Pluto's auto_reload update an open notebook in place);
+# cells beyond the reused set get fresh uuids. Empty `reuse_ids` (a fresh create) → all fresh. Each cell
+# is normalised so multi-statement cells load in Pluto. Pure — unit-tested in api/test.
+function _pluto_notebook_source(cells::AbstractVector; reuse_ids::AbstractVector = String[])::String
     all_cells = vcat(Any[_NB_ACTIVATION_CELL], collect(cells))
     ids  = String[]
     body = IOBuffer()
     for (i, code) in enumerate(all_cells)
-        id = i == 1 ? "10000000-0000-0000-0000-000000000001" : _cell_uuid()
+        id = i == 1 ? _NB_ACTIVATION_ID :
+             (i - 1) <= length(reuse_ids) ? String(reuse_ids[i - 1]) : _cell_uuid()
         push!(ids, id)
         print(body, "# ╔═╡ ", id, "\n", _wrap_multi_expr(String(code)), "\n\n")
     end
@@ -522,7 +547,10 @@ function api_notebooks_revise(body_bytes::Vector{UInt8})
 
     # freeze the current live state first, then overwrite — nothing is lost (restorable via History)
     snap = api_notebooks_snapshot(Vector{UInt8}(JSON3.write((; projectUid = uid, file = file))))
-    open(dest, "w") do io; write(io, _pluto_notebook_source(collect(cells))); end
+    # Reuse the prior version's cell ids (read BEFORE we truncate) so Pluto's auto_reload_from_file can
+    # merge the change into an OPEN notebook in place instead of leaving it stale.
+    reuse = _content_cell_ids(dest)
+    open(dest, "w") do io; write(io, _pluto_notebook_source(collect(cells); reuse_ids = reuse)); end
 
     reg = _read_registry(uid)
     e = get(reg, file, Dict{String,Any}("current" => 0))

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -292,6 +292,21 @@ end
     # end-to-end through the serialiser: a multi-statement caller cell comes out wrapped
     @test occursin("begin\nusing Cecelia\ndf = pop_df", _pluto_notebook_source(["using Cecelia\ndf = pop_df(img, \"flow\", [\"/T\"])"]))
 
+    # Cell-id preservation across a revise (so Pluto's auto_reload can update an OPEN notebook in place).
+    ids_of(src) = (p = tempname() * ".jl"; write(p, src); v = _content_cell_ids(p); rm(p; force = true); v)
+    # A fresh serialise → the activation id is pinned + excluded; content cells get distinct v4 uuids.
+    src1 = _pluto_notebook_source(["using Cecelia", "df = 1", "plot(df)"])
+    ids1 = ids_of(src1)
+    @test length(ids1) == 3 && allunique(ids1) && _NB_ACTIVATION_ID ∉ ids1
+    # Re-serialising WITH the prior ids reuses them positionally → the same ids come back out.
+    src2 = _pluto_notebook_source(["using Cecelia", "df = 2", "plot(df)"]; reuse_ids = ids1)
+    @test ids_of(src2) == ids1                                # ids stable ⇒ auto_reload matches cells
+    @test occursin("df = 2", src2)                            # …but the code did change
+    # Extra cells beyond the reused set get fresh ids; the reused prefix stays put.
+    src3 = _pluto_notebook_source(["using Cecelia", "df = 3", "plot(df)", "extra = 4"]; reuse_ids = ids1)
+    ids3 = ids_of(src3)
+    @test ids3[1:3] == ids1 && length(ids3) == 4 && ids3[4] ∉ ids1
+
     conf = cecelia_conf(); dirs = get!(conf, "dirs", Dict{String,Any}())
     had  = haskey(dirs, "projects"); old = get(dirs, "projects", nothing)
     tmp  = mktempdir(); dirs["projects"] = tmp


### PR DESCRIPTION
## Problem

Revising a notebook that's **open in Pluto** didn't show the new version — you had to restart the whole notebook server. Cecelia sets `auto_reload_from_file = true` precisely so an app-side overwrite updates an open notebook live, so this shouldn't be necessary.

## Cause

`_pluto_notebook_source` gave **every** content cell a fresh UUID on each write. Pluto's `auto_reload_from_file` reconciles an on-disk change against the live session **by cell id** — all-new ids read as "delete every cell + add new ones", which it can't merge in place, so the open notebook goes stale. (`Restore` live-reloads fine because it byte-copies a snapshot, keeping the original ids.)

## Fix (`api/src/notebooks_api.jl`)

`revise` now **preserves cell ids** across versions:
- `_content_cell_ids(path)` reads the prior version's content-cell ids (in order; excludes the pinned activation id).
- `_pluto_notebook_source(cells; reuse_ids)` reuses those ids **positionally** — a revise that keeps the same cells (new code, same structure) keeps identical ids, so `auto_reload` updates the open notebook in place; cells added beyond the prior set get fresh ids.
- The activation cell keeps its pinned id (extracted to `_NB_ACTIVATION_ID`).

Create is unchanged (empty `reuse_ids` → all fresh). Pure serialiser, unit-tested (api/test): fresh ids are distinct, a re-serialise with prior ids round-trips them, extra cells get new ids. `pixi run test-api`: all pass (notebooks testset 30/30).

## Reservations

- **Not verified end-to-end** — the serialiser id-preservation is unit-tested, but "an open notebook actually adopts the revision via auto_reload" needs the live app (revise a notebook that's open in Pluto → does it update without a server restart?). I can't exercise the running Pluto here.
- **Positional reuse**: if a revise reorders or inserts/removes cells mid-notebook, ids shift from that point and Pluto re-runs more than the minimum (still correct, just not minimal). The common case (same cells, changed code) is optimal.
- **Autosave race**: if Pluto still re-saves its in-memory copy over the external change in some cases, we may additionally need a per-notebook reload action or an open-session guard (like `restore`/`delete` have). Deferred until the live test shows whether this fix alone suffices.
- `api/src/*.jl` isn't Revise-tracked — takes effect on the next `pixi run dev` (backend restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
