### PR TITLE
Fix cohort-QC test: assert image UID, not name (stale since #312)

### DIFF
--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -939,10 +939,11 @@ end
         _check((; projectUid = proj.uid, setUid = s.uid, funName = "clustTracks.cluster"))
         @test isfile(joinpath(tmp, proj.uid, "1", s.uid, "qc", "cohort", "clustTracks.cluster", "B.json"))
         # the cross-image detail lands in the lab log under a "[Cecelia — Cohort check]" entry, by image
-        # NAME (i1), with the label set and value-vs-median — not just a bare count
+        # UID (refs are uid-based; the panel resolves uid→name on demand), with the label set and
+        # value-vs-median — not just a bare count
         ll = JSON3.read(api_lablog_read(HTTP.Request("GET", "/api/lablog?projectUid=$(proj.uid)"))[2]).content
         @test occursin("Cohort check", ll) && occursin("clustTracks.cluster (B)", ll)
-        @test occursin("i1 — nTracks", ll) && occursin("cohort median", ll)   # image NAME + detail
+        @test occursin("$(i1) — nTracks", ll) && occursin("cohort median", ll)   # image UID (refs are uid-based) + detail
     finally
         had ? (dirs["projects"] = old) : delete!(dirs, "projects")
         rm(tmp; recursive = true, force = true)


### PR DESCRIPTION
## What

Fixes the `API: cohort QC` test, red on `main` since **#312**.

## Root cause

#312 (`feat/lablog-drop-tuning`, "store image refs by UID") switched the cohort-check lab-log line to reference images by **stable UID** — `cohort_qc_summary_lines` now defaults to `name_of = identity`, and `routes.jl` calls it with no uid→name map. #312 updated `app/test/runtests.jl` but missed the API-side assertion in `api/test/runtests.jl`, which still expected the old image **name** (`"i1"`). CI history confirms the boundary: **#311 green → #312 / #313 / #314 red**.

## Fix

Assert the image **UID** (already bound in the test as `i1 = images(s)[1].uid`) instead of the name. Test-only — no production code changed.

## Verification

`pixi run test-api` green end to end; `API: cohort QC` 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
