### PR TITLE
UX adoption sweep (semantic utilities)

### DIFF
--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -83,9 +83,22 @@ skipped (kept bespoke), not forced.
 
 **Done — muted text / subtitles / simple empties → `.cc-muted`:** `NotebooksModule` (`.nb-sub`/`.nb-hint`),
 `SetupModule` (`.setup-sub`), `LegacyMigrateDialog` (`.lm-sub`), `GatingCopyDialog` (`.cg-empty`),
-`FileBrowser` (`.fb-empty`), `NotebookTable` (`.nbt-empty`) — plus `MoviesModule`/`AnimationModule`
-(seeded earlier). This also **fixed several dead `--cc-text-muted` references** (an undefined token that
-silently fell back to `#888` instead of the real `--cc-text-dim`).
+`FileBrowser` (`.fb-empty`), `NotebookTable` (`.nbt-empty`), `SummaryCanvas` (`.sc-empty`), `LayoutCanvas`
+(`.lc-empty`), `GatingPlots` (`.gp-empty`), `SeriesPicker`/`PopulationManager` (`.pm-empty`), `UmapView`
+(`.uv-pop-empty`), `TaskRunner` (`.defs-empty-msg`) — plus `MoviesModule`/`AnimationModule` (seeded
+earlier). This also **fixed several dead `--cc-text-muted` references** (an undefined token that silently
+fell back to `#888` instead of the real `--cc-text-dim`).
+
+**Roadblock — value readouts (`.cc-readout`) and eyebrows (`.cc-eyebrow`) NOT swept.** Their font sizes
+are context-tuned (0.6–0.78rem: dense inline readouts, tiny node labels) and the neighbouring widths are
+tuned to those sizes; the coarse 3-step scale (`--cc-fs-xs/sm`) would enlarge them and drift the layout.
+Some readouts are intentionally accent-coloured (`.pt-val`) or `--cc-text` (not dim). So `.cc-readout` /
+`.cc-eyebrow` are used only where the size already matches (e.g. `MoviesModule` zoom). Adopt the rest
+opportunistically per-file where the values line up — not a sweep.
+
+**Roadblock — card/surface (`.cc-card`) NOT swept.** ~29 panel/card blocks with radii spread 0.2–0.5rem
+and mixed surface-1/2; normalising all to `--cc-radius-md` + surface-1 would visibly change many. Use
+`.cc-card` for new containers; migrate existing ones only when a file is already being touched.
 
 **Roadblocks — deliberately kept bespoke (do NOT force onto the utils):**
 - **Rich empty state** — `ImageTable` `.empty-state` (+ `.empty-icon/-title/-hint/-cta`): a full icon +

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -76,6 +76,30 @@ Remaining — incremental adoption only (no forced sweeps):
 **Healthy / no action:** Modals (`BaseModal`), popovers (`TeleportPopover`), tabs (`TabbedCanvas`),
 chips (`ChipSelect`), colour dropdown (`SwatchSelect`).
 
