### PR TITLE
Stream segmentation norm-params histogram (2nd OOM vector)

### DIFF
--- a/python/cecelia/tests/test_segmentation_streaming.py
+++ b/python/cecelia/tests/test_segmentation_streaming.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
+import dask.array as da
 import ome_types
 import zarr
 
@@ -112,6 +113,37 @@ class PredictFromZarrTest(unittest.TestCase):
         self.assertEqual(counts, {'base': 24, 'nuc': 24})
         self.assertEqual(_fingerprint(base), gold)
         self.assertEqual(_fingerprint(nuc), gold)
+
+
+class ComputeNormParamsStreamingTest(unittest.TestCase):
+    """Scale-to-whole normalisation on a SINGLE-LEVEL store (drift/AF/cellpose-corrected output)
+    must derive its global percentile from a streamed histogram, not by materialising the whole
+    level (the second OOM vector). For integer data that matches np.percentile over nonzero values
+    to within one intensity bin (histogram CDF vs linear interpolation)."""
+
+    def test_single_level_matches_numpy_percentile(self):
+        du = DimUtils(ome_types.from_xml(_ome_xml(1, 1, 2, 41, 29)), use_channel_axis=True)
+        du.calc_image_dimensions((2, 41, 29))          # C,Y,X (size-1 T,Z dropped)
+        c_idx = du.dim_idx('C')
+        rng = np.random.default_rng(3)
+        im0 = rng.integers(0, 5000, size=tuple(du.im_dim), dtype=np.uint16)
+        im0[im0 < 500] = 0                              # sprinkle background zeros
+
+        seg = SegmentationUtils({'taskDir': tempfile.gettempdir()}, du)
+        mp = {'cellChannels': [1], 'nucChannels': [], 'normalise': 99.9}
+        # single-level store -> streaming histogram path
+        got = seg._compute_norm_params([da.from_array(im0)], mp)
+
+        idx = [slice(None)] * im0.ndim
+        idx[c_idx] = 1
+        valid = im0[tuple(idx)].ravel()
+        valid = valid[valid > 0]
+        lo_ref = np.percentile(valid, 0.1)
+        hi_ref = np.percentile(valid, 99.9)
+
+        self.assertIn(1, got)
+        self.assertLessEqual(abs(got[1][0] - lo_ref), 1.0)
+        self.assertLessEqual(abs(got[1][1] - hi_ref), 1.0)
 
 
 if __name__ == "__main__":

--- a/python/cecelia/utils/intensity_utils.py
+++ b/python/cecelia/utils/intensity_utils.py
@@ -41,18 +41,23 @@ def _n_channels(arr, channel_axis):
     return 1 if channel_axis is None else int(arr.shape[channel_axis])
 
 
-def channel_histograms(arr, channel_axis):
+def channel_histograms(arr, channel_axis, channels=None):
     """
     One integer histogram per channel over the whole stack (all axes except `channel_axis`).
 
     Integer dtype only — the histogram is indexed by pixel value in [0, iinfo(dtype).max]. Returns a
-    list of 1-D numpy arrays (length = max value + 1), one per channel. Streams over dask chunks.
+    list of 1-D numpy arrays (length = max value + 1). Streams over dask chunks (bounded memory).
+
+    `channels`: optional list of channel indices to histogram (default: all). The returned list is
+    aligned with `channels` when given — so callers that only need a subset (e.g. segmentation
+    normalising just its cell/nuc channels) don't pay to scan every channel.
     """
     if not np.issubdtype(arr.dtype, np.integer):
         raise ValueError(f"channel_histograms requires an integer dtype, got {arr.dtype}")
     nbins = int(np.iinfo(arr.dtype).max) + 1
+    chans = range(_n_channels(arr, channel_axis)) if channels is None else channels
     hists = []
-    for c in range(_n_channels(arr, channel_axis)):
+    for c in chans:
         flat = _take_channel(arr, channel_axis, c).ravel()
         if _is_dask(flat):
             hist = da.bincount(flat, minlength=nbins).compute()

--- a/python/cecelia/utils/segmentation_utils.py
+++ b/python/cecelia/utils/segmentation_utils.py
@@ -11,9 +11,11 @@ stardist, etc.).
 import os
 import shutil
 import numpy as np
+import dask.array as da
 import zarr
 
 import cecelia.utils.zarr_utils as zarr_utils
+import cecelia.utils.intensity_utils as intensity_utils
 
 from skimage import morphology, segmentation
 from scipy import ndimage
@@ -257,23 +259,46 @@ class SegmentationUtils:
     # ── Normalisation ─────────────────────────────────────────────────────────
 
     def _compute_norm_params(self, im_dat, model_params):
