### PR TITLE
docs: mark ZARR_STREAMING plan complete

### DIFF
--- a/docs/todo/ZARR_STREAMING_PLAN.md
+++ b/docs/todo/ZARR_STREAMING_PLAN.md
@@ -1,8 +1,10 @@
 # Zarr/Dask processing rework — plan
 
-Status: planning (no branch yet). Scope guardrail (Dominik): **don't overengineer — only changes
-with an actual measured benefit.** This doc deliberately marks which candidate changes pay off and
-which are churn to skip.
+Status: **COMPLETE — shipped in PRs #315, #317, #319** (Phase 2 measured out; Phase 3.2/3.3 parked).
+Kept as history for the rationale + locked decisions; the shipped helpers are indexed in
+`INVENTORY.md` (Data access → streaming writers). Scope guardrail (Dominik): **don't overengineer —
+only changes with an actual measured benefit.** This doc deliberately marks which candidate changes
+paid off and which were churn to skip.
 
 ## Goal
 


### PR DESCRIPTION
Tidy-up. Flips the plan doc's stale `Status: planning` to **complete** now that the zarr/dask rework shipped (#315/#317/#319), and notes it's kept as history (rationale + decisions), with the shipped helpers indexed in `INVENTORY.md`. Doc-only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)