### PR TITLE
Make the UX-primitive lookup mandatory (docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,17 @@ Using a hand-rolled solution when a util or component already exists is a bug, n
 this is the concrete, do-this-first version of the divergent-re-implementation warning above. When
 you add a significant new shared component, add a line to `INVENTORY.md` in the same change.
 
+**UX elements — MANDATORY lookup before you render any control.** The recurring worst case is
+frontend chrome: a fresh session hand-rolls a checkbox-as-toggle, a `.btn-sm` that renders as a raw
+browser button, a bespoke slider/dialog/empty-state — because it didn't know the canonical one
+exists. Before adding **any** button, on/off toggle, slider, dialog/modal, popover, tabs, chips,
+empty state, spinner, badge, or collapsible section, you MUST consult the **UX-primitive catalog** in
+[`docs/UI.md`](docs/UI.md) (the *"check before building"* table at the top of the components section)
+and use the canonical component/utility (`CcToggle`, `.cc-btn*`, `ChipSelect`, `SwatchSelect`,
+`BaseModal`, `TeleportPopover`, `TabbedCanvas`, `CollapsibleSection`, `ConfirmButton`, …). Rendering a
+new variant of a primitive that already has a canonical form is a bug — same rule as H5AD/zarr/`run_py`.
+Unification status + what's not-yet-extracted lives in [`docs/todo/UX_PRIMITIVES_PLAN.md`](docs/todo/UX_PRIMITIVES_PLAN.md).
+
 ## Previous prompts
 
 Completed prompt files are kept in a `previous-prompts/` folder in the **workspace root** (outside `cecelia-pineapple/`) — set aside but accessible. They are **reference only**: historical context for finished work, not instructions to be re-run.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -92,6 +92,7 @@ Last audited: 2026-07-16 (full six-area ground-truth read; against `main` @ c1ce
 
 ## Frontend (`frontend/src/`)
 
+- **UX primitive catalog (check before building ANY control)**: `docs/UI.md` → *UX primitive catalog — CHECK BEFORE BUILDING* is the mandatory one-glance lookup for buttons / toggles / sliders / dialogs / popovers / tabs / chips / collapsibles / confirms. Use the canonical component; hand-rolling a variant is a bug (see `CLAUDE.md`). Unification status: `docs/todo/UX_PRIMITIVES_PLAN.md`.
 - **appControl store** (`stores/appControl.ts`): all app-lifecycle actions — `quit`, `checkUpdate`/`applyUpdate`, dev `restartBackend`/`switchWorktree`, setup state.
 - **ws store** (`stores/ws.ts`): THE WebSocket client (connect/reconnect/`send`/`on`/`off`); dispatches all `task:*`/`chain:*`/`napari:*`/`server:log` events.
 - **Domain stores** (`stores/`): `gating` (pop/gating, pop_type-agnostic), `project`/`projectMeta`, `settings`, `tasks`, `taskDefs`, `customModules` (user drop-in modules: status/reload + category list).

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -5,6 +5,35 @@ The language-boundary and WS protocol are in `ARCHITECTURE.md`; this document is
 
 ---
 
+## UX primitive catalog — CHECK BEFORE BUILDING (mandatory)
+
+Before you render **any** of these controls, use the canonical component/utility below — **do not
+hand-roll a variant**. A new copy of a primitive that already has a canonical form is a bug (same rule
+as the H5AD/zarr/`run_py` single-helpers; see `CLAUDE.md` → *Before implementing anything*). This is
+the one glanceable lookup; each row links to its detailed section. Unification status for the few
+primitives still being extracted lives in `docs/todo/UX_PRIMITIVES_PLAN.md`.
+
+| Need | Use | Never |
+|------|-----|-------|
+| Button | `.cc-btn` + `-primary`/`-ghost`/`-danger`/`-danger-ghost` (`style.css`) | scoped `.btn-sm`/`.btn-primary` in a component |
+| On/off option (applies on flip) | `components/CcToggle.vue` | a native checkbox styled as a switch |
+| Select from a list (multi/single) | native `<input type="checkbox">`, or `ChipSelect` for chips | a column of toggle switches |
+| Chips / segmented picker | `components/ChipSelect.vue` | hand-rolled pill/`.seg` rows |
+| Colour picker dropdown | `components/SwatchSelect.vue` | a bespoke swatch grid |
+| Modal / dialog | `components/BaseModal.vue` | a hand-rolled `position:fixed` backdrop |
+| Popover / dropdown menu | `components/TeleportPopover.vue` | an absolutely-positioned panel |
+| Tabs | `components/canvas/TabbedCanvas.vue` | a hand-rolled tab strip |
+| Collapsible section (chevron + heading) | `components/CollapsibleSection.vue` | a per-file chevron toggle |
+| Confirm / destructive-confirm | `components/ConfirmButton.vue` / `ConfirmDeleteButton.vue` | `window.confirm` or an inline arm flag |
+| Range slider | `components/RangeSlider.vue` (dual-thumb) *(single-value `CcRange` in progress — see the tracker)* | a raw `<input type=range>` with bespoke label/value markup |
+| Status colour / severity | `lib/severity.ts` + `--cc-sev-*` tokens | a hand-typed traffic-light colour |
+
+If what you need isn't here and isn't obviously covered by an existing component, grep first
+(`INVENTORY.md` → *Frontend*); only build new if the search is genuinely empty, and then add it here +
+to `INVENTORY.md` in the same change.
+
+---
+
 ## Design tokens
 
 All tokens live in `frontend/src/style.css` under `.cc-dark` (always applied at the `<body>` level).


### PR DESCRIPTION
Fresh sessions kept hand-rolling frontend chrome (checkbox-as-toggle, non-global `.btn-sm`, bespoke sliders/dialogs) because the canonical component existed but no rule forced them to look first. This makes the lookup **mandatory**, same enforcement level as the H5AD/zarr/`run_py` single-helper rules.

- **`CLAUDE.md`** → *Before implementing anything*: a mandatory UX-element clause — consult the catalog and use the canonical component before rendering any button/toggle/slider/dialog/popover/tabs/chips/empty-state/spinner/badge/collapsible.
- **`docs/UI.md`**: a glanceable **"UX primitive catalog — CHECK BEFORE BUILDING"** table at the top (need → use → never).
- **`INVENTORY.md`**: Frontend section now leads with a pointer to that catalog.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
