### PR TITLE
Centralize native byte-order in zarr writers (plan Phase 3.1)

### DIFF
--- a/docs/todo/ZARR_STREAMING_PLAN.md
+++ b/docs/todo/ZARR_STREAMING_PLAN.md
@@ -55,15 +55,21 @@ multiple planes/tiles per call improves GPU utilization. Low complexity, isolate
 - **Measure before/after** on a real GPU run; keep only if the speedup is real (batch size is a
   tuning knob — too large re-introduces a memory spike, defeating Phase 1). Skip if marginal.
 
-### Phase 3 — cheap cleanups (only while already in the file)
-Each is small; do opportunistically, not as a dedicated sweep.
-- **Centralize byte-order** (`newbyteorder('=')`, the napari big-endian fix) into the writer so tasks
-  stop copy-pasting it. Real dedup, ~zero risk.
-- **Two tilers → one:** `slice_utils.create_slices` vs segmentation's `_create_xy_tiles` overlap.
-  Consolidate **only if** it merges without contortion (they return different shapes today —
-  dim-ordered slice tuples vs read/write/crop triples). Evaluate; don't force it.
-- **Retire `da.store(lock=False)`+rechunk** in `create_multiscales` once crop/rescale (its last dask
-  callers) stream too. Low benefit (it works now) — do only if it removes real complexity.
+### Phase 3 — cheap cleanups
+- **3.1 Centralize byte-order** — ✅ DONE. One helper `zarr_utils.native_dtype` applied by every
+  writer that creates a zarr array (`create_multiscales`, `write_multiscale_pyramid`,
+  `open_multiscales_for_writing`, `create_zarr_from_ndarray`); tasks dropped their scattered
+  `.newbyteorder('=')`. Also fixed latent big-endian output in `cellpose_correct` + `cropImage`.
+- **3.2 Two tilers → one — PARKED (won't do).** `slice_utils.create_slices` (dim-ordered slice
+  tuples) and segmentation's `_create_xy_tiles` (read/write/crop overlap triples) return genuinely
+  different shapes for different needs; merging would contort more than it saves. No real benefit.
+- **3.3 Retire `da.store(lock=False)`+rechunk — PARKED (won't do).** It works correctly today and is
+  regression-tested (`test_zarr_store`); retiring it only pays off if it cleanly removes the branch,
+  which needs crop/rescale migrated too for little gain. Not worth the churn.
+
+**Rework status: complete.** The wins shipped — two OOM vectors (label stack + norm-params) and the
+read-frame-once speed (#315, #317), byte-order dedup (3.1). Phase 2 measured out (no benefit); Phase
+3.2/3.3 parked as churn. Reopen only if a concrete need appears.
 
 ## Explicitly NOT doing (and why)
 

--- a/python/cecelia/tasks/cleanupImages/af_correct_run.py
+++ b/python/cecelia/tasks/cleanupImages/af_correct_run.py
@@ -64,7 +64,7 @@ def run(params):
     # channels + inverses) never lives in RAM (was the OOM on large time-lapses). Size level 0 up
     # front (channel count = C + one per inverse), fill per-channel, then build the pyramid.
     out_shape = correction_utils.af_correction_output_shape(im_dat[0], dim_utils, af_combinations)
-    out_dtype = im_dat[0].dtype.newbyteorder('=')
+    out_dtype = im_dat[0].dtype   # writer forces native byte order (zarr_utils.native_dtype)
     group, level0, pchunks = zarr_utils.open_multiscales_for_writing(
         im_correction_path, out_shape, out_dtype, dim_utils, nscales=len(im_dat))
     correction_utils.af_correct_image(

--- a/python/cecelia/tasks/cleanupImages/cellpose_correct_run.py
+++ b/python/cecelia/tasks/cleanupImages/cellpose_correct_run.py
@@ -54,9 +54,9 @@ def run(params):
     # `fortify(im_dat[0])` — a full T×C×Z×Y×X copy, the OOM on large time-lapses). Create the
     # on-disk level 0, copy the input through one timepoint at a time (so uncorrected channels /
     # frames carry over unchanged), then overwrite only the corrected planes in place below.
-    out_dtype = im_dat[0].dtype
     group, output_image, pchunks = zarr_utils.open_multiscales_for_writing(
-        im_correction_path, im_dat[0].shape, out_dtype, dim_utils, nscales=len(im_dat))
+        im_correction_path, im_dat[0].shape, im_dat[0].dtype, dim_utils, nscales=len(im_dat))
+    out_dtype = output_image.dtype   # native (writer forces byte order via zarr_utils.native_dtype)
     zarr_utils.copy_stream(output_image, im_dat[0], dim_utils)
 
     # Physical pixel size (µm/px); divides the user-supplied µm diameter to get pixels.

--- a/python/cecelia/tasks/cleanupImages/drift_correct_run.py
+++ b/python/cecelia/tasks/cleanupImages/drift_correct_run.py
@@ -58,7 +58,7 @@ def run(params):
     # corrected image never lives in RAM (was the OOM on large time-lapses). Create level 0 up
     # front (shape known from the shifts), fill it per-timepoint, then build the pyramid from disk.
     out_shape, _ = correction_utils.drift_correct_shape(im_dat[0], dim_utils, shifts)
-    out_dtype = im_dat[0].dtype.newbyteorder('=')
+    out_dtype = im_dat[0].dtype   # writer forces native byte order (zarr_utils.native_dtype)
     group, level0, pchunks = zarr_utils.open_multiscales_for_writing(
         im_correction_path, out_shape, out_dtype, dim_utils, nscales=len(im_dat))
     correction_utils.drift_correct_im(

--- a/python/cecelia/tests/test_correction_utils.py
+++ b/python/cecelia/tests/test_correction_utils.py
@@ -64,7 +64,7 @@ class DriftStreamingEquivalenceTest(unittest.TestCase):
             self.assertEqual(tuple(out_shape), tuple(legacy.shape))
             path = os.path.join(d, "drift.ome.zarr")
             _, level0, _ = zu.open_multiscales_for_writing(
-                path, out_shape, arr.dtype.newbyteorder('='), du, nscales=1)
+                path, out_shape, arr.dtype, du, nscales=1)   # writer forces native byte order
             cu.drift_correct_im(arr, du, 0, shifts=shifts, out=level0)
             streamed = zarr.open_group(path, mode="r")["0"][:]
         finally:
@@ -109,7 +109,7 @@ class AfStreamingEquivalenceTest(unittest.TestCase):
             self.assertEqual(tuple(out_shape), tuple(legacy.shape))
             path = os.path.join(d, "af.ome.zarr")
             _, level0, _ = zu.open_multiscales_for_writing(
-                path, out_shape, base.dtype.newbyteorder('='), du, nscales=1)
+                path, out_shape, base.dtype, du, nscales=1)   # writer forces native byte order
             cu.af_correct_image(
                 _src(), af_combinations, dim_utils=du, logfile_utils=_Log(),
                 apply_gaussian=True, apply_gaussian_to_others=True, out=level0)

--- a/python/cecelia/tests/test_zarr_store.py
+++ b/python/cecelia/tests/test_zarr_store.py
@@ -107,6 +107,28 @@ class StreamingWritersTest(unittest.TestCase):
         du.calc_image_dimensions(tuple(shape))
         return du
 
+    def test_writer_forces_native_byteorder(self):
+        # Big-endian source (e.g. >u2 from bioformats2raw) must be stored NATIVE — big-endian
+        # mis-renders in napari/OpenGL on little-endian systems. Both writers coerce; values kept.
+        be = (np.arange(2 * 3 * 4, dtype=np.uint16).reshape(2, 3, 4)).astype(">u2")
+        self.assertFalse(np.dtype(be.dtype).isnative)   # sanity: the source really is big-endian
+        d = tempfile.mkdtemp()
+        try:
+            p1 = os.path.join(d, "stream.zarr")
+            _, level0, _ = zu.open_multiscales_for_writing(p1, be.shape, be.dtype, None, nscales=1)
+            level0[:] = be
+            g1 = zarr.open_group(p1, mode="r")["0"]
+            self.assertTrue(np.dtype(g1.dtype).isnative, "streaming writer left non-native dtype")
+            self.assertTrue(np.array_equal(g1[:], be), "byte-order coercion corrupted values")
+
+            p2 = os.path.join(d, "ms.zarr")
+            zu.create_multiscales(da.from_array(be, chunks=be.shape), p2, nscales=1)
+            g2 = zarr.open_group(p2, mode="r")["0"]
+            self.assertTrue(np.dtype(g2.dtype).isnative, "create_multiscales left non-native dtype")
+            self.assertTrue(np.array_equal(g2[:], be))
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
     def test_copy_stream_roundtrips_timeseries_and_static(self):
         for size_t in (4, 1):   # timeseries (per-frame copy) and static (whole copy)
             du = self._du(size_t=size_t, size_c=2, size_y=13, size_x=11)

--- a/python/cecelia/utils/correction_utils.py
+++ b/python/cecelia/utils/correction_utils.py
@@ -129,9 +129,9 @@ def drift_correct_im(
 
     drift_im_shape_round, first_im_pos = drift_correct_shape(input_array, dim_utils, shifts)
 
-    # Use native byte order — big-endian source data (e.g. >u2 from bioformats2raw)
-    # is not rendered correctly by napari/OpenGL on little-endian systems.
-    result_dtype = input_array.dtype.newbyteorder('=')
+    # The writer owns byte order (zarr_utils.native_dtype): when `out` is a pre-created native store
+    # we match it; the out=None numpy path returns source-order and create_multiscales makes it native.
+    result_dtype = out.dtype if out is not None else input_array.dtype
 
     # `out`, when given, is a pre-created on-disk zarr of `drift_im_shape_round` — each timepoint is
     # written straight to disk so the whole (expanded) corrected image never lives in RAM. When None
@@ -495,8 +495,9 @@ def af_correct_image(input_image, af_combinations, dim_utils, logfile_utils,
     for d in dim_utils.spatial_axis():
         sigma[dim_utils.dim_idx(d)] = gaussian_sigma
 
-    # native byte order — big-endian source (e.g. >u2 from bioformats2raw) mis-renders in napari
-    out_dtype = input_image.dtype.newbyteorder('=')
+    # the writer owns byte order (zarr_utils.native_dtype): match the native `out` store when
+    # streaming; the out=None path returns source-order and create_multiscales makes it native.
+    out_dtype = out.dtype if out is not None else input_image.dtype
 
     # inverse channels are appended after the C corrected channels, in ascending channel order
     inverse_channels = _af_inverse_channels(af_combinations, dim_utils)

--- a/python/cecelia/utils/zarr_utils.py
+++ b/python/cecelia/utils/zarr_utils.py
@@ -61,6 +61,16 @@ def fortify(im_array):
     return im_array
 
 
+def native_dtype(dtype):
+    """Force NATIVE byte order for a STORED dtype. Big-endian data (e.g. `>u2` from bioformats2raw)
+    is not rendered correctly by napari/OpenGL on little-endian systems, so every image store we
+    write must be native-endian. Centralised here and applied by the writers (create_multiscales,
+    write_multiscale_pyramid, open_multiscales_for_writing, create_zarr_from_ndarray) so callers
+    don't each remember `.newbyteorder('=')`. No-op for 1-byte dtypes and already-native data;
+    values are preserved (numpy/zarr convert byte order on write)."""
+    return np.dtype(dtype).newbyteorder('=')
+
+
 def chunks(im_array):
     im_chunks = None
     if isinstance(im_array, zarr.Array):
@@ -292,7 +302,7 @@ def create_zarr_from_ndarray(im_array, dim_utils, reference_zarr=None, im_chunks
         mode='w',
         shape=im_array.shape,
         chunks=im_chunks,
-        dtype=im_array.dtype,
+        dtype=native_dtype(im_array.dtype),
         zarr_format=2,
     )
 
@@ -355,7 +365,7 @@ def create_multiscales(im_array, filepath, dim_utils=None, im_chunks=None,
         # T/C axes (~128 MB chunks) and makes every napari plane access a full-timecourse read.
         pchunks = plane_chunks(im_array.shape, dim_utils)
         dest = multiscales_zarr.create_array(
-            "0", shape=im_array.shape, chunks=pchunks, dtype=im_array.dtype
+            "0", shape=im_array.shape, chunks=pchunks, dtype=native_dtype(im_array.dtype)
         )
         # Rechunk the SOURCE to the destination grid before storing. `da.store(lock=False)` is only safe
         # when each dest chunk has exactly one writer; im_array's own (auto) chunking does NOT align with
@@ -367,7 +377,7 @@ def create_multiscales(im_array, filepath, dim_utils=None, im_chunks=None,
         da.store(im_array.rechunk(pchunks), dest, lock=False)
         im_chunks = list(pchunks)
     elif isinstance(im_array, zarr.Array):
-        dest = multiscales_zarr.create_array("0", shape=im_array.shape, chunks=im_array.chunks, dtype=im_array.dtype)
+        dest = multiscales_zarr.create_array("0", shape=im_array.shape, chunks=im_array.chunks, dtype=native_dtype(im_array.dtype))
         dest[:] = im_array[:]
         im_chunks = chunks(im_array)
     else:
@@ -427,7 +437,7 @@ def write_multiscale_pyramid(multiscales_zarr, level_source, dim_utils, nscales,
         # a chunk larger than the axis — only the chunk layout changes, never the pixel values
         dest_chunks = tuple(max(1, min(c, s)) for c, s in zip(im_chunks, dest_shape))
         dest = multiscales_zarr.create_array(
-            str(i + 1), shape=dest_shape, chunks=dest_chunks, dtype=level_source.dtype)
+            str(i + 1), shape=dest_shape, chunks=dest_chunks, dtype=native_dtype(level_source.dtype))
         if t_idx is None:
             dest[:] = _read(tuple(x))
         else:
@@ -462,7 +472,8 @@ def open_multiscales_for_writing(filepath, shape, dtype, dim_utils,
         axes, nscales, scale_for_axis=scale_for_axis, keyword=keyword)
 
     pchunks = plane_chunks(tuple(shape), dim_utils)
-    level0 = multiscales_zarr.create_array("0", shape=tuple(shape), chunks=pchunks, dtype=dtype)
+    level0 = multiscales_zarr.create_array("0", shape=tuple(shape), chunks=pchunks,
+                                           dtype=native_dtype(dtype))
     return multiscales_zarr, level0, pchunks
 
 


### PR DESCRIPTION
Phase 3 item #1 from `docs/todo/ZARR_STREAMING_PLAN.md`.

## Why
Big-endian source data (`>u2` from bioformats2raw) mis-renders in napari/OpenGL on little-endian systems, so every image store we write must be native-endian. That was enforced by scattered `.newbyteorder('=')` copy-pasted into each task — easy to forget, and `cellpose_correct`/`cropImage` *did* forget (they stored source byte order).

## What
One helper — `zarr_utils.native_dtype(dtype)` — applied by every writer that creates a zarr array: `create_multiscales` (dask/zarr/numpy branches), `write_multiscale_pyramid`, `open_multiscales_for_writing`, `create_zarr_from_ndarray`. Tasks drop their `newbyteorder` calls. Now no output can silently ship big-endian.

- Drift/AF: unchanged (already native).
- **cellpose_correct + cropImage: latent big-endian output fixed** (now native). Values identical — numpy/zarr convert byte order on write.

## Tests
115 pass. New `test_writer_forces_native_byteorder` pins that a big-endian source is stored native by both the streaming writer and `create_multiscales`, with values preserved.

## Reservations
- Behavior change for cellpose_correct/cropImage output byte representation (values identical; a napari-rendering fix).
- Mechanism + value preservation unit-tested; not run through a fresh correction task end-to-end on a big-endian image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)