### PR TITLE
Title card UI: compact batch row; animation card spans all keyframes

### DIFF
--- a/docs/todo/ANIMATION_PLAN.md
+++ b/docs/todo/ANIMATION_PLAN.md
@@ -273,12 +273,14 @@ separate doc. Applies to all three movie paths: single record, batch, animation 
   server-side, since it has no live client snapshot). Movie panel gains a title toggle/duration/note
   row, persisted per set in `getMovieConfig().titleCard` (default ON).
 - **~~H4 — animation page~~ — DONE** (`AnimationModule.vue` → `record_keyframes`). Same live-view path
-  as single-record: the frontend builds the payload from the FIRST keyframe's snapshot via the SHARED
-  `buildTitleCard` (→ `captureViewLegend`) and sends it; `record_keyframes` re-applies keyframe 0
-  after `animate` so `_maybe_prepend_title` reads the matching Channels. Header gains a title
-  toggle/duration/note, persisted per project in `stores/animation.ts` (`titleCard`, default ON).
-  `buildTitleCard` (title + populations + colour-by) is now the ONE card-payload builder shared by
-  single-record and the animation page.
+  as single-record, but the card describes everything shown **at some point across the animation**: the
+  frontend merges all keyframes into a UNION snapshot (`unionViewSnapshot` — a layer is shown if visible
+  in any keyframe) and builds the payload from it via the SHARED `buildTitleCard` with
+  `includeChannels: true` (the recorder can't reconstruct the union from one live view, so the animation
+  card carries its own Channels section; `_maybe_prepend_title` skips the viewer read when a Channels
+  section is already present). Header gains a title toggle/duration/note, persisted per project in
+  `stores/animation.ts` (`titleCard`, default ON). `buildTitleCard` (title + channels? + populations +
+  colour-by) is the ONE card-payload builder shared by single-record and the animation page.
 
 ## References
 

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -11,7 +11,7 @@ import { useProjectStore } from '../stores/project'
 import { useLogStore } from '../stores/log'
 import { useAnimationStore, type AnimSnapshot } from '../stores/animation'
 import { useSettingsStore } from '../stores/settings'
-import { buildTitleCard, type TitleCardPayload } from '../utils/napariOverlays'
+import { buildTitleCard, unionViewSnapshot, type TitleCardPayload } from '../utils/napariOverlays'
 import { napariColormapHex } from '../utils/napariColormap'
 import { elapsedLabel } from '../utils/stillOverlay'
 import ConfirmDeleteButton from '../components/ConfirmDeleteButton.vue'
@@ -216,16 +216,18 @@ async function render() {
       viewState: f.snapshot,
       steps: Math.max(1, Math.round((f.duration ?? 1) * anim.fps)),
     }))
