### PR TITLE
Movie title card: animation page (H4) + title word-wrap

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -487,9 +487,15 @@ function api_napari_record_animation(body_bytes::Vector{UInt8})
 
     path = _movie_named_path(img, image_uid; suffix = "_animation")
 
+    # Phase H4: optional title card. Like single-record, the FRONTEND builds the non-channel sections
+    # from the FIRST keyframe's view via the shared captureViewLegend path and sends them; we pass them
+    # through unchanged and the recorder adds Channels from that keyframe. nothing/disabled → no card.
+    tc   = get(data, :titleCard, nothing)
+    card = (tc isa AbstractDict && Bool(get(tc, :enabled, false))) ? tc : nothing
+
     _with_viewer() do
         try
-            resp = record_keyframes!(v, path, keyframes; fps = fps)
+            resp = record_keyframes!(v, path, keyframes; fps = fps, title_card = card)
             200, JSON3.write((; ok = true, path = path,
                 frames = get(resp, "frames", 0), keyframes = get(resp, "keyframes", 0)))
         catch e

--- a/app/src/napari.jl
+++ b/app/src/napari.jl
@@ -241,6 +241,9 @@ end
 # `keyframes` = ordered [(; viewState, steps)], each tweened `steps` frames from the previous. Returns
 # the bridge reply (frame count + path). See docs/todo/ANIMATION_PLAN.md (F2).
 record_keyframes!(v::NapariViewer, path::String, keyframes::AbstractVector; fps::Int=15,
-                  canvas_only::Bool=true)::Dict{String,Any} =
-    send(v, Dict{String,Any}("type"=>"record_keyframes", "path"=>path, "fps"=>fps,
-                             "canvas_only"=>canvas_only, "keyframes"=>keyframes))
+                  canvas_only::Bool=true, title_card=nothing)::Dict{String,Any} = begin
+    cmd = Dict{String,Any}("type"=>"record_keyframes", "path"=>path, "fps"=>fps,
+                           "canvas_only"=>canvas_only, "keyframes"=>keyframes)
+    title_card !== nothing && (cmd["title_card"] = title_card)   # Phase H4 description slide
+    send(v, cmd)
+end

--- a/docs/todo/ANIMATION_PLAN.md
+++ b/docs/todo/ANIMATION_PLAN.md
@@ -1,8 +1,9 @@
 # Analysis figures & movies (animation)
 
