### PR TITLE
Fix crop dropping calibration; relocate image-strip per-frame actions

### DIFF
--- a/app/src/tasks/editImages/cropImage.jl
+++ b/app/src/tasks/editImages/cropImage.jl
@@ -1,5 +1,29 @@
 struct CropImage <: CciaTask end
 
+# Pure: derive the crop's inherited calibration meta from the SOURCE image's `meta` + the (half-open)
+# crop `box`. A crop keeps the same physical pixel size, channels and frame interval — only the extent
+# shrinks — so the physical scale/unit and channel count carry over unchanged; the Z/T counts shrink to
+# the box when that axis is trimmed (a `-1` bound means "keep the whole axis"). Kept out of `_run_task`
+# so it's unit-testable without a project/zarr on disk. See the crop-metadata note in `_run_task`.
+function _crop_inherited_meta(src_meta::AbstractDict, box::NamedTuple)::Dict{String,Any}
+    out = Dict{String,Any}()
+    for k in ("PhysicalSizeX", "PhysicalSizeY", "PhysicalSizeZ", "PhysicalSizeUnit",
+              "PhysicalSizeZ_raw", "TimeIncrement", "TimeIncrementUnit", "SizeC")
+        haskey(src_meta, k) && (out[k] = src_meta[k])
+    end
+    if box.z0 != -1 && box.z1 != -1
+        out["SizeZ"] = box.z1 - box.z0
+    elseif haskey(src_meta, "SizeZ")
+        out["SizeZ"] = src_meta["SizeZ"]
+    end
+    if box.t0 != -1 && box.t1 != -1
+        out["SizeT"] = box.t1 - box.t0
+    elseif haskey(src_meta, "SizeT")
+        out["SizeT"] = src_meta["SizeT"]
+    end
+    out
+end
+
 # Crop an image to a pixel bounding box and register the result as a NEW image in the same set (a crop
 # changes the extent, so it can't be a version of the source — it's a new image). The box (full-res
 # pixels, half-open) comes from the napari 3D-crop draw (bridge `crop_box`); z0/z1/t0/t1 are -1 when
@@ -42,13 +66,26 @@ function _run_task(task::CropImage, img::CciaImage, params::Dict{String,Any};
     z0 = Int(get(params, "z0", -1)); z1 = Int(get(params, "z1", -1))
     t0 = Int(get(params, "t0", -1)); t1 = Int(get(params, "t1", -1))
 
+    # Inherit the source image's calibration onto the crop (SizeC/T/Z, PhysicalSize*, TimeIncrement).
+    # `read_ome_metadata` can't re-derive it here — it hardcodes the bioformats2raw nested `0/.zattrs`
+    # layout, but a crop is written FLAT by `create_multiscales` (multiscales at the ROOT `.zattrs`; see
+    # the OME-ZARR dual-format trap in CLAUDE.md) — so carry it from the source's ccid `meta`, the same
+    # source→crop pattern already used for `imChannelNames` below. Without this the crop's ccid had NO
+    # calibration, so the metadata dialog showed "—" and the strip timestamp had no Δt to draw.
+    src_meta  = Dict{String,Any}(String(k) => v for (k, v) in get(raw, "meta", Dict{String,Any}()))
+    crop_meta = Dict{String,Any}(
+        "crop_source_uid"        => img.uid,
+        "crop_source_value_name" => value_name,
+        "crop_box" => Dict{String,Any}("x0"=>x0, "x1"=>x1, "y0"=>y0, "y1"=>y1,
+                                       "z0"=>z0, "z1"=>z1, "t0"=>t0, "t1"=>t1))
+    merge!(crop_meta, _crop_inherited_meta(src_meta, (; x0, x1, y0, y1, z0, z1, t0, t1)))
+    # provenance: a crop derives from the source's original file, so carry `ori_path` forward. Best-effort
+    # — images imported before source-path tracking have none, so the crop's dialog still reads "not
+    # recorded" (it inherits the source's gap rather than inventing one).
+    haskey(src_meta, "ori_path") && (crop_meta["ori_path"] = src_meta["ori_path"])
+
     # register a NEW image in the set (new uid + {proj}/0|1/{uid} dirs, appended to the set manifest)
-    new_img = add_image!(s; name = "$(img.name) (cropped)", kind = img.kind,
-        meta = Dict{String,Any}(
-            "crop_source_uid"        => img.uid,
-            "crop_source_value_name" => value_name,
-            "crop_box" => Dict{String,Any}("x0"=>x0, "x1"=>x1, "y0"=>y0, "y1"=>y1,
-                                           "z0"=>z0, "z1"=>z1, "t0"=>t0, "t1"=>t1)))
+    new_img = add_image!(s; name = "$(img.name) (cropped)", kind = img.kind, meta = crop_meta)
 
     # per-task run subdirs (mirrors the import route) so downstream tasks have their homes on the new image
     task_dirs = get(get(cecelia_conf(), "dirs", Dict()), "tasks", Dict())

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -861,6 +861,28 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
                                           "z0" => 2, "z1" => 8, "t0" => -1, "t1" => -1)) === nothing
     end
 
