### PR TITLE
docs: drop stale qcProbe.jl reference

### DIFF
--- a/docs/CUSTOM_MODULES.md
+++ b/docs/CUSTOM_MODULES.md
@@ -134,8 +134,7 @@ Cecelia.register_cohort_metrics!("customExamples.myTask", ["nCells"])
 ```
 
 The category you tag in the JSON (`"category": "customExamples"`) automatically appears in the lab-log
-mute bar's **Module pages** group — so a user can mute your module's `[Cecelia]` digest lines. A
-runnable QC example lives in `dev/modules/…/customExamples/qcProbe.jl`.
+mute bar's **Module pages** group — so a user can mute your module's `[Cecelia]` digest lines.
 
 ## Loading & reloading
 


### PR DESCRIPTION
Removes a dangling doc reference in `CUSTOM_MODULES.md` — `dev/modules/…/customExamples/qcProbe.jl` no longer exists. This was the one genuinely-uncommitted edit found while cleaning up the shared working tree; landing it so it isn't lost. The `customExamples.qcProbeTest` fixture in `app/test/runtests.jl` is a separate in-test thing and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)