### PR TITLE
Attribute unpooled background ops in the task console

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -676,11 +676,11 @@ function run_batch_movies(task_id::String, project_uid::String, image_uids::Vect
     # the live window, so napari must already be running.
     if isnothing(_viewer()) || !_viewer_alive()
         ws_log(nothing, task_id, "[ERROR] Napari is not running — open an image first, then generate")
-        ws_status(nothing, task_id, "failed", rep)
+        ws_status(nothing, task_id, "failed", rep; fun="movie:batch", pool="viewer")
         _batch_clear!(task_id)
         return nothing
     end
-    ws_status(nothing, task_id, "running", rep)
+    ws_status(nothing, task_id, "running", rep; fun="movie:batch", pool="viewer")
     ws_progress(nothing, task_id, 0, n)
     t_start = Int(get(config, :tStart, 0))
     t_end_v = get(config, :tEnd, nothing)
@@ -719,7 +719,7 @@ function run_batch_movies(task_id::String, project_uid::String, image_uids::Vect
     status    = cancelled ? "cancelled" : (isempty(errors) ? "done" : "failed")
     ws_result(nothing, task_id, rep,
         Dict{String,Any}("done" => done, "total" => n, "errors" => errors, "cancelled" => cancelled))
-    ws_status(nothing, task_id, status, rep; image_uids = image_uids)
+    ws_status(nothing, task_id, status, rep; image_uids = image_uids, fun="movie:batch", pool="viewer")
     _batch_clear!(task_id)
     nothing
 end

--- a/api/src/sockets.jl
+++ b/api/src/sockets.jl
@@ -13,9 +13,14 @@ ws_log(_ws, task_id, line)             = _broadcast_task((; type="task:log",    
 # (task-refresh; see docs/todo/TASK_DATA_REFRESH_PLAN.md). Defaults empty → single-image tasks fall back
 # to `imageUid` on the frontend.
 # `fun` carries the task fun_name so a WS observer (mcp/) can attribute a module-page run to a
-# function for the 10-attempts pattern (chain nodes already carry `fn`; module tasks didn't). Empty
-# for non-task status frames (batch movies). The frontend ignores the extra field.
-ws_status(_ws, task_id, status, uid=""; image_uids=String[], fun="") = _broadcast_task((; type="task:status", taskId=task_id, status=status, imageUid=uid, imageUids=image_uids, fun=fun))
+# function for the 10-attempts pattern (chain nodes already carry `fn`; module tasks didn't).
+# `pool` ATTRIBUTES the work to what governs it — scheduler tasks get theirs from the /api/tasks
+# snapshot (cpu/gpu/io/network), but non-scheduler producers (batch movies, background jobs) never
+# hit that snapshot, so they pass it here ("viewer" for the napari viewer, "job" for jobs.jl work).
+# Without it those show a BLANK pool in the task console. NOT a real scheduler pool (no slot budget) —
+# purely a label so they read as intentional instead of floating unattributed. The frontend ignores
+# both extra fields.
+ws_status(_ws, task_id, status, uid=""; image_uids=String[], fun="", pool="") = _broadcast_task((; type="task:status", taskId=task_id, status=status, imageUid=uid, imageUids=image_uids, fun=fun, pool=pool))
 ws_result(_ws, task_id, uid, meta)     = _broadcast_task((; type="task:result",    taskId=task_id, imageUid=uid, meta=meta))
 
 ws_progress(_ws, task_id, fraction::Float64) =
@@ -77,10 +82,10 @@ function handle_project_export(ws, data)
     isempty(task_id) && return
     if isempty(project_uid) || !isdir(joinpath(projects_dir(), project_uid))
         ws_log(ws, task_id, "[ERROR] Project not found: $project_uid")
-        ws_status(ws, task_id, "failed"); return
+        ws_status(ws, task_id, "failed"; fun="project:export", pool="job"); return
     end
     Threads.@spawn begin
-        ws_status(ws, task_id, "running")
+        ws_status(ws, task_id, "running"; fun="project:export", pool="job")
         bundle = try
             export_project(project_uid;
                 out_dir     = isempty(out_dir) ? default_export_dir() : out_dir,
@@ -90,7 +95,7 @@ function handle_project_export(ws, data)
         catch ex
             ws_log(ws, task_id, "[ERROR] " * sprint(showerror, ex)); ""
         end
-        ws_status(ws, task_id, isempty(bundle) ? "failed" : "done")
+        ws_status(ws, task_id, isempty(bundle) ? "failed" : "done"; fun="project:export", pool="job")
     end
 end
 
@@ -101,10 +106,10 @@ function handle_project_import(ws, data)
     isempty(task_id) && return
     if isempty(bundle) || !isdir(bundle)
         ws_log(ws, task_id, "[ERROR] Bundle not found: $bundle")
-        ws_status(ws, task_id, "failed"); return
+        ws_status(ws, task_id, "failed"; fun="project:import", pool="job"); return
     end
     Threads.@spawn begin
-        ws_status(ws, task_id, "running")
+        ws_status(ws, task_id, "running"; fun="project:import", pool="job")
         uid = try
             import_project(bundle;
                 mode        = mode,
@@ -114,7 +119,7 @@ function handle_project_import(ws, data)
         catch ex
             ws_log(ws, task_id, "[ERROR] " * sprint(showerror, ex)); ""
         end
-        ws_status(ws, task_id, isempty(uid) ? "failed" : "done")
+        ws_status(ws, task_id, isempty(uid) ? "failed" : "done"; fun="project:import", pool="job")
     end
 end
 
@@ -127,19 +132,20 @@ function handle_maintenance_run(ws, data)
     patch_id    = String(get(data, :patchId, ""))
     project_uid = String(get(data, :projectUid, ""))
     apply       = Bool(get(data, :apply, false))
+    fun_lbl     = isempty(patch_id) ? "maintenance" : "maintenance:$patch_id"   # task-console attribution
 
     patch = maintenance_patch(patch_id)
     if isnothing(patch)
         ws_log(ws, task_id, "[ERROR] Unknown data patch: $patch_id")
-        ws_status(ws, task_id, "failed"); return
+        ws_status(ws, task_id, "failed"; fun=fun_lbl, pool="job"); return
     end
     if !isdir(joinpath(projects_dir(), project_uid))
         ws_log(ws, task_id, "[ERROR] Project not found: $project_uid")
-        ws_status(ws, task_id, "failed"); return
+        ws_status(ws, task_id, "failed"; fun=fun_lbl, pool="job"); return
     end
 
     Threads.@spawn begin
-        ws_status(ws, task_id, "running")
+        ws_status(ws, task_id, "running"; fun=fun_lbl, pool="job")
         ok = try
             proj = load_project(project_uid)
             run_maintenance_patch(patch, proj; apply = apply, task_id = task_id,
@@ -148,7 +154,7 @@ function handle_maintenance_run(ws, data)
         catch ex
             ws_log(ws, task_id, "[ERROR] " * sprint(showerror, ex)); false
         end
-        ws_status(ws, task_id, ok ? "done" : "failed")
+        ws_status(ws, task_id, ok ? "done" : "failed"; fun=fun_lbl, pool="job")
     end
 end
 
@@ -171,7 +177,7 @@ function handle_movie_batch(ws, data)
     scale       = get(data, :scale, 1)
     if isempty(image_uids)
         ws_log(ws, task_id, "[ERROR] no images selected for batch movies")
-        ws_status(ws, task_id, "failed", "")
+        ws_status(ws, task_id, "failed", ""; fun="movie:batch", pool="viewer")
         return
     end
     _batch_register!(task_id)
@@ -180,7 +186,7 @@ function handle_movie_batch(ws, data)
     catch e
         @warn "batch movies crashed" exception = e
         ws_log(ws, task_id, "[ERROR] batch crashed: $(sprint(showerror, e))")
-        ws_status(ws, task_id, "failed", first(image_uids))
+        ws_status(ws, task_id, "failed", first(image_uids); fun="movie:batch", pool="viewer")
         _batch_clear!(task_id)
     end
 end

--- a/api/task_console.jl
+++ b/api/task_console.jl
@@ -173,7 +173,12 @@ function handle_ws(raw::AbstractString)
         if type == "task:status"
             id = String(get(msg, :taskId, "")); (isempty(id) || id in SEEN_TERM) && return
             status = String(get(msg, :status, ""))
-            fn = haskey(TASKS, id) ? TASKS[id].fun_name : ""
+            # Non-scheduler producers (batch movies, jobs) carry fun/pool on the event itself — they
+            # never hit the /api/tasks snapshot, so without this their rows show a blank function AND a
+            # blank pool ("floating in space"). Prefer the event's values; fall back to the snapshot's.
+            ev_fun  = String(get(msg, :fun,  ""))
+            ev_pool = String(get(msg, :pool, ""))
+            fn = !isempty(ev_fun) ? ev_fun : (haskey(TASKS, id) ? TASKS[id].fun_name : "")
             push_event!("status", string(col(BOLD, short(id)), " ",
                         col(status_colour(status), status),
                         isempty(fn) ? "" : col(DIM, " ($fn)"));
@@ -182,7 +187,9 @@ function handle_ws(raw::AbstractString)
                 _note_terminal!(id, status)            # collapse to a count, drop the row
             else
                 t = _task!(id)
-                isempty(status) || (t.status = status)
+                isempty(status)  || (t.status = status)
+                isempty(ev_fun)  || (t.fun_name = ev_fun)     # label WS-only ops (else blank FUNCTION)
+                isempty(ev_pool) || (t.pool_name = ev_pool)   # …and their POOL (viewer / job)
                 uid = String(get(msg, :imageUid, "")); isempty(uid) || (t.image_uid = uid)
                 t.updated = Dates.now()
             end

--- a/docs/JOBS.md
+++ b/docs/JOBS.md
@@ -5,6 +5,14 @@ the WebSocket *task rail* (`task:log` / `task:progress` / `task:status`, keyed b
 with a Cancel button) — but the backend machinery and the kind of work they suit are different. This
 doc is the map: what each is, why both exist, and where new code goes.
 
+> **Pool attribution.** A scheduler task's `pool` (cpu/gpu/io/network) is read from the `/api/tasks`
+> snapshot. A background job never hits that snapshot, so it would show a **blank pool** in the task
+> console — it's not scheduler-pooled. To keep it legible (not "floating unattributed"), jobs pass a
+> `pool` *label* on their `ws_status` frames: `"job"` for jobs.jl work (export/import/data patches),
+> `"viewer"` for the napari-viewer batch-movie path. This is a display label only — NOT a real pool
+> with a slot budget (see `ws_status` in `api/src/sockets.jl`, and the task console's `task:status`
+> handling).
+
 ## The two mechanisms
 
 ### Scheduler task — `CciaTask` (`app/src/tasks/scheduler.jl`, `docs/SCHEDULER.md`)


### PR DESCRIPTION
Follow-up to #325. Batch movies and jobs.jl work (project export/import, data patches) stream over the WS task rail but never appear in the `/api/tasks` snapshot, so in the terminal console (`pixi run console`) they showed up with a **blank FUNCTION and blank POOL** — floating unattributed.

Fix (attribution, not throttling): `ws_status` gains an optional `pool` label, and these ops now emit it alongside a `fun` name:
- batch movies → `fun="movie:batch"`, `pool="viewer"`
- export / import → `fun="project:export"/"project:import"`, `pool="job"`
- data patches → `fun="maintenance:<patch>"`, `pool="job"`

The console reads both off the `task:status` event, so those rows now show a real function + a `viewer`/`job` pool instead of two empty columns.

**These are display labels only** — not real scheduler pools (no slot budget, nothing is throttled). One-off/synchronous ops (single-image screenshot & recorders, crop preview, Pluto launch, legacy scan, self-update, AI agent) don't emit `task:status` rows, so they never floated and are intentionally left alone. The frontend GUI ignores the extra fields (its `task:status` handler reads only status/imageUid).

Tests: `pixi run test-api` green; all changed Julia files parse-check clean. Doc note added to `docs/JOBS.md`.

Not verified: the console can't run headless (needs a live server + TTY + an export/movie in flight), so the rendered labels are logic/parse-checked only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
