### PR TITLE
Fix ⋯ row-actions menu: run the action before closing

### DIFF
--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -219,8 +219,10 @@ function toggleActions(uid: string, e: MouseEvent) {
   actionsAnchor.value = e.currentTarget as HTMLElement
   actionsUid.value = uid
 }
-// close the menu, then run the chosen action (opens a dialog / toggles a flag)
-function runAction(fn: () => void) { actionsUid.value = null; fn() }
+// Run the chosen action, THEN close the menu. Order matters: the item closures read `actionsImg`,
+// a computed derived from `actionsUid` — clearing it first would null `actionsImg` and the closure's
+// `actionsImg!.uid` would throw (silently swallowing the click). Run first, close after.
+function runAction(fn: () => void) { fn(); actionsUid.value = null }
 // open run-history from the menu, re-anchored to the same ⋯ button the menu came from
 function openRunLogFromMenu(uid: string) {
   runLogAnchor.value = actionsAnchor.value


### PR DESCRIPTION
## Bug

Clicking any item in the new ⋯ row-actions menu (Move to another set, Metadata, Crop, Copy UID, Include/Exclude) did nothing.

`runAction(fn)` cleared `actionsUid` **before** invoking `fn()`. `actionsImg` is a computed derived from `actionsUid`, so clearing it first nulled `actionsImg`, and each menu item's closure — `actionsImg!.uid` — threw. The error was swallowed inside the click handler, so the click silently no-op'd.

Every item was dead **except Run history**, whose uid is read *before* the clear — which is exactly why that one worked and masked the bug.

## Fix

One line: run `fn()` first, then close the menu (`actionsUid = null`). Added a comment explaining the ordering so it doesn't regress.

## Not verified
- Frontend-only, `vue-tsc` clean, but not clicked live — this is a runtime ordering bug types can't catch, and the repo's frontend tests are utils-only (no component mounting), so there's no automated test for it. Needs a click to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
