### PR TITLE
Movie title card: batch path (H2)

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -664,6 +664,40 @@ _batch_cancelled(id)      = lock(() -> get(_batch_cancel, id, false),           
 _batch_clear!(id)         = lock(() -> delete!(_batch_cancel, id),                        _batch_cancel_lock)
 request_batch_cancel!(id) = lock(() -> (haskey(_batch_cancel, id) && (_batch_cancel[id] = true); nothing), _batch_cancel_lock)
 
+# Assemble the Julia-side title-card content for an image under a movie config (Phase H). Title = image
+# name + its attribute values ("MERTK — mouse 1 — location B"); the colour-by section from the CANONICAL
+# `overlay_legend_content` helper. CHANNELS are NOT added here — the recorder adds them from the live
+# viewer (the only place channel colour lives). Returns `nothing` when the card is disabled/absent so the
+# recorder skips it. (Point-population rows are a deferred follow-up — see ANIMATION_PLAN.md → H.)
+function _title_card_content(img, config)
+    tc = get(config, :titleCard, nothing)
+    (tc === nothing || !(tc isa AbstractDict) || !Bool(get(tc, :enabled, false))) && return nothing
+
+    attrs = String[]
+    if img.attr isa AbstractDict
+        for k in sort(collect(keys(img.attr)))
+            v = strip(String(img.attr[k])); isempty(v) || push!(attrs, v)
+        end
+    end
+    title = join(vcat([img.name], attrs), " — ")
+
+    sections = Vector{Dict{String,Any}}()
+    column   = String(get(config, :colourBy, ""))
+    if !isempty(column)
+        legend = overlay_legend_content(img, column, nothing, get(config, :colourOverrides, nothing))
+        items  = [Dict{String,Any}("label" => it["label"], "colour" => it["colour"]) for it in legend.colourBy["items"]]
+        isempty(items) || push!(sections, Dict{String,Any}("heading" => "Colour by", "items" => items))
+    end
+
+    Dict{String,Any}(
+        "enabled"     => true,
+        "durationSec" => Float64(get(tc, :durationSec, 3.0)),
+        "title"       => title,
+        "note"        => String(get(tc, :note, "")),
+        "sections"    => sections,   # the recorder prepends a "Channels" section from the live viewer
+    )
+end
+
 # F1.3 batch runner — invoked async from the WS layer (`movie:batch`). For each image: apply the config,
 # record the T-sweep to an attr-named mp4, emit task:progress/log so it drives the existing task UI. `rep`
 # = representative uid for status/result. Errors on one image are logged and the batch continues.
@@ -705,7 +739,8 @@ function run_batch_movies(task_id::String, project_uid::String, image_uids::Vect
                 _apply_movie_config!(project_uid, uid, img, config)
                 v = _viewer()
                 v === nothing && error("Napari not running")
-                record_timelapse!(v, path; fps = fps, scale = scale, t_start = t_start, t_end = t_end)
+                record_timelapse!(v, path; fps = fps, scale = scale, t_start = t_start, t_end = t_end,
+                                  title_card = _title_card_content(img, config))
             end
             done += 1
             ws_log(nothing, task_id, "[$i/$n] done → $(basename(path))")
@@ -973,14 +1008,53 @@ _pop_labels_for(img, column::AbstractString, pop_types) =
 # Merge the client's user colour overrides ({value(str) => hex}, from recolouring a legend swatch) on
 # TOP of the pop-derived overrides — the user's explicit choice wins (categories with no population have
 # no colour defined anywhere, so this is the only source; for pop-backed values it's a display override).
-function _merge_user_overrides!(overrides::Dict{String,String}, data)::Dict{String,String}
-    user = get(data, :colourOverrides, nothing)
-    user === nothing && return overrides
+function _apply_user_overrides!(overrides::Dict{String,String}, user)::Dict{String,String}
+    (user === nothing || !(user isa AbstractDict)) && return overrides
     for (k, v) in pairs(user)
         (v === nothing || isempty(String(v))) && continue
         overrides[String(k)] = String(v)
     end
     overrides
+end
+_merge_user_overrides!(overrides::Dict{String,String}, data)::Dict{String,String} =
+    _apply_user_overrides!(overrides, get(data, :colourOverrides, nothing))
+
+# CANONICAL legend content for an image's overlays — the single source of truth shared by the
+# overlay-legend endpoint (strip legend / napari strip, Phase C) AND the movie title card (Phase H),
+# so all three read identical rows. Pure (no viewer). Given a `column` (colour-by measure), the
+# `overlay_pops` list ({valueName, popType, path} or nothing) and user recolours, returns:
+#  • colourBy: {column, items:[{value, colour(pop hex), label(pop name)}]} for each value on `column`
+#  • populations: [{name, colour}] for each requested point/track pop (deduped by name).
+function overlay_legend_content(img, column::AbstractString, overlay_pops, user_overrides)
+    pt_all  = ("trackclust", "track", "clust", "flow")
+    colours = _apply_user_overrides!(_colour_overrides_for(img, column, pt_all), user_overrides)
+    labels  = _pop_labels_for(img, column, pt_all)
+    cby = [Dict{String,Any}("value" => k, "colour" => colours[k], "label" => get(labels, k, k))
+           for k in sort(collect(keys(colours)))]
+
+    pops = Vector{Dict{String,Any}}()
+    if overlay_pops !== nothing
+        seen = Set{String}()   # dedupe by pop NAME — one pop spans segmentations (one layer each)
+        for pp in overlay_pops
+            vn   = String(get(pp, :valueName, ""))
+            pt   = String(get(pp, :popType, ""))
+            path = String(get(pp, :path, ""))
+            (isempty(vn) || isempty(pt)) && continue
+            if endswith(path, "_tracked")   # whole-segmentation "all tracks" → one generic grey row
+                if !("tracks" in seen); push!(seen, "tracks"); push!(pops, Dict{String,Any}("name" => "tracks", "colour" => "#9ca3af")); end
+                continue
+            end
+            try
+                p = pop_at(_live_map(img, vn, pt), path)
+                p.name in seen && continue
+                push!(seen, p.name)
+                push!(pops, Dict{String,Any}("name" => p.name, "colour" => p.colour))
+            catch
+                # pop map / path unavailable → skip
+            end
+        end
+    end
+    (; colourBy = Dict{String,Any}("column" => column, "items" => cby), populations = pops)
 end
 
 # ── REST: POST /api/napari/colour-labels ──────────────────────────────────────
@@ -1033,42 +1107,9 @@ function api_napari_overlay_legend(body_bytes::Vector{UInt8})
     column      = String(get(data, :colourBy, ""))
     img, err = _gating_image(project_uid, image_uid)
     err === nothing || return err
-
-    # colour-by legend: pop colour + pop name per value on `column`, plus any user recolours
-    pt_all  = ("trackclust", "track", "clust", "flow")
-    colours = _merge_user_overrides!(_colour_overrides_for(img, column, pt_all), data)
-    labels  = _pop_labels_for(img, column, pt_all)
-    cby = [Dict{String,Any}("value" => k, "colour" => colours[k], "label" => get(labels, k, k))
-           for k in sort(collect(keys(colours)))]
-
-    # population legend: name + colour from each requested pop's map — points AND track/track-cluster
-    # ribbons. Entries that aren't a named population (e.g. the whole-segmentation "/_tracked" layer) fail
-    # `pop_at` and are skipped, so only real pops get a legend row.
-    pops = Vector{Dict{String,Any}}()
-    req  = get(data, :overlayPops, nothing)
-    if req !== nothing
-        seen = Set{String}()   # dedupe by pop NAME — the same cluster/pop spans segmentations (one layer
-        for pp in req          # each) but is ONE population in the legend (no "Meandering" ×N).
-            vn = String(get(pp, :valueName, ""))
-            pt = String(get(pp, :popType, ""))
-            path = String(get(pp, :path, ""))
-            (isempty(vn) || isempty(pt)) && continue
-            # whole-segmentation "all tracks" overlay isn't a named pop → one generic grey "tracks" row
-            if endswith(path, "_tracked")
-                if !("tracks" in seen); push!(seen, "tracks"); push!(pops, Dict{String,Any}("name" => "tracks", "colour" => "#9ca3af")); end
-                continue
-            end
-            try
-                p = pop_at(_live_map(img, vn, pt), path)
-                p.name in seen && continue
-                push!(seen, p.name)
-                push!(pops, Dict{String,Any}("name" => p.name, "colour" => p.colour))
-            catch
-                # pop map / path unavailable → skip this entry
-            end
-        end
-    end
-    200, JSON3.write((; ok = true, colourBy = Dict("column" => column, "items" => cby), populations = pops))
+    content = overlay_legend_content(img, column, get(data, :overlayPops, nothing),
+                                     get(data, :colourOverrides, nothing))
+    200, JSON3.write((; ok = true, colourBy = content.colourBy, populations = content.populations))
 end
 
 # ── REST: POST /api/napari/start-selection ────────────────────────────────────

--- a/app/src/napari.jl
+++ b/app/src/napari.jl
@@ -226,10 +226,14 @@ apply_view_state!(v::NapariViewer, snapshot) =
 # path). `fps`/`scale` control frame rate + supersampling; `t_start`/`t_end` bound the range (default
 # the whole stack). Phase F1 batch-movie primitive — see docs/todo/ANIMATION_PLAN.md.
 record_timelapse!(v::NapariViewer, path::String; fps::Int=15, canvas_only::Bool=true,
-                  scale::Real=1, t_start::Int=0, t_end::Union{Int,Nothing}=nothing)::Dict{String,Any} = begin
+                  scale::Real=1, t_start::Int=0, t_end::Union{Int,Nothing}=nothing,
+                  title_card=nothing)::Dict{String,Any} = begin
     cmd = Dict{String,Any}("type"=>"record_timelapse", "path"=>path, "fps"=>fps,
                            "canvas_only"=>canvas_only, "scale"=>scale, "t_start"=>t_start)
     t_end !== nothing && (cmd["t_end"] = t_end)
+    # Phase H: an optional title-card slide prepended to the recording (assembled in api/napari_api.jl;
+    # the bridge adds channels from the live viewer and composites it). nothing/disabled → no card.
+    title_card !== nothing && (cmd["title_card"] = title_card)
     send(v, cmd)
 end
 

--- a/docs/todo/ANIMATION_PLAN.md
+++ b/docs/todo/ANIMATION_PLAN.md
@@ -248,11 +248,17 @@ separate doc. Applies to all three movie paths: single record, batch, animation 
   the original). `content = { title, note, sections: [{ heading, items: [{label, colour}] }] }`. Pure
   + testable without napari (`python/cecelia/tests/test_title_card.py`). Add Pillow to the env if not
   already declared.
