### PR TITLE
Notebook version prune (keep current, drop older snapshots)

### DIFF
--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -694,3 +694,35 @@ function api_notebooks_restore(body_bytes::Vector{UInt8})
     _write_registry!(uid, reg)
     200, JSON3.write((; ok = true, restoredFrom = ver, version = ver))
 end
+
+# POST /api/notebooks/prune  { projectUid, file }  → { ok, kept, removed }
+# Trim version history down to the CURRENT version: delete every snapshot on disk EXCEPT the one the
+# live notebook currently reflects (registry `current`). The live notebook (.jl) and its registry entry
+# — crucially its description — are left untouched; prune only removes older .snapshots/ files. Answers
+# "I'm happy with this version, drop the rest." No-op-safe: if `current` is 0 or its snapshot is missing,
+# it aborts rather than wiping the whole history (so an unset pointer can't nuke everything).
+function api_notebooks_prune(body_bytes::Vector{UInt8})
+    body = JSON3.read(String(body_bytes))
+    uid  = String(get(body, :projectUid, ""))
+    file = _safe_nb_file(get(body, :file, ""))
+    (isempty(uid) || file === nothing) && return 400, JSON3.write((; error = "projectUid + file required"))
+    isdir(joinpath(projects_dir(), uid)) || return 404, JSON3.write((; error = "Project not found"))
+
+    reg = _read_registry(uid)
+    cur = _reg_current(get(reg, file, Dict{String,Any}()))
+    cur == 0 && return 409, JSON3.write((; error = "No current version to keep — snapshot this notebook first, then prune."))
+
+    snapdir = joinpath(_project_notebooks_dir(uid), ".snapshots")
+    stem    = splitext(file)[1]
+    isfile(joinpath(snapdir, "$(stem)@v$(cur).jl")) ||
+        return 409, JSON3.write((; error = "Current version v$cur has no snapshot on disk — nothing pruned."))
+
+    removed = String[]
+    for v in _snapshot_versions(uid, file)
+        v == cur && continue
+        p = joinpath(snapdir, "$(stem)@v$(v).jl")
+        isfile(p) && (rm(p); push!(removed, "$(stem)@v$(v).jl"))
+    end
+    # Registry (incl. description) is deliberately NOT rewritten — prune never changes the description.
+    200, JSON3.write((; ok = true, kept = cur, removed = removed))
+end

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -394,6 +394,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_notebooks_snapshot(body_bytes)
         elseif path == "/api/notebooks/restore"
             api_notebooks_restore(body_bytes)
+        elseif path == "/api/notebooks/prune"
+            api_notebooks_prune(body_bytes)
         elseif path == "/api/notebooks/shutdown"
             api_notebooks_shutdown(body_bytes)
         elseif path == "/api/notebooks/restart"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -253,6 +253,23 @@ end
         @test _post(api_notebooks_create, Dict("projectUid"=>uid, "name"=>"nbcap", "description"=>repeat("x", 300)))[1] == 200
         @test length(find("nbcap.jl").description) == _NB_DESC_MAX
 
+        # prune: keep ONLY the current version's snapshot, drop the older ones; description is untouched.
+        # State here: several snapshots on disk, current pointer set by the revise above.
+        let cur = find("nb1.jl").version
+            @test cur > 1 && length(snaps()) > 1              # precondition: history to prune
+            @test _post(api_notebooks_describe, Dict("projectUid"=>uid,"file"=>"nb1.jl","description"=>"keep me"))[1] == 200
+            pr = JSON3.read(_post(api_notebooks_prune, Dict("projectUid"=>uid,"file"=>"nb1.jl"))[2])
+            @test pr.ok == true && pr.kept == cur
+            @test [s.version for s in snaps()] == [cur]       # only the current version survives
+            @test find("nb1.jl").version == cur               # pointer unchanged
+            @test find("nb1.jl").description == "keep me"      # description NOT pruned
+            # idempotent: pruning again removes nothing (single snapshot = the current one)
+            @test JSON3.read(_post(api_notebooks_prune, Dict("projectUid"=>uid,"file"=>"nb1.jl"))[2]).removed |> length == 0
+        end
+        # prune with no current version (never snapshotted) aborts rather than wiping — 409, history intact
+        @test _post(api_notebooks_create, Dict("projectUid"=>uid, "name"=>"nbfresh"))[1] == 200
+        @test _post(api_notebooks_prune, Dict("projectUid"=>uid,"file"=>"nbfresh.jl"))[1] == 409
+
         # delete — pass force=true so this is deterministic regardless of whether a Pluto server is
         # running locally. The guard 409s on a live server without force (a dev machine with the
         # notebook server up would otherwise fail this + the two asserts below); force is what the

