### PR TITLE
Crop polish: grey disabled icon, carry napari colours, better icon

### DIFF
--- a/app/src/tasks/editImages/cropImage.jl
+++ b/app/src/tasks/editImages/cropImage.jl
@@ -77,6 +77,17 @@ function _run_task(task::CropImage, img::CciaImage, params::Dict{String,Any};
     raw2["status"] = "done"   # a crop is a complete image (zarr written) — mark it imported, not 'pending'
     open(new_ccid, "w") do io; JSON3.write(io, raw2); end
 
+    # Carry the source's napari layer-props sidecar (per-channel colormap/contrast JSON) to the crop, so
+    # it opens in napari with the same colours the user set. The crop keeps all channels in order, so the
+    # props map 1:1. Best-effort: only if the source was opened with autosave (sidecar exists). Named to
+    # match the crop's default zarr (_props_path = {basename(zarr)}.json under the image's data/ dir).
+    src_sidecar = joinpath(img._dir, "data", basename(string(filename)) * ".json")
+    if isfile(src_sidecar)
+        dst_dir = joinpath(new_img._dir, "data"); mkpath(dst_dir)
+        cp(src_sidecar, joinpath(dst_dir, out_filename * ".json"); force = true)
+        on_log("[INFO] Carried napari colours to the crop")
+    end
+
     on_log("[INFO] Crop complete → new image $(new_img.uid)")
     Dict{String,Any}("newImageUid" => new_img.uid, "newImageName" => new_img.name, "setUid" => s.uid)
 end

--- a/frontend/src/components/CropDialog.vue
+++ b/frontend/src/components/CropDialog.vue
@@ -19,7 +19,7 @@ const projectMeta = useProjectMetaStore()
 <template>
   <BaseModal width="640px" @close="$emit('close')">
     <template #title>
-      <i class="pi pi-clone" /> Crop — {{ image.name }}
+      <i class="pi pi-image" /> Crop — {{ image.name }}
     </template>
     <!-- crop the ACTIVE version (drift/AF/cellpose-corrected variants are the norm, not 'default');
          empty → the backend falls back to 'default' -->

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -634,7 +634,7 @@ onUnmounted(stopResize)
             <button class="row-icon-btn" :disabled="!isImported(img)"
               @click.stop="cropDialogUid = img.uid"
               v-tooltip.right="isImported(img) ? 'Crop to a sub-region → new image (draw a rectangle on the projection, set z/t)' : 'Import this image first'">
-              <i class="pi pi-clone" />
+              <i class="pi pi-image" />
             </button>
             <button class="row-icon-btn" @click.stop="copyUid(img.uid)"
               v-tooltip.right="copiedUid === img.uid ? 'Copied!' : 'Copy UID to clipboard'">
@@ -955,6 +955,10 @@ th:hover .resize-handle::after { opacity: 1; }
 }
 .image-row:hover .row-icon-btn { opacity: 1; }
 .row-icon-btn:hover { color: var(--cc-text); background: var(--cc-surface-2); }
+/* disabled (e.g. Crop on a not-yet-imported image): visibly greyed, no hover highlight, not-allowed */
+.row-icon-btn:disabled { cursor: not-allowed; }
+.image-row:hover .row-icon-btn:disabled { opacity: 0.3; }
+.row-icon-btn:disabled:hover { color: var(--cc-text-dim); background: none; }
 
 /* editable attribute cell: click to edit; subtle hover affordance */
 .attr-cell { cursor: text; border-radius: 3px; padding: 0 2px; }


### PR DESCRIPTION
Follow-ups from live testing:

- **Disabled crop icon now greys** — `.row-icon-btn` had no `:disabled` style, so the Crop icon was *functionally* disabled on un-imported images (same `isImported` gate as the napari eye) but rendered the same as active. Added the disabled styling (greyed, not-allowed, no hover), so it matches the eye.
- **Carry napari colours to the crop** — `cropImage` copies the source's layer-props sidecar (per-channel colormap/contrast JSON) to the new image, so the crop opens in napari with the same channel colours (crop keeps all channels in order → props map 1:1). Best-effort: only when the source has a sidecar (was opened with autosave).
- **Icon** — `pi-clone` (reads as "duplicate") → `pi-image` (the crop makes a new image). PrimeIcons has no scissors/crop glyph; happy to swap if you'd prefer another.

Frontend typecheck clean. `cropImage.jl` is Revise-tracked (hot-reloads); the icon/CSS are Vite HMR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
