### PR TITLE
Movie title card: render primitive + Phase H plan (H1)

### DIFF
--- a/docs/todo/ANIMATION_PLAN.md
+++ b/docs/todo/ANIMATION_PLAN.md
@@ -1,8 +1,8 @@
 # Analysis figures & movies (animation)
 
-Status (updated 2026-07-14): **complete.** A, B, C, D, E, G, F1 (F1.1–F1.3) and F2 (MVP + render engine
-+ timeline editor) are all **done/merged**. Supersedes the ad-hoc parts of the image-strip tasks
-(#00032 legend, #00036 zoom-to-source) — both now live on the shared snapshot foundation.
+Status (updated 2026-07-24): A–G + F1/F2 **done/merged**. **Phase H (movie title card) IN PROGRESS**
+— see the H section below. Supersedes the ad-hoc parts of the image-strip tasks (#00032 legend,
+#00036 zoom-to-source) — both now live on the shared snapshot foundation.
 
 ## Goal
 
@@ -199,6 +199,65 @@ matches how figures are actually made; F2 is the advanced follow-on.
     sync napari, update-from-napari, per-keyframe reset + "edited" badge, drag-reorder, timepoint (h/min),
     fps 1–40, amber selection (`--cc-selected`). Decision (2026-07-14): **timeline, not a node graph** —
     a movie is 1-D, so the graph's branching buys nothing.
+
+## H. Movie title card (prepended description slide) — IN PROGRESS
+
+A toggle on movie generation that prepends a short **title card** to the recorded `.mp4` — an
+auto-generated description slide (image name + attributes, the channels shown with their colours, the
+populations/tracks with colours, and the colour-by legend), plus an optional free-text note. Answers
+"which image / mouse / location is this, and what are the colours?" without opening the project or a
+separate doc. Applies to all three movie paths: single record, batch, animation page.
+
+### Decisions (2026-07-24, confirmed with Dominik)
+
+1. **Content = full auto + optional note.** Auto-fill from the image + view: `title` = `img.name`
+   joined with its `img.attr` values ("MERTK — mouse 1 — location B"); a **channels** section
+   (name + colour swatch); a **populations/tracks** section (name + colour); a **colour-by** section
+   (value label + colour); plus one optional user note line. No retyping.
+2. **Duration** default **3 s**, adjustable **1–10 s** per movie.
+3. **On by default.** The toggle defaults ON — every generated movie gets a card unless turned off.
+4. **Reuse the ONE canonical legend source — do not add a third.** Pops + colour-by come from the
+   same Julia helpers behind `POST /api/napari/overlay-legend` (`_colour_overrides_for` /
+   `_pop_labels_for` / `pop_at().name/.colour`); extract a shared `overlay_legend_content(img, …)`
+   in `napari_api.jl` so the endpoint AND the card call it (consolidation, not duplication). The board
+   strip legend + napari strip already consume this — the card must produce identical rows.
+5. **Channels are read from the live napari viewer at record time**, NOT from a hardcoded map.
+   There is no Julia/Python channel-colour function — channel colour lives only in the napari layer
+   state (the frontend `viewLegend.ts`/`napariColormap.ts` approximates it for the board strip, where
+   there's no live viewer). Recording always drives the live window, so at record time the visible
+   image layers carry the authoritative `name` + `colormap`; Python reads `layer.colormap.map([1.0])`
+   → hex. This avoids duplicating the frontend's colormap→hex table.
+6. **Card is composited in Python as a post-record step** (`python/cecelia/utils/title_card.py`),
+   NOT inside napari-animation (its `anim.animate()` writes the mp4 directly; frames aren't exposed).
+   After the movie is written, render N = `duration × fps` title frames (PIL, at the movie's exact
+   resolution + fps) and prepend them, re-writing via **imageio-ffmpeg** (already a dep). One honest
+   cost: this **re-encodes the clip once** — fine for short intravital movies; documented.
+7. **Threading:** one `titleCard: { enabled, note, durationSec }` object (camelCase in JSON/Julia,
+   snake_case in the bridge cmd + Python) flows each frontend → Julia handler → the shared
+   `record_timelapse!` / `record_keyframes!` (`app/src/napari.jl`) → bridge cmd
+   (`napari_bridge.py`) → `napari_utils.record_*` → `title_card`. Non-channel content (title, note,
+   pops, colour-by) is assembled in Julia and passed in `title_card`; channels are added in Python
+   from the live viewer.
+
+### Sub-phases (independently shippable; order H1 → H2 → H3 → H4)
+
+- **H1 — render primitive (backend, unit-tested).** `python/cecelia/utils/title_card.py`:
+  `render_title_card(content, width, height, *, fps, duration_sec) -> list[frames]` and
+  `prepend_title_to_movie(movie_path, content, *, duration_sec)` (reads the movie's fps+size via
+  imageio, renders the card at that size, writes card frames + movie frames to a temp file, replaces
+  the original). `content = { title, note, sections: [{ heading, items: [{label, colour}] }] }`. Pure
+  + testable without napari (`python/cecelia/tests/test_title_card.py`). Add Pillow to the env if not
+  already declared.
+- **H2 — batch path** (richest config; the headline `generateMovies` use). Assemble content in
+  `run_batch_movies` (Julia) per image via the shared `overlay_legend_content` helper + `img.name`/
+  `img.attr`; thread `titleCard` through `record_timelapse!`; add the toggle/note/duration to
+  `BatchMoviesPanel.vue` (config in `utils/batchMovie.ts`). Channels read from the live viewer in
+  `napari_utils.record_timelapse`.
+- **H3 — single record** (`ViewerPanel.vue` → `api_napari_record_timelapse`). No overlay config
+  exists on this path, so the card shows title + channels (+ note); pops/colour-by best-effort/empty.
+- **H4 — animation page** (`AnimationModule.vue` → `record_keyframes`). Card reflects the FIRST
+  keyframe's view; channels read after applying keyframe 0. Pops/colour-by derived from the first
+  keyframe's overlay layers if feasible, else title + channels + note.
 
 ## References
 

--- a/python/cecelia/tests/test_title_card.py
+++ b/python/cecelia/tests/test_title_card.py
@@ -1,0 +1,94 @@
+"""Tests for the movie title-card renderer (docs/todo/ANIMATION_PLAN.md → Phase H).
+
+Pure rendering + the mp4 prepend, exercised without napari (imageio-ffmpeg encodes the tiny fixture
+movie). Run via `pixi run test-py`.
+"""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+from cecelia.utils import title_card as tc
+
+
+class TitleFrameCountTests(unittest.TestCase):
+    def test_fps_times_duration(self):
+        self.assertEqual(tc.title_frame_count(15, 3), 45)
+        self.assertEqual(tc.title_frame_count(24, 2.5), 60)
+
+    def test_never_below_one(self):
+        self.assertEqual(tc.title_frame_count(15, 0), 1)   # zero duration → still 1 frame
+        self.assertEqual(tc.title_frame_count(0, 3), 1)
+        self.assertEqual(tc.title_frame_count(None, None), 1)
+
+
+class HexRgbTests(unittest.TestCase):
+    def test_forms(self):
+        self.assertEqual(tc._hex_rgb("#00ff00"), (0, 255, 0))
+        self.assertEqual(tc._hex_rgb("00ff00"), (0, 255, 0))
+        self.assertEqual(tc._hex_rgb("f00"), (255, 0, 0))       # shorthand
+
+    def test_invalid_is_none(self):
+        for bad in ("", None, "nope", "#12", "#1234567"):
+            self.assertIsNone(tc._hex_rgb(bad))
+
+
+class RenderCardFrameTests(unittest.TestCase):
+    CONTENT = {
+        "title": "MERTK — mouse 1 — location B",
+        "sections": [
+            {"heading": "Channels", "items": [{"label": "gBT", "colour": "#00ff00"},
+                                              {"label": "SHG", "colour": "#808080"}]},
+            {"heading": "Tracks",   "items": [{"label": "T cells", "colour": "#00bfff"}]},
+        ],
+        "note": "15s intravital, day 3",
+    }
+
+    def test_shape_and_dtype(self):
+        arr = tc.render_card_frame(self.CONTENT, 400, 300)
+        self.assertEqual(arr.shape, (300, 400, 3))
+        self.assertEqual(arr.dtype, np.uint8)
+
+    def test_draws_content_and_swatch(self):
+        arr = tc.render_card_frame(self.CONTENT, 400, 300)
+        # not just background — text/swatches were drawn
+        self.assertTrue((arr > 40).any())
+        # the pure-green channel swatch shows up (high green, low red/blue somewhere)
+        green = (arr[:, :, 1] > 180) & (arr[:, :, 0] < 80) & (arr[:, :, 2] < 80)
+        self.assertTrue(green.any())
+
+    def test_empty_content_is_blank_card(self):
+        arr = tc.render_card_frame({}, 200, 120)
+        self.assertEqual(arr.shape, (120, 200, 3))          # no crash, just the background
+
+    def test_sections_without_items_skipped(self):
+        arr = tc.render_card_frame({"title": "T", "sections": [{"heading": "Empty", "items": []}]}, 200, 120)
+        self.assertEqual(arr.shape, (120, 200, 3))
+
+
+class PrependTests(unittest.TestCase):
+    def test_prepends_card_frames(self):
+        import imageio.v2 as imageio
+        d = tempfile.mkdtemp()
+        path = os.path.join(d, "movie.mp4")
+        # a tiny 6-frame movie with even dimensions (yuv420p-safe)
+        with imageio.get_writer(path, fps=10, macro_block_size=1) as w:
+            for i in range(6):
+                w.append_data(np.full((120, 160, 3), min(255, i * 40), dtype=np.uint8))
+
+        n = tc.prepend_title_to_movie(path, {"title": "Test"}, duration_sec=1.0)
+        self.assertEqual(n, 10)                              # 10 fps × 1s
+
+        with imageio.get_reader(path) as r:
+            total = sum(1 for _ in r)
+        # card frames + the 6 originals (allow a small codec fudge on re-encode)
+        self.assertGreaterEqual(total, n + 6 - 2)
+        # first frame should now be the card (near-uniform dark bg), distinct from the movie's frame 0
+        with imageio.get_reader(path) as r:
+            first = r.get_data(0)
+        self.assertLess(int(first.mean()), 120)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/cecelia/utils/title_card.py
+++ b/python/cecelia/utils/title_card.py
@@ -1,0 +1,167 @@
+"""Movie title card — render a description slide and prepend it to a recorded .mp4.
+
+Part of the animation title-card feature (docs/todo/ANIMATION_PLAN.md → Phase H). A recorded movie is
+written by napari-animation's ``Animation.animate()`` (frames not exposed), so the card is composited
+as a POST-record step here: render N = ``duration × fps`` still frames of a dark slide (image name +
+attributes, channel/population/colour-by legend rows with colour swatches, an optional note) at the
+movie's exact resolution, then rewrite the file with those frames prepended. The rewrite re-encodes
+the clip once (acceptable for short movies).
+
+Content is passed in as a plain dict (assembled by the caller from the CANONICAL legend source — see
+Phase H, decision 4; channels are added by the recorder from the live viewer, decision 5):
+
+    content = {
+      "title":    "MERTK — mouse 1 — location B",     # image name + attrs
+      "note":     "15s intravital, day 3",             # optional free-text line ("" to omit)
+      "sections": [                                     # legend blocks, in display order
+        {"heading": "Channels",  "items": [{"label": "gBT", "colour": "#00ff00"}, …]},
+        {"heading": "Tracks",    "items": [{"label": "T cells", "colour": "#00bfff"}]},
+        {"heading": "Colour by", "items": [{"label": "Directed", "colour": "#ff1493"}, …]},
+      ],
+    }
+
+Pure + testable without napari (only PIL + numpy for rendering; imageio only for the prepend, both
+already in the env via scikit-image / imageio-ffmpeg). See python/cecelia/tests/test_title_card.py.
+"""
+import os
+
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+
+# Dark palette matched to the app surface (not exact tokens — this renders to pixels, not CSS).
+_BG        = (11, 11, 18)
+_FG_TITLE  = (240, 240, 245)
+_FG_HEAD   = (150, 150, 160)
+_FG_LABEL  = (222, 222, 228)
+_FG_NOTE   = (170, 170, 180)
+_SWATCH_BORDER = (255, 255, 255)
+
+
+def _font(size):
+    """A font at ``size`` px. Prefers the scalable built-in (Pillow ≥ 10), then a bundled TrueType,
+    then the fixed default — so we never hard-depend on a font file being present."""
+    size = max(8, int(size))
+    try:
+        return ImageFont.load_default(size=size)          # Pillow ≥ 10 scales the built-in
+    except TypeError:
+        pass
+    for name in ("DejaVuSans.ttf", "Arial.ttf", "LiberationSans-Regular.ttf"):
+        try:
+            return ImageFont.truetype(name, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _hex_rgb(value):
+    """'#00ff00' / '00ff00' / 'f00' → (r, g, b); None for missing/invalid (→ no swatch drawn)."""
+    if not value:
+        return None
+    s = str(value).lstrip("#")
+    if len(s) == 3:
+        s = "".join(c * 2 for c in s)
+    if len(s) != 6:
+        return None
+    try:
+        return (int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16))
+    except ValueError:
+        return None
+
+
+def title_frame_count(fps, duration_sec):
+    """Number of still frames for the card = fps × duration, at least 1."""
+    return max(1, int(round(float(fps or 0) * float(duration_sec or 0))))
+
+
+def render_card_frame(content, width, height):
+    """Render the title card once as an (H, W, 3) uint8 RGB array. Content that overflows the height
+    is clipped (movies are tall enough for the small legend in practice); long lines are ellipsised."""
+    width = max(2, int(width))
+    height = max(2, int(height))
+    img = Image.new("RGB", (width, height), _BG)
+    d = ImageDraw.Draw(img)
+    margin = max(16, int(width * 0.045))
+    x = margin
+    y = margin
+    max_w = width - 2 * margin
+
+    def text_h(font, sample="Ag"):
+        b = d.textbbox((0, 0), sample, font=font)
+        return b[3] - b[1]
+
+    def clip(s, font):
+        if d.textlength(s, font=font) <= max_w:
+            return s
+        while s and d.textlength(s + "…", font=font) > max_w:
+            s = s[:-1]
+        return (s + "…") if s else s
+
+    def line(px, py, s, font, fill):
+        d.text((px, py), s, font=font, fill=fill)
+        return int(text_h(font) * 1.35)
+
+    title = str(content.get("title") or "").strip()
+    if title:
+        tf = _font(height * 0.06)
+        y += line(x, y, clip(title, tf), tf, _FG_TITLE) + int(height * 0.02)
+
+    head_f = _font(height * 0.032)
+    label_f = _font(height * 0.030)
+    row_h = int(text_h(label_f) * 1.5)
+    swatch = int(text_h(label_f))
+
+    for section in (content.get("sections") or []):
+        items = section.get("items") or []
+        if not items:
+            continue
+        heading = str(section.get("heading") or "").strip()
+        if heading:
+            y += line(x, y, heading, head_f, _FG_HEAD) + int(height * 0.006)
+        for it in items:
+            rgb = _hex_rgb(it.get("colour"))
+            label_x = x
+            if rgb is not None:
+                d.rectangle([x, y + 2, x + swatch, y + 2 + swatch], fill=rgb, outline=_SWATCH_BORDER)
+                label_x = x + swatch + int(swatch * 0.5)
+            d.text((label_x, y), clip(str(it.get("label") or ""), label_f), font=label_f, fill=_FG_LABEL)
+            y += row_h
+        y += int(height * 0.015)
+
+    note = str(content.get("note") or "").strip()
+    if note:
+        nf = _font(height * 0.028)
+        y += int(height * 0.01)
+        d.text((x, y), clip(note, nf), font=nf, fill=_FG_NOTE)
+
+    return np.asarray(img, dtype=np.uint8)
+
+
+def prepend_title_to_movie(movie_path, content, *, duration_sec=3.0):
+    """Prepend the rendered title card to an existing .mp4, rewriting it in place. Reads the movie's
+    fps + frame size (so the card matches exactly), writes card frames then the movie's frames to a
+    temp file, and atomically replaces the original. Returns the number of card frames prepended.
+    Re-encodes the clip once (the source frames are read back and re-written)."""
+    import imageio.v2 as imageio   # local import: only the prepend step needs it, keeps render_* light
+
+    movie_path = str(movie_path)
+    with imageio.get_reader(movie_path) as r:
+        meta = r.get_meta_data()
+        fps = float(meta.get("fps") or 15)
+        frame0 = r.get_data(0)
+    height, width = int(frame0.shape[0]), int(frame0.shape[1])
+
+    card = render_card_frame(content, width, height)
+    n = title_frame_count(fps, duration_sec)
+
+    tmp = movie_path + ".tmp.mp4"
+    # macro_block_size=1 keeps the card + source frames at their exact (even) dimensions — no resize,
+    # so the appended source frames always match the writer's frame size.
+    with imageio.get_writer(tmp, fps=fps, codec="libx264", quality=8,
+                            macro_block_size=1, pixelformat="yuv420p") as out, \
+            imageio.get_reader(movie_path) as r2:
+        for _ in range(n):
+            out.append_data(card)
+        for frame in r2:
+            out.append_data(frame)
+    os.replace(tmp, movie_path)
+    return n


### PR DESCRIPTION
First slice (**H1**) of the auto-generated movie title card (`docs/todo/ANIMATION_PLAN.md` → Phase H): a description slide prepended to recorded movies — image name + attributes, the channels/populations/colour-by shown (with colour swatches), and an optional note. Confirmed with Dominik: full-auto content + note, 3s default (1–10s), on by default.

**This PR = the backend render primitive only** (`python/cecelia/utils/title_card.py`):
- `render_card_frame(content, w, h)` → dark slide at the movie's exact resolution (title, legend sections with swatches, note; long lines ellipsised).
- `prepend_title_to_movie(path, content, duration_sec)` → reads the movie's fps/size, prepends `fps×duration` card frames, rewrites via imageio-ffmpeg (re-encodes once — fine for short clips).
- Pure/testable without napari; **9 unit tests** pass (frame count, hex parsing, render shape + green-swatch presence, empty content, real mp4 prepend round-trip).

**Not yet wired** — it's dead code until the wiring slices land, kept separate so this is a small reviewable foundation:
- **H2** batch (richest config; the `generateMovies` path)
- **H3** single record
- **H4** animation page

Content will be assembled from the **canonical** legend source (pops/colour-by via the same Julia helpers behind `/api/napari/overlay-legend`, extracted into a shared `overlay_legend_content`; channels read from the live viewer at record time) — no third legend implementation.

Note: opened from a fresh worktree branch (`feat/movie-title-card-v2`) to avoid a shared-checkout tangle; unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
