### PR TITLE
fix(ui): keep BaseModal open on drag-release; crop dialog closes on dispatch (runs in background)

### DIFF
--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -25,13 +25,20 @@ const emit = defineEmits<{ (e: 'close'): void }>()
 
 const boxStyle = computed(() => ({ width: props.width, ...(props.height ? { height: props.height } : {}) }))
 
+// Close on overlay click ONLY when the press *started* on the overlay — otherwise a drag that
+// begins inside the dialog (e.g. dragging a slider) and releases over the overlay fires a `click`
+// whose target is the overlay, closing the dialog mid-drag. Track the mousedown origin to guard it.
+let pressedOnOverlay = false
+function onOverlayMouseDown(e: MouseEvent) { pressedOnOverlay = e.target === e.currentTarget }
+function onOverlayClick() { if (pressedOnOverlay) emit('close'); pressedOnOverlay = false }
+
 function onKey(e: KeyboardEvent) { if (e.key === 'Escape') emit('close') }
 onMounted(() => window.addEventListener('keydown', onKey))
 onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
 </script>
 
 <template>
-  <div class="cc-modal-overlay" @click.self="emit('close')">
+  <div class="cc-modal-overlay" @mousedown="onOverlayMouseDown" @click.self="onOverlayClick">
     <div class="cc-modal" :style="boxStyle">
       <div class="cc-modal-header">
         <span class="cc-modal-title">

--- a/frontend/src/components/CropDialog.vue
+++ b/frontend/src/components/CropDialog.vue
@@ -46,7 +46,8 @@ function defaultValueName(): string {
                :image-uid="image.uid"
                :image-name="image.name"
                :value-name="selectedValueName"
-               :set-uid="setUid" />
+               :set-uid="setUid"
+               @submitted="$emit('close')" />
   </BaseModal>
 </template>
 

--- a/frontend/src/components/CropPanel.vue
+++ b/frontend/src/components/CropPanel.vue
@@ -11,6 +11,9 @@ import { cropBoxFromRect, fracRangeLabel, normalizeRange, type CropInfo, type No
 import RangeSlider from './RangeSlider.vue'
 
 const props = defineProps<{ projectUid: string; imageUid: string; imageName: string; valueName: string; setUid: string }>()
+// Emitted once the crop is DISPATCHED (not when it finishes) — the parent closes the dialog so the
+// user isn't left staring at a blocking-looking modal; the crop runs in the background (task console).
+const emit = defineEmits<{ (e: 'submitted'): void }>()
 
 const taskStore = useTaskStore()
 const ws        = useWsStore()
@@ -114,9 +117,10 @@ function save() {
     type: 'task:run', taskId: task.id, funName: 'editImages.cropImage', params,
     imageUid: props.imageUid, projectUid: props.projectUid, setUid: props.setUid, poolName: 'io',
   })
-  log.info('Cropping image → new image in the set (appears when the task finishes).', { source: 'crop' })
+  log.info('Cropping image → new image in the set (runs in the background; watch the task console).', { source: 'crop' })
   rect.value = null
-  setTimeout(() => { saving.value = false }, 1500)
+  saving.value = false
+  emit('submitted')   // close the dialog — the crop is now running in the background (task console)
 }
 </script>
 


### PR DESCRIPTION
Two small dialog-UX fixes (frontend-only, `vue-tsc -b` green):

**1. BaseModal doesn't close mid-drag.** The overlay only closes when the *press started* on the overlay (track mousedown origin), so dragging a slider that begins inside the dialog and releases over the overlay no longer dismisses it. Affected crop and every other `BaseModal` dialog.

**2. Crop dialog closes on dispatch.** The crop already runs in the background via the task rail, but the dialog stayed open — looking hung ("did it crash?"). CropPanel now emits `submitted` right after dispatching `task:run`, and CropDialog closes; progress shows in the task console.

Reservation: BaseModal's close behavior changes for all dialogs (broad but strict improvement — only closes on a genuine overlay click). Not clicked through live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)