-Status (updated 2026-07-24): A–G + F1/F2 **done/merged**. **Phase H (movie title card) IN PROGRESS**
-— see the H section below. Supersedes the ad-hoc parts of the image-strip tasks (#00032 legend,
-#00036 zoom-to-source) — both now live on the shared snapshot foundation.
+Status (updated 2026-07-24): A–G + F1/F2 **done/merged**. **Phase H (movie title card) DONE** across
+all three entry points (H1 primitive, H2 batch, H3 single record, H4 animation) — see the H section
+below. Supersedes the ad-hoc parts of the image-strip tasks (#00032 legend, #00036 zoom-to-source) —
+both now live on the shared snapshot foundation.
 
 ## Goal
 
@@ -271,9 +272,13 @@ separate doc. Applies to all three movie paths: single record, batch, animation 
   are provably ONE capture-legend path (the batch path uses the same `overlay_legend_content` resolver
   server-side, since it has no live client snapshot). Movie panel gains a title toggle/duration/note
   row, persisted per set in `getMovieConfig().titleCard` (default ON).
-- **H4 — animation page** (`AnimationModule.vue` → `record_keyframes`). Card reflects the FIRST
-  keyframe's view; channels read after applying keyframe 0. Pops/colour-by derived from the first
-  keyframe's overlay layers if feasible, else title + channels + note.
+- **~~H4 — animation page~~ — DONE** (`AnimationModule.vue` → `record_keyframes`). Same live-view path
+  as single-record: the frontend builds the payload from the FIRST keyframe's snapshot via the SHARED
+  `buildTitleCard` (→ `captureViewLegend`) and sends it; `record_keyframes` re-applies keyframe 0
+  after `animate` so `_maybe_prepend_title` reads the matching Channels. Header gains a title
+  toggle/duration/note, persisted per project in `stores/animation.ts` (`titleCard`, default ON).
+  `buildTitleCard` (title + populations + colour-by) is now the ONE card-payload builder shared by
+  single-record and the animation page.
 
 ## References
 

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -5,7 +5,7 @@ import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import { useWsStore } from '../stores/ws'
 import { useLogStore } from '../stores/log'
-import { pushTracks as apiPushTracks, pushPopulations as apiPushPopulations, pushColourLabels as apiPushColourLabels, captureViewLegend } from '../utils/napariOverlays'
+import { pushTracks as apiPushTracks, pushPopulations as apiPushPopulations, pushColourLabels as apiPushColourLabels, buildTitleCard, type TitleCardPayload } from '../utils/napariOverlays'
 import type { TitleCardCfg } from '../utils/batchMovie'
 import ConfirmDeleteButton from './ConfirmDeleteButton.vue'
 
@@ -173,11 +173,10 @@ async function recordTimelapse() {
   recording.value = true
   log.info('Recording timelapse… (this can take a moment)', { source: 'napari' })
   try {
-    // Title card (Phase H): build the non-channel sections from the CURRENT view exactly as the
-    // analysis-board strip does — capture the view state, then the SHARED captureViewLegend
-    // (parseOverlays → /api/napari/overlay-legend). Channels are added by the recorder from the live
-    // viewer, so we omit them here (consistent with batch). No bespoke legend logic in this component.
-    let titleCard: Record<string, unknown> | undefined
+    // Title card (Phase H): capture the CURRENT view state (no PNG) and build the payload via the
+    // SHARED buildTitleCard — the same path the animation page uses. Channels are added by the recorder
+    // from the live viewer, so the frontend supplies only title + non-channel sections.
+    let titleCard: TitleCardPayload | undefined
     if (titleCardOn.value) {
       const colourBy  = currentSetUid.value ? settings.getColourBy(currentSetUid.value) : ''
       const overrides = (currentSetUid.value && colourBy) ? settings.getColourOverrides(currentSetUid.value, colourBy) : {}
@@ -187,17 +186,8 @@ async function recordTimelapse() {
           method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ projectUid }) })
         if (vsr.ok) snapshot = ((await vsr.json()) as { viewState?: { layers?: Record<string, unknown> } }).viewState ?? null
       } catch { /* best-effort — card still renders title + channels */ }
-      const leg = await captureViewLegend(projectUid, uid, snapshot, colourBy, overrides)
-      const sections: { heading: string; items: { label: string; colour: string }[] }[] = []
-      const pops = leg.populations.map(p => ({ label: p.name, colour: p.colour }))
-      if (pops.length) sections.push({ heading: 'Populations', items: pops })
-      const cby = (leg.colourBy?.items ?? []).filter(it => it.colour).map(it => ({ label: it.label, colour: it.colour }))
-      if (cby.length) sections.push({ heading: leg.colourBy?.column || 'Colour by', items: cby })
-      // title = image name + its attribute values (sorted by key) — matches the batch card
-      const img = napariImage.value
-      const attrs = img?.attr ? Object.keys(img.attr).sort().map(k => (img.attr as Record<string, string>)[k]?.trim()).filter(Boolean) : []
-      const title = [img?.name ?? '', ...attrs].filter(Boolean).join(' — ')
-      titleCard = { enabled: true, note: titleNote.value, durationSec: titleDur.value, title, sections }
+      titleCard = await buildTitleCard(projectUid, uid, snapshot, napariImage.value,
+        { note: titleNote.value, durationSec: titleDur.value, colourBy, colourOverrides: overrides })
     }
     const res = await fetch('/api/napari/record-timelapse', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -10,6 +10,8 @@ import { useProjectMetaStore } from '../stores/projectMeta'
 import { useProjectStore } from '../stores/project'
 import { useLogStore } from '../stores/log'
 import { useAnimationStore, type AnimSnapshot } from '../stores/animation'
+import { useSettingsStore } from '../stores/settings'
+import { buildTitleCard, type TitleCardPayload } from '../utils/napariOverlays'
 import { napariColormapHex } from '../utils/napariColormap'
 import { elapsedLabel } from '../utils/stillOverlay'
 import ConfirmDeleteButton from '../components/ConfirmDeleteButton.vue'
@@ -18,6 +20,7 @@ const projectMeta = useProjectMetaStore()
 const projectStore = useProjectStore()
 const log = useLogStore()
 const anim = useAnimationStore()
+const settings = useSettingsStore()
 
 const projectUid = computed(() => projectMeta.current?.uid ?? '')
 const hasProject = computed(() => projectMeta.hasProject)
@@ -213,9 +216,20 @@ async function render() {
       viewState: f.snapshot,
       steps: Math.max(1, Math.round((f.duration ?? 1) * anim.fps)),
     }))
