### PR TITLE
Add a little vertical space between image name and uid rows

### DIFF
--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -998,6 +998,7 @@ th:hover .resize-handle::after { opacity: 1; }
   align-items: center;
   gap: 0.25rem;
   min-width: 0;
+  margin-top: 0.3rem;
 }
 /* run-history cog + popover (fixed so it escapes the table's horizontal scroll) */
 .runlog-cell { position: relative; display: inline-flex; flex-shrink: 0; }


### PR DESCRIPTION
Tiny spacing tweak in the image table: adds `margin-top: 0.3rem` to `.uid-row` so the image name row and the uid + run-tag row aren't flush against each other.

CSS-only, single line. Not yet viewed rendered live — value judged from the rem math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