--- a/docs/NOTEBOOKS.md
+++ b/docs/NOTEBOOKS.md
@@ -92,6 +92,10 @@ Provenance without git or file-watching:
   snapshot. It does **not** create a snapshot (so repeated restores don't pile up versions); a
   two-click confirm guards un-snapshotted edits — snapshot first if you want to keep the current state.
   Pluto auto-reloads the file (`auto_reload_from_file`), so an open notebook updates live.
+- **Prune** (in History, when >1 snapshot exists) deletes every snapshot EXCEPT the current version —
+  "I'm happy with this one, drop the rest". Two-click confirm. It touches only `.snapshots/` files:
+  the live notebook and the registry entry (**including the description**) are left as-is, and it
+  aborts (409) rather than wiping history if the current pointer is unset or its snapshot is missing.
 - The **Ver** column shows which snapshot the notebook currently reflects: a fresh notebook is `—`,
   Snapshot advances it to the new number, and Restore sets it to the version you restored (restore v3
   → the column reads `v3`). It is a *pointer to current state*, not a monotonic counter.
@@ -164,6 +168,7 @@ Routes:
 | `POST /api/notebooks/snapshot` | freeze a version |
 | `GET  /api/notebooks/snapshots?projectUid=&file=` | list a notebook's snapshots |
 | `POST /api/notebooks/restore` | restore a snapshot into the live notebook |
+| `POST /api/notebooks/prune` | keep only the current version's snapshot, delete the older ones (description untouched) |
 | `POST /api/notebooks/shutdown` | stop the server (only one this app spawned) |
 | `POST /api/notebooks/restart` | stop + relaunch |
 

--- a/frontend/src/components/NotebookTable.vue
+++ b/frontend/src/components/NotebookTable.vue
@@ -102,6 +102,7 @@ const restoreVersion = ref<number | null>(null)   // the version chosen in the d
 async function loadSnapshots(file: string) {
   snapsLoading.value = true
   confirmingRestore.value = null
+  confirmingPrune.value = null
   try {
     const res = await fetch(`/api/notebooks/snapshots?projectUid=${encodeURIComponent(props.projectUid)}&file=${encodeURIComponent(file)}`)
     const d = await res.json()
@@ -128,6 +129,7 @@ const confirmingRestore = ref<string | null>(null)
 async function restore(nb: Notebook) {
   const version = restoreVersion.value
   if (version == null) return
+  confirmingPrune.value = null
   if (confirmingRestore.value !== nb.file) { confirmingRestore.value = nb.file; return }
   confirmingRestore.value = null
   busy.value = true
@@ -138,6 +140,28 @@ async function restore(nb: Notebook) {
     log.info(`Restored ${nb.file} to v${version}.`, { source: 'notebooks' })
   } catch (e) {
     log.error(`Restore failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
+  } finally {
+    busy.value = false
+  }
+}
+
+// Prune: keep only the current version's snapshot, delete the older ones. Two-click confirm (destructive
+// of history). Prunes to nb.version (the live/current version), independent of the restore dropdown.
+// The description is a per-notebook field and is never touched by prune.
+const confirmingPrune = ref<string | null>(null)
+async function prune(nb: Notebook) {
+  confirmingRestore.value = null
+  if (confirmingPrune.value !== nb.file) { confirmingPrune.value = nb.file; return }
+  confirmingPrune.value = null
+  busy.value = true
+  try {
+    const d = await post('/api/notebooks/prune', { projectUid: props.projectUid, file: nb.file })
+    await refresh()
+    if (expandedFile.value === nb.file) await loadSnapshots(nb.file)
+    const n = d.removed?.length ?? 0
+    log.info(`Pruned ${nb.file} — kept v${d.kept}, removed ${n} older snapshot${n !== 1 ? 's' : ''}.`, { source: 'notebooks' })
+  } catch (e) {
+    log.error(`Prune failed: ${e instanceof Error ? e.message : String(e)}`, { source: 'notebooks' })
   } finally {
     busy.value = false
   }
@@ -284,6 +308,15 @@ defineExpose({ refresh })
                           : 'Overwrites the current notebook — snapshot first if you want to keep it'">
                   <i class="pi pi-replay" /> {{ confirmingRestore === nb.file ? 'Confirm restore' : 'Restore' }}
                 </button>
+                <span class="nbt-hist-sep" />
+                <button v-if="snapshots.length > 1" class="cc-btn"
+                        :class="confirmingPrune === nb.file ? 'cc-btn-primary' : 'cc-btn-ghost'"
+                        :disabled="busy" @click="prune(nb)"
+                        v-tooltip.top="confirmingPrune === nb.file
+                          ? `Click Confirm to delete every snapshot except the current (v${nb.version})`
+                          : `Keep only the current version (v${nb.version}) — delete older snapshots`">
+                  <i class="pi pi-filter" /> {{ confirmingPrune === nb.file ? 'Confirm prune' : 'Prune' }}
+                </button>
               </template>
             </div>
           </td>
@@ -317,6 +350,7 @@ defineExpose({ refresh })
 .nbt-history-row td { background: var(--cc-surface-2, rgba(255,255,255,0.03)); }
 .nbt-history { display: flex; align-items: center; flex-wrap: wrap; gap: .5rem; font-size: .85rem; }
 .nbt-hist-label { color: var(--cc-text-muted, #888); }
+.nbt-hist-sep { flex: 1 1 auto; }   /* push Prune to the far end, away from the Restore control */
 .nbt-snap { display: inline-flex; align-items: center; gap: .25rem; border: 1px solid var(--cc-border, #333); border-radius: 6px; padding: .1rem .1rem .1rem .5rem; }
 .nbt-snap-ver { font-variant-numeric: tabular-nums; }
 .nbt-snap .cc-btn { padding: .15rem .4rem; }


### PR DESCRIPTION
## What

Adds a **Prune** action to notebook version history: keep only the current version's snapshot and delete the older ones — "I'm happy with this version, drop the rest."

## Backend — `POST /api/notebooks/prune`

- Deletes every `.snapshots/<name>@v<N>.jl` **except** the current version (registry `current` pointer).
- Leaves the live `.jl` and the registry entry — **including the description** — untouched. Prune never drops the description.
- No-op-safe: 409 (aborts) if `current` is `0` or its snapshot is missing, so an unset pointer can't wipe the whole history.
- Registered in `server.jl`; documented in `docs/NOTEBOOKS.md`.

## Frontend — `NotebookTable.vue`

- **Prune** button in the History panel, shown only when >1 snapshot exists, placed past Restore.
- Two-click confirm (mirrors Restore/Delete); tooltip states the kept version. Arming Prune/Restore is mutually exclusive.

## Tests

`api/test/runtests.jl` (46/46): prune keeps only the current snapshot, leaves the pointer + description intact, is idempotent, and 409s on a never-snapshotted notebook. Frontend typecheck clean.

## Notes / reservations

- Not yet verified live in the running app (unit + typecheck only).
- Prune is irreversible for deleted snapshots (by design; two-click confirm guards it).
- No server-running guard (unlike restore/delete) — deliberate: prune only touches `.snapshots/` files, never the live `.jl` Pluto has open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