-- **H2 — batch path** (richest config; the headline `generateMovies` use). Assemble content in
-  `run_batch_movies` (Julia) per image via the shared `overlay_legend_content` helper + `img.name`/
-  `img.attr`; thread `titleCard` through `record_timelapse!`; add the toggle/note/duration to
-  `BatchMoviesPanel.vue` (config in `utils/batchMovie.ts`). Channels read from the live viewer in
-  `napari_utils.record_timelapse`.
+- **~~H2 — batch path~~ — DONE (scoped)** (richest config; the headline `generateMovies` use).
+  `overlay_legend_content` extracted in `napari_api.jl` and reused by the overlay-legend endpoint AND
+  `_title_card_content(img, config)` (title = `img.name` + attr values; **colour-by** section from the
+  shared helper). `titleCard {enabled, note, durationSec}` threads `run_batch_movies` →
+  `record_timelapse!` (`napari.jl`) → bridge → `napari_utils.record_timelapse`, which reads the
+  **Channels** section from the live viewer (`_visible_channel_legend`, colormap→hex) and prepends the
+  card best-effort (`_maybe_prepend_title` — never fails the recording). Frontend toggle/note/duration
+  in `BatchMoviesPanel.vue` (config + clamp in `utils/batchMovie.ts`, default ON), persisted per set.
+  **Deferred:** the explicit point-**populations** rows (deriving the exact shown-pop set from the
+  batch config robustly needs care; the colour-by section already covers the split-by-cluster case).
+  Card content so far = title + channels + colour-by + note.
 - **H3 — single record** (`ViewerPanel.vue` → `api_napari_record_timelapse`). No overlay config
   exists on this path, so the card shows title + channels (+ note); pops/colour-by best-effort/empty.
 - **H4 — animation page** (`AnimationModule.vue` → `record_keyframes`). Card reflects the FIRST

