### PR TITLE
Generalise UX by scenario: semantic tokens + utility classes

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -25,8 +25,19 @@ primitives still being extracted lives in `docs/todo/UX_PRIMITIVES_PLAN.md`.
 | Tabs | `components/canvas/TabbedCanvas.vue` | a hand-rolled tab strip |
 | Collapsible section (chevron + heading) | `components/CollapsibleSection.vue` | a per-file chevron toggle |
 | Confirm / destructive-confirm | `components/ConfirmButton.vue` / `ConfirmDeleteButton.vue` | `window.confirm` or an inline arm flag |
-| Range slider | `components/RangeSlider.vue` (dual-thumb) *(single-value `CcRange` in progress — see the tracker)* | a raw `<input type=range>` with bespoke label/value markup |
+| Range slider (min+max) | `components/RangeSlider.vue` | a hand-rolled dual-thumb range |
 | Status colour / severity | `lib/severity.ts` + `--cc-sev-*` tokens | a hand-typed traffic-light colour |
+
+**Semantic role utilities** (global classes in `style.css` — *compose* them, add only layout in scoped CSS). These generalise recurring text/surface **scenarios** rather than a component per widget:
+
+| Scenario | Use | Never |
+|------|-----|-------|
+| Secondary / muted text (hint, subtitle, caption, meta) | `.cc-muted` | a scoped `color: var(--cc-text-dim); font-size: …` |
+| Empty / "nothing here yet" state | `.cc-empty` (drop icon/title/CTA inside for the rich variant) | a new `.*-empty` class |
+| Numeric value readout beside a control | `.cc-readout` (+ `.cc-readout-strong` for a prominent count) | a bespoke `.*-val`/`.*-num` |
+| Eyebrow / section label (uppercase dim heading) | `.cc-eyebrow` | a scoped uppercase-heading rule |
+| Card / panel / surface container | `.cc-card` | a scoped `surface + 1px border + radius` block |
+| Corner radius / small text size | tokens `--cc-radius-sm/md`, `--cc-fs-xs/sm/md` | a raw `rem` radius or font-size |
 
 If what you need isn't here and isn't obviously covered by an existing component, grep first
 (`INVENTORY.md` → *Frontend*); only build new if the search is genuinely empty, and then add it here +

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -29,42 +29,53 @@ and use it. When you unify a category, tick it here and add the rule to `docs/UI
 | Plot-area spinner | `components/plots/PlotSpinner.vue` | plot area only; inline busy spinners are ad-hoc (see Phase 6). |
 | Severity colours | `lib/severity.ts` + `--cc-sev-*` | status colours should route through this. |
 
-## Phases (priority order — biggest divergence / highest bug-risk first)
+## Approach — generalise by SCENARIO, not one component per widget
 
-- [x] **Phase 0 — Toggles.** `CcToggle` created; all immediate-option checkboxes migrated; multi-select
-  lists kept as native checkboxes. (PR #341.)
-- [x] **Phase 1 — Buttons.** Deleted 8 scoped `.btn-*` blocks (`PhysicalSizeDialog`, `ProjectPanel`,
-  `SetBar`, `FileBrowser`, `ImageTable`, `MetadataPanel`, `GatingCopyDialog`, `AnimationModule`);
-  migrated all markup to `.cc-btn` + modifier; added canonical `.cc-btn-danger` (solid) and
-  `.cc-btn-danger-ghost` (subtle) to `style.css`, resolving the two drifted danger schemes. Also fixed
-  the Movies refresh button (raw browser button — used the non-global `.btn-sm`).
-- [ ] **Phase 2 — Range sliders.** ~26 raw `<input type="range">` across ~12 files, each with its own
-  label/value/width markup (`.pt-slider`, `.cz-range`, `.anim-range`, `.movie-range`, `.po-row` ranges,
-  …). Add a single-value `CcRange` (label + value readout + track); `RangeSlider` stays the dual-thumb
-  specialist. High count; inconsistent value/step display.
-- [ ] **Phase 3 — Empty states.** ~23 distinct scoped `*-empty` classes, no component (richest is
-  `ImageTable`'s `.empty-state` — icon + title + hint + CTA). Add `<EmptyState>` (icon/title/hint +
-  optional CTA slot). High visual divergence, low bug-risk.
-- [ ] **Phase 4 — Collapsible section headers.** `CollapsibleSection` exists but ~15 chevron+heading
-  toggles are hand-rolled (`PlotOptions` ×4 `.po-toggle`, `MetadataPanel`, `ParamRenderer`,
-  `PopulationManager`, `CanvasPanel`, `TaskList`, `ErrorConsole`, `AppSidebar` nav groups). Migrate onto
-  `CollapsibleSection` or a shared `.cc-section-toggle`.
-- [ ] **Phase 5 — Status colours / badges.** Duplicated status→icon maps (`TasksModule`, `TaskList`,
-  `ChainLiveNode`) and traffic-light colours not on `--cc-sev-*` (already flagged in `style.css`). Route
-  through `severity.ts`; optional `<CcBadge>` for counts. Correctness/CVD-safety relevance.
-- [ ] **Phase 6 — Inline spinners.** 40+ inline `pi-spin` busy icons, two spellings (`pi-cog` vs
-  `pi-spinner`). Standardize the busy-icon idiom (or a tiny `<CcSpinner>`). Low bug-risk, high count.
-- [ ] **Phase 7 — Card/panel chrome.** 200+ repeated surface+border+radius blocks; no `.cc-card` util.
-  Add `.cc-card`/`.cc-surface`. Cosmetic, largest raw duplication, lowest priority.
-- [ ] **Phase 8 (optional) — Icon-only buttons.** ~90 bespoke `*-btn`/`*-ico` classes; mostly
-  intentional (different sizes, hover-reveal, viewer-green accents). Optional `.cc-icon-btn` base +
-  per-component sizing; not the same trap as `.btn-*`.
+The first sweep unified two **components** where the divergence was a real bug (buttons rendered
+unstyled; a checkbox-as-toggle was the wrong affordance). But the audit's remaining "phases" were
+ranked by raw count, and count ≠ value: the rest is progressively cosmetic. More importantly, they are
+**not distinct problems** — they collapse into a handful of recurring **scenarios (semantic roles)**
+that repeat across many different elements. E.g. a prominent pool-size count and a dim slider `°/s/×`
+readout look different but are the SAME scenario ("a value readout"), differing only in *prominence*.
+
+So the generalisation grain is the scenario → a **semantic token / utility class** (with variant
+modifiers), NOT a `CcRange`/`CcEmptyState`/`CcCard`/… per widget. Adoption is **incremental**: define
+the vocabulary, make the lookup mandatory (so new code uses it), and migrate existing sites
+opportunistically. **Do not** force a 300-site sweep, and do not chase the cosmetic tail.
+
+Done — components (real bugs):
+- [x] **Toggles** → `CcToggle`; all immediate-option checkboxes migrated, multi-select lists kept native. (PR #341)
+- [x] **Buttons** → global `.cc-btn` + `-primary/-ghost/-danger/-danger-ghost`; 8 scoped `.btn-*` blocks deleted, drifted danger schemes resolved. (PR #343)
+
+Done — the mandatory lookup:
+- [x] `CLAUDE.md` discovery clause + `docs/UI.md` "check before building" catalog + `INVENTORY.md` pointer, so new divergence can't accrue unreviewed. (PR #345)
+
+Done — semantic-role vocabulary (the generalisation; adopt incrementally):
+- [x] Tokens `--cc-radius-sm/md`, `--cc-fs-xs/sm/md`; utilities `.cc-muted` (secondary text),
+  `.cc-empty` (empty state), `.cc-readout` + `.cc-readout-strong` (value readout), `.cc-eyebrow`
+  (section label), `.cc-card` (surface). Seeded in `MoviesModule` + `AnimationModule` as the reference
+  adoptions. This scenario vocabulary replaces the would-be Phase 2/3/6/7 components — the ~23 `*-empty`
+  classes, the slider readouts, the subtitles/hints, and the card chrome all compose from it.
+
+Remaining — incremental adoption + one correctness item (no forced sweeps):
+- [ ] **Status/severity colours (correctness).** Route the 56 raw traffic-light hexes + the duplicated
+  status→icon maps (`TasksModule`, `TaskList`, `ChainLiveNode`, `ParamRenderer`) through `--cc-sev-*` /
+  `lib/severity.ts`. CVD-safety relevance; already flagged in `style.css`. **Worth doing.**
+- [ ] **Collapsible section headers.** `CollapsibleSection` exists but ~15 chevron+heading toggles
+  bypass it (`PlotOptions` ×4, `MetadataPanel`, `ParamRenderer`, `PopulationManager`, …). Migrate
+  opportunistically, or extract `.cc-section-toggle`.
+- [ ] **Opportunistic muted-text / card / readout adoption.** Replace scoped `.*-empty` / `.*-val` /
+  subtitle / surface blocks with the semantic utils as files are touched — NOT a dedicated sweep.
+- [ ] **Not recommended as sweeps:** single-value range wrapper (base already accent-themed; readout now
+  covered by `.cc-readout`; sliders are layout-entangled and some commit on release) and icon-only
+  buttons (~90, mostly intentional — different sizes/hover-reveal/viewer-green). Governed by the rule.
 
 **Healthy / no action:** Modals (`BaseModal`), popovers (`TeleportPopover`), tabs (`TabbedCanvas`),
-chips (`ChipSelect`), colour dropdown (`SwatchSelect`), toggles (`CcToggle`).
+chips (`ChipSelect`), colour dropdown (`SwatchSelect`).
 
 ## Convention going forward
 
-Each unified primitive gets a one-liner in `docs/UI.md` (the *when to use which*) and a line in
-`INVENTORY.md` (the *where it lives*). A new hand-rolled copy of a primitive that has a canonical form
-is a bug, caught in review — same reflex as the H5AD/zarr/`run_py` single-helper rules in `CLAUDE.md`.
+Each canonical primitive/utility gets a one-liner in `docs/UI.md` (the *when to use which*, in the
+catalog) and a line in `INVENTORY.md` (the *where it lives*). A new hand-rolled copy of a primitive or
+scenario that already has a canonical form is a bug, caught in review — same reflex as the
+H5AD/zarr/`run_py` single-helper rules in `CLAUDE.md`.

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -248,7 +248,7 @@ async function render() {
     <header class="anim-head">
       <div>
         <h1>Animation</h1>
-        <p class="anim-sub">A timeline of napari view snapshots. Capture a base look, add keyframes, toggle
+        <p class="anim-sub cc-muted">A timeline of napari view snapshots. Capture a base look, add keyframes, toggle
           channels/populations per keyframe, then render — the movie interpolates between keyframes.</p>
       </div>
       <div class="anim-head-ctl">
@@ -274,8 +274,8 @@ async function render() {
       </div>
     </header>
 
-    <p v-if="!hasProject" class="anim-empty">Open a project to build an animation.</p>
-    <p v-else-if="!openImageUid" class="anim-empty">Open an image in napari to start capturing keyframes.</p>
+    <p v-if="!hasProject" class="cc-empty">Open a project to build an animation.</p>
+    <p v-else-if="!openImageUid" class="cc-empty">Open an image in napari to start capturing keyframes.</p>
 
     <template v-else>
       <div class="anim-toolbar">
@@ -297,7 +297,7 @@ async function render() {
           v-tooltip.bottom="'Show the selected keyframe in napari when you click it (so you can see / tweak it)'" />
       </div>
 
-      <p v-if="!frames.length" class="anim-empty">No keyframes yet — set up the view in napari and
+      <p v-if="!frames.length" class="cc-empty">No keyframes yet — set up the view in napari and
         <strong>Capture view</strong>.</p>
 
       <div v-else class="anim-timeline">
@@ -370,7 +370,7 @@ async function render() {
 .anim-page { padding: 1rem 1.25rem; height: 100%; overflow: auto; }
 .anim-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 0.8rem; }
 .anim-head h1 { font-size: 1.1rem; margin: 0 0 0.2rem; }
-.anim-sub { font-size: 0.8rem; color: var(--cc-text-dim); max-width: 46rem; margin: 0; }
+.anim-sub { max-width: 46rem; margin: 0; }   /* + .cc-muted */
 .anim-head-ctl { display: flex; align-items: center; gap: 0.9rem; flex-shrink: 0; }
 .anim-fps { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.4rem; }
 .anim-range { width: 5rem; accent-color: var(--cc-accent); }
@@ -378,7 +378,6 @@ async function render() {
 .anim-title-toggle { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.35rem; cursor: pointer; }
 .anim-note { font-size: 0.72rem; width: 9rem; padding: 2px 6px; border: 1px solid var(--cc-border);
   border-radius: 4px; background: var(--cc-surface-1); color: var(--cc-text); }
-.anim-empty { font-size: 0.85rem; color: var(--cc-text-dim); margin-top: 1.5rem; }
 .anim-toolbar { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.9rem; }
 .anim-img { font-size: 0.78rem; font-weight: 600; color: var(--cc-text); margin-right: 0.2rem; }
 .anim-sync { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; color: var(--cc-text-dim); cursor: pointer; }

--- a/frontend/src/modules/MoviesModule.vue
+++ b/frontend/src/modules/MoviesModule.vue
@@ -166,7 +166,7 @@ function movieTime(mtime: number): string {
     <header class="mov-head">
       <div>
         <h1>Movies</h1>
-        <p class="mov-sub">Play the movies rendered for this project (single image, animation and batch).
+        <p class="mov-sub cc-muted">Play the movies rendered for this project (single image, animation and batch).
           Native player with adjustable speed and zoom.</p>
       </div>
       <div class="mov-head-ctl">
@@ -180,7 +180,7 @@ function movieTime(mtime: number): string {
           <i class="pi pi-search-plus" />
           <input type="range" :min="MOVIES_ZOOM_MIN" :max="MOVIES_ZOOM_MAX" step="0.25" :value="settings.moviesZoom"
                  @input="onZoomSlider(($event.target as HTMLInputElement).valueAsNumber)" class="mov-range" />
-          <span class="mov-num">{{ zoomLabel }}</span>
+          <span class="mov-num cc-readout">{{ zoomLabel }}</span>
         </label>
         <CcToggle class="mov-ctl" v-model="settings.moviesAutoplay" label="Autoplay"
                   v-tooltip.bottom="'Play a movie automatically when you select it'" />
@@ -193,8 +193,8 @@ function movieTime(mtime: number): string {
       </div>
     </header>
 
-    <p v-if="!hasProject" class="mov-empty">Open a project to browse its movies.</p>
-    <p v-else-if="!movies.length && !loading" class="mov-empty">No movies yet — record one from the
+    <p v-if="!hasProject" class="cc-empty">Open a project to browse its movies.</p>
+    <p v-else-if="!movies.length && !loading" class="cc-empty">No movies yet — record one from the
       Animation, Batch movies or Viewer panels; they appear here.</p>
 
     <div v-else class="mov-body">
@@ -205,13 +205,13 @@ function movieTime(mtime: number): string {
                  :autoplay="settings.moviesAutoplay" :loop="settings.moviesLoop"
                  :style="videoStyle" @loadedmetadata="onLoadedMeta" />
         </div>
-        <p v-else class="mov-empty">Select a movie to play.</p>
+        <p v-else class="cc-empty">Select a movie to play.</p>
         <div v-if="selected" class="mov-caption">{{ movieDisplayName(selected) }}</div>
       </div>
 
       <!-- Playlist -->
-      <aside class="mov-list">
-        <div class="mov-list-head">{{ movies.length }} movie{{ movies.length === 1 ? '' : 's' }}</div>
+      <aside class="mov-list cc-card">
+        <div class="mov-list-head cc-eyebrow">{{ movies.length }} movie{{ movies.length === 1 ? '' : 's' }}</div>
         <button v-for="m in movies" :key="m.name" class="mov-item"
                 :class="{ active: m.name === selected }" @click="select(m.name)">
           <i class="pi pi-video mov-item-ico" />
@@ -229,17 +229,15 @@ function movieTime(mtime: number): string {
 .mov-page { padding: 1rem 1.25rem; display: flex; flex-direction: column; height: 100%; min-height: 0; }
 .mov-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; flex-wrap: wrap; }
 .mov-head h1 { margin: 0; font-size: 1.15rem; }
-.mov-sub { margin: 0.2rem 0 0; font-size: 0.78rem; color: var(--cc-text-dim); max-width: 46rem; }
+.mov-sub { margin: 0.2rem 0 0; max-width: 46rem; }   /* + .cc-muted (colour/size) */
 .mov-head-ctl { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
 .mov-ctl { display: flex; align-items: center; gap: 0.35rem; font-size: 0.78rem; color: var(--cc-text-dim); }
 .mov-select {
   background: var(--cc-surface-2); color: var(--cc-text); border: 1px solid var(--cc-border);
-  border-radius: 0.3rem; padding: 0.15rem 0.35rem; font-size: 0.78rem;
+  border-radius: var(--cc-radius-sm); padding: 0.15rem 0.35rem; font-size: 0.78rem;
 }
 .mov-range { width: 6rem; }
-.mov-num { font-variant-numeric: tabular-nums; min-width: 2.2rem; }
-
-.mov-empty { color: var(--cc-text-dim); font-size: 0.85rem; margin-top: 2rem; }
+.mov-num { min-width: 2.2rem; }   /* + .cc-readout (tabular-nums/colour/size) */
 
 .mov-body { display: flex; gap: 1rem; flex: 1; min-height: 0; margin-top: 1rem; }
 
@@ -256,14 +254,8 @@ function movieTime(mtime: number): string {
 .mov-caption { font-size: 0.8rem; color: var(--cc-text); word-break: break-all; }
 
 /* Playlist */
-.mov-list {
-  width: 18rem; flex-shrink: 0; overflow-y: auto; border: 1px solid var(--cc-border);
-  border-radius: 0.4rem; background: var(--cc-surface-1); padding: 0.35rem;
-}
-.mov-list-head {
-  font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--cc-text-dim);
-  padding: 0.35rem 0.5rem 0.5rem;
-}
+.mov-list { width: 18rem; flex-shrink: 0; overflow-y: auto; padding: 0.35rem; }   /* + .cc-card (surface/border/radius) */
+.mov-list-head { padding: 0.35rem 0.5rem 0.5rem; }   /* + .cc-eyebrow (uppercase/dim/spacing) */
 .mov-item {
   display: flex; align-items: center; gap: 0.5rem; width: 100%; text-align: left;
   background: none; border: none; cursor: pointer; color: var(--cc-text-dim);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -46,6 +46,18 @@
   --cc-runner-w:       280px;
   --cc-console-bar-h:  30px;
   --cc-console-open-h: 210px;
+
+  /* Corner radius scale — collapses the ~8 ad-hoc radii (0.2/0.25/0.3/0.35/0.4…) to two steps.
+     -sm = small controls/chips/inputs; -md = cards/panels/dialogs. Use these, not a raw rem. */
+  --cc-radius-sm: 0.25rem;
+  --cc-radius-md: 0.4rem;
+
+  /* Small-text scale — collapses the ~10 ad-hoc sizes (0.6–0.85rem) to three steps for the
+     "secondary text" scenarios (labels, hints, readouts, meta). Body stays 13px; these are for
+     de-emphasised chrome. Use with `.cc-muted` etc., not a raw rem. */
+  --cc-fs-xs: 0.68rem;
+  --cc-fs-sm: 0.75rem;
+  --cc-fs-md: 0.82rem;
 }
 
 /* ── Reset / base ──────────────────────────────────────────────────────────── */
@@ -138,6 +150,36 @@ body {
   color: #fca5a5;
 }
 .cc-btn-danger-ghost:hover:not(:disabled) { background: #7f1d1d88; }
+
+/* ── Semantic role utilities ───────────────────────────────────────────────────
+   Generalise the recurring UX *scenarios* (roles that repeat across many different elements) instead
+   of styling each site ad-hoc. Compose them; add only layout (width/margin/flex) in scoped CSS.
+   See docs/UI.md → "UX primitive catalog" and docs/todo/UX_PRIMITIVES_PLAN.md. */
+
+/* Secondary / de-emphasised text — hints, subtitles, captions, meta lines. */
+.cc-muted { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
+
+/* Empty / placeholder state — "nothing here yet" message. Centred, muted, padded; drop an icon /
+   title / CTA inside for the rich variant (it's a flex column). */
+.cc-empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 0.4rem; padding: 2rem 1rem;
+  color: var(--cc-text-dim); font-size: var(--cc-fs-md); text-align: center;
+}
+
+/* Numeric value readout shown beside a control/metric (slider values, counts, occupancy). Default is
+   muted; add .cc-readout-strong for a prominent count (same scenario, higher prominence). */
+.cc-readout { font-variant-numeric: tabular-nums; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
+.cc-readout-strong { color: var(--cc-text); font-weight: 600; }
+
+/* Eyebrow / section label — small uppercase dim heading above a group of controls. */
+.cc-eyebrow {
+  font-size: var(--cc-fs-xs); font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--cc-text-dim);
+}
+
+/* Surface / container chrome — a card/panel body (surface-1 + hairline border + md radius). */
+.cc-card { background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); }
 
 /* ── Form controls — modern, consistent base for ALL native inputs ─────────── */
 /* Applies app-wide so bare <select>/<input> look the same everywhere. Components  */


### PR DESCRIPTION
Per your steer — generalise the remaining UX divergence by **recurring scenario (semantic role)**, not one component per widget. The audit's leftover "phases" aren't distinct problems: they collapse into a few roles that repeat across many elements. A prominent pool-size count and a dim slider `°/s/×` readout *look* different but are the **same scenario** ("a value readout"), differing only in prominence — so the grain is a semantic token/utility with a variant, not a `CcRange`.

## What this adds (a vocabulary, adopted incrementally — not a mass migration)
- **`style.css` tokens:** radius scale `--cc-radius-sm/md` (collapses ~8 ad-hoc radii), small-text scale `--cc-fs-xs/sm/md` (collapses ~10 sizes).
- **Semantic utilities:** `.cc-muted` (secondary text), `.cc-empty` (empty state), `.cc-readout` + `.cc-readout-strong` (value readout), `.cc-eyebrow` (section label), `.cc-card` (surface). These dissolve the would-be empty-state / readout / subtitle / card "phases" into one composable set.
- **Seed adoptions** in `MoviesModule` + `AnimationModule` (subtitle → `.cc-muted`, empties → `.cc-empty`, zoom readout → `.cc-readout`, playlist header → `.cc-eyebrow`, playlist → `.cc-card`), with their scoped CSS trimmed to layout-only — the reference for how to adopt.
- **Docs:** the semantic-role utilities are in the `docs/UI.md` "check before building" catalog; `UX_PRIMITIVES_PLAN.md` rewritten to the scenario approach — adoption incremental, the only remaining *worth-doing* item is routing status colours through `--cc-sev-*`/`severity.ts`; ranges/cards/icon-buttons explicitly **not** swept.

## Verification
Typecheck clean; 340 frontend tests pass.

## Reservations
- `.cc-empty` centres placeholder text (the seeded empties were left-aligned) — deliberate small visual change; seeded sites also shift to the token font-scale. Cosmetic.
- Foundation, **not** a migration: 300+ existing sites still use scoped styles by design; the tokens/utils are the canonical vocabulary for new + opportunistic adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
