### PR TITLE
fix(projects): reset state when creating a project (stale image table)

### DIFF
--- a/frontend/src/stores/projectMeta.ts
+++ b/frontend/src/stores/projectMeta.ts
@@ -41,6 +41,7 @@ export const useProjectMetaStore = defineStore('projectMeta', () => {
 
   async function createProject(name: string, type: ProjectType): Promise<boolean> {
     loading.value = true
+    let newUid = ''
     try {
       const res = await fetch('/api/projects/create', {
         method: 'POST',
@@ -49,16 +50,19 @@ export const useProjectMetaStore = defineStore('projectMeta', () => {
       })
       const body = await res.json().catch(() => ({})) as { project?: ProjectRecord; error?: string }
       if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
-      current.value = body.project!
-      await fetchRecent()
+      newUid = body.project!.uid
       log.info(`Created project "${name}".`, { source: 'project' })
-      return true
     } catch (e) {
       log.error(`Failed to create project: ${e instanceof Error ? e.message : String(e)}`, { source: 'project' })
       return false
     } finally {
       loading.value = false
     }
+    // Switch to it through the canonical open path so ALL per-project state resets (sets/images, and
+    // the analysis boards / module canvases / animations). Previously createProject only set `current`
+    // and never loaded the new project's sets, so the image table kept showing the PREVIOUS project's
+    // images (and its boards/animations) until a browser reload.
+    return openProject(newUid)
   }
 
   async function openProject(uid: string): Promise<boolean> {


### PR DESCRIPTION
## Problem
Creating a new project while already in one kept showing the **previous project's images** (and boards/animations) until a full browser reload.

## Cause
`createProject` (`stores/projectMeta.ts`) set `current` and refreshed the recent list but — unlike `openProject` — never called `projectStore.loadFromApi(...)`, so the new project's sets never loaded and every per-project store kept the old project's data.

## Fix
After the backend create, delegate to `openProject(newUid)` — the one canonical path that loads the new (empty) sets and clears/rehydrates the analysis boards, module canvases, and animations. One reset path instead of two divergent ones.

`vue-tsc -b` clean; 275/275 vitest pass.

## Reservations
- Not clicked through in a browser (typecheck + unit tests only); it reuses the already-working `openProject` path.
- Create now does a second round-trip (`/api/projects/load` after `/api/projects/create`) and logs both "Created…" and "Opened… 0 sets, 0 images".
- `createProject` now returns `false` if the post-create load fails (previously `true` on create alone) — arguably more correct (you're not really "in" a project that didn't load), but a behaviour change.
- No new unit test: Pinia store action; the frontend test rule is pure-utils-only (no store/component mounting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)