### PR TITLE
Add image version picker to the crop dialog

### DIFF
--- a/frontend/src/components/CropDialog.vue
+++ b/frontend/src/components/CropDialog.vue
@@ -5,6 +5,7 @@
   See docs/todo/CROP_PANEL_PLAN.md.
 -->
 <script setup lang="ts">
+import { ref, computed } from 'vue'
 import BaseModal from './BaseModal.vue'
 import CropPanel from './CropPanel.vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
@@ -14,19 +15,49 @@ const props = defineProps<{ image: CciaImage; setUid: string }>()
 defineEmits<{ (e: 'close'): void }>()
 
 const projectMeta = useProjectMetaStore()
+
+// Every registered version/iteration of this image is a valid crop source (drift/AF/cellpose-corrected
+// variants are the norm, not just 'default'). Offer them all; default to the active one. Mirrors the
+// version selector in ViewerPanel.vue. Empty → the backend falls back to 'default'.
+const valueNames = computed(() => Object.keys(props.image.filepaths ?? {}))
+const selectedValueName = ref(defaultValueName())
+function defaultValueName(): string {
+  const names = valueNames.value
+  const nonDefault = names.filter(n => n !== 'default')
+  return props.image.activeValueName && names.includes(props.image.activeValueName) ? props.image.activeValueName
+    : nonDefault.length > 0 ? nonDefault[nonDefault.length - 1]
+    : names.includes('default') ? 'default' : (names[0] ?? '')
+}
 </script>
 
 <template>
   <BaseModal width="640px" @close="$emit('close')">
     <template #title>
       <i class="pi pi-image" /> Crop — {{ image.name }}
+      <span v-if="selectedValueName" class="crop-version-tag">{{ selectedValueName }}</span>
     </template>
-    <!-- crop the ACTIVE version (drift/AF/cellpose-corrected variants are the norm, not 'default');
-         empty → the backend falls back to 'default' -->
+    <div v-if="valueNames.length > 1" class="crop-version-row">
+      <span class="crop-version-lbl" v-tooltip.right="'Which image version/iteration to crop'">Version</span>
+      <select v-model="selectedValueName" class="crop-version-select">
+        <option v-for="vn in valueNames" :key="vn" :value="vn">{{ vn }}</option>
+      </select>
+    </div>
     <CropPanel :project-uid="projectMeta.current?.uid ?? ''"
                :image-uid="image.uid"
                :image-name="image.name"
-               :value-name="image.activeValueName ?? ''"
+               :value-name="selectedValueName"
                :set-uid="setUid" />
   </BaseModal>
 </template>
+
+<style scoped>
+.crop-version-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem; }
+.crop-version-lbl { color: var(--cc-text-muted, #888); font-size: 0.7rem; }
+.crop-version-select { flex: 0 1 auto; }
+.crop-version-tag {
+  margin-left: 0.4rem; padding: 0.05rem 0.4rem; border-radius: 0.5rem;
+  font-size: 0.62rem; font-weight: 600; vertical-align: middle;
+  color: var(--cc-accent, #a855f7);
+  background: color-mix(in srgb, var(--cc-accent, #a855f7) 15%, transparent);
+}
+</style>

--- a/frontend/src/components/CropPanel.vue
+++ b/frontend/src/components/CropPanel.vue
@@ -164,8 +164,11 @@ function save() {
 
 <style scoped>
 .crop-panel { display: flex; flex-direction: column; gap: 0.4rem; }
-.crop-view { position: relative; display: inline-block; line-height: 0; cursor: crosshair; touch-action: none; user-select: none; }
-.crop-img { max-width: 100%; border: 1px solid var(--cc-border, #2a2a2a); border-radius: 0.3rem; background: #000; }
+/* Fill the modal width so switching versions doesn't jump the preview size — the server downsamples each
+   version's MIP by an INTEGER factor to a ≤512px long side, so different native dims render at different
+   pixel sizes. width:100% pins the width; only the true aspect ratio (height) varies between versions. */
+.crop-view { position: relative; display: block; width: 100%; line-height: 0; cursor: crosshair; touch-action: none; user-select: none; }
+.crop-img { display: block; width: 100%; height: auto; border: 1px solid var(--cc-border, #2a2a2a); border-radius: 0.3rem; background: #000; }
 .crop-placeholder { display: flex; align-items: center; justify-content: center; width: 100%; min-height: 8rem; color: var(--cc-text-muted, #888); }
 .crop-rect { position: absolute; border: 1.5px solid var(--cc-accent, #a855f7); background: color-mix(in srgb, var(--cc-accent, #a855f7) 12%, transparent); pointer-events: none; }
 .crop-loading { position: absolute; top: 0.3rem; right: 0.3rem; color: var(--cc-accent); font-size: 0.8rem; }


### PR DESCRIPTION
## What

The in-app crop dialog was locked to the image's **active** version. This adds a **version dropdown** so you can crop any registered iteration (default / drift-corrected / AF-corrected / cellpose-corrected variants).

- Dropdown appears when an image has more than one registered version; defaults to the active one (reuses the selection logic from `ViewerPanel.vue`'s napari version picker).
- Selected version shown as a **tag in the dialog title**.
- The chosen `valueName` is passed to `CropPanel` instead of the fixed `image.activeValueName`.

## Why frontend-only

The whole backend chain — `/api/crop/info`, `/api/crop/frame`, and the `editImages.cropImage` task — already accepted a `valueName` param end-to-end (and records `crop_source_value_name` on the new image). Nothing on the Julia/Python side needed changing.

## Preview size fix

Switching versions used to jump the preview size: the server downsamples each version's z-MIP by an integer factor to a ≤512px long side, so versions with different native XY dims render at different pixel sizes. The preview `<img>` now uses `width: 100%` (fills the modal), so only the true aspect ratio varies between versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
