### PR TITLE
Movie title card: single record via shared capture-legend (H3)

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -448,9 +448,16 @@ function api_napari_record_timelapse(body_bytes::Vector{UInt8})
     # if the name is blank / unsafe. (F1.3 will switch to attr-based names for batch runs.)
     path = _movie_named_path(img, image_uid)
 
+    # Phase H (H3): optional title card. Single-record captures the CURRENT view, so the FRONTEND builds
+    # the non-channel sections (title + populations + colour-by) via the shared captureViewLegend path
+    # (same as the analysis-board strip) and sends them here; we pass them through unchanged. The
+    # recorder adds the Channels section from the live viewer (as for batch). nothing/disabled → no card.
+    tc   = get(data, :titleCard, nothing)
+    card = (tc isa AbstractDict && Bool(get(tc, :enabled, false))) ? tc : nothing
+
     _with_viewer() do
         try
-            resp = record_timelapse!(v, path; fps = fps, scale = scale)
+            resp = record_timelapse!(v, path; fps = fps, scale = scale, title_card = card)
             200, JSON3.write((; ok = true, path = path,
                 frames = get(resp, "frames", 0), nTimepoints = get(resp, "n_timepoints", 0)))
         catch e
@@ -664,11 +671,62 @@ _batch_cancelled(id)      = lock(() -> get(_batch_cancel, id, false),           
 _batch_clear!(id)         = lock(() -> delete!(_batch_cancel, id),                        _batch_cancel_lock)
 request_batch_cancel!(id) = lock(() -> (haskey(_batch_cancel, id) && (_batch_cancel[id] = true); nothing), _batch_cancel_lock)
 
+# Append every non-transient, shown pop of `(vn, pt)` to `out` as {valueName, popType, path} — the shape
+# overlay_legend_content consumes. Uses the SAME pop-map primitives the show-tracks handler does, so the
+# card can't drift from what's actually rendered.
+function _append_config_pop_paths!(out::Vector{Dict{String,Any}}, img, vn::AbstractString, pt::AbstractString)
+    try
+        m = _live_map(img, vn, pt)
+        for path in pop_paths(m)
+            p = pop_at(m, path)
+            (p.transient || !p.show) && continue
+            push!(out, Dict{String,Any}("valueName" => vn, "popType" => pt, "path" => path))
+        end
+    catch
+        # pop map for this (vn, pt) unavailable → nothing to contribute
+    end
+end
+
+# The overlay pops a movie config would SHOW, as one list of {valueName, popType, path} (the shape
+# overlay_legend_content turns into {name, colour}) — point pops AND tracks together, matching the ONE
+# "Populations" section the analysis-board strip / single-record card use. Reuses the CANONICAL
+# resolvers the show-handlers use — `resolve_pops` for point pops, the pop maps for track gates &
+# clusters, "/_tracked" for a segmentation's whole-track overlay — so it can't drift from what renders.
+function _config_overlay_pops(img, config)
+    out = Vector{Dict{String,Any}}()
+    _has_label_props(img) || return out
+    segs = String[v for v in versioned_keys(img.label_props) if !is_reserved_value_name(v)]
+
+    if Bool(get(config, :showPopulations, false))
+        pt = String(get(config, :popType, "flow"))
+        for vn in segs
+            try
+                for L in resolve_pops(img, pt; value_name = vn)
+                    (L.show && !L.is_track) || continue
+                    push!(out, Dict{String,Any}("valueName" => vn, "popType" => pt, "path" => L.path))
+                end
+            catch
+            end
+        end
+    end
+
+    if Bool(get(config, :showTracks, false))
+        for vn in collect(String, get(config, :trackValueNames, String[]))   # whole-seg → generic "tracks" row
+            haskey(img.label_props, vn) && push!(out, Dict{String,Any}("valueName" => vn, "popType" => "track", "path" => "/_tracked"))
+        end
+        for vn in segs
+            Bool(get(config, :showGatedTracks, false)) && _append_config_pop_paths!(out, img, vn, "track")
+            Bool(get(config, :showTrackclust, false))  && _append_config_pop_paths!(out, img, vn, "trackclust")
+        end
+    end
+    out
+end
+
 # Assemble the Julia-side title-card content for an image under a movie config (Phase H). Title = image
-# name + its attribute values ("MERTK — mouse 1 — location B"); the colour-by section from the CANONICAL
-# `overlay_legend_content` helper. CHANNELS are NOT added here — the recorder adds them from the live
-# viewer (the only place channel colour lives). Returns `nothing` when the card is disabled/absent so the
-# recorder skips it. (Point-population rows are a deferred follow-up — see ANIMATION_PLAN.md → H.)
+# name + its attribute values ("MERTK — mouse 1 — location B"); the Populations / Tracks / Colour-by
+# sections all come from the CANONICAL `overlay_legend_content` helper. CHANNELS are NOT added here — the
+# recorder adds them from the live viewer (the only place channel colour lives). Returns `nothing` when
+# the card is disabled/absent so the recorder skips it.
 function _title_card_content(img, config)
     tc = get(config, :titleCard, nothing)
     (tc === nothing || !(tc isa AbstractDict) || !Bool(get(tc, :enabled, false))) && return nothing
@@ -682,7 +740,16 @@ function _title_card_content(img, config)
     title = join(vcat([img.name], attrs), " — ")
 
     sections = Vector{Dict{String,Any}}()
-    column   = String(get(config, :colourBy, ""))
+    # Populations (incl. track pops) — the shown pops through the canonical legend helper → {name, colour}
+    # rows. ONE section, matching the strip / single-record card (overlay_legend_content dedups by name).
+    plist = _config_overlay_pops(img, config)
+    if !isempty(plist)
+        rows  = overlay_legend_content(img, "", plist, nothing).populations
+        items = [Dict{String,Any}("label" => p["name"], "colour" => p["colour"]) for p in rows]
+        isempty(items) || push!(sections, Dict{String,Any}("heading" => "Populations", "items" => items))
+    end
+    # Colour-by — value → pop colour + name for the colour-by measure.
+    column = String(get(config, :colourBy, ""))
     if !isempty(column)
         legend = overlay_legend_content(img, column, nothing, get(config, :colourOverrides, nothing))
         items  = [Dict{String,Any}("label" => it["label"], "colour" => it["colour"]) for it in legend.colourBy["items"]]

--- a/docs/todo/ANIMATION_PLAN.md
+++ b/docs/todo/ANIMATION_PLAN.md
@@ -256,11 +256,21 @@ separate doc. Applies to all three movie paths: single record, batch, animation 
   **Channels** section from the live viewer (`_visible_channel_legend`, colormap→hex) and prepends the
   card best-effort (`_maybe_prepend_title` — never fails the recording). Frontend toggle/note/duration
   in `BatchMoviesPanel.vue` (config + clamp in `utils/batchMovie.ts`, default ON), persisted per set.
-  **Deferred:** the explicit point-**populations** rows (deriving the exact shown-pop set from the
-  batch config robustly needs care; the colour-by section already covers the split-by-cluster case).
-  Card content so far = title + channels + colour-by + note.
-- **H3 — single record** (`ViewerPanel.vue` → `api_napari_record_timelapse`). No overlay config
-  exists on this path, so the card shows title + channels (+ note); pops/colour-by best-effort/empty.
+  **Populations section:** `_config_overlay_pops(img, config)` lists the shown pops (point pops AND
+  tracks, one list) via the SAME canonical resolvers the show-handlers use (`resolve_pops` for point
+  pops; the pop maps for track gates & clusters; `/_tracked` → a generic "tracks" row), fed through
+  `overlay_legend_content` → ONE **Populations** section (deduped by name), matching the strip /
+  single-record card. Card content (batch) = title + channels + populations + colour-by + note.
+- **~~H3 — single record~~ — DONE** (`ViewerPanel.vue` → `api_napari_record_timelapse`). Single-record
+  captures the CURRENT view, so — like the analysis-board strip — the FRONTEND builds the card's
+  non-channel sections via the **shared `captureViewLegend`** (`utils/napariOverlays.ts`): capture the
+  view state (`/api/napari/view-state`, no PNG) → `parseOverlays` → `/api/napari/overlay-legend` →
+  Populations + colour-by; title = image name + attr values. It sends the full `titleCard` (title +
+  sections); the handler passes it through unchanged and the recorder adds Channels from the live
+  viewer. `ImageStripView` was refactored onto the same `captureViewLegend`, so strip + single-record
+  are provably ONE capture-legend path (the batch path uses the same `overlay_legend_content` resolver
+  server-side, since it has no live client snapshot). Movie panel gains a title toggle/duration/note
+  row, persisted per set in `getMovieConfig().titleCard` (default ON).
 - **H4 — animation page** (`AnimationModule.vue` → `record_keyframes`). Card reflects the FIRST
   keyframe's view; channels read after applying keyframe 0. Pops/colour-by derived from the first
   keyframe's overlay layers if feasible, else title + channels + note.

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -5,7 +5,8 @@ import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import { useWsStore } from '../stores/ws'
 import { useLogStore } from '../stores/log'
-import { pushTracks as apiPushTracks, pushPopulations as apiPushPopulations, pushColourLabels as apiPushColourLabels } from '../utils/napariOverlays'
+import { pushTracks as apiPushTracks, pushPopulations as apiPushPopulations, pushColourLabels as apiPushColourLabels, captureViewLegend } from '../utils/napariOverlays'
+import type { TitleCardCfg } from '../utils/batchMovie'
 import ConfirmDeleteButton from './ConfirmDeleteButton.vue'
 
 const projectStore = useProjectStore()
@@ -80,6 +81,14 @@ const movieFps = computed<number>({
 const movieScale = computed<number>({
   get: () => currentSetUid.value ? settings.getMovieConfig(currentSetUid.value).scale : 1,
   set: v => { if (currentSetUid.value) settings.setMovieConfig(currentSetUid.value, { scale: v }) } })
+// Title card (Phase H, H3) — per-set, merge-patched so each control keeps the others' values.
+const movieTitleCard = computed<TitleCardCfg>(() =>
+  currentSetUid.value ? settings.getMovieConfig(currentSetUid.value).titleCard : { enabled: true, note: '', durationSec: 3 })
+function patchMovieTitle(p: Partial<TitleCardCfg>) {
+  if (currentSetUid.value) settings.setMovieConfig(currentSetUid.value, { titleCard: { ...movieTitleCard.value, ...p } }) }
+const titleCardOn = computed<boolean>({ get: () => movieTitleCard.value.enabled, set: v => patchMovieTitle({ enabled: v }) })
+const titleNote   = computed<string>({  get: () => movieTitleCard.value.note,    set: v => patchMovieTitle({ note: v }) })
+const titleDur    = computed<number>({  get: () => movieTitleCard.value.durationSec, set: v => patchMovieTitle({ durationSec: Math.min(10, Math.max(1, v)) }) })
 
 
 watch(napariImage, (img) => {
@@ -164,9 +173,35 @@ async function recordTimelapse() {
   recording.value = true
   log.info('Recording timelapse… (this can take a moment)', { source: 'napari' })
   try {
+    // Title card (Phase H): build the non-channel sections from the CURRENT view exactly as the
+    // analysis-board strip does — capture the view state, then the SHARED captureViewLegend
+    // (parseOverlays → /api/napari/overlay-legend). Channels are added by the recorder from the live
+    // viewer, so we omit them here (consistent with batch). No bespoke legend logic in this component.
+    let titleCard: Record<string, unknown> | undefined
+    if (titleCardOn.value) {
+      const colourBy  = currentSetUid.value ? settings.getColourBy(currentSetUid.value) : ''
+      const overrides = (currentSetUid.value && colourBy) ? settings.getColourOverrides(currentSetUid.value, colourBy) : {}
+      let snapshot: { layers?: Record<string, unknown> } | null = null
+      try {
+        const vsr = await fetch('/api/napari/view-state', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ projectUid }) })
+        if (vsr.ok) snapshot = ((await vsr.json()) as { viewState?: { layers?: Record<string, unknown> } }).viewState ?? null
+      } catch { /* best-effort — card still renders title + channels */ }
+      const leg = await captureViewLegend(projectUid, uid, snapshot, colourBy, overrides)
+      const sections: { heading: string; items: { label: string; colour: string }[] }[] = []
+      const pops = leg.populations.map(p => ({ label: p.name, colour: p.colour }))
+      if (pops.length) sections.push({ heading: 'Populations', items: pops })
+      const cby = (leg.colourBy?.items ?? []).filter(it => it.colour).map(it => ({ label: it.label, colour: it.colour }))
+      if (cby.length) sections.push({ heading: leg.colourBy?.column || 'Colour by', items: cby })
+      // title = image name + its attribute values (sorted by key) — matches the batch card
+      const img = napariImage.value
+      const attrs = img?.attr ? Object.keys(img.attr).sort().map(k => (img.attr as Record<string, string>)[k]?.trim()).filter(Boolean) : []
+      const title = [img?.name ?? '', ...attrs].filter(Boolean).join(' — ')
+      titleCard = { enabled: true, note: titleNote.value, durationSec: titleDur.value, title, sections }
+    }
     const res = await fetch('/api/napari/record-timelapse', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectUid, imageUid: uid, fps: movieFps.value, scale: movieScale.value }),
+      body: JSON.stringify({ projectUid, imageUid: uid, fps: movieFps.value, scale: movieScale.value, titleCard }),
     })
     if (!res.ok) { log.error(`Record timelapse failed: ${await _resError(res)}`, { source: 'napari' }); return }
     const j = (await res.json()) as { path?: string; frames?: number }
@@ -716,6 +751,19 @@ onUnmounted(() => {
             <i :class="['pi', recording ? 'pi-spin pi-spinner' : 'pi-video']" />
           </button>
         </div>
+        <!-- Title card (Phase H): prepend a description slide (name, attributes, channels & colours) -->
+        <div class="movie-row movie-title-row">
+          <label class="movie-lbl movie-title-toggle"
+                 v-tooltip.bottom="'Prepend a title slide: image name, attributes, channels & their colours'">
+            <input type="checkbox" v-model="titleCardOn" /> title
+          </label>
+          <template v-if="titleCardOn">
+            <input type="range" min="1" max="10" step="1" v-model.number="titleDur" class="movie-range"
+                   v-tooltip.bottom="'Title-card duration (seconds)'" />
+            <span class="movie-val">{{ titleDur }}s</span>
+            <input type="text" v-model="titleNote" class="movie-note" placeholder="note (optional)" />
+          </template>
+        </div>
       </div>
     </template>
     <div v-else class="viewer-section"><span class="viewer-hint">No image open in Napari.</span></div>
@@ -781,6 +829,10 @@ onUnmounted(() => {
 .movie-range { flex: 1; min-width: 2.5rem; accent-color: #7c3aed; }
 .movie-val { font-size: 0.64rem; color: var(--cc-text); width: 1.4rem; text-align: right; flex-shrink: 0; font-variant-numeric: tabular-nums; }
 .movie-rec { margin-left: 0.1rem; }
+.movie-title-row { margin-top: 0.25rem; }
+.movie-title-toggle { display: inline-flex; align-items: center; gap: 0.25rem; cursor: pointer; text-transform: none; letter-spacing: 0; }
+.movie-note { flex: 2; min-width: 3rem; font-size: 0.64rem; padding: 1px 4px;
+  border: 1px solid var(--cc-border); border-radius: 3px; background: var(--cc-surface-1); color: var(--cc-text); }
 
 /* colour-by legend: value → swatch (a population's colour where one matches, else default) */
 .cby-legend { display: flex; flex-wrap: wrap; gap: 0.15rem 0.5rem; margin-top: 0.25rem; }

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -18,6 +18,7 @@ import { useProjectStore } from '../../stores/project'
 import { channelLegend } from '../../utils/viewLegend'
 import { elapsedLabel } from '../../utils/stillOverlay'
 import { parseOverlays, overlayPushConfig } from '../../utils/overlayLayers'
+import { captureViewLegend } from '../../utils/napariOverlays'
 import { restoreOverlays } from '../../utils/napariOverlays'
 import ViewLegend from '../ViewLegend.vue'
 import StillOverlay from '../StillOverlay.vue'
@@ -129,22 +130,13 @@ async function capture(i: number) {
     // the snapshot's overlay layer names; the backend skips any that aren't a named population (e.g. the
     // whole-segmentation "/_tracked" layer), so track-cluster + gated track pops get legend entries too.
     if (c.imageUid) {
-      const overlayPops = parseOverlays(c.snapshot?.layers as Record<string, unknown>)
-        .map(o => ({ valueName: o.valueName, popType: o.popType, path: o.path }))
       // include the set's user recolours for this colour-by so the captured legend matches what's shown
       // (a recoloured category — e.g. an HMM state with no population — wins over the default colour).
       const colourOverrides = (props.setUid && c.colourBy)
         ? settings.getColourOverrides(props.setUid, c.colourBy) : {}
-      try {
-        const lr = await fetch('/api/napari/overlay-legend', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ projectUid: props.projectUid, imageUid: c.imageUid, colourBy: c.colourBy, overlayPops, colourOverrides }),
-        })
-        if (lr.ok) {
-          const j = await lr.json() as OverlaysLegend & { ok?: boolean }
-          c.overlaysLegend = { colourBy: j.colourBy, populations: j.populations }
-        }
-      } catch { /* legend is best-effort */ }
+      // shared capture-legend path (also used by the single-record movie card) — best-effort
+      const leg = await captureViewLegend(props.projectUid, c.imageUid, c.snapshot as { layers?: Record<string, unknown> }, c.colourBy ?? '', colourOverrides)
+      c.overlaysLegend = { colourBy: leg.colourBy, populations: leg.populations }
     }
   } catch (e) { err.value = e instanceof Error ? e.message : String(e) }
   finally { capturing.value = -1 }

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
+import { TITLE_CARD_DEFAULT, type TitleCardCfg } from '../utils/batchMovie'
 
 export const useSettingsStore = defineStore('settings', () => {
   const taskListAutoFollow = ref(
@@ -130,7 +131,7 @@ export const useSettingsStore = defineStore('settings', () => {
     colourByOverrides?: Record<string, Record<string, string>>
     // timelapse-recording params (extensible — F1.2 adds channels/pops/T-range here). fps = frame rate,
     // scale = supersample factor (2 = 2× resolution). Per-set like the other viewer prefs.
-    movie?: { fps?: number; scale?: number }
+    movie?: { fps?: number; scale?: number; titleCard?: TitleCardCfg }   // titleCard: Phase H (H3)
     // 3D-crop z-range and t-range as 0–100 % (per set — the XY crop box itself is per-session, drawn in
     // napari each time since a region is image-specific). Only the ranges persist, like other prefs.
     cropZ?: { lo?: number; hi?: number }
@@ -183,11 +184,12 @@ export const useSettingsStore = defineStore('settings', () => {
     _patchSet(setUid, { colourByOverrides: all })
   }
   // timelapse-recording params (per set); defaults match the backend (fps 15, scale 1×)
-  const getMovieConfig = (setUid: string): { fps: number; scale: number } => ({
+  const getMovieConfig = (setUid: string): { fps: number; scale: number; titleCard: TitleCardCfg } => ({
     fps: _setPrefs.value[setUid]?.movie?.fps ?? 15,
     scale: _setPrefs.value[setUid]?.movie?.scale ?? 1,
+    titleCard: _setPrefs.value[setUid]?.movie?.titleCard ?? { ...TITLE_CARD_DEFAULT },
   })
-  function setMovieConfig(setUid: string, patch: { fps?: number; scale?: number }) {
+  function setMovieConfig(setUid: string, patch: { fps?: number; scale?: number; titleCard?: TitleCardCfg }) {
     _patchSet(setUid, { movie: { ...(_setPrefs.value[setUid]?.movie ?? {}), ...patch } })
   }
   // 3D-crop z-range (per set) as 0–100 %; default full depth (0–100)

--- a/frontend/src/utils/napariOverlays.ts
+++ b/frontend/src/utils/napariOverlays.ts
@@ -3,11 +3,42 @@
 // the strip) go through these builders, so there's a single request shape per endpoint instead of two
 // divergent inline copies. Each builder returns the raw Response (or undefined on a network error) so
 // callers can still harvest the legend from the reply; it does not read/parse the body itself.
-import type { OverlayPushConfig } from './overlayLayers'
+import { parseOverlays, type OverlayPushConfig } from './overlayLayers'
+import { channelLegend, type LegendItem } from './viewLegend'
 
 const _post = (path: string, body: unknown): Promise<Response | undefined> =>
   fetch(path, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
     .catch(() => undefined)
+
+// ── Capture-view legend (shared: analysis-board strip + movie title card) ───────
+// The ONE path that turns a captured napari view snapshot into legend pieces: channels from the
+// snapshot's layer colormaps (channelLegend), populations + colour-by from the canonical
+// /api/napari/overlay-legend (overlay pops parsed from the snapshot's layer names). Both the board
+// strip (ImageStripView) and the single-record movie card go through this, so their legends match.
+export interface CapturedViewLegend {
+  channels: LegendItem[]
+  populations: { name: string; colour: string }[]
+  colourBy?: { column: string; items: { value: string; colour: string; label: string }[] }
+}
+export async function captureViewLegend(
+  projectUid: string, imageUid: string,
+  snapshot: { layers?: Record<string, unknown> } | null | undefined,
+  colourBy: string, colourOverrides: Record<string, string> = {},
+): Promise<CapturedViewLegend> {
+  const layers = (snapshot?.layers ?? {}) as Record<string, { colormap?: string; visible?: boolean }>
+  const channels = channelLegend(layers)
+  const overlayPops = parseOverlays(snapshot?.layers as Record<string, unknown>)
+    .map(o => ({ valueName: o.valueName, popType: o.popType, path: o.path }))
+  let populations: { name: string; colour: string }[] = []
+  let cby: CapturedViewLegend['colourBy'] | undefined
+  const res = await _post('/api/napari/overlay-legend', { projectUid, imageUid, colourBy, overlayPops, colourOverrides })
+  if (res?.ok) {
+    const j = await res.json().catch(() => ({})) as CapturedViewLegend & { ok?: boolean }
+    populations = j.populations ?? []
+    cby = j.colourBy
+  }
+  return { channels, populations, colourBy: cby }
+}
 
 export interface PushTracksOpts {
   valueNames: string[]            // segmentations whose whole-segmentation (_tracked) ribbons to show


### PR DESCRIPTION
Builds on #327 (H1) + #329 (H2), both merged. Wires the title card into **single-image record** and consolidates the legend path so there are no parallel systems.

**Consolidation (the point of this PR):**
- New `captureViewLegend` (`utils/napariOverlays.ts`) is the ONE live-view capture→legend path: `parseOverlays` → `/api/napari/overlay-legend` (canonical `overlay_legend_content`) → populations + colour-by; channels via `channelLegend`.
- `ImageStripView` refactored onto it — its inline overlay-legend fetch removed. So **board strip + single record are provably one path**.
- Batch card unified to **one "Populations" section** (points + tracks) via `_config_overlay_pops` → the same `overlay_legend_content` resolver, matching the strip / single record.
- Net: **one** frontend capture-legend fetch, **one** backend pop/colour resolver, plus the batch-only `_config_overlay_pops` (reuses `resolve_pops`, needed because a server-side batch has no live client snapshot).

**Single record (`ViewerPanel`):** on record, capture the view state (`/api/napari/view-state`, no PNG) → `captureViewLegend` → sections + title (image name + attribute values) → full `titleCard` payload. The `record-timelapse` handler passes it through; the recorder adds the Channels section from the live viewer (as for batch). Movie panel gains a title toggle/duration/note row (default on), persisted per set.

**Verified:** Julia parse, frontend typecheck, 327/327 frontend tests.
**Not verified (no napari here):** the capture→legend→prepend path for single-record and the batch pops are parse/type-checked + pure-unit-tested only. `ImageStripView` was refactored (same fetch/fields, behavior should be identical) but is a change to a working strip component — eyeball the board-strip legend live. `captureViewLegend` is impure (a fetch) so untested; its pure pieces (`parseOverlays`/`channelLegend`) are.

Remaining: **H4** (animation page) — the last entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