+## Adoption sweep — log (in progress)
+
+Migrating existing sites onto the semantic vocabulary, scenario by scenario. Roadblocks are noted and
+skipped (kept bespoke), not forced.
+
+**Done — muted text / subtitles / simple empties → `.cc-muted`:** `NotebooksModule` (`.nb-sub`/`.nb-hint`),
+`SetupModule` (`.setup-sub`), `LegacyMigrateDialog` (`.lm-sub`), `GatingCopyDialog` (`.cg-empty`),
+`FileBrowser` (`.fb-empty`), `NotebookTable` (`.nbt-empty`) — plus `MoviesModule`/`AnimationModule`
+(seeded earlier). This also **fixed several dead `--cc-text-muted` references** (an undefined token that
+silently fell back to `#888` instead of the real `--cc-text-dim`).
+
+**Roadblocks — deliberately kept bespoke (do NOT force onto the utils):**
+- **Rich empty state** — `ImageTable` `.empty-state` (+ `.empty-icon/-title/-hint/-cta`): a full icon +
+  title + hint + CTA block with generous padding. `.cc-empty` is the plain column; a rich `<EmptyState>`
+  variant could wrap it later, but it's the one genuinely rich case — leave it.
+- **Absolute-positioned overlay empty** — `UmapView` `.uv-empty` (`position:absolute; inset:0`): not a
+  flow block; `.cc-empty` doesn't apply.
+- **Tiny / italic micro-empties** — `ChainQcNode` `.qc-empty` (9px italic), `PopulationManager`
+  `.pm-chip-empty` (10px italic), `CropPanel`/`ChainQcNode` italic hints: sub-`--cc-fs-xs` sizes +
+  italic are intentional dense-context chrome; `.cc-muted` (0.75rem, non-italic) would enlarge them.
+- **`HintCallout.vue`** is a full component (icon + dismiss), not a text scenario — leave it.
+- **`ChainModule`** empties/hints (`.live-empty`, `.canvas-empty`, `.no-chains-hint`, palette hints):
+  several are richer (icons, multi-line CTAs) inside the whiteboard; adopt opportunistically, not swept.
+
 ## Convention going forward
 
 Each canonical primitive/utility gets a one-liner in `docs/UI.md` (the *when to use which*, in the

--- a/frontend/src/components/FileBrowser.vue
+++ b/frontend/src/components/FileBrowser.vue
@@ -237,7 +237,7 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
             </tr>
 
             <tr v-if="listing && listing.entries.length === 0">
-              <td colspan="3" class="fb-empty">Empty directory</td>
+              <td colspan="3" class="fb-empty cc-muted">Empty directory</td>
             </tr>
           </tbody>
         </table>
@@ -354,7 +354,7 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 .row-name { vertical-align: middle; }
 .dim { color: var(--cc-text-dim); font-size: 0.75rem; }
 
-.fb-empty { text-align: center; padding: 2rem; color: var(--cc-text-dim); font-size: 0.8rem; }
+.fb-empty { text-align: center; padding: 2rem; }   /* + .cc-muted */
 
 /* footer */
 .sel-count { font-size: 0.78rem; color: var(--cc-text); flex: 1; }

--- a/frontend/src/components/LegacyMigrateDialog.vue
+++ b/frontend/src/components/LegacyMigrateDialog.vue
@@ -190,10 +190,10 @@ async function confirmImport() {
                 <td><input type="checkbox" :checked="selected.has(im.uid)" @change="toggle(im.uid)" /></td>
                 <td>
                   <div class="lm-name">{{ im.name }}</div>
-                  <div class="lm-sub">{{ im.uid }} · {{ im.kind }}</div>
+                  <div class="cc-muted">{{ im.uid }} · {{ im.kind }}</div>
                   <div v-for="w in im.warnings" :key="w" class="lm-warn"><i class="pi pi-info-circle" /> {{ w }}</div>
                 </td>
-                <td class="lm-sub">
+                <td class="cc-muted">
                   <span v-if="im.size.SizeC">{{ im.size.SizeC }}c</span>
                   <span v-if="im.size.SizeZ && im.size.SizeZ > 1"> · {{ im.size.SizeZ }}z</span>
                   <span v-if="im.size.SizeT && im.size.SizeT > 1"> · {{ im.size.SizeT }}t</span>
@@ -202,11 +202,11 @@ async function confirmImport() {
                   <span class="lm-tag ok">image</span>
                   <span v-for="s in im.segmentation" :key="s" class="lm-tag ok">seg: {{ s }}</span>
                   <span v-if="isTracked(im)" class="lm-tag ok">tracking: {{ nTracks(im) }}</span>
-                  <span v-if="!im.segmentation.length" class="lm-sub">image only</span>
+                  <span v-if="!im.segmentation.length" class="cc-muted">image only</span>
                 </td>
                 <td>
                   <span v-for="x in excludedList(im)" :key="x" class="lm-tag off-tag">{{ x }}</span>
-                  <span v-if="!excludedList(im).length" class="lm-sub">—</span>
+                  <span v-if="!excludedList(im).length" class="cc-muted">—</span>
                 </td>
               </tr>
             </tbody>
@@ -255,7 +255,7 @@ async function confirmImport() {
 .lm-table thead th { position: sticky; top: 0; background: var(--cc-surface-1); font-weight: 600; color: var(--cc-text-dim); }
 .lm-table tr.off { opacity: 0.45; }
 .lm-name { font-weight: 500; }
-.lm-sub { color: var(--cc-text-dim); font-size: 0.78rem; }
+.cc-muted { color: var(--cc-text-dim); font-size: 0.78rem; }
 .lm-warn { color: #fbbf24; font-size: 0.78rem; margin-top: 0.15rem; }
 .lm-tag { display: inline-block; margin: 0.1rem 0.2rem 0.1rem 0; padding: 0.05rem 0.4rem; border-radius: 4px; font-size: 0.76rem; }
 .lm-tag.ok { background: #16653433; color: #4ade80; }

--- a/frontend/src/components/NotebookTable.vue
+++ b/frontend/src/components/NotebookTable.vue
@@ -323,7 +323,7 @@ defineExpose({ refresh })
         </tr>
         </template>
         <tr v-if="!notebooks.length && !loading">
-          <td colspan="5" class="nbt-empty">No notebooks yet — add one, or duplicate an example.</td>
+          <td colspan="5" class="nbt-empty cc-muted">No notebooks yet — add one, or duplicate an example.</td>
         </tr>
       </tbody>
     </table>
@@ -346,7 +346,7 @@ defineExpose({ refresh })
 .nbt-actions .cc-btn { padding: .25rem .45rem; }
 .nbt-danger { color: #f85149; }
 .nbt-active { color: #58a6ff; }
-.nbt-empty { color: var(--cc-text-muted, #888); text-align: center; padding: 1rem; }
+.nbt-empty { text-align: center; padding: 1rem; }   /* + .cc-muted */
 .nbt-history-row td { background: var(--cc-surface-2, rgba(255,255,255,0.03)); }
 .nbt-history { display: flex; align-items: center; flex-wrap: wrap; gap: .5rem; font-size: .85rem; }
 .nbt-hist-label { color: var(--cc-text-muted, #888); }

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -381,7 +381,7 @@ defineExpose({ capturePage, collectCsvs })
 
 <template>
   <div class="layout-canvas">
-    <div v-if="!imageUid" class="lc-empty">Select one or more images above to plot.</div>
+    <div v-if="!imageUid" class="lc-empty cc-muted">Select one or more images above to plot.</div>
     <template v-else>
       <!-- controls, grouped so nothing crowds: Layout row (uniform + custom sliders), Plates row
            (varied presets, wraps to two lines), then the data/compare row. -->
@@ -567,7 +567,7 @@ defineExpose({ capturePage, collectCsvs })
 
 <style scoped>
 .layout-canvas { display: flex; flex-direction: column; }
-.lc-empty { padding: 20px; color: var(--cc-text-dim); }
+.lc-empty { padding: 20px; }   /* + .cc-muted */
 .lc-bar { display: flex; flex-direction: column; gap: 6px; padding: 8px 4px; font-size: 12px; flex-shrink: 0; }
 .lc-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 /* sits right after the sliders (NOT pushed to the far right) so it doesn't shift when the compare

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -273,7 +273,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
         </div>
       </div>
 
-      <div v-if="!visiblePops.length" class="pm-empty">
+      <div v-if="!visiblePops.length" class="pm-empty cc-muted">
         {{ clusterMode ? 'No populations yet — add one, then tick clusters into it.' : 'No populations yet — draw a gate.' }}
       </div>
 
@@ -415,7 +415,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
 <style scoped>
 /* row / options styles — applied to content rendered into PopulationPanelShell's slots (slotted
    content keeps THIS component's scoped styles; the floating chrome + scope footer live in the shell). */
-.pm-empty { padding: 12px; color: var(--cc-text-dim); }
+.pm-empty { padding: 12px; }   /* + .cc-muted */
 .pm-row { display: flex; align-items: center; gap: 6px; padding: 4px 8px 4px 6px; cursor: pointer; border-bottom: 1px solid var(--cc-border); }
 .pm-row:hover { background: var(--cc-surface-2); }
 .pm-row.active { background: color-mix(in srgb, var(--cc-accent) 22%, transparent); }

--- a/frontend/src/components/canvas/SeriesPicker.vue
+++ b/frontend/src/components/canvas/SeriesPicker.vue
@@ -38,7 +38,7 @@ const depthOf = (path: string) => Math.max(0, path.split('/').length - 2)
 <template>
   <PopulationPanelShell :count="total" :scope="scope" :vis="vis" :docked="docked"
                         @update:scope="emit('update:scope', $event)" @update:vis="emit('update:vis', $event)">
-    <div v-if="!total" class="pm-empty">No populations in the selected segmentations.</div>
+    <div v-if="!total" class="pm-empty cc-muted">No populations in the selected segmentations.</div>
     <template v-for="grp in groups" :key="grp.valueName">
       <div v-if="grp.populations.length" class="pm-group-head">{{ grp.valueName }}</div>
       <div v-for="p in grp.populations" :key="p.popType + grp.valueName + p.path"
@@ -61,7 +61,7 @@ const depthOf = (path: string) => Math.max(0, path.split('/').length - 2)
 <style scoped>
 /* row styles — applied to the population list rendered into PopulationPanelShell's default slot
    (slotted content keeps THIS component's scoped styles; the chrome lives in the shell). */
-.pm-empty { padding: 12px; color: var(--cc-text-dim); }
+.pm-empty { padding: 12px; }   /* + .cc-muted */
 .pm-group-head {
   padding: 5px 8px; background: var(--cc-surface-2); color: var(--cc-text-dim);
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em;

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -127,7 +127,7 @@ watch(segPops, () => {
 
 <template>
   <div class="summary-canvas">
-    <div v-if="!imageUid" class="sc-empty">Select one or more images above to plot.</div>
+    <div v-if="!imageUid" class="sc-empty cc-muted">Select one or more images above to plot.</div>
     <template v-else>
       <div class="sc-bar">
         <select class="sc-add" v-tooltip.bottom="'Add a plot'"
@@ -199,7 +199,7 @@ watch(segPops, () => {
 
 <style scoped>
 .summary-canvas { display: flex; flex-direction: column; height: 100%; min-height: 80vh; }
-.sc-empty { padding: 20px; color: var(--cc-text-dim); }
+.sc-empty { padding: 20px; }   /* + .cc-muted */
 .sc-bar { display: flex; align-items: center; gap: 12px; padding: 8px 4px; font-size: 12px; flex-shrink: 0; flex-wrap: wrap; }
 .sc-bar label { display: flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .sc-add { min-width: 8rem; }

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -623,7 +623,7 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
           <template v-if="usePopIdx">
             <div class="uv-opt-sep">Populations</div>
             <div class="uv-pop">
-              <div v-if="!popGroups.length" class="uv-pop-empty">No populations in the clustered segmentations.</div>
+              <div v-if="!popGroups.length" class="uv-pop-empty cc-muted">No populations in the clustered segmentations.</div>
               <template v-for="grp in popGroups" :key="grp.valueName">
                 <div v-if="grp.populations.length" class="uv-pop-head">{{ grp.valueName }}</div>
                 <div v-for="p in grp.populations" :key="p.popType + grp.valueName + p.path"
@@ -693,7 +693,7 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
   border-top: 1px solid var(--cc-border); padding-top: 6px; margin-top: 2px; }
 /* population checklist (inside the options popover) */
 .uv-pop { max-height: 14rem; overflow-y: auto; border: 1px solid var(--cc-border); border-radius: 5px; }
-.uv-pop-empty { padding: 10px; color: var(--cc-text-dim); font-size: 12px; }
+.uv-pop-empty { padding: 10px; }   /* + .cc-muted */
 .uv-pop-head { padding: 4px 8px; background: var(--cc-surface-2); color: var(--cc-text-dim);
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; position: sticky; top: 0; }
 .uv-pop-row { display: flex; align-items: center; gap: 6px; padding: 4px 8px; cursor: pointer; font-size: 12px; color: var(--cc-text); }

--- a/frontend/src/modules/NotebooksModule.vue
+++ b/frontend/src/modules/NotebooksModule.vue
@@ -135,7 +135,7 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
   <div class="notebooks-page">
     <header class="nb-header">
       <h1><i class="pi pi-book" /> Notebooks</h1>
-      <p class="nb-sub">
+      <p class="nb-sub cc-muted">
         Pure-Julia downstream analysis with <strong>Pluto</strong> — load objects, pull cell tables
         via <code>pop_df</code>, plot, and export. Runs in its own Julia session.
       </p>
@@ -175,7 +175,7 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
             </button>
           </template>
         </div>
-        <p v-if="server === 'starting'" class="nb-hint">
+        <p v-if="server === 'starting'" class="nb-hint cc-muted">
           First launch precompiles — this can take up to a minute.
         </p>
         <p v-if="errorMsg" class="nb-error"><i class="pi pi-exclamation-triangle" /> {{ errorMsg }}</p>
@@ -199,7 +199,7 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
              : sysimage === 'error' ? 'Retry fast-plot build'
              : 'Enable fast plots' }}
           </button>
-          <span class="nb-hint">
+          <span class="nb-hint cc-muted">
             {{ sysimage === 'stale'
               ? 'A package update outdated the cached image — rebuild to keep the first plot fast.'
              : sysimage === 'error'
@@ -207,7 +207,7 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
               : 'Optional: skip the ~20 s first-plot compile. Notebooks work without it.' }}
           </span>
         </div>
-        <p v-else-if="sysimage === 'ready'" class="nb-hint">
+        <p v-else-if="sysimage === 'ready'" class="nb-hint cc-muted">
           <i class="pi pi-bolt" /> Fast plots enabled.
         </p>
       </section>
@@ -224,7 +224,7 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
 <style scoped>
 .notebooks-page { padding: 1.25rem 1.5rem; max-width: 980px; }
 .nb-header h1 { display: flex; align-items: center; gap: .5rem; margin: 0 0 .25rem; font-size: 1.4rem; }
-.nb-sub { color: var(--cc-text-muted, #888); margin: 0 0 1rem; max-width: 640px; }
+.nb-sub { margin: 0 0 1rem; max-width: 640px; }   /* + .cc-muted */
 .nb-empty { display: flex; align-items: center; gap: .5rem; color: var(--cc-text-muted, #888); padding: 2rem 0; }
 .nb-section { margin-bottom: 1.5rem; }
 .nb-section h2 { font-size: 1.05rem; margin: 0 0 .5rem; }
@@ -232,7 +232,7 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
 .nb-status { display: inline-flex; align-items: center; gap: .4rem; font-size: .9rem; }
 .nb-status.is-running .pi { color: #3fb950; }
 .nb-status.is-stopped .pi, .nb-status.is-unknown .pi { color: var(--cc-text-muted, #888); }
-.nb-hint { color: var(--cc-text-muted, #888); font-size: .85rem; margin: .5rem 0 0; }
+.nb-hint { margin: .5rem 0 0; }   /* + .cc-muted */
 .nb-error { color: #f0883e; font-size: .85rem; margin: .5rem 0 0; display: flex; align-items: center; gap: .4rem; }
 .nb-note {
   display: flex; align-items: flex-start; gap: .55rem; margin: .75rem 0 0; padding: .65rem .8rem;

--- a/frontend/src/modules/SetupModule.vue
+++ b/frontend/src/modules/SetupModule.vue
@@ -84,7 +84,7 @@ async function waitForBackend(timeoutMs = 60000) {
     <div class="setup-card">
       <div class="setup-logo">🍍</div>
       <h1 class="setup-title">Welcome to Cecelia</h1>
-      <p class="setup-sub">Where would you like to store your projects?</p>
+      <p class="setup-sub cc-muted">Where would you like to store your projects?</p>
 
       <label class="setup-label" for="setup-path">Projects folder</label>
       <input id="setup-path" v-model="path" class="setup-input" type="text" spellcheck="false"
@@ -133,7 +133,7 @@ async function waitForBackend(timeoutMs = 60000) {
 }
 .setup-logo { font-size: 2.5rem; line-height: 1; }
 .setup-title { margin: 0.5rem 0 0; font-size: 1.4rem; font-weight: 600; }
-.setup-sub { margin: 0 0 1rem; color: var(--cc-text-dim); }
+.setup-sub { margin: 0 0 1rem; }   /* + .cc-muted */
 .setup-label { font-size: 0.8rem; color: var(--cc-text-dim); margin-bottom: 0.15rem; }
 .setup-input { width: 100%; font-family: var(--cc-mono, monospace); }
 .setup-hint {

--- a/frontend/src/modules/gate/GatingCopyDialog.vue
+++ b/frontend/src/modules/gate/GatingCopyDialog.vue
@@ -91,9 +91,9 @@ async function copy() {
       <p class="cg-warn"><i class="pi pi-exclamation-triangle" />
         Overwrites the {{ label }} on each selected image ({{ valueName }}) — no undo.</p>
 
-      <p v-if="checking" class="cg-empty">Checking images…</p>
+      <p v-if="checking" class="cg-empty cc-muted">Checking images…</p>
       <template v-else>
-        <p v-if="!siblings.length" class="cg-empty">No other images in this set.</p>
+        <p v-if="!siblings.length" class="cg-empty cc-muted">No other images in this set.</p>
 
         <template v-if="available.length">
           <label class="cg-all"><input type="checkbox" :checked="allPicked" @change="toggleAll" /> Select all</label>
@@ -106,7 +106,7 @@ async function copy() {
           <CcToggle class="cg-layout" v-model="copyLayout" label="Also copy plot layout"
             v-tooltip.top="'Also copy the plot layout (plots, channels, parents).'" />
         </template>
-        <p v-else-if="siblings.length" class="cg-empty">No images have the “{{ valueName }}” segmentation.</p>
+        <p v-else-if="siblings.length" class="cg-empty cc-muted">No images have the “{{ valueName }}” segmentation.</p>
 
         <!-- flagged: no such segmentation → never copied to -->
         <div v-if="missing.length" class="cg-missing">
@@ -130,7 +130,7 @@ async function copy() {
 .cg-body { display: flex; flex-direction: column; gap: 0.7rem; }   /* padding from BaseModal */
 .cg-warn { display: flex; align-items: center; gap: 0.4rem; margin: 0; font-size: 0.78rem; color: #fcd34d;
   background: #7c2d1244; border: 1px solid #92400e55; border-radius: 0.3rem; padding: 0.4rem 0.55rem; line-height: 1.35; }
-.cg-empty { margin: 0; font-size: 0.8rem; color: var(--cc-text-dim); }
+.cg-empty { margin: 0; }   /* + .cc-muted */
 .cg-all { font-size: 0.75rem; color: var(--cc-text-dim); display: flex; align-items: center; gap: 0.4rem; cursor: pointer; }
 .cg-list { display: flex; flex-direction: column; gap: 0.15rem; max-height: 240px; overflow: auto;
   border: 1px solid var(--cc-border); border-radius: 0.35rem; padding: 0.4rem 0.5rem; }

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -207,7 +207,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
 
 <template>
   <div class="gating-plots">
-    <div v-if="!props.imageUid" class="gp-empty">Select one image above to gate.</div>
+    <div v-if="!props.imageUid" class="gp-empty cc-muted">Select one image above to gate.</div>
     <template v-else>
       <div class="gp-bar">
         <label>segmentation
@@ -293,7 +293,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
 <style scoped>
 /* fill all available height so the plot workspace isn't capped */
 .gating-plots { display: flex; flex-direction: column; height: 100%; min-height: 80vh; }
-.gp-empty { padding: 20px; color: var(--cc-text-dim); }
+.gp-empty { padding: 20px; }   /* + .cc-muted */
 .gp-bar { display: flex; align-items: center; gap: 14px; padding: 8px 4px; font-size: 12px; flex-shrink: 0; }
 .gp-bar label { display: flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .gp-bar select { min-width: 9rem; }   /* visual styling from the global form base */

--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -303,7 +303,7 @@ const { width: sidebarWidth, onResizeStart } =
 
     <!-- ── Empty state (server not ready / JSON parse error) ── -->
     <section v-if="!defs.length" class="runner-section defs-empty">
-      <p class="defs-empty-msg">No functions available — the server may still be starting.</p>
+      <p class="defs-empty-msg cc-muted">No functions available — the server may still be starting.</p>
       <button v-if="onReloadDefs" class="cc-btn cc-btn-secondary" @click="onReloadDefs">
         <i class="pi pi-refresh" /> Reload
       </button>
@@ -537,7 +537,7 @@ const { width: sidebarWidth, onResizeStart } =
 .fn-select:focus { outline: 1px solid var(--cc-accent); }
 
 .defs-empty { display: flex; flex-direction: column; align-items: flex-start; gap: 0.6rem; }
-.defs-empty-msg { font-size: 0.8rem; color: var(--cc-text-muted); margin: 0; }
+.defs-empty-msg { margin: 0; }   /* + .cc-muted (was undefined --cc-text-muted) */
 
 .fn-meta { display: flex; gap: 0.3rem; margin-top: 0.4rem; }
 .env-badge {


### PR DESCRIPTION
Progressive adoption of the semantic-utility vocabulary (`.cc-muted`/`.cc-empty`/`.cc-readout`/`.cc-eyebrow`/`.cc-card` + tokens) across existing sites, per scenario. **This PR grows as I sweep** — one branch, thematic commits, reviewable by commit; merge as a unit at the end. Roadblocks are logged in `docs/todo/UX_PRIMITIVES_PLAN.md` and kept bespoke, not forced.

### Commit 1 — muted text / subtitles / simple empties → `.cc-muted`
`NotebooksModule` (`.nb-sub`/`.nb-hint`), `SetupModule` (`.setup-sub`), `LegacyMigrateDialog` (`.lm-sub`), `GatingCopyDialog` (`.cg-empty`), `FileBrowser` (`.fb-empty`), `NotebookTable` (`.nbt-empty`). Scoped colour/font-size dropped, layout kept.

**Bonus bug fix:** several of these referenced an **undefined `--cc-text-muted`** token that silently fell back to `#888` instead of the real `--cc-text-dim` — now consistent.

### Roadblocks (kept bespoke, logged)
Rich empty state (`ImageTable`), absolute-positioned overlay empty (`UmapView`), tiny/italic micro-empties (`ChainQcNode`/`PopulationManager`), `HintCallout` (a component), richer `ChainModule` whiteboard empties.

Typecheck clean; 340 frontend tests pass. More commits (readouts, eyebrows, cards, collapsible headers) to follow on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
