### PR TITLE
Unify hand-rolled .btn-* into global .cc-btn (+ UX primitives tracker)

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -102,9 +102,21 @@ Global classes defined in `style.css` — use these everywhere instead of scoped
 <button class="cc-btn cc-btn-primary" @click="...">
   <i class="pi pi-plus" /> Add images
 </button>
+
+<!-- Destructive: solid (prominent, standalone) vs ghost (subtle, inline in a table/bar) -->
+<button class="cc-btn cc-btn-danger" @click="...">Delete project</button>
+<button class="cc-btn cc-btn-danger-ghost" @click="...">Delete</button>
 ```
 
-Both support `:disabled` (opacity 0.35, not-allowed cursor) and work with `v-tooltip`.
+`.cc-btn` is always the base; add exactly one colour modifier (`-primary` / `-ghost` / `-danger` /
+`-danger-ghost`). All support `:disabled` (opacity 0.35, not-allowed cursor) and `v-tooltip`.
+
+**Never hand-roll `.btn-sm` / `.btn-primary` / `.btn-danger` in a component's scoped `<style>`.** That
+was the old trap: a class that *looks* shared but is re-declared per file (and drifts — the danger
+colour was `#b91c1c` in one place and `#7f1d1d44` in three, disabled opacity varied 0.35/0.4/0.55), and
+a page that used the class without its own copy got a raw browser button (the Movies refresh bug). One
+source: these utilities. (Bespoke *icon-only* buttons — `.po-toggle`, viewer-green action icons, etc. —
+are a separate, intentional case, not this family.)
 
 ## Form controls
 

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -1,0 +1,70 @@
+# UX primitives — unification tracker
+
+**Purpose.** A living checklist of the app's UX primitives (buttons, toggles, sliders, empty states,
+…) recording, for each: whether a **single canonical shared component/util** exists, where
+**divergent hand-rolled copies** still live, and the unification status. This exists because the
+"looks shared but is re-declared per file, and drifts" pattern (the [divergent re-implementation
+trap](../../CLAUDE.md)) keeps recurring — a checkbox styled as a toggle in one place and a native box
+in another; a `.btn-sm` that renders as a raw browser button on a page that forgot to copy the CSS.
+The rule for every entry: **one canonical thing; the second copy is the bug.**
+
+**How to use it.** Before adding a boolean/button/slider/empty-state/etc., check the "canonical" column
+and use it. When you unify a category, tick it here and add the rule to `docs/UI.md`. Snapshot from the
+2026-07 audit (counts are approximate and drift as files change — re-grep before starting a phase).
+
+## Canonical components/utilities (the baseline — use these)
+
+| Primitive | Canonical | Notes |
+|-----------|-----------|-------|
+| On/off toggle (option) | `components/CcToggle.vue` | `v-model`, `label` prop/slot, `disabled`. Rule: toggle = one immediate option; checkbox = selection from a list. |
+| Chips / segmented select | `components/ChipSelect.vue` | pill/segmented, single/multi, reorderable. |
+| Colour dropdown | `components/SwatchSelect.vue` | |
+| Confirm / delete | `components/ConfirmButton.vue`, `ConfirmDeleteButton.vue` | arm→confirm; some dialogs still inline their own confirm flow. |
+| Buttons | `.cc-btn` + `-primary`/`-ghost`/`-danger`/`-danger-ghost` (`style.css`) | never hand-roll `.btn-*` in scoped CSS. |
+| Modal / dialog | `components/BaseModal.vue` | backdrop + panel + close; ~9 consumers. |
+| Popover / dropdown | `components/TeleportPopover.vue` | ~11 consumers. |
+| Tabs | `components/canvas/TabbedCanvas.vue` | + `ChipSelect` segmented. |
+| Collapsible section | `components/CollapsibleSection.vue` | ~7 consumers; **but ~15 hand-rolled chevron toggles bypass it** (see Phase 4). |
+| Range (dual-thumb) | `components/RangeSlider.vue` | min+max only; **no single-value wrapper yet** (see Phase 2). |
+| Plot-area spinner | `components/plots/PlotSpinner.vue` | plot area only; inline busy spinners are ad-hoc (see Phase 6). |
+| Severity colours | `lib/severity.ts` + `--cc-sev-*` | status colours should route through this. |
+
+## Phases (priority order — biggest divergence / highest bug-risk first)
+
+- [x] **Phase 0 — Toggles.** `CcToggle` created; all immediate-option checkboxes migrated; multi-select
+  lists kept as native checkboxes. (PR #341.)
+- [x] **Phase 1 — Buttons.** Deleted 8 scoped `.btn-*` blocks (`PhysicalSizeDialog`, `ProjectPanel`,
+  `SetBar`, `FileBrowser`, `ImageTable`, `MetadataPanel`, `GatingCopyDialog`, `AnimationModule`);
+  migrated all markup to `.cc-btn` + modifier; added canonical `.cc-btn-danger` (solid) and
+  `.cc-btn-danger-ghost` (subtle) to `style.css`, resolving the two drifted danger schemes. Also fixed
+  the Movies refresh button (raw browser button — used the non-global `.btn-sm`).
+- [ ] **Phase 2 — Range sliders.** ~26 raw `<input type="range">` across ~12 files, each with its own
+  label/value/width markup (`.pt-slider`, `.cz-range`, `.anim-range`, `.movie-range`, `.po-row` ranges,
+  …). Add a single-value `CcRange` (label + value readout + track); `RangeSlider` stays the dual-thumb
+  specialist. High count; inconsistent value/step display.
+- [ ] **Phase 3 — Empty states.** ~23 distinct scoped `*-empty` classes, no component (richest is
+  `ImageTable`'s `.empty-state` — icon + title + hint + CTA). Add `<EmptyState>` (icon/title/hint +
+  optional CTA slot). High visual divergence, low bug-risk.
+- [ ] **Phase 4 — Collapsible section headers.** `CollapsibleSection` exists but ~15 chevron+heading
+  toggles are hand-rolled (`PlotOptions` ×4 `.po-toggle`, `MetadataPanel`, `ParamRenderer`,
+  `PopulationManager`, `CanvasPanel`, `TaskList`, `ErrorConsole`, `AppSidebar` nav groups). Migrate onto
+  `CollapsibleSection` or a shared `.cc-section-toggle`.
+- [ ] **Phase 5 — Status colours / badges.** Duplicated status→icon maps (`TasksModule`, `TaskList`,
+  `ChainLiveNode`) and traffic-light colours not on `--cc-sev-*` (already flagged in `style.css`). Route
+  through `severity.ts`; optional `<CcBadge>` for counts. Correctness/CVD-safety relevance.
+- [ ] **Phase 6 — Inline spinners.** 40+ inline `pi-spin` busy icons, two spellings (`pi-cog` vs
+  `pi-spinner`). Standardize the busy-icon idiom (or a tiny `<CcSpinner>`). Low bug-risk, high count.
+- [ ] **Phase 7 — Card/panel chrome.** 200+ repeated surface+border+radius blocks; no `.cc-card` util.
+  Add `.cc-card`/`.cc-surface`. Cosmetic, largest raw duplication, lowest priority.
+- [ ] **Phase 8 (optional) — Icon-only buttons.** ~90 bespoke `*-btn`/`*-ico` classes; mostly
+  intentional (different sizes, hover-reveal, viewer-green accents). Optional `.cc-icon-btn` base +
+  per-component sizing; not the same trap as `.btn-*`.
+
+**Healthy / no action:** Modals (`BaseModal`), popovers (`TeleportPopover`), tabs (`TabbedCanvas`),
+chips (`ChipSelect`), colour dropdown (`SwatchSelect`), toggles (`CcToggle`).
+
+## Convention going forward
+
+Each unified primitive gets a one-liner in `docs/UI.md` (the *when to use which*) and a line in
+`INVENTORY.md` (the *where it lives*). A new hand-rolled copy of a primitive that has a canonical form
+is a bug, caught in review — same reflex as the H5AD/zarr/`run_py` single-helper rules in `CLAUDE.md`.

--- a/frontend/src/components/FileBrowser.vue
+++ b/frontend/src/components/FileBrowser.vue
@@ -166,7 +166,7 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 
         <div v-else-if="error" class="fb-state error">
           <i class="pi pi-exclamation-triangle" /> {{ error }}
-          <button class="btn-ghost btn-sm" @click="navigate('')">Back to home</button>
+          <button class="cc-btn cc-btn-ghost" @click="navigate('')">Back to home</button>
         </div>
 
         <table v-else class="fb-table">
@@ -251,17 +251,17 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
       <span class="sel-count dim" v-else>{{ mode === 'bundle' ? 'No bundle selected' : 'No files selected' }}</span>
 
       <div class="footer-actions">
-        <button class="btn-ghost btn-sm" @click="$emit('close')"
+        <button class="cc-btn cc-btn-ghost" @click="$emit('close')"
           v-tooltip.top="'Cancel and close the file browser.'">
           Cancel
         </button>
         <!-- dir mode: pick the current folder; image/bundle: confirm the selection -->
-        <button v-if="mode === 'dir'" class="btn-primary btn-sm"
+        <button v-if="mode === 'dir'" class="cc-btn cc-btn-primary"
           :disabled="!listing?.current" @click="confirm"
           v-tooltip.top="'Use this folder.'">
           <i class="pi pi-check" /> Use this folder
         </button>
-        <button v-else class="btn-primary btn-sm"
+        <button v-else class="cc-btn cc-btn-primary"
           :disabled="selected.size === 0" @click="confirm"
           v-tooltip.top="mode === 'bundle'
             ? 'Import the selected bundle.'
@@ -359,17 +359,5 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 /* footer */
 .sel-count { font-size: 0.78rem; color: var(--cc-text); flex: 1; }
 .footer-actions { display: flex; gap: 0.4rem; }
-
-.btn-sm {
-  display: flex; align-items: center; gap: 0.3rem;
-  font-size: 0.78rem; font-weight: 500;
-  padding: 0.35rem 0.75rem;
-  border-radius: 0.35rem; border: 1px solid transparent;
-  cursor: pointer;
-}
-.btn-ghost { background: var(--cc-surface-2); border-color: var(--cc-border); color: var(--cc-text-dim); }
-.btn-ghost:hover { color: var(--cc-text); }
-.btn-primary { background: var(--cc-accent); color: #fff; }
-.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
-.btn-primary:disabled { opacity: 0.35; cursor: not-allowed; background: var(--cc-surface-2); color: var(--cc-text-dim); }
+/* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -604,11 +604,11 @@ onUnmounted(stopResize)
   <!-- delete confirmation -->
   <div v-if="deleteUid" class="delete-confirm">
     <span>Remove <strong>{{ images.find(i => i.uid === deleteUid)?.name }}</strong>?</span>
-    <button class="btn-danger btn-sm" @click="doDelete"
+    <button class="cc-btn cc-btn-danger-ghost" @click="doDelete"
       v-tooltip.right="'Remove this image from the set. The original file is not deleted.'">
       Remove
     </button>
-    <button class="btn-ghost btn-sm" @click="deleteUid = null">Cancel</button>
+    <button class="cc-btn cc-btn-ghost" @click="deleteUid = null">Cancel</button>
   </div>
 
   <!-- move to another set -->
@@ -621,10 +621,10 @@ onUnmounted(stopResize)
     </select>
     <input v-if="!moveTargetUid" class="move-name-input" v-model="moveNewName"
       placeholder="New set name…" @keydown.enter="doMove" @keydown.escape="moveUid = null" autofocus />
-    <button class="btn-primary btn-sm" @click="doMove" :disabled="moving">
+    <button class="cc-btn cc-btn-primary" @click="doMove" :disabled="moving">
       <i v-if="moving" class="pi pi-spin pi-cog" /><template v-else>Move</template>
     </button>
-    <button class="btn-ghost btn-sm" @click="moveUid = null">Cancel</button>
+    <button class="cc-btn cc-btn-ghost" @click="moveUid = null">Cancel</button>
   </div>
 
   <div v-if="images.length === 0" class="empty-state">
@@ -1234,20 +1234,7 @@ th:hover .resize-handle::after { opacity: 1; }
 .action-btn:disabled { opacity: 0.25 !important; cursor: not-allowed; }
 .del-btn:hover { background: #7f1d1d55; color: #fca5a5; }
 
-/* ── Shared buttons ──────────────────────────────────────────────────────────── */
-
-.btn-sm {
-  display: flex; align-items: center; gap: 0.3rem;
-  font-size: 0.78rem; font-weight: 500; padding: 0.3rem 0.65rem;
-  border-radius: 0.35rem; border: 1px solid transparent; cursor: pointer;
-}
-.btn-ghost  { background: var(--cc-surface-2); border-color: var(--cc-border); color: var(--cc-text-dim); }
-.btn-ghost:hover { color: var(--cc-text); }
-.btn-danger { background: #7f1d1d44; border-color: #7f1d1d; color: #fca5a5; }
-.btn-danger:hover { background: #7f1d1d88; }
-.btn-primary { background: var(--cc-accent); color: #fff; }
-.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
-.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+/* ── Buttons: use the global .cc-btn utilities (style.css) ─────────────────────── */
 
 .move-bar {
   display: flex; align-items: center; gap: 0.6rem;

--- a/frontend/src/components/PhysicalSizeDialog.vue
+++ b/frontend/src/components/PhysicalSizeDialog.vue
@@ -304,19 +304,19 @@ async function fillFlagged() {
       </div>
 
     <template #footer>
-      <button class="btn-ghost btn-sm" :disabled="propagating" @click="fillFlagged"
+      <button class="cc-btn cc-btn-ghost" :disabled="propagating" @click="fillFlagged"
         v-tooltip.top="'Fill this image\'s values into the OTHER selected images that are flagged — same-session acquisitions usually match exactly.'">
         <i v-if="propagating" class="pi pi-spin pi-cog" /><i v-else class="pi pi-share-alt" />
         Fill flagged
       </button>
-      <button class="btn-ghost btn-sm" :disabled="copying" @click="copyToSelected"
+      <button class="cc-btn cc-btn-ghost" :disabled="copying" @click="copyToSelected"
         v-tooltip.top="'Copy this image\'s values to the other selected images.'">
         <i v-if="copying" class="pi pi-spin pi-cog" /><i v-else class="pi pi-copy" />
         Copy to selected
       </button>
       <span class="footer-spacer" />
-      <button class="btn-ghost btn-sm" @click="emit('close')">Cancel</button>
-      <button class="btn-primary btn-sm" :disabled="saving" @click="apply"
+      <button class="cc-btn cc-btn-ghost" @click="emit('close')">Cancel</button>
+      <button class="cc-btn cc-btn-primary" :disabled="saving" @click="apply"
         v-tooltip.top="`Apply to ${targetUids.length} image(s). Doesn't retroactively recompute derived measures (e.g. track speed).`">
         <i v-if="saving" class="pi pi-spin pi-cog" /><i v-else class="pi pi-check" />
         Apply
@@ -361,18 +361,5 @@ async function fillFlagged() {
 .unit-input { flex: 0 0 4.2rem; }
 
 .footer-spacer { flex: 1; }
-
-.btn-sm {
-  display: flex; align-items: center; gap: 0.3rem;
-  font-size: 0.78rem; font-weight: 500;
-  padding: 0.35rem 0.75rem;
-  border-radius: 0.35rem; border: 1px solid transparent;
-  cursor: pointer; white-space: nowrap;
-}
-.btn-ghost { background: var(--cc-surface-2); border-color: var(--cc-border); color: var(--cc-text-dim); }
-.btn-ghost:hover:not(:disabled) { color: var(--cc-text); }
-.btn-ghost:disabled { opacity: 0.4; cursor: not-allowed; }
-.btn-primary { background: var(--cc-accent); color: #fff; }
-.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
-.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+/* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/components/ProjectPanel.vue
+++ b/frontend/src/components/ProjectPanel.vue
@@ -232,7 +232,7 @@ const typeColour: Record<ProjectType, string> = {
         <div v-if="projectMeta.recent.length === 0" class="pp-empty">
           <i class="pi pi-folder" style="font-size:2rem; opacity:0.2" />
           <p>No projects yet.<br>A project holds all your images and analysis for one experiment.</p>
-          <button class="btn-ghost btn-sm" @click="tab = 'new'">
+          <button class="cc-btn cc-btn-ghost" @click="tab = 'new'">
             <i class="pi pi-plus" /> Create your first project
           </button>
         </div>
@@ -347,14 +347,14 @@ const typeColour: Record<ProjectType, string> = {
 
       <!-- footer -->
       <div class="pp-footer">
-        <button class="btn-ghost btn-sm" @click="$emit('close')"
+        <button class="cc-btn cc-btn-ghost" @click="$emit('close')"
           v-tooltip.top="'Close without changes.'">
           Cancel
         </button>
 
         <template v-if="tab === 'recent'">
           <button
-            class="btn-primary btn-sm"
+            class="cc-btn cc-btn-primary"
             :disabled="!selectedUid || projectMeta.loading || selectedUid === projectMeta.current?.uid"
             @click="openSelected"
             v-tooltip.top="selectedUid && selectedUid !== projectMeta.current?.uid
@@ -367,7 +367,7 @@ const typeColour: Record<ProjectType, string> = {
 
         <template v-if="tab === 'new'">
           <button
-            class="btn-primary btn-sm"
+            class="cc-btn cc-btn-primary"
             :disabled="projectMeta.loading"
             @click="createProject"
             v-tooltip.top="'Create the project and open it.'">
@@ -403,7 +403,7 @@ const typeColour: Record<ProjectType, string> = {
             <div class="pp-io-dest">
               <span class="dim">Exports to</span>
               <code class="pp-io-destpath" v-tooltip.top="exportDir">{{ exportDir || 'cecelia_exports (default)' }}</code>
-              <button class="btn-ghost btn-sm" :disabled="ioBusy" @click="browserMode = 'export'"
+              <button class="cc-btn cc-btn-ghost" :disabled="ioBusy" @click="browserMode = 'export'"
                       v-tooltip.top="'Choose where exported bundles are written (any folder, incl. mounted servers/drives).'">
                 <i class="pi pi-folder-open" /> Change
               </button>
@@ -423,11 +423,11 @@ const typeColour: Record<ProjectType, string> = {
                      :placeholder="bundles.length ? '…or paste / browse to a .ccbundle path' : 'Paste or browse to a .ccbundle folder…'"
                      @keyup.enter="importBundle"
                      v-tooltip.top="'Absolute path to a .ccbundle folder produced by Export.'" />
-              <button class="btn-ghost btn-sm" :disabled="ioBusy" @click="browserMode = 'import'"
+              <button class="cc-btn cc-btn-ghost" :disabled="ioBusy" @click="browserMode = 'import'"
                       v-tooltip.top="'Browse for a .ccbundle folder anywhere (incl. mounted servers/drives).'">
                 <i class="pi pi-folder-open" /> Browse
               </button>
-              <button class="btn-ghost btn-sm" :disabled="!importPath.trim() || ioBusy" @click="importBundle"
+              <button class="cc-btn cc-btn-ghost" :disabled="!importPath.trim() || ioBusy" @click="importBundle"
                       v-tooltip.top="'Import a project from a .ccbundle folder.'">
                 <i class="pi pi-upload" /> Import
               </button>
@@ -457,16 +457,16 @@ const typeColour: Record<ProjectType, string> = {
         permanently deletes the existing project's data and cannot be undone — at your own risk.</p>
     </div>
     <template #footer>
-      <button class="btn-ghost btn-sm" @click="conflict = null"
+      <button class="cc-btn cc-btn-ghost" @click="conflict = null"
               v-tooltip.top="'Do nothing — keep the existing project.'">Cancel</button>
-      <button class="btn-danger btn-sm" :disabled="projectMeta.current?.uid === conflict.uid"
+      <button class="cc-btn cc-btn-danger" :disabled="projectMeta.current?.uid === conflict.uid"
               @click="doImport(conflict!.path, 'replace')"
               v-tooltip.top="projectMeta.current?.uid === conflict.uid
                 ? 'Close the project first — can\'t replace the one that\'s open.'
                 : 'Overwrite the existing project — destructive, cannot be undone.'">
         <i class="pi pi-exclamation-triangle" /> Replace (at your own risk)
       </button>
-      <button class="btn-primary btn-sm" @click="doImport(conflict!.path, 'copy')"
+      <button class="cc-btn cc-btn-primary" @click="doImport(conflict!.path, 'copy')"
               v-tooltip.top="'Import as a new project (new id) — keeps both.'">
         <i class="pi pi-copy" /> Import as copy
       </button>
@@ -482,9 +482,9 @@ const typeColour: Record<ProjectType, string> = {
         snapshot of a store that's being written. Best to wait until they finish.</p>
     </div>
     <template #footer>
-      <button class="btn-primary btn-sm" @click="exportWarn = null"
+      <button class="cc-btn cc-btn-primary" @click="exportWarn = null"
               v-tooltip.top="'Wait for the running tasks to finish.'">Wait</button>
-      <button class="btn-ghost btn-sm" @click="doExport(exportWarn!.p)"
+      <button class="cc-btn cc-btn-ghost" @click="doExport(exportWarn!.p)"
               v-tooltip.top="'Export now despite the running tasks.'">Export anyway</button>
     </template>
   </BaseModal>
@@ -644,21 +644,7 @@ const typeColour: Record<ProjectType, string> = {
   flex-shrink: 0;
 }
 
-.btn-sm {
-  display: flex; align-items: center; gap: 0.3rem;
-  font-size: 0.78rem; font-weight: 500;
-  padding: 0.35rem 0.75rem;
-  border-radius: 0.35rem; border: 1px solid transparent;
-  cursor: pointer;
-}
-.btn-ghost { background: var(--cc-surface-2); border-color: var(--cc-border); color: var(--cc-text-dim); }
-.btn-ghost:hover { color: var(--cc-text); }
-.btn-primary { background: var(--cc-accent); color: #fff; }
-.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
-.btn-primary:disabled { opacity: 0.35; cursor: not-allowed; background: var(--cc-surface-2); color: var(--cc-text-dim); border-color: transparent; }
-.btn-danger { background: #b91c1c; color: #fff; }
-.btn-danger:hover:not(:disabled) { filter: brightness(1.15); }
-.btn-danger:disabled { opacity: 0.35; cursor: not-allowed; background: var(--cc-surface-2); color: var(--cc-text-dim); border-color: transparent; }
+/* buttons use the global .cc-btn utilities (style.css) */
 .pp-danger-note {
   color: #fca5a5; font-size: 0.78rem; display: flex; gap: 0.4rem; align-items: flex-start;
   margin-top: 0.6rem; padding: 0.4rem 0.55rem; border-radius: 0.3rem;

--- a/frontend/src/components/SetBar.vue
+++ b/frontend/src/components/SetBar.vue
@@ -126,16 +126,16 @@ async function deleteSet() {
           autofocus
           v-tooltip.bottom="'Press Enter to create, Escape to cancel.'"
         />
-        <button class="btn-primary btn-sm" @click="createSet" :disabled="creating"
+        <button class="cc-btn cc-btn-primary" @click="createSet" :disabled="creating"
           v-tooltip.bottom="'Create this image set.'">
           <i v-if="creating" class="pi pi-spin pi-cog" />
           <template v-else>Create</template>
         </button>
-        <button class="btn-ghost btn-sm" @click="showNewInput = false"
+        <button class="cc-btn cc-btn-ghost" @click="showNewInput = false"
           v-tooltip.bottom="'Cancel.'">Cancel</button>
       </template>
       <template v-else>
-        <button class="btn-ghost btn-sm" @click="showNewInput = true"
+        <button class="cc-btn cc-btn-ghost" @click="showNewInput = true"
           v-tooltip.bottom="'Create a new image set to group related images together.'">
           <i class="pi pi-plus" /> New set
         </button>
@@ -144,18 +144,18 @@ async function deleteSet() {
       <span class="spacer" />
 
       <template v-if="activeSet && !confirmDelete">
-        <button class="btn-danger btn-sm" @click="confirmDelete = true"
+        <button class="cc-btn cc-btn-danger-ghost" @click="confirmDelete = true"
           v-tooltip.bottom="`Delete set '${activeSet.name}' and all its images. This cannot be undone.`">
           <i class="pi pi-trash" /> Delete set
         </button>
       </template>
       <template v-if="confirmDelete">
         <span class="confirm-text">Delete <strong>{{ activeSet?.name }}</strong>?</span>
-        <button class="btn-danger btn-sm" @click="deleteSet"
+        <button class="cc-btn cc-btn-danger-ghost" @click="deleteSet"
           v-tooltip.bottom="'Permanently delete this set and remove all its images from disk.'">
           Confirm
         </button>
-        <button class="btn-ghost btn-sm" @click="confirmDelete = false"
+        <button class="cc-btn cc-btn-ghost" @click="confirmDelete = false"
           v-tooltip.bottom="'Cancel deletion.'">Cancel</button>
       </template>
     </template>
@@ -202,17 +202,5 @@ async function deleteSet() {
 .set-name-input { width: 180px; border-color: var(--cc-accent); }
 .spacer { flex: 1; }
 .confirm-text { font-size: 0.82rem; color: var(--cc-text-dim); }
-.btn-sm {
-  display: flex; align-items: center; gap: 0.3rem;
-  font-size: 0.78rem; font-weight: 500; padding: 0.3rem 0.65rem;
-  border-radius: 0.35rem; border: 1px solid transparent;
-  cursor: pointer; transition: background 0.12s;
-}
-.btn-primary { background: var(--cc-accent); color: #fff; }
-.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
-.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
-.btn-ghost { background: var(--cc-surface-2); border-color: var(--cc-border); color: var(--cc-text-dim); }
-.btn-ghost:hover { color: var(--cc-text); border-color: #484f58; }
-.btn-danger { background: #7f1d1d44; border-color: #7f1d1d; color: #fca5a5; }
-.btn-danger:hover { background: #7f1d1d88; }
+/* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -266,7 +266,7 @@ async function render() {
           </label>
           <input type="text" v-model="anim.titleCard.note" class="anim-note" placeholder="note (optional)" />
         </template>
-        <button class="btn-primary" :disabled="!canRender" @click="render"
+        <button class="cc-btn cc-btn-primary" :disabled="!canRender" @click="render"
                 v-tooltip.bottom="canRender ? 'Render the timeline to an mp4'
                   : 'Need ≥2 keyframes for this image, open in napari'">
           <i :class="['pi', rendering ? 'pi-spin pi-spinner' : 'pi-play']" /> Render
@@ -280,15 +280,15 @@ async function render() {
     <template v-else>
       <div class="anim-toolbar">
         <span class="anim-img">{{ imageName(openImageUid) }}</span>
-        <button class="btn-sm" :disabled="capturing" @click="capture"
+        <button class="cc-btn cc-btn-ghost" :disabled="capturing" @click="capture"
                 v-tooltip.bottom="'Capture the current napari view as a keyframe (a base look)'">
           <i :class="['pi', capturing ? 'pi-spin pi-spinner' : 'pi-camera']" /> Capture view
         </button>
-        <button class="btn-sm" :disabled="!frames.length" @click="addKeyframe"
+        <button class="cc-btn cc-btn-ghost" :disabled="!frames.length" @click="addKeyframe"
                 v-tooltip.bottom="'Duplicate the last keyframe to vary it via the rows'">
           <i class="pi pi-plus" /> Add keyframe
         </button>
-        <button class="btn-sm" :disabled="!selectedId || updating" @click="updateSelected"
+        <button class="cc-btn cc-btn-ghost" :disabled="!selectedId || updating" @click="updateSelected"
                 v-tooltip.bottom="'Replace the selected keyframe with the current napari view (re-capture)'">
           <i :class="['pi', updating ? 'pi-spin pi-spinner' : 'pi-refresh']" /> Update selected
         </button>
@@ -424,12 +424,5 @@ async function render() {
 .tl-absent { color: var(--cc-text-dim); opacity: 0.35; }
 .tl-cam { font-size: 0.68rem; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
 
-.btn-sm { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; padding: 0.35rem 0.6rem;
-  border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-2); color: var(--cc-text); cursor: pointer; }
-.btn-sm:hover:not(:disabled) { border-color: var(--cc-accent); }
-.btn-sm:disabled { opacity: 0.55; cursor: default; }
-.btn-primary { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.78rem; padding: 0.4rem 0.8rem;
-  border: 1px solid var(--cc-accent); border-radius: 0.35rem; background: var(--cc-accent); color: #fff; cursor: pointer; }
-.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
-.btn-primary:disabled { opacity: 0.55; cursor: default; }
+/* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/modules/gate/GatingCopyDialog.vue
+++ b/frontend/src/modules/gate/GatingCopyDialog.vue
@@ -117,8 +117,8 @@ async function copy() {
     </div>
 
     <template #footer>
-      <button class="btn-ghost btn-sm" @click="emit('close')">Cancel</button>
-      <button class="btn-primary btn-sm" :disabled="busy || checking || !picked.size" @click="copy">
+      <button class="cc-btn cc-btn-ghost" @click="emit('close')">Cancel</button>
+      <button class="cc-btn cc-btn-primary" :disabled="busy || checking || !picked.size" @click="copy">
         <i v-if="busy" class="pi pi-spin pi-cog" /><i v-else class="pi pi-copy" />
         Copy to {{ picked.size }} image{{ picked.size === 1 ? '' : 's' }}
       </button>
@@ -143,11 +143,5 @@ async function copy() {
 .cg-missing-head { display: flex; align-items: center; gap: 0.35rem; color: #f59e0b; }
 .cg-missing-names { padding-left: 1.1rem; word-break: break-word; }
 
-.btn-sm { display: flex; align-items: center; gap: 0.3rem; font-size: 0.78rem; font-weight: 500;
-  padding: 0.35rem 0.75rem; border-radius: 0.35rem; border: 1px solid transparent; cursor: pointer; white-space: nowrap; }
-.btn-ghost { background: var(--cc-surface-2); border-color: var(--cc-border); color: var(--cc-text-dim); }
-.btn-ghost:hover:not(:disabled) { color: var(--cc-text); }
-.btn-primary { background: var(--cc-accent); color: #fff; }
-.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
-.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+/* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/modules/metadata/MetadataPanel.vue
+++ b/frontend/src/modules/metadata/MetadataPanel.vue
@@ -282,7 +282,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
     <!-- ── Physical size & timing ───────────────────────────────── -->
     <section class="panel-section">
       <div class="section-title">Physical size &amp; timing</div>
-      <button class="btn-ghost btn-sm" :disabled="!physFocusUid" @click="showPhysDialog = true"
+      <button class="cc-btn cc-btn-ghost" :disabled="!physFocusUid" @click="showPhysDialog = true"
         v-tooltip.bottom="'View or fix voxel size and frame interval for the selected image(s).'">
         <i class="pi pi-ruler" /> Open editor
         <span v-if="flaggedCount" class="warn-count" v-tooltip.bottom="`${flaggedCount} image(s) in this set are flagged`">{{ flaggedCount }}</span>
@@ -301,7 +301,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
         <input class="field-input flex1" v-model="newAttrName" placeholder="New attribute name…"
           @keydown.enter="createAttr"
           v-tooltip.bottom="'Name for the new metadata column — e.g. condition, timepoint.'" />
-        <button class="btn-primary btn-sm" @click="createAttr" :disabled="!newAttrName.trim()"
+        <button class="cc-btn cc-btn-primary" @click="createAttr" :disabled="!newAttrName.trim()"
           v-tooltip.bottom="'Add this attribute key to all images in the set.'">
           Create
         </button>
@@ -330,7 +330,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
           :disabled="attrDisabled"
           @keydown.enter="assignSingleValue"
           v-tooltip.bottom="'Assign this value to the selected attribute for all target images.'" />
-        <button class="btn-ghost btn-sm" :disabled="attrDisabled || !singleValue"
+        <button class="cc-btn cc-btn-ghost" :disabled="attrDisabled || !singleValue"
           @click="assignSingleValue"
           v-tooltip.bottom="'Apply to selected images, or all images if none are selected.'">
           Assign
@@ -346,7 +346,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
           :disabled="attrDisabled"
           @keydown.enter="assignRegexp"
           v-tooltip.bottom="'Regex over the name; a (group) if present, else the whole match. e.g. M(\\d+)→4. New to regex? Use the builder.'" />
-        <button class="btn-ghost btn-sm" :disabled="attrDisabled || !regexpValue"
+        <button class="cc-btn cc-btn-ghost" :disabled="attrDisabled || !regexpValue"
           @click="assignRegexp"
           v-tooltip.bottom="'Extract a value from each image filename or path.'">
           Apply
@@ -468,7 +468,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
     <section class="panel-section">
       <div class="section-title">Group sequences</div>
       <p class="section-hint">Numbers images within each attribute group (<strong>GroupSeq</strong>).</p>
-      <button class="btn-ghost btn-sm" @click="assignGroupSequences"
+      <button class="cc-btn cc-btn-ghost" @click="assignGroupSequences"
         :disabled="attrNames.length === 0"
         v-tooltip.bottom="'Assign GroupSeq from the current attribute values.'">
         Assign
@@ -484,7 +484,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
           placeholder="One channel name per line…"
           v-tooltip.bottom="'Assign these channel names to the selected images (or all if none selected).'" />
         <div class="field-row">
-          <button class="btn-ghost btn-sm" :disabled="!channelNameList.trim()"
+          <button class="cc-btn cc-btn-ghost" :disabled="!channelNameList.trim()"
             @click="assignChannelNames"
             v-tooltip.bottom="'Set channel names on the target images.'">
             Assign channels
@@ -632,19 +632,5 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
   background: #7c2d1244; color: #fcd34d;
 }
 
-.btn-sm {
-  display: flex; align-items: center; gap: 0.3rem;
-  font-size: 0.78rem; font-weight: 500; padding: 0.3rem 0.65rem;
-  border-radius: 0.35rem; border: 1px solid transparent;
-  cursor: pointer; white-space: nowrap; transition: background 0.1s;
-}
-.btn-primary { background: var(--cc-accent); color: #fff; }
-.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
-.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
-.btn-ghost { background: var(--cc-surface-2); border-color: var(--cc-border); color: var(--cc-text-dim); }
-.btn-ghost:hover:not(:disabled) { color: var(--cc-text); border-color: #484f58; }
-.btn-ghost:disabled { opacity: 0.4; cursor: not-allowed; }
-.btn-danger { background: #7f1d1d44; border-color: #7f1d1d; color: #fca5a5; }
-.btn-danger:hover:not(:disabled) { background: #7f1d1d88; }
-.btn-danger:disabled { opacity: 0.4; cursor: not-allowed; }
+/* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -121,6 +121,24 @@ body {
 }
 .cc-btn-ghost:hover:not(:disabled) { color: var(--cc-text); }
 
+/* Destructive actions. Two variants, like primary/ghost: `danger` is solid/prominent (a standalone
+   destructive action, e.g. delete a project); `danger-ghost` is a subtle outline (an inline delete in
+   a table/bar, where a wall of solid red would be too heavy). Both were previously hand-copied per
+   component with drifted colours — this is the one source. */
+.cc-btn-danger {
+  background: #b91c1c;
+  color: #fff;
+  border-color: #b91c1c;
+}
+.cc-btn-danger:hover:not(:disabled) { filter: brightness(1.15); }
+
+.cc-btn-danger-ghost {
+  background: #7f1d1d44;
+  border-color: #7f1d1d;
+  color: #fca5a5;
+}
+.cc-btn-danger-ghost:hover:not(:disabled) { background: #7f1d1d88; }
+
 /* ── Form controls — modern, consistent base for ALL native inputs ─────────── */
 /* Applies app-wide so bare <select>/<input> look the same everywhere. Components  */
 /* may refine spacing, but should not reintroduce old-school borders/backgrounds.  */


### PR DESCRIPTION
Buttons were the worst divergent-re-implementation case the UX audit found. A parallel `.btn-sm`/`.btn-primary`/`.btn-ghost`/`.btn-danger` family was **hand-copied into 8 components' scoped `<style>`**, already drifted:
- danger colour: `#b91c1c` solid (ProjectPanel) vs `#7f1d1d44` subtle (SetBar/ImageTable/MetadataPanel)
- disabled opacity: 0.35 / 0.4 / 0.55
- ghost hover: sometimes changes border, sometimes not; AnimationModule's copy fully diverged (0.72rem, different padding)
- …and a file that used the class **without** copying the CSS got a raw browser button — the Movies refresh bug you spotted.

## Changes
- **`style.css`**: add canonical `.cc-btn-danger` (solid, prominent — standalone destructive) and `.cc-btn-danger-ghost` (subtle outline — inline table/bar deletes). Two variants like primary/ghost, so **both** prior looks are preserved as one source instead of drifted copies.
- Migrate all markup in the 8 files to `.cc-btn` + modifier and **delete every scoped `.btn-*` block** (PhysicalSizeDialog, ProjectPanel, SetBar, FileBrowser, ImageTable, MetadataPanel, GatingCopyDialog, AnimationModule).
- **`docs/UI.md`**: the button rule (never hand-roll `.btn-*`; bespoke icon-only buttons are a separate intentional case).
- **`docs/todo/UX_PRIMITIVES_PLAN.md`** — a living tracker of every UX primitive (canonical vs hand-rolled) with a phased unification checklist: toggles ✅ + buttons ✅ done; ranges, empty states, collapsible headers, status colours, spinners, cards, icon-buttons queued by priority. This is the "hand-rolled UX features audit" as a backlog we tick off.

## Verification
Typecheck clean; 340 frontend tests pass.

## Reservations
- AnimationModule buttons resize slightly (its primary was larger, its ghost buttons 0.72rem) → canonical `.cc-btn` sizing now. Cosmetic.
- SetBar/MetadataPanel ghost buttons changed *border* colour on hover; global `.cc-btn-ghost:hover` changes only text colour. Minor.
- The solid-vs-subtle danger split is my design call to preserve both looks — trivially collapsible to one if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