-        """Compute per-channel percentile clipping range from lowest-res level."""
-        low_res = np.asarray(im_dat[-1])
+        """Per-channel percentile clipping range for scale-to-whole normalisation.
+
+        Scale-to-whole is required — a per-tile/per-frame window would swing with local brightness
+        and give inconsistent masks — so the percentile is GLOBAL. Two ways to get it without a
+        per-tile/frame dependency:
+          • pyramided store → take it from the small lowest-res level (a cheap whole-image proxy),
+            exactly as before.
+          • single-level store (drift/AF/cellpose-corrected outputs, nscales=1) → `im_dat[-1]` IS the
+            full-res level, so materialising it OOMs on large movies. Instead stream a per-value
+            histogram (exact for integer data, ~256 KB/channel regardless of size) and read the
+            percentile off its CDF. Same statistic, bounded memory. See ZARR_STREAMING_PLAN.md.
+        Excludes background zeros in both paths (matches the historical `data[data > 0]`)."""
         c_idx = self.dim_utils.dim_idx('C')
         normalise_perc = float(model_params.get('normalise', 99.9))
+        channels = [int(c) for c in (list(model_params.get('cellChannels', [])) +
+                                     list(model_params.get('nucChannels', [])))]
         result = {}
 
-        all_channels = (list(model_params.get('cellChannels', [])) +
-                        list(model_params.get('nucChannels', [])))
-        for ch in all_channels:
+        if len(im_dat) == 1:
+            # bounded streaming histogram over the (single, full-res) level
+            level = im_dat[0]
+            darr = level if isinstance(level, da.Array) else da.from_array(level)
+            hists = intensity_utils.channel_histograms(darr, c_idx, channels=channels)
+            for ch, hist in zip(channels, hists):
+                hist = hist.copy()
+                hist[0] = 0                       # drop background zeros
+                if int(hist.sum()) > 100:
+                    result[ch] = (float(intensity_utils.hist_percentile(hist, 100 - normalise_perc)),
+                                  float(intensity_utils.hist_percentile(hist, normalise_perc)))
+            return result
+
+        low_res = np.asarray(im_dat[-1])
+        for ch in channels:
             idx = [slice(None)] * low_res.ndim
-            idx[c_idx] = int(ch)
+            idx[c_idx] = ch
             ch_data = low_res[tuple(idx)].ravel()
             valid = ch_data[ch_data > 0]
             if len(valid) > 100:
-                norm_min = float(np.percentile(valid, 100 - normalise_perc))
-                norm_max = float(np.percentile(valid, normalise_perc))
-                result[int(ch)] = (norm_min, norm_max)
+                result[ch] = (float(np.percentile(valid, 100 - normalise_perc)),
+                              float(np.percentile(valid, normalise_perc)))
         return result
 
     # ── Post-processing ───────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #315. That PR bounded the label-stack memory; this fixes the **second** OOM vector on the segmentation path, surfaced while validating #315 on a real image.

## Why
`segmentation_utils._compute_norm_params` (scale-to-whole normalisation) read its global percentile via `np.asarray(im_dat[-1])`. For a **single-level** store — which is exactly what drift/AF/cellpose-corrected outputs are (`create_multiscales`, `nscales=1`), the usual segmentation input — `im_dat[-1]` *is* the full-res level, so it materialised the whole (multi-GB) image in RAM just to compute percentiles. On a large movie that's as big as the label stack #315 fixed.

Scale-to-whole is **required** (a per-tile/frame window swings with local brightness → inconsistent masks), so the percentile stays global — we just gather it without holding the pixels.

## What
- **Single-level store** → stream a per-value histogram (exact for integer data, ~256 KB/channel) and read the percentile off its CDF. Matches `np.percentile` over nonzero values to within one intensity bin. Bounded memory.
- **Pyramided store** → unchanged (cheap small lowest-res level).
- Reuses `intensity_utils` (`channel_histograms` + `hist_percentile`) — the same streaming machinery the 8-bit import rescale uses; `channel_histograms` gains an optional channel subset so only the model's cell/nuc channels are scanned.

## Tests / validation
- 114 Python tests pass; new test pins histogram-CDF percentile ≈ `np.percentile(nonzero)` within one bin.
- Validated end-to-end on a real image (proj 4kS67f / set XcPcu8 image EaMaVq, drift-corrected 3D timeseries, time-cropped): real cellpose cyto2 on GPU, streaming 3D segmentation → 61 cells, identical with the new norm path. Peak label residency ~24 MB/frame-type vs ~4.8 GB whole-movie.

## Reservations
- Single-level norm percentile now uses histogram-CDF vs `np.percentile` linear interpolation (≤1 intensity bin); segmentation output on single-level inputs may shift infinitesimally (it previously OOM'd on large ones).
- Not run through the Julia→`run_py`→napari GUI path (Python layer exercised directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