+    @testset "CropImage inherits source calibration (pure helper)" begin
+        # A crop must carry the source's physical calibration onto the new image (else the metadata
+        # dialog shows "—" and the strip timestamp has no Δt) — see cropImage.jl.
+        src = Dict{String,Any}(
+            "SizeC" => 4, "SizeZ" => 20, "SizeT" => 181,
+            "PhysicalSizeX" => 0.33, "PhysicalSizeY" => 0.33, "PhysicalSizeZ" => 2.0,
+            "PhysicalSizeUnit" => "micrometer", "TimeIncrement" => 15, "TimeIncrementUnit" => "second",
+            "ori_path" => "/should/not/carry")                       # non-calibration keys stay behind
+        # Z trimmed [2,8), T kept whole (-1) → SizeZ shrinks, SizeT & the scale/unit carry over unchanged
+        m = Cecelia._crop_inherited_meta(src, (; x0=0, x1=100, y0=0, y1=100, z0=2, z1=8, t0=-1, t1=-1))
+        @test m["SizeZ"] == 6                     # 8 - 2 (half-open)
+        @test m["SizeT"] == 181                   # axis kept → source count
+        @test m["SizeC"] == 4                     # channels invariant under crop
+        @test m["PhysicalSizeX"] == 0.33 && m["TimeIncrement"] == 15
+        @test m["TimeIncrementUnit"] == "second"
+        @test !haskey(m, "ori_path")              # only calibration is inherited
+        # T also trimmed [10,40); a source missing SizeZ → no SizeZ key invented
+        m2 = Cecelia._crop_inherited_meta(Dict{String,Any}("SizeC" => 2),
+                                          (; x0=0, x1=50, y0=0, y1=50, z0=-1, z1=-1, t0=10, t1=40))
+        @test m2["SizeT"] == 30 && m2["SizeC"] == 2 && !haskey(m2, "SizeZ")
+    end
+
     @testset "Custom module registry (drop-in tasks)" begin
         # A user drops a task by calling register_task! with an instance + a spec path; it must then
         # resolve through _task_from_fun_name / _spec_path / validate_params exactly like a built-in.

--- a/frontend/src/components/StillOverlay.vue
+++ b/frontend/src/components/StillOverlay.vue
@@ -34,21 +34,30 @@ const barY = computed(() => ey.value - my.value - barH.value)
 </script>
 
 <template>
-  <svg v-if="ok" class="still-ovl" :viewBox="`0 0 ${ex} ${ey}`" preserveAspectRatio="xMidYMid meet">
-    <!-- timestamp, top-left -->
-    <text v-if="showTimestamp && timeLabel" :x="mx" :y="my + font" :font-size="font"
-          class="ovl-text" text-anchor="start">{{ timeLabel }}</text>
-    <!-- scale bar, bottom-right: bar + label centered above it -->
-    <template v-if="showScaleBar && bar">
+  <div class="still-ovl">
+    <!-- elapsed-time timestamp, top-left: plain HTML so it draws even when the frame has NO physical
+         extent — a timestamp needs no µm scale (the scale bar below does). Previously it lived inside the
+         extent-gated <svg v-if="ok">, so ticking "timestamp" on a frame without an extent did nothing. -->
+    <div v-if="showTimestamp && timeLabel" class="ovl-ts">{{ timeLabel }}</div>
+    <!-- vector scale bar, bottom-right: an SVG whose viewBox IS the frame's physical extent (µm), so the
+         bar length is correct by construction and stays aligned to the letterboxed image. Needs the extent. -->
+    <svg v-if="ok && showScaleBar && bar" class="ovl-svg" :viewBox="`0 0 ${ex} ${ey}`" preserveAspectRatio="xMidYMid meet">
       <rect :x="barX1" :y="barY" :width="bar.um" :height="barH" class="ovl-fill" />
       <text :x="(barX1 + barX2) / 2" :y="barY - font * 0.35" :font-size="font"
             class="ovl-text" text-anchor="middle">{{ bar.label }}</text>
-    </template>
-  </svg>
+    </svg>
+  </div>
 </template>
 
 <style scoped>