--- a/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
+++ b/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
@@ -18,7 +18,7 @@ import { useTaskStore } from '../../stores/tasks'
 import { useWsStore } from '../../stores/ws'
 import { useLogStore } from '../../stores/log'
 import { CHANNEL_COLORMAP_OPTIONS } from '../../utils/napariColormap'
-import { buildBatchMovieConfig, movieFilename, seedConfigFromViewState, defaultChannelSeed, MOVIE_CHANNELS_TOKEN, type BatchMovieCfg } from '../../utils/batchMovie'
+import { buildBatchMovieConfig, movieFilename, seedConfigFromViewState, defaultChannelSeed, MOVIE_CHANNELS_TOKEN, TITLE_CARD_DEFAULT, type BatchMovieCfg, type TitleCardCfg } from '../../utils/batchMovie'
 import SwatchSelect, { type SwatchOption } from '../../components/SwatchSelect.vue'
 import ChipSelect, { type ChipOption } from '../../components/ChipSelect.vue'
 import TaskList from '../../tasks/TaskList.vue'
@@ -63,6 +63,14 @@ const colourLabels = computed<boolean>({ get: () => !!cfg.value.colourLabels,   
 const popType      = computed<string>({ get: () => cfg.value.popType ?? 'flow',      set: v => patch({ popType: v }) })
 const tailWidth    = computed<number>({ get: () => cfg.value.tailWidth ?? 4,         set: v => patch({ tailWidth: v }) })
 const pointsSize   = computed<number>({ get: () => cfg.value.pointsSize ?? 6,        set: v => patch({ pointsSize: v }) })
+
+// Title card (Phase H) — merge-patch so each control keeps the others' values.
+function patchTitle(p: Partial<TitleCardCfg>) {
+  patch({ titleCard: { ...TITLE_CARD_DEFAULT, ...(cfg.value.titleCard ?? {}), ...p } })
+}
+const titleCardOn = computed<boolean>({ get: () => cfg.value.titleCard?.enabled ?? TITLE_CARD_DEFAULT.enabled, set: v => patchTitle({ enabled: v }) })
+const titleNote   = computed<string>({  get: () => cfg.value.titleCard?.note ?? '',                                set: v => patchTitle({ note: v }) })
+const titleDur    = computed<number>({  get: () => cfg.value.titleCard?.durationSec ?? TITLE_CARD_DEFAULT.durationSec, set: v => patchTitle({ durationSec: Math.min(10, Math.max(1, v)) }) })
 
 // channel-colormap picker options: a leading "hidden" (no colour) + the standard swatch palette
 const colormapOpts: SwatchOption[] = [
@@ -293,6 +301,25 @@ async function previewOpen() {
         <p class="bm-preview">→ movies/<b>{{ filenamePreview }}</b></p>
       </section>
 
+      <!-- Title card (Phase H) — auto description slide prepended to each movie -->
+      <section class="bm-sec">
+        <h4>
+          <label class="bm-title-toggle"><input type="checkbox" v-model="titleCardOn" /> Title card</label>
+          <span class="bm-sub">name, attributes, channels &amp; colours — prepended to each movie</span>
+        </h4>
+        <template v-if="titleCardOn">
+          <div class="bm-inset">
+            <span class="bm-lbl">duration</span>
+            <input type="range" min="1" max="10" step="1" v-model.number="titleDur" />
+            <span class="bm-val">{{ titleDur }}s</span>
+          </div>
+          <div class="bm-attrs">
+            <span class="bm-lbl">note <span class="bm-sub">optional extra line</span></span>
+            <input type="text" class="bm-note" v-model="titleNote" placeholder="e.g. 15s intravital, day 3" />
+          </div>
+        </template>
+      </section>
+
       <!-- Actions -->
       <div class="bm-actions">
         <button class="cc-btn cc-btn-ghost" :disabled="!project.napariImageUid" @click="previewOpen"
@@ -338,4 +365,7 @@ async function previewOpen() {
 .bm-preview { font-size: 0.76rem; color: var(--cc-text-dim); margin: 6px 0 0; word-break: break-all; }
 .bm-preview b { color: var(--cc-text); }
 .bm-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.bm-title-toggle { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; }
+.bm-note { width: 100%; box-sizing: border-box; font: inherit; padding: 3px 6px;
+  border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-1); color: var(--cc-text); }
 </style>

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -147,6 +147,7 @@ export const useSettingsStore = defineStore('settings', () => {
       colourLabels?: boolean
       fileAttrs?: string[]                  // attr names composing the output filename
       tStart?: number; tEnd?: number | null
+      titleCard?: { enabled: boolean; note: string; durationSec: number }   // Phase H description slide
     }
   }
   const _setPrefs = ref<Record<string, NapariSetPrefs>>(

--- a/frontend/src/utils/batchMovie.test.ts
+++ b/frontend/src/utils/batchMovie.test.ts
@@ -35,6 +35,18 @@ describe('buildBatchMovieConfig', () => {
     expect(c.tailWidth).toBe(8)
     expect(c.colourOverrides).toEqual({ '2': '#ff1493' })
   })
+
+  it('defaults the title card ON with a 3s duration', () => {
+    const c = buildBatchMovieConfig({}, [], {})
+    expect(c.titleCard).toEqual({ enabled: true, note: '', durationSec: 3 })
+  })
+
+  it('passes the title card through and clamps duration to 1–10s', () => {
+    expect(buildBatchMovieConfig({ titleCard: { enabled: false, note: 'day 3', durationSec: 5 } }, [], {}).titleCard)
+      .toEqual({ enabled: false, note: 'day 3', durationSec: 5 })
+    expect(buildBatchMovieConfig({ titleCard: { enabled: true, note: '', durationSec: 99 } }, [], {}).titleCard.durationSec).toBe(10)
+    expect(buildBatchMovieConfig({ titleCard: { enabled: true, note: '', durationSec: 0 } }, [], {}).titleCard.durationSec).toBe(1)
+  })
 })
 
 describe('movieFilename', () => {

--- a/frontend/src/utils/batchMovie.ts
+++ b/frontend/src/utils/batchMovie.ts
@@ -5,6 +5,13 @@
 //  - movieFilename: the output filename preview, mirroring the backend `_movie_basename`
 //    (<attr1>_<attr2>_..._<uid>.mp4; blanks dropped, uid always terminates, unsafe chars → '_').
 
+// Title-card options (Phase H) — a description slide prepended to each recorded movie.
+export interface TitleCardCfg {
+  enabled: boolean
+  note: string
+  durationSec: number
+}
+
 export interface BatchMovieCfg {
   valueName?: string
   channels?: Record<string, string>
@@ -17,6 +24,7 @@ export interface BatchMovieCfg {
   colourLabels?: boolean
   tailWidth?: number
   pointsSize?: number
+  titleCard?: TitleCardCfg
 }
 
 export interface BatchMovieRequestConfig {
@@ -33,13 +41,18 @@ export interface BatchMovieRequestConfig {
   pointsSize: number
   colourLabels: boolean
   colourOverrides: Record<string, string>
+  titleCard: TitleCardCfg
 }
+
+// Title card is ON by default (Phase H decision 3); duration clamped to 1–10s.
+export const TITLE_CARD_DEFAULT: TitleCardCfg = { enabled: true, note: '', durationSec: 3 }
 
 export function buildBatchMovieConfig(
   cfg: BatchMovieCfg,
   segNames: string[],
   colourOverrides: Record<string, string>,
 ): BatchMovieRequestConfig {
+  const tc = cfg.titleCard
   return {
     valueName: cfg.valueName ?? '',
     channels: cfg.channels ?? {},
@@ -54,6 +67,11 @@ export function buildBatchMovieConfig(
     pointsSize: cfg.pointsSize ?? 6,
     colourLabels: !!cfg.colourLabels,
     colourOverrides: colourOverrides ?? {},
+    titleCard: {
+      enabled: tc?.enabled ?? TITLE_CARD_DEFAULT.enabled,
+      note: tc?.note ?? '',
+      durationSec: Math.min(10, Math.max(1, tc?.durationSec ?? TITLE_CARD_DEFAULT.durationSec)),
+    },
   }
 }
 

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -1151,11 +1151,11 @@ class NapariState:
                 except Exception: pass
 
     def record_timelapse(self, path: str, fps: int = 15, canvas_only: bool = True,
-                         scale=1, t_start: int = 0, t_end=None):
+                         scale=1, t_start: int = 0, t_end=None, title_card=None):
         """Record the open image's T-sweep to `path` (mp4). Resolves the T slider index from the image
         axes and delegates to the shared `napari_utils.record_timelapse` (keyframe→animate). Returns the
         frame count + path. Raises if the image has no time axis. Phase F1 of the batch-movie work
-        (docs/todo/ANIMATION_PLAN.md); F1.2/F1.3 add per-image config + batch."""
+        (docs/todo/ANIMATION_PLAN.md); F1.2/F1.3 add per-image config + batch; H adds `title_card`."""
         axes = self._display_axes()                       # non-channel axes, dims.current_step order
         if "t" not in axes:
             raise RuntimeError("this image has no time axis to record")
@@ -1164,7 +1164,8 @@ class NapariState:
             raise RuntimeError("this image has a single timepoint — nothing to sweep")
         frames = napari_utils.record_timelapse(
             self._viewer, path, t_axis_index=axes.index("t"), n_timepoints=n_t,
-            fps=fps, canvas_only=canvas_only, scale=scale, t_start=t_start, t_end=t_end)
+            fps=fps, canvas_only=canvas_only, scale=scale, t_start=t_start, t_end=t_end,
+            title_card=title_card)
         return {"frames": frames, "path": path, "n_timepoints": n_t}
 
     def record_keyframes(self, path: str, keyframes, fps: int = 15, canvas_only: bool = True):
@@ -1296,7 +1297,8 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
             res = state.record_timelapse(cmd["path"], fps=cmd.get("fps", 15),
                                          canvas_only=cmd.get("canvas_only", True),
                                          scale=cmd.get("scale", 1),
-                                         t_start=cmd.get("t_start", 0), t_end=cmd.get("t_end"))
+                                         t_start=cmd.get("t_start", 0), t_end=cmd.get("t_end"),
+                                         title_card=cmd.get("title_card"))
             return {"type": "ok", "cmd": t, **res}
 
         elif t == "record_keyframes":

--- a/python/cecelia/utils/napari_utils.py
+++ b/python/cecelia/utils/napari_utils.py
@@ -392,13 +392,59 @@ def apply_view_state(viewer, snapshot):
 # in the pixi env); kept here (not the bridge) so it's a shared, testable primitive. See
 # docs/todo/ANIMATION_PLAN.md (Phase F1) and docs/NAPARI.md.
 
+# ── Title card (Phase H) — prepend a description slide to a recorded movie ─────
+def _visible_channel_legend(viewer):
+  """``[{label, colour}]`` for each visible Image layer: channel name + its colormap's max colour as
+  hex. Channel colour lives ONLY in the napari layer state (ANIMATION_PLAN.md Phase H, decision 5), so
+  the title card reads it here rather than duplicating a colormap→hex table. (A grayscale ramp maps its
+  max to white; single-hue channels give their hue — the common case.)"""
+  try:
+    from napari.layers import Image as _ImageLayer
+  except Exception:
+    _ImageLayer = None
+  out = []
+  for layer in getattr(viewer, "layers", []):
+    if _ImageLayer is not None and not isinstance(layer, _ImageLayer):
+      continue
+    if not getattr(layer, "visible", False):
+      continue
+    colour = None
+    try:
+      rgba = layer.colormap.map(np.array([1.0]))[0]
+      colour = "#{:02x}{:02x}{:02x}".format(
+        int(round(float(rgba[0]) * 255)), int(round(float(rgba[1]) * 255)), int(round(float(rgba[2]) * 255)))
+    except Exception:
+      pass
+    out.append({"label": str(getattr(layer, "name", "")), "colour": colour})
+  return out
+
+
+def _maybe_prepend_title(viewer, path, title_card):
+  """If a title card is enabled, prepend it to the just-recorded movie: build the Channels section from
+  the live viewer, prepend it to the Julia-assembled sections (colour-by, …), and composite via
+  ``cecelia.utils.title_card``. Best-effort — a failure logs and leaves the movie untouched; it never
+  fails the recording."""
+  if not title_card or not title_card.get("enabled"):
+    return
+  try:
+    from cecelia.utils import title_card as _tc
+    channels = _visible_channel_legend(viewer)
+    sections = ([{"heading": "Channels", "items": channels}] if channels else []) \
+        + list(title_card.get("sections") or [])
+    content = {"title": title_card.get("title", ""), "note": title_card.get("note", ""), "sections": sections}
+    _tc.prepend_title_to_movie(path, content, duration_sec=float(title_card.get("durationSec", 3.0)))
+  except Exception as e:
+    print(f"[WARN] title card skipped: {e}")
+
+
 def record_timelapse(viewer, path, *, t_axis_index, n_timepoints, fps=15,
-                     canvas_only=True, scale=1, t_start=0, t_end=None):
+                     canvas_only=True, scale=1, t_start=0, t_end=None, title_card=None):
   """Record ``viewer``'s T-sweep (dims slider index ``t_axis_index``) from ``t_start``..``t_end``
   (default the full ``n_timepoints`` range) to ``path`` (an ``.mp4``), one frame per timepoint, at
   ``fps``. ``canvas_only`` excludes the napari UI chrome; ``scale`` supersamples (2 = 2× resolution).
-  Returns the number of frames written. Raises ``ValueError`` for a single-timepoint stack. Ports the
-  old R ``generateMovies`` T-playback: two keyframes (first/last T) + linear slider interpolation."""
+  ``title_card`` (Phase H) optionally prepends a description slide after recording. Returns the number
+  of frames written. Raises ``ValueError`` for a single-timepoint stack. Ports the old R
+  ``generateMovies`` T-playback: two keyframes (first/last T) + linear slider interpolation."""
   n = int(n_timepoints)
   if n <= 1:
     raise ValueError("record_timelapse needs a stack with >1 timepoint (no time axis to sweep)")
@@ -417,6 +463,7 @@ def record_timelapse(viewer, path, *, t_axis_index, n_timepoints, fps=15,
   _set_t(t0); anim.capture_keyframe()
   _set_t(t1); anim.capture_keyframe(steps=(t1 - t0))   # one interpolated frame per timepoint between
   anim.animate(path, fps=int(fps), canvas_only=canvas_only, scale_factor=scale)
+  _maybe_prepend_title(viewer, path, title_card)        # Phase H: optional description slide
   return (t1 - t0) + 1
 
 


### PR DESCRIPTION
Builds on #327 (H1, merged). Wires the auto title card into **batch movie generation** (`docs/todo/ANIMATION_PLAN.md` → Phase H2).

- **One canonical legend source, not three:** extracted `overlay_legend_content` in `napari_api.jl`; the overlay-legend endpoint (board strip legend / napari strip) AND the title card now both call it, so rows match.
- **Content assembly** (`_title_card_content`): title = image name + attribute values; **colour-by** section from the shared helper. **Channels** section is read from the **live viewer** at record time (`_visible_channel_legend`, colormap→hex — the only place channel colour lives), so it's authoritative.
- **Threading:** `titleCard {enabled, note, durationSec}` flows `run_batch_movies` → `record_timelapse!` → bridge → `napari_utils.record_timelapse`, which prepends the card **best-effort** (`_maybe_prepend_title` — a failure logs and leaves the movie intact, never fails the recording).
- **Batch UI:** toggle + note + duration (default **on**, 1–10s), persisted per set.

Card content = title + channels + colour-by + note. **Point-population rows deferred** (deriving the exact shown-pop set from batch config robustly needs care; colour-by already covers the split-by-cluster case). H3 (single record) + H4 (animation) still to come.

**Verified:** `title_card` 9/9 + `batchMovie` 15/15 unit tests, frontend typecheck, Julia parse, Python syntax.
**Not verified:** the record→prepend path can't run headless (no napari) — the H2 wiring is parse/type-checked only, so validate live that the card prepends and channels read correctly. `test-api` not run (worktree has no instantiated env) — the `overlay_legend_content` refactor passed a parse check + uses only existing symbols; run `pixi run test-api` in a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