-    // Title card (Phase H4): build from the FIRST keyframe's view via the SHARED buildTitleCard (same
-    // path as single-record). The recorder re-applies keyframe 0 to add the matching Channels.
+    // Title card (Phase H4): describe everything shown "at some point" across the animation — build from
+    // a UNION of all keyframes' views (channels + overlays merged), via the SHARED buildTitleCard. It
+    // includes the Channels section itself (from the union), since the recorder can't reconstruct the
+    // union from one live view.
     let titleCard: TitleCardPayload | undefined
     if (anim.titleCard.enabled && frames.value.length) {
       const setUid   = projectStore.setUidOfImage(openImageUid.value ?? '') ?? ''
       const colourBy = setUid ? settings.getColourBy(setUid) : ''
       const overrides = (setUid && colourBy) ? settings.getColourOverrides(setUid, colourBy) : {}
-      const first = frames.value[0].snapshot as { layers?: Record<string, unknown> } | undefined
-      titleCard = await buildTitleCard(projectUid.value, openImageUid.value ?? '', first, openImage.value,
-        { note: anim.titleCard.note, durationSec: anim.titleCard.durationSec, colourBy, colourOverrides: overrides })
+      const union = unionViewSnapshot(frames.value.map(f => f.snapshot as { layers?: Record<string, unknown> } | undefined))
+      titleCard = await buildTitleCard(projectUid.value, openImageUid.value ?? '', union, openImage.value,
+        { note: anim.titleCard.note, durationSec: anim.titleCard.durationSec, colourBy, colourOverrides: overrides, includeChannels: true })
     }
     const res = await fetch('/api/napari/record-animation', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
@@ -253,10 +255,10 @@ async function render() {
           fps <input type="range" min="1" max="40" step="1" v-model.number="anim.fps" class="anim-range" />
           <span class="anim-num">{{ anim.fps }}</span>
         </label>
-        <!-- Title card (Phase H4): prepend a description slide built from the FIRST keyframe's view -->
+        <!-- Title card (Phase H4): prepend a slide describing everything shown across the keyframes -->
         <label class="anim-title-toggle"
-               v-tooltip.bottom="'Prepend a title slide (name, attributes, channels & colours) from the first keyframe'">
-          <input type="checkbox" v-model="anim.titleCard.enabled" /> title
+               v-tooltip.bottom="'Prepend a title slide — name, attributes, and every channel / population / colour-by shown at some point across the animation'">
+          <input type="checkbox" v-model="anim.titleCard.enabled" /> Title card
         </label>
         <template v-if="anim.titleCard.enabled">
           <label class="anim-fps" v-tooltip.bottom="'Title-card duration (seconds)'">

--- a/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
+++ b/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
@@ -303,21 +303,19 @@ async function previewOpen() {
 
       <!-- Title card (Phase H) — auto description slide prepended to each movie -->
       <section class="bm-sec">
-        <h4>
-          <label class="bm-title-toggle"><input type="checkbox" v-model="titleCardOn" /> Title card</label>
-          <span class="bm-sub">name, attributes, channels &amp; colours — prepended to each movie</span>
-        </h4>
-        <template v-if="titleCardOn">
-          <div class="bm-inset">
-            <span class="bm-lbl">duration</span>
-            <input type="range" min="1" max="10" step="1" v-model.number="titleDur" />
+        <div class="bm-title-row">
+          <label class="bm-title-toggle"
+                 v-tooltip.bottom="'Name, attributes, channels &amp; colours — prepended to each movie'">
+            <input type="checkbox" v-model="titleCardOn" /> Title card
+          </label>
+          <template v-if="titleCardOn">
+            <input type="range" min="1" max="10" step="1" v-model.number="titleDur" class="bm-title-range"
+                   v-tooltip.bottom="'Title-card duration (seconds)'" />
             <span class="bm-val">{{ titleDur }}s</span>
-          </div>
-          <div class="bm-attrs">
-            <span class="bm-lbl">note <span class="bm-sub">optional extra line</span></span>
-            <input type="text" class="bm-note" v-model="titleNote" placeholder="e.g. 15s intravital, day 3" />
-          </div>
-        </template>
+          </template>
+        </div>
+        <input v-if="titleCardOn" type="text" class="bm-note" v-model="titleNote"
+               placeholder="note (optional)" />
       </section>
 
       <!-- Actions -->
@@ -365,7 +363,9 @@ async function previewOpen() {
 .bm-preview { font-size: 0.76rem; color: var(--cc-text-dim); margin: 6px 0 0; word-break: break-all; }
 .bm-preview b { color: var(--cc-text); }
 .bm-actions { display: flex; gap: 8px; flex-wrap: wrap; }
-.bm-title-toggle { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; }
-.bm-note { width: 100%; box-sizing: border-box; font: inherit; padding: 3px 6px;
+.bm-title-row { display: flex; align-items: center; gap: 0.5rem; }
+.bm-title-toggle { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; flex-shrink: 0; font-weight: 600; }
+.bm-title-range { flex: 1; min-width: 3rem; accent-color: var(--cc-accent); }
+.bm-note { width: 100%; box-sizing: border-box; font: inherit; padding: 3px 6px; margin-top: 5px;
   border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-1); color: var(--cc-text); }
 </style>

--- a/frontend/src/utils/napariOverlays.test.ts
+++ b/frontend/src/utils/napariOverlays.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { unionViewSnapshot } from './napariOverlays'
+
+// Only the pure helper is tested here; the fetch-backed capture/build functions are exercised live.
+describe('unionViewSnapshot', () => {
+  it('includes a layer visible in ANY keyframe, keeping a colormap from where it is shown', () => {
+    const u = unionViewSnapshot([
+      { layers: { gBT: { colormap: 'green', visible: true }, SHG: { colormap: 'gray', visible: false } } },
+      { layers: { SHG: { colormap: 'gray', visible: true }, '(flow) segA/tcells': { visible: true } } },
+    ])
+    const layers = u.layers as Record<string, { colormap?: string; visible?: boolean }>
+    expect(layers.gBT).toMatchObject({ visible: true, colormap: 'green' })
+    expect(layers.SHG).toMatchObject({ visible: true, colormap: 'gray' })   // shown in kf2 → included
+    expect(layers['(flow) segA/tcells'].visible).toBe(true)                 // overlay layer carried through
+  })
+
+  it('a layer hidden in every keyframe stays not-visible', () => {
+    const u = unionViewSnapshot([
+      { layers: { X: { colormap: 'red', visible: false } } },
+      { layers: { X: { colormap: 'red', visible: false } } },
+    ])
+    expect((u.layers as Record<string, { visible?: boolean }>).X.visible).toBe(false)
+  })
+
+  it('tolerates empty / missing snapshots', () => {
+    expect(unionViewSnapshot([undefined, null, {}]).layers).toEqual({})
+  })
+})

--- a/frontend/src/utils/napariOverlays.ts
+++ b/frontend/src/utils/napariOverlays.ts
@@ -52,15 +52,18 @@ export interface TitleCardPayload {
 // Build the title-card payload for a captured view — the ONE builder shared by single-record and the
 // animation page (both live-view paths). Title = image name + its attribute values; Populations +
 // colour-by sections come from captureViewLegend (the same path as the board strip). Channels are
-// added by the recorder from the viewer, so they're intentionally omitted here.
+// normally added by the recorder from the live viewer and omitted here — EXCEPT when `includeChannels`
+// is set (the animation page, which passes a UNION snapshot across all keyframes so the card reflects
+// everything shown "at some point"; the recorder can't reconstruct that union from one live view).
 export async function buildTitleCard(
   projectUid: string, imageUid: string,
   snapshot: { layers?: Record<string, unknown> } | null | undefined,
   image: { name?: string; attr?: Record<string, string> } | null | undefined,
-  opts: { note: string; durationSec: number; colourBy: string; colourOverrides?: Record<string, string> },
+  opts: { note: string; durationSec: number; colourBy: string; colourOverrides?: Record<string, string>; includeChannels?: boolean },
 ): Promise<TitleCardPayload> {
   const leg = await captureViewLegend(projectUid, imageUid, snapshot, opts.colourBy, opts.colourOverrides ?? {})
   const sections: TitleCardPayload['sections'] = []
+  if (opts.includeChannels && leg.channels.length) sections.push({ heading: 'Channels', items: leg.channels })
   const pops = leg.populations.map(p => ({ label: p.name, colour: p.colour }))
   if (pops.length) sections.push({ heading: 'Populations', items: pops })
   const cby = (leg.colourBy?.items ?? []).filter(it => it.colour).map(it => ({ label: it.label, colour: it.colour }))
@@ -68,6 +71,30 @@ export async function buildTitleCard(
   const attrs = image?.attr ? Object.keys(image.attr).sort().map(k => image.attr![k]?.trim()).filter(Boolean) : []
   const title = [image?.name ?? '', ...attrs].filter(Boolean).join(' — ')
   return { enabled: true, note: opts.note, durationSec: opts.durationSec, title, sections }
+}
+
+// Merge the layers of several view snapshots into ONE — a layer is present/visible if it's visible in
+// ANY snapshot, with a colormap taken from a snapshot where it's shown. Lets the animation card describe
+// every channel/overlay that appears "at some point" across the keyframes (Phase H4). Pure.
+export function unionViewSnapshot(
+  snapshots: ({ layers?: Record<string, unknown> } | null | undefined)[],
+): { layers: Record<string, unknown> } {
+  const merged: Record<string, { colormap?: string; visible?: boolean; [k: string]: unknown }> = {}
+  for (const s of snapshots) {
+    const layers = (s?.layers ?? {}) as Record<string, { colormap?: string; visible?: boolean }>
+    for (const [name, l] of Object.entries(layers)) {
+      const prev = merged[name]
+      const shownHere = l?.visible !== false
+      merged[name] = {
+        ...(prev ?? {}), ...l,
+        visible: shownHere || prev?.visible === true,
+        // keep a colormap from a snapshot where the layer is actually shown
+        colormap: (shownHere && typeof l?.colormap === 'string') ? l.colormap
+          : (prev?.colormap ?? (typeof l?.colormap === 'string' ? l.colormap : undefined)),
+      }
+    }
+  }
+  return { layers: merged }
 }
 
 export interface PushTracksOpts {

--- a/python/cecelia/utils/napari_utils.py
+++ b/python/cecelia/utils/napari_utils.py
@@ -420,17 +420,21 @@ def _visible_channel_legend(viewer):
 
 
 def _maybe_prepend_title(viewer, path, title_card):
-  """If a title card is enabled, prepend it to the just-recorded movie: build the Channels section from
-  the live viewer, prepend it to the Julia-assembled sections (colour-by, …), and composite via
-  ``cecelia.utils.title_card``. Best-effort — a failure logs and leaves the movie untouched; it never
-  fails the recording."""
+  """If a title card is enabled, prepend it to the just-recorded movie: add a Channels section read from
+  the live viewer (unless the payload ALREADY carries one — the animation page supplies a union across
+  all keyframes, which the single live view can't reconstruct), prepend it to the caller's sections
+  (populations / colour-by, …), and composite via ``cecelia.utils.title_card``. Best-effort — a failure
+  logs and leaves the movie untouched; it never fails the recording."""
   if not title_card or not title_card.get("enabled"):
     return
   try:
     from cecelia.utils import title_card as _tc
-    channels = _visible_channel_legend(viewer)
-    sections = ([{"heading": "Channels", "items": channels}] if channels else []) \
-        + list(title_card.get("sections") or [])
+    sections = list(title_card.get("sections") or [])
+    has_channels = any((s.get("heading") or "").strip().lower() == "channels" for s in sections)
+    if not has_channels:
+      channels = _visible_channel_legend(viewer)
+      if channels:
+        sections = [{"heading": "Channels", "items": channels}] + sections
     content = {"title": title_card.get("title", ""), "note": title_card.get("note", ""), "sections": sections}
     _tc.prepend_title_to_movie(path, content, duration_sec=float(title_card.get("durationSec", 3.0)))
   except Exception as e:
@@ -484,10 +488,8 @@ def record_keyframes(viewer, path, keyframes, *, fps=15, canvas_only=True, title
     steps = 15 if i == 0 else max(1, int(kf.get("steps", 15)))   # first keyframe: no in-transition
     anim.capture_keyframe(steps=steps)
   anim.animate(path, fps=int(fps), canvas_only=canvas_only)
-  # Phase H4: the card reflects the FIRST keyframe (the frontend built its sections from it) — re-apply
-  # that view so _maybe_prepend_title reads the matching Channels from the viewer, then prepend.
-  if title_card and title_card.get("enabled"):
-    apply_view_state(viewer, keyframes[0].get("viewState") or {})
+  # Phase H4: the animation card carries its OWN Channels section (a union across all keyframes, built
+  # by the frontend), so _maybe_prepend_title uses that and does not read the live viewer here.
   _maybe_prepend_title(viewer, path, title_card)
   return sum(max(1, int(kf.get("steps", 15))) for kf in keyframes[1:]) + 1
 


### PR DESCRIPTION
Two polish items on the (now-complete) title card.

**Batch page — compact.** The "name, attributes, channels & colours — prepended to each movie" blurb moves to a **tooltip** on the Title-card checkbox, and the **duration slider is inline** next to the checkbox instead of a dedicated row; the optional note drops below only when the card is enabled.

**Animation page — card spans the whole animation.** The header toggle is relabeled "Title card" (clearer). The card now describes everything shown **at some point across the keyframes**, not just the first: a new pure `unionViewSnapshot` merges all keyframes' layers (a channel/overlay is counted if visible in *any* keyframe), and `buildTitleCard(..., includeChannels: true)` builds from that union. `napari_utils._maybe_prepend_title` skips its live-viewer channel read when the payload already carries a Channels section (no double-count), and the now-dead keyframe-0 re-apply in `record_keyframes` is removed.

**Verified:** frontend typecheck, 330 frontend tests (incl. a new `unionViewSnapshot` test), Python syntax.
**Not verified (no napari here):** the animation union card + Python skip-channels are logic/unit-tested only; the batch UI compaction isn't browser-checked by me.

Note: depends on #336 (the CI fix restoring `_wrap_lines`) being merged for CI to pass on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
