### PR TITLE
Fix isImported (stable has-converted-file, not task status) + crop openability

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -829,8 +829,11 @@ function api_images_register(body_bytes::Vector{UInt8})
             "name"      => img.name,
             "kind"      => img.kind,
             "status"    => "pending",
-            "filepath"  => abs_path,
-            "filepaths" => Dict{String,Any}("default" => "ccidImage.ome.zarr"),
+            "filepath"  => abs_path,            # SOURCE path, for display only (not the converted zarr)
+            # No versioned `filepaths` yet — the OME-ZARR doesn't exist until the import task converts it.
+            # (Faking `{default: …}` here made a pending row look "imported" — see isImported / the crop
+            # + open gates. The conversion task writes the real versioned filepath.)
+            "filepaths" => Dict{String,Any}(),
         ))
     end
 

--- a/app/src/tasks/editImages/cropImage.jl
+++ b/app/src/tasks/editImages/cropImage.jl
@@ -74,6 +74,7 @@ function _run_task(task::CropImage, img::CciaImage, params::Dict{String,Any};
     versioned_set_field!(raw2, "filepath", out_filename, VERSIONED_DEFAULT_VAL)
     ch_names = versioned_get_field(raw, "imChannelNames", VERSIONED_DEFAULT_VAL)
     isnothing(ch_names) || versioned_set_field!(raw2, "imChannelNames", ch_names, VERSIONED_DEFAULT_VAL)
+    raw2["status"] = "done"   # a crop is a complete image (zarr written) — mark it imported, not 'pending'
     open(new_ccid, "w") do io; JSON3.write(io, raw2); end
 
     on_log("[INFO] Crop complete → new image $(new_img.uid)")

--- a/frontend/src/utils/inclusion.test.ts
+++ b/frontend/src/utils/inclusion.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from 'vitest'
 import { isExcluded, isIncluded, includedUids, dropExcluded, isImported } from './inclusion'
 
 describe('isImported', () => {
-  it('true only once conversion is done', () => {
-    expect(isImported({ status: 'done' })).toBe(true)
+  it('true once a converted version exists (stable — independent of task status)', () => {
+    expect(isImported({ filepaths: { default: 'ccidImage.ome.zarr' } })).toBe(true)
+    expect(isImported({ filepaths: { corrected: 'x.ome.zarr' } })).toBe(true)
   })
-  it('false while pending/converting/failed (placeholder filepath is set at register, so status is the signal)', () => {
-    expect(isImported({ status: 'pending' })).toBe(false)
-    expect(isImported({ status: 'converting' })).toBe(false)
-    expect(isImported({ status: 'failed' })).toBe(false)
+  it('false for a not-yet-converted row (no versioned filepaths)', () => {
     expect(isImported({})).toBe(false)
+    expect(isImported({ filepaths: {} })).toBe(false)
+    expect(isImported({ filepaths: null })).toBe(false)
   })
 })
 

--- a/frontend/src/utils/inclusion.ts
+++ b/frontend/src/utils/inclusion.ts
@@ -7,16 +7,14 @@ export interface Includable { uid: string; included?: boolean | null }
 
 // THE canonical "is this image usable yet?" predicate — one source of truth for every gate that needs
 // real image data (open in napari, crop, segment, measure, run a chain, …). Use this instead of
-// hand-rolling checks. The signal is `status === 'done'`: an image is IMPORTED once its OME-ZARR has
-// been written (the bf2raw conversion task sets status 'done'). We CANNOT key off `filepath`/`filepaths`
-// — `api_images_register` pre-populates both with a placeholder at queue time (a 'pending' row already
-// has `filepaths: { default: 'ccidImage.ome.zarr' }`), so they're truthy before any data exists. This is
-// the practical equivalent of the old R `imFilepath == null` check (there the path was null until
-// converted; here the status carries that). NB status also goes 'converting' while a LATER task runs on
-// an already-imported image — so this reads as "converted and not mid-task", which is the right gate for
-// "can I operate on it now?".
-export function isImported(img: { status?: string }): boolean {
-  return img.status === 'done'
+// hand-rolling checks. An image is IMPORTED once its converted OME-ZARR exists, i.e. it has a real
+// versioned `filepaths` entry (the bf2raw conversion writes it; a still-`pending` row's ccid has none).
+// This is the old R `imFilepath == null` check — and crucially it is STABLE: it does NOT flip while a
+// later task runs on the image (unlike `status`, which cycles pending/converting/done/failed per task),
+// so an imported image stays openable no matter what you run on it. `filepath` (singular) is NOT used:
+// `api_images_register` sets it to the SOURCE path for display before conversion.
+export function isImported(img: { filepaths?: Record<string, string> | null }): boolean {
+  return Object.keys(img.filepaths ?? {}).length > 0
 }
 
 /** Excluded from further processing (explicitly `included === false`). */


### PR DESCRIPTION
## Why
#299 shipped an `isImported` based on `status === 'done'` — which is **wrong**: running any task flips an image to `converting`/`failed`, so an already-imported image would become un-openable mid-task (Dominik caught this). And a fresh crop couldn't be opened.

## Fix
- **`isImported` = has a real versioned `filepaths` entry** (the converted OME-ZARR exists) — the old R `imFilepath == null` model. **Stable**: it never changes when you run tasks on the image.
- **`api_images_register` no longer fakes `filepaths: {default: …}`** in its response for a still-`pending` row (the ccid has none until conversion). That fake made un-imported images look importable, so Crop/Open stayed active.
- **`cropImage` marks the new image `status: 'done'`** (it already wrote the versioned filepath), so a crop reads as imported and opens; the existing live-add (`task:result` → `/api/images/meta`) reflects it.

## Verify
- `isImported` tests updated; frontend typecheck clean; 23/23 utils tests.

## After merge (what needs what)
- `inclusion.ts` → Vite HMR (the **already-cropped image becomes openable on reload** — its ccid already has a filepath).
- `routes.jl` (register) → **server restart** (affects newly-registered images; reload to clear the fake on existing pending rows).
- `cropImage.jl` → Revise hot-reload (next crops get `status: done`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