+    // Title card (Phase H4): build from the FIRST keyframe's view via the SHARED buildTitleCard (same
+    // path as single-record). The recorder re-applies keyframe 0 to add the matching Channels.
+    let titleCard: TitleCardPayload | undefined
+    if (anim.titleCard.enabled && frames.value.length) {
+      const setUid   = projectStore.setUidOfImage(openImageUid.value ?? '') ?? ''
+      const colourBy = setUid ? settings.getColourBy(setUid) : ''
+      const overrides = (setUid && colourBy) ? settings.getColourOverrides(setUid, colourBy) : {}
+      const first = frames.value[0].snapshot as { layers?: Record<string, unknown> } | undefined
+      titleCard = await buildTitleCard(projectUid.value, openImageUid.value ?? '', first, openImage.value,
+        { note: anim.titleCard.note, durationSec: anim.titleCard.durationSec, colourBy, colourOverrides: overrides })
+    }
     const res = await fetch('/api/napari/record-animation', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectUid: projectUid.value, imageUid: openImageUid.value, keyframes, fps: anim.fps }),
+      body: JSON.stringify({ projectUid: projectUid.value, imageUid: openImageUid.value, keyframes, fps: anim.fps, titleCard }),
     })
     const j = await res.json().catch(() => ({}))
     if (!res.ok) { log.error(`Render failed: ${j?.error ?? res.status}`, { source: 'napari' }); return }