-.still-ovl { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+.still-ovl { position: absolute; inset: 0; pointer-events: none; }
+.ovl-svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+/* timestamp: white with a dark outline (four text-shadows ≈ SVG paint-order stroke) so it reads on any
+   background, matching the channel legend's on-image styling (.is-legend). */
+.ovl-ts { position: absolute; top: 5px; left: 6px; color: #fff; font-weight: 700; line-height: 1;
+  font-family: system-ui, sans-serif; font-size: 11px;
+  text-shadow: -1px -1px 0 rgba(0,0,0,0.85), 1px -1px 0 rgba(0,0,0,0.85),
+               -1px 1px 0 rgba(0,0,0,0.85), 1px 1px 0 rgba(0,0,0,0.85); }
 /* white with a dark outline so it reads on any background (like napari's overlays) */
 .ovl-text { fill: #fff; paint-order: stroke; stroke: rgba(0,0,0,0.85); stroke-width: 0.5;
   font-weight: 700; font-family: system-ui, sans-serif; }

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -417,11 +417,16 @@ defineExpose({ exportImage })
 .is-capture { flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px;
   border: 1px dashed var(--cc-border); background: transparent; color: var(--cc-text-dim); cursor: pointer; font-size: 12px; }
 .is-capture:hover { color: var(--cc-text); border-color: #7c3aed; }
-/* per-frame actions (recapture / remove): TOP-right. The BOTTOM band is owned by the panel footer
-   overlay (Duplicate / Export) — the actions used to collide with the Duplicate button there. The top
-   band only holds the LEFT-aligned strip toolbar, so top-right is clear; z-index 7 keeps them above
-   the auto-hide toolbar (z-index 6) so hovering never masks them (the earlier "retake masked" bug). */
-.is-actions { position: absolute; top: 4px; right: 4px; display: flex; gap: 4px; z-index: 7; }
+/* per-frame actions (zoom-to-source / recapture / remove): BOTTOM-left, revealed on cell hover.
+   They used to sit TOP-right (z-index 7) — but that's exactly where the CanvasPanel's OWN controls
+   live (pin / duplicate / ⋯ menu, z-index 6), so the always-on strip actions sat on top and blocked
+   them. Bottom-right holds the scale bar and the panel footer (Duplicate/Export), so bottom-left is
+   the free corner. Auto-hide (like the toolbar) so they never permanently obscure the frame or the
+   optional channel legend that also anchors bottom-left; z-index 8 keeps them above it while hovering,
+   and the `.is-strip.capturing` rule below drops them from the PDF export. */
+.is-actions { position: absolute; bottom: 4px; left: 4px; display: flex; gap: 4px; z-index: 8;
+  opacity: 0; transition: opacity 0.12s ease; }
+.is-cell:hover .is-actions { opacity: 1; }
 /* per-frame action buttons — match the app's icon buttons (like .is-gear / .opt-btn) rather than the
    old dark translucent pills: solid surface + border, purple accent on hover. Sit over the image, so a
    solid surface reads cleanly. */


### PR DESCRIPTION
## Problem

Cropping an image lost **all** its calibration. `cropImage_run.py` writes correct OME-XML into the cropped zarr, but the Julia handler only wrote `crop_source_uid` / `crop_box` / channel names into the new image's `ccid.json` meta — never `SizeC/T/Z`, `PhysicalSize*`, or `TimeIncrement*`. And `read_ome_metadata` can't back-fill them: the crop is written **flat** (`create_multiscales` → multiscales at the root `.zattrs`) while that reader hardcodes the bioformats2raw nested `0/.zattrs` layout (the documented OME-ZARR dual-format trap).

Downstream, cropped images showed `—` for every field in the metadata dialog, and the Analysis-board image-strip timestamp had no Δt to compute, so ticking "timestamp" did nothing.

## Changes

- **`cropImage.jl`** — inherit the source's calibration onto the crop (`SizeC` + `PhysicalSize*` + `TimeIncrement*` invariant; `SizeZ`/`SizeT` shrunk to the half-open crop box) plus `ori_path` provenance, via a pure, unit-tested helper `_crop_inherited_meta` — the same source→crop pattern already used for `imChannelNames`. **+ package test.**
- **`ImageStripView.vue`** — moved the per-frame actions (zoom-to-source / recapture / remove) from top-right, where they sat on top of the CanvasPanel's own pin/duplicate/⋯ controls (`z-index 7` over `6`) and blocked them, to **bottom-left**, revealed on cell hover.
- **`StillOverlay.vue`** — decoupled the timestamp from the scale-bar's physical-extent gate (it was inside `<svg v-if="ok">`, so a frame without a µm extent drew no timestamp even though a timestamp needs none). Now HTML, matching the channel legend.

## Tests

- Frontend: `npm run typecheck` clean; 327/327 vitest pass.
- Julia: new `_crop_inherited_meta` testset passes; all suites green **except** one pre-existing, unrelated failure — `run_py custom-modules PYTHONPATH` expects `.../modules/python` but the code returns `.../modules` (out of sync with the py-package-boundary refactor; outside this diff).

## Notes

- Fixes forward crops only. Existing crops need re-cropping or a manual meta backfill (I repaired the one in the dev `zolIMa` project directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
