### PR TITLE
feat(ui): universal 'started in background' toast on job dispatch

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,6 +15,8 @@ import FloatingPanel from './components/FloatingPanel.vue'
 import ViewerPanel from './components/ViewerPanel.vue'
 import LabLogPanel from './components/LabLogPanel.vue'
 import Toast from 'primevue/toast'
+import { useToast } from 'primevue/usetoast'
+import { useTaskStore } from './stores/tasks'
 
 const ws = useWsStore()
 const settings = useSettingsStore()
@@ -24,6 +26,17 @@ const appCtl = useAppControlStore()
 const observer = useObserverStore()
 const pm = useProjectMetaStore()
 watch(() => pm.current?.uid, () => observer.refresh(), { immediate: true })
+
+// Universal "started in background" confirmation: any client-dispatched background job (crop, copy,
+// project export/import, task:run) registers via taskStore.add(), which bumps `lastStarted`. One
+// toast here means no dialog needs its own "it's running" feedback and users don't have to open the
+// task console to confirm a job started.
+const toast = useToast()
+const taskStore = useTaskStore()
+watch(() => taskStore.lastStarted, (t) => {
+  if (t) toast.add({ severity: 'success', summary: 'Started', life: 2500,
+                     detail: `${t.label} — running in the background` })
+})
 // Cecelia's automatic activity summaries: fire capture_context! after a task/chain node finishes,
 // which upserts the rolling DAILY [Cecelia] digest (app-lifetime install, since the lab-log panel is
 // v-if'd). Firing per task is cheap — the backend regenerates today's one block. See stores/labCapture.ts.

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -30,9 +30,17 @@ export const useTaskStore = defineStore('tasks', () => {
   const tasks   = ref<TaskEntry[]>([])
   const _seqRef = ref(0)
 
+  // Signal for a UNIVERSAL "started in background" confirmation. `add()` is the client-dispatch
+  // entry point (crop, copy, project export/import, generic task:run) — incoming server events go
+  // through setStatus/setProgress by id, and chain steps through addFromChainEvent, so bumping this
+  // only on add() fires one toast per user-initiated background job. App.vue watches it (component
+  // context needed for useToast). Avoids each dialog rolling its own "it's running" feedback.
+  const lastStarted = ref<TaskEntry | null>(null)
+
   function add(t: Omit<TaskEntry, 'id' | 'log' | 'seq'>): TaskEntry {
     const entry: TaskEntry = { ...t, id: shortId(), log: [], seq: ++_seqRef.value }
     tasks.value.unshift(entry)
+    lastStarted.value = entry
     return entry
   }
 
@@ -153,5 +161,5 @@ export const useTaskStore = defineStore('tasks', () => {
     return entry
   }
 
-  return { tasks, add, addFromChainEvent, appendLog, setStatus, setProgress, restart, cancel, cancelChainRun, remove, clearFinished, forModule, running, jumpToId }
+  return { tasks, lastStarted, add, addFromChainEvent, appendLog, setStatus, setProgress, restart, cancel, cancelChainRun, remove, clearFinished, forModule, running, jumpToId }
 })


### PR DESCRIPTION
Several ops dispatch then run in the background (crop, copy, project export/import, generic `task:run`) — before this you had to open the task console just to confirm one started. `taskStore.add()` is the single client-dispatch entry point (incoming server events update by id; chain steps use `addFromChainEvent`), so it now bumps a `lastStarted` signal that `App.vue` watches to fire **one** success toast (`<label> — running in the background`). Centralised — no dialog rolls its own 'it's running' feedback.

Frontend-only, `vue-tsc -b` green. Independent of #342.

Reservation: fires per `taskStore.add()`, so a batch that dispatches many tasks at once shows many toasts (could debounce later if noisy). Not clicked through live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)