@@ -239,6 +253,18 @@ async function render() {
           fps <input type="range" min="1" max="40" step="1" v-model.number="anim.fps" class="anim-range" />
           <span class="anim-num">{{ anim.fps }}</span>
         </label>
+        <!-- Title card (Phase H4): prepend a description slide built from the FIRST keyframe's view -->
+        <label class="anim-title-toggle"
+               v-tooltip.bottom="'Prepend a title slide (name, attributes, channels & colours) from the first keyframe'">
+          <input type="checkbox" v-model="anim.titleCard.enabled" /> title
+        </label>
+        <template v-if="anim.titleCard.enabled">
+          <label class="anim-fps" v-tooltip.bottom="'Title-card duration (seconds)'">
+            <input type="range" min="1" max="10" step="1" v-model.number="anim.titleCard.durationSec" class="anim-range" />
+            <span class="anim-num">{{ anim.titleCard.durationSec }}s</span>
+          </label>
+          <input type="text" v-model="anim.titleCard.note" class="anim-note" placeholder="note (optional)" />
+        </template>
         <button class="btn-primary" :disabled="!canRender" @click="render"
                 v-tooltip.bottom="canRender ? 'Render the timeline to an mp4'
                   : 'Need ≥2 keyframes for this image, open in napari'">
@@ -349,6 +375,9 @@ async function render() {
 .anim-fps { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.4rem; }
 .anim-range { width: 5rem; accent-color: var(--cc-accent); }
 .anim-num { font-size: 0.72rem; color: var(--cc-text); font-variant-numeric: tabular-nums; min-width: 1.2rem; }
+.anim-title-toggle { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.35rem; cursor: pointer; }
+.anim-note { font-size: 0.72rem; width: 9rem; padding: 2px 6px; border: 1px solid var(--cc-border);
+  border-radius: 4px; background: var(--cc-surface-1); color: var(--cc-text); }
 .anim-empty { font-size: 0.85rem; color: var(--cc-text-dim); margin-top: 1.5rem; }
 .anim-toolbar { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.9rem; }
 .anim-img { font-size: 0.78rem; font-weight: 600; color: var(--cc-text); margin-right: 0.2rem; }

--- a/frontend/src/stores/animation.ts
+++ b/frontend/src/stores/animation.ts
@@ -6,6 +6,7 @@
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 import { useProjectMetaStore } from './projectMeta'
+import { TITLE_CARD_DEFAULT, type TitleCardCfg } from '../utils/batchMovie'
 
 export interface AnimSnapshot {
   id: string
@@ -21,13 +22,15 @@ export interface AnimSnapshot {
 export const useAnimationStore = defineStore('animation', () => {
   const snapshots = ref<AnimSnapshot[]>([])
   const fps = ref(15)                    // output frame rate (per project)
+  const titleCard = ref<TitleCardCfg>({ ...TITLE_CARD_DEFAULT })   // Phase H4 description slide (per project)
   const _restoring = ref(false)         // suppress autosave while hydrating from the project load
 
   // hydrate from the project-load response (or clear on a project with none / on switch)
-  function load(data: { snapshots?: AnimSnapshot[]; fps?: number } | null | undefined) {
+  function load(data: { snapshots?: AnimSnapshot[]; fps?: number; titleCard?: TitleCardCfg } | null | undefined) {
     _restoring.value = true
     snapshots.value = data?.snapshots ?? []
     fps.value = data?.fps ?? 15
+    titleCard.value = data?.titleCard ?? { ...TITLE_CARD_DEFAULT }
     _restoring.value = false
   }
   function add(s: AnimSnapshot) { snapshots.value = [...snapshots.value, s] }
@@ -58,12 +61,13 @@ export const useAnimationStore = defineStore('animation', () => {
     timer = setTimeout(() => {
       fetch('/api/projects/animations', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ projectUid: uid, animations: { snapshots: snapshots.value, fps: fps.value } }),
+        body: JSON.stringify({ projectUid: uid, animations: { snapshots: snapshots.value, fps: fps.value, titleCard: titleCard.value } }),
       }).catch(() => { /* autosave is best-effort */ })
     }, 600)
   }
   watch(snapshots, _save, { deep: true })
   watch(fps, _save)
+  watch(titleCard, _save, { deep: true })
 
   // drag-and-drop: place the dragged keyframe at the target's position (both must be the same image —
   // the timeline is per-image).
@@ -78,5 +82,5 @@ export const useAnimationStore = defineStore('animation', () => {
     snapshots.value = arr
   }
 
-  return { snapshots, fps, load, add, remove, move, reorder }
+  return { snapshots, fps, titleCard, load, add, remove, move, reorder }
 })

--- a/frontend/src/utils/napariOverlays.ts
+++ b/frontend/src/utils/napariOverlays.ts
@@ -40,6 +40,36 @@ export async function captureViewLegend(
   return { channels, populations, colourBy: cby }
 }
 
+// The movie title-card payload the recorder consumes (Phase H). Channels are NOT included here — the
+// recorder adds them from the live viewer; the frontend supplies only the non-channel sections + title.
+export interface TitleCardPayload {
+  enabled: boolean
+  note: string
+  durationSec: number
+  title: string
+  sections: { heading: string; items: { label: string; colour: string }[] }[]
+}
+// Build the title-card payload for a captured view — the ONE builder shared by single-record and the
+// animation page (both live-view paths). Title = image name + its attribute values; Populations +
+// colour-by sections come from captureViewLegend (the same path as the board strip). Channels are
+// added by the recorder from the viewer, so they're intentionally omitted here.
+export async function buildTitleCard(
+  projectUid: string, imageUid: string,
+  snapshot: { layers?: Record<string, unknown> } | null | undefined,
+  image: { name?: string; attr?: Record<string, string> } | null | undefined,
+  opts: { note: string; durationSec: number; colourBy: string; colourOverrides?: Record<string, string> },
+): Promise<TitleCardPayload> {
+  const leg = await captureViewLegend(projectUid, imageUid, snapshot, opts.colourBy, opts.colourOverrides ?? {})
+  const sections: TitleCardPayload['sections'] = []
+  const pops = leg.populations.map(p => ({ label: p.name, colour: p.colour }))
+  if (pops.length) sections.push({ heading: 'Populations', items: pops })
+  const cby = (leg.colourBy?.items ?? []).filter(it => it.colour).map(it => ({ label: it.label, colour: it.colour }))
+  if (cby.length) sections.push({ heading: leg.colourBy?.column || 'Colour by', items: cby })
+  const attrs = image?.attr ? Object.keys(image.attr).sort().map(k => image.attr![k]?.trim()).filter(Boolean) : []
+  const title = [image?.name ?? '', ...attrs].filter(Boolean).join(' — ')
+  return { enabled: true, note: opts.note, durationSec: opts.durationSec, title, sections }
+}
+
 export interface PushTracksOpts {
   valueNames: string[]            // segmentations whose whole-segmentation (_tracked) ribbons to show
   showGatedTracks: boolean

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -1168,12 +1168,13 @@ class NapariState:
             title_card=title_card)
         return {"frames": frames, "path": path, "n_timepoints": n_t}
 
-    def record_keyframes(self, path: str, keyframes, fps: int = 15, canvas_only: bool = True):
+    def record_keyframes(self, path: str, keyframes, fps: int = 15, canvas_only: bool = True, title_card=None):
         """Render an interpolated keyframe animation to `path` (mp4): each keyframe's saved view state is
         applied + captured with `steps` tween frames from the previous one (camera/contrast/colour/T
-        interpolation). The "connect animation steps" render — see docs/todo/ANIMATION_PLAN.md (F2).
-        Delegates to the shared `napari_utils.record_keyframes`. Needs ≥2 keyframes."""
-        frames = napari_utils.record_keyframes(self._viewer, path, keyframes, fps=fps, canvas_only=canvas_only)
+        interpolation). The "connect animation steps" render — see docs/todo/ANIMATION_PLAN.md (F2);
+        H4 adds `title_card`. Delegates to the shared `napari_utils.record_keyframes`. Needs ≥2 keyframes."""
+        frames = napari_utils.record_keyframes(self._viewer, path, keyframes, fps=fps,
+                                               canvas_only=canvas_only, title_card=title_card)
         return {"frames": frames, "path": path, "keyframes": len(keyframes)}
 
     # ── Task dir (needed for labels / props) ──────────────────────────────────
@@ -1303,7 +1304,8 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
 
         elif t == "record_keyframes":
             res = state.record_keyframes(cmd["path"], cmd.get("keyframes", []),
-                                         fps=cmd.get("fps", 15), canvas_only=cmd.get("canvas_only", True))
+                                         fps=cmd.get("fps", 15), canvas_only=cmd.get("canvas_only", True),
+                                         title_card=cmd.get("title_card"))
             return {"type": "ok", "cmd": t, **res}
 
         elif t == "save_screenshot":

--- a/python/cecelia/tests/test_title_card.py
+++ b/python/cecelia/tests/test_title_card.py
@@ -67,6 +67,33 @@ class RenderCardFrameTests(unittest.TestCase):
         self.assertEqual(arr.shape, (120, 200, 3))
 
 
+class WrapTests(unittest.TestCase):
+    def _draw(self):
+        from PIL import Image, ImageDraw
+        return ImageDraw.Draw(Image.new("RGB", (10, 10)))
+
+    def test_short_title_stays_one_line(self):
+        d, font = self._draw(), tc._font(16)
+        self.assertEqual(tc._wrap_lines(d, "MERTK", font, 10_000), ["MERTK"])
+
+    def test_long_name_wraps_and_every_line_fits(self):
+        d, font = self._draw(), tc._font(16)
+        name = "M1a-MERTK_KAT-SWHL-GFP-Tom-res_0001 — mouse 1 — location B"
+        max_w = 120
+        lines = tc._wrap_lines(d, name, font, max_w)
+        self.assertGreater(len(lines), 1)                       # actually wrapped
+        for ln in lines:
+            self.assertLessEqual(d.textlength(ln, font=font), max_w + 0.5)
+        # nothing dropped: joining the pieces back (ignoring the wrap spaces) preserves every character
+        self.assertEqual("".join(lines).replace(" ", ""), name.replace(" ", ""))
+
+    def test_hard_break_prefers_separator(self):
+        d, font = self._draw(), tc._font(16)
+        # a long no-space token → first line should end at a '-' or '_' where possible
+        lines = tc._wrap_lines(d, "aaa-bbb_ccc-ddd-eee", font, 40)
+        self.assertTrue(lines[0].endswith("-") or lines[0].endswith("_"))
+
+
 class PrependTests(unittest.TestCase):
     def test_prepends_card_frames(self):
         import imageio.v2 as imageio

--- a/python/cecelia/utils/napari_utils.py
+++ b/python/cecelia/utils/napari_utils.py
@@ -467,13 +467,14 @@ def record_timelapse(viewer, path, *, t_axis_index, n_timepoints, fps=15,
   return (t1 - t0) + 1
 
 
-def record_keyframes(viewer, path, keyframes, *, fps=15, canvas_only=True):
+def record_keyframes(viewer, path, keyframes, *, fps=15, canvas_only=True, title_card=None):
   """Render an interpolated keyframe animation to ``path`` (mp4). Each keyframe carries a saved view
   state (``{"viewState": {...}, "steps": N}``); we apply it to ``viewer`` and capture it as a
   napari-animation keyframe with ``steps`` interpolated frames FROM the previous keyframe — so the
   movie tweens between views (camera pans/zooms, contrast/colour fades, T scrubbing). The first
   keyframe just starts the sequence (its ``steps`` is ignored). Needs ≥ 2 keyframes. The "super-simple
-  OpenShot" render path; see docs/todo/ANIMATION_PLAN.md (F2). Returns the frame count."""
+  OpenShot" render path; see docs/todo/ANIMATION_PLAN.md (F2/H4). ``title_card`` (Phase H4) optionally
+  prepends a description slide. Returns the frame count."""
   if len(keyframes) < 2:
     raise ValueError("record_keyframes needs at least 2 keyframes")
   Animation = _require_napari_animation()
@@ -483,6 +484,11 @@ def record_keyframes(viewer, path, keyframes, *, fps=15, canvas_only=True):
     steps = 15 if i == 0 else max(1, int(kf.get("steps", 15)))   # first keyframe: no in-transition
     anim.capture_keyframe(steps=steps)
   anim.animate(path, fps=int(fps), canvas_only=canvas_only)
+  # Phase H4: the card reflects the FIRST keyframe (the frontend built its sections from it) — re-apply
+  # that view so _maybe_prepend_title reads the matching Channels from the viewer, then prepend.
+  if title_card and title_card.get("enabled"):
+    apply_view_state(viewer, keyframes[0].get("viewState") or {})
+  _maybe_prepend_title(viewer, path, title_card)
   return sum(max(1, int(kf.get("steps", 15))) for kf in keyframes[1:]) + 1
 
 


### PR DESCRIPTION
Completes the title card across all three entry points (H1 primitive #327, H2 batch #329, H3 single-record #331 all merged).

**H4 — animation page.** `titleCard` threads `record_keyframes!` → bridge → `napari_utils.record_keyframes`, which **re-applies the first keyframe** after `animate` so the Channels section reads the view the frontend built the card from, then prepends. `api_napari_record_animation` passes the frontend card through. `AnimationModule` gets a title toggle/duration/note in the header, persisted per project in `stores/animation.ts`.

**Consolidation.** New `buildTitleCard` (`utils/napariOverlays.ts`) is the ONE card-payload builder (title + populations + colour-by via `captureViewLegend`) shared by single-record and the animation page. `ViewerPanel` refactored onto it — no duplication.

**Title clipping fix.** The card title was ellipsised, cutting off long image names. Now it renders with a slightly smaller font and **word-wraps**, breaking long unbroken names (`M1a-MERTK_KAT-…-res_0001`) at `-`/`_` where possible so the whole name shows. Pure `_wrap_lines` helper, unit-tested.

**Verified:** Julia parse, Python syntax, frontend typecheck, 327 frontend tests, 12 Python title-card tests (incl. 3 new wrap tests).
**Not verified (no napari here):** the animation record→prepend + first-keyframe channel re-apply, and the wrapped card rendered live — parse/type-checked + unit-tested only.

The card is now complete: **batch · single record · animation**, all sharing one legend/pop resolver (`overlay_legend_content`) and one live-view builder (`buildTitleCard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
