### PR TITLE
UX tokens: fix dead CSS tokens, add modifier axes, tokenise all raw sizes/radii

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -33,12 +33,43 @@ primitives still being extracted lives in `docs/todo/UX_PRIMITIVES_PLAN.md`.
 
 | Scenario | Use | Never |
 |------|-----|-------|
-| Secondary / muted text (hint, subtitle, caption, meta) | `.cc-muted` | a scoped `color: var(--cc-text-dim); font-size: …` |
-| Empty / "nothing here yet" state | `.cc-empty` (drop icon/title/CTA inside for the rich variant) | a new `.*-empty` class |
-| Numeric value readout beside a control | `.cc-readout` (+ `.cc-readout-strong` for a prominent count) | a bespoke `.*-val`/`.*-num` |
-| Eyebrow / section label (uppercase dim heading) | `.cc-eyebrow` | a scoped uppercase-heading rule |
-| Card / panel / surface container | `.cc-card` | a scoped `surface + 1px border + radius` block |
-| Corner radius / small text size | tokens `--cc-radius-sm/md`, `--cc-fs-xs/sm/md` | a raw `rem` radius or font-size |
+| Secondary / muted text (hint, subtitle, caption, meta) | `.cc-muted` (+ `-dense`/`-micro` in dense chrome) | a scoped `color: var(--cc-text-dim); font-size: …` |
+| Empty / "nothing here yet" state | `.cc-empty` (+ `-inline` one-liner / `-overlay` over a plot / `-lg` rich page empty) | a new `.*-empty` class |
+| Numeric value readout beside a control | `.cc-readout` (+ `-strong` prominent, `-dense` inline) | a bespoke `.*-val`/`.*-num` |
+| Eyebrow / section label (uppercase dim heading) | `.cc-eyebrow` (+ `-dense` for list/table headers) | a scoped uppercase-heading rule |
+| Card / panel / surface container | `.cc-card` (+ `-2` when it sits *on* a surface-1 panel) | a scoped `surface + 1px border + radius` block |
+| Corner radius | `--cc-radius-xs/sm/md/lg/pill` | a raw `rem`/`px` radius |
+| Small text size | `--cc-fs-3xs/2xs/xs/sm/md/lg` | a raw `rem`/`px` font-size (incl. inline `style=`) |
+
+**Each utility varies on exactly one axis, and the modifier is that axis** — density (`-dense`/`-micro`),
+surface (`-2`), layout (`-inline`/`-overlay`/`-lg`). Reach for the modifier instead of re-declaring the
+scenario locally: baking a value into the base is what stranded ~10 sites as "bespoke" before. Per-site
+*emphasis* (`font-style: italic`) and *geometry* (width/margin/flex/padding) still belong in scoped CSS.
+
+**There are no raw sizes or radii left, and the tests keep it that way.** Both scales were derived from
+the actual distribution rather than guessed: 33 distinct font-size spellings collapsed onto 6 steps (98%
+of them were already within 0.5px of a step), and 15 radius spellings onto 5. `--cc-radius-sm` was retuned
+`0.25rem`→`0.3rem` because 4.8px is the modal radius, which halved the worst-case shift. A literal
+`font-size`/`border-radius` anywhere — scoped CSS **or** an inline `style=` — now fails
+`utils/cssScenarios.test.ts`. Exempt by rule: display type (>15px), pill radii, `0`, and `em` (which is
+deliberately container-relative, e.g. `ViewLegend` scaling with the export).
+
+**Re-implementing a scenario is a test failure, not a style opinion.** `utils/cssScenarios.test.ts`
+detects a scoped rule that spells out a canonical utility's defining declarations — a dim colour plus a
+hard-coded size *is* `.cc-muted` — and holds a per-file baseline that **may shrink and must never grow**.
+Touch a file, migrate its rules and lower its number; add a new one and the suite names it. Card chrome
+is deliberately *not* checked: `surface + border + radius` is the shape of a card, an input, a chip, a
+badge and an icon-button alike, and ~60% of matches wanted `.cc-btn`/`ChipSelect` instead, so it stays a
+review-time rule.
+
+**Every custom property you reference must be declared somewhere.** An undeclared one does not warn —
+it makes the whole declaration invalid at computed-value time, so `var(--cc-text-muted, #888)` silently
+freezes a hard-coded grey that never tracks the theme, and a fallback-less `background: var(--cc-surface)`
+drops the *entire* `background` shorthand (a `<select>` lost both its fill and the global custom caret this
+way). `utils/cssTokens.test.ts` fails the build on any such reference — add the token, don't add a fallback.
+It checks **all** `--*` properties, not just `--cc-*` (a stray `--text-muted` had been hiding behind the
+prefix), and counts a component-local declaration — including an inline `:style="{ '--foo': … }"` for a
+dynamic value — as valid.
 
 If what you need isn't here and isn't obviously covered by an existing component, grep first
 (`INVENTORY.md` → *Frontend*); only build new if the search is genuinely empty, and then add it here +
@@ -67,6 +98,8 @@ All tokens live in `frontend/src/style.css` under `.cc-dark` (always applied at 
 | `--cc-sev-warn` | `#fab219` | Severity **warn** (a QC warn finding) |
 | `--cc-sev-fail` | `#d03b3b` | Severity **fail** (a task failed) |
 | `--cc-mono` | system monospace stack | Log output, code |
+| `--cc-radius-sm` / `-md` | `0.25rem` / `0.4rem` | Small controls/chips/inputs · cards/panels/dialogs |
+| `--cc-fs-3xs` … `-md` | `0.56` / `0.62` / `0.68` / `0.75` / `0.82rem` | Small-text scale (≈9/10/11/12px + 0.82). Use in place of a raw `rem` **or** `px` size |
 | `--cc-header-h` | `40px` | Fixed header height |
 | `--cc-sidebar-w` | `190px` | Fixed sidebar width |
 | `--cc-runner-w` | `280px` | TaskRunner panel width |

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -24,10 +24,13 @@ and use it. When you unify a category, tick it here and add the rule to `docs/UI
 | Modal / dialog | `components/BaseModal.vue` | backdrop + panel + close; ~9 consumers. |
 | Popover / dropdown | `components/TeleportPopover.vue` | ~11 consumers. |
 | Tabs | `components/canvas/TabbedCanvas.vue` | + `ChipSelect` segmented. |
-| Collapsible section | `components/CollapsibleSection.vue` | ~7 consumers; **but ~15 hand-rolled chevron toggles bypass it** (see Phase 4). |
-| Range (dual-thumb) | `components/RangeSlider.vue` | min+max only; **no single-value wrapper yet** (see Phase 2). |
-| Plot-area spinner | `components/plots/PlotSpinner.vue` | plot area only; inline busy spinners are ad-hoc (see Phase 6). |
+| Collapsible section | `components/CollapsibleSection.vue` | ~7 consumers; **but ~10 hand-rolled chevron toggles bypass it** (see *Remaining*). |
+| Range (dual-thumb) | `components/RangeSlider.vue` | min+max only; no single-value wrapper (not recommended — see *Remaining*). |
+| Plot-area spinner | `components/plots/PlotSpinner.vue` | plot area only. Inline busy spinners were long listed here as "ad-hoc" — **measured, and they aren't**: of 48 `pi-spin` usages only 13 carry a styled class, all token-sized or inheriting, and the rest are the shared `<i class="pi pi-spin pi-spinner" />` idiom inline in a button. Nothing to unify. |
 | Severity colours | `lib/severity.ts` + `--cc-sev-*` | status colours should route through this. |
+| Task/chain status | `lib/taskStatus.ts` (`TASK_STATUS`) | the ONE 5-state status→icon/colour map. |
+| Semantic text/surface scenarios | `.cc-muted` · `.cc-empty` · `.cc-readout` · `.cc-eyebrow` · `.cc-card` (+ one modifier axis each) | full catalog in `docs/UI.md`. |
+| Design tokens | `--cc-fs-3xs…md`, `--cc-radius-sm/md`, colours in `style.css` | guarded: `utils/cssTokens.test.ts` fails on an undeclared `--cc-*`. |
 
 ## Approach — generalise by SCENARIO, not one component per widget
 
@@ -56,6 +59,12 @@ Done — semantic-role vocabulary (the generalisation; adopt incrementally):
   (section label), `.cc-card` (surface). Seeded in `MoviesModule` + `AnimationModule` as the reference
   adoptions. This scenario vocabulary replaces the would-be Phase 2/3/6/7 components — the ~23 `*-empty`
   classes, the slider readouts, the subtitles/hints, and the card chrome all compose from it.
+- [x] **One modifier axis per scenario** — density (`-dense`/`-micro` + `--cc-fs-2xs/3xs`), surface
+  (`.cc-card-2`), layout (`.cc-empty-inline/-overlay/-lg`). This is what unblocked the stalled
+  adoption sweep; see *Re-read of the roadblocks* below for why the axes were the whole problem.
+- [x] **Dead-token guard** — `utils/cssTokens.ts` + test: referencing a `--cc-*` token that `style.css`
+  doesn't declare now fails the suite (it was silently freezing hard-coded greys and, once, killing a
+  `<select>`'s fill *and* caret).
 
 Done — the correctness item:
 - [x] **Status/severity colours.** `lib/taskStatus.ts` (`TASK_STATUS`) — the ONE 5-state status map;
@@ -64,9 +73,13 @@ Done — the correctness item:
   `ParamRenderer`'s QC flag already used `lib/severity.ts`. (PR #TBD)
 
 Remaining — incremental adoption only (no forced sweeps):
-- [ ] **Collapsible section headers.** `CollapsibleSection` exists but ~15 chevron+heading toggles
-  bypass it (`PlotOptions` ×4, `MetadataPanel`, `ParamRenderer`, `PopulationManager`, …). Migrate
-  opportunistically, or extract `.cc-section-toggle`.
+- [ ] **Collapsible section headers.** `CollapsibleSection` exists but **~10** chevron+heading toggles
+  bypass it: `PlotOptions` ×4, `ParamRenderer` ×2, `ModuleLayout` ×2, `MetadataPanel`, `PopulationManager`.
+  Migrate opportunistically, or extract `.cc-section-toggle`. (Recount: the earlier "~15" swept in six
+  sites that are **not** sections and should stay as they are — `AnimationModule`'s two chevron-left/right
+  *reorder* buttons, the dropdown carets in `SwatchSelect`/`GatePairsPanel`, and the whole-panel collapse
+  in `CanvasPanel`/`PopulationPanelShell`. A seventh scenario is genuinely distinct and recurring:
+  **per-row disclosure** in a list — `TaskList`, `ErrorConsole` — worth naming if a third site appears.)
 - [ ] **Opportunistic muted-text / card / readout adoption.** Replace scoped `.*-empty` / `.*-val` /
   subtitle / surface blocks with the semantic utils as files are touched — NOT a dedicated sweep.
 - [ ] **Not recommended as sweeps:** single-value range wrapper (base already accent-themed; readout now
@@ -89,29 +102,132 @@ skipped (kept bespoke), not forced.
 earlier). This also **fixed several dead `--cc-text-muted` references** (an undefined token that silently
 fell back to `#888` instead of the real `--cc-text-dim`).
 
-**Roadblock — value readouts (`.cc-readout`) and eyebrows (`.cc-eyebrow`) NOT swept.** Their font sizes
-are context-tuned (0.6–0.78rem: dense inline readouts, tiny node labels) and the neighbouring widths are
-tuned to those sizes; the coarse 3-step scale (`--cc-fs-xs/sm`) would enlarge them and drift the layout.
-Some readouts are intentionally accent-coloured (`.pt-val`) or `--cc-text` (not dim). So `.cc-readout` /
-`.cc-eyebrow` are used only where the size already matches (e.g. `MoviesModule` zoom). Adopt the rest
-opportunistically per-file where the values line up — not a sweep.
+### Re-read of the roadblocks (2026-07-25) — they were one problem, and it's fixed
 
-**Roadblock — card/surface (`.cc-card`) NOT swept.** ~29 panel/card blocks with radii spread 0.2–0.5rem
-and mixed surface-1/2; normalising all to `--cc-radius-md` + surface-1 would visibly change many. Use
-`.cc-card` for new containers; migrate existing ones only when a file is already being touched.
+Every roadblock above had the same cause: **the utility hard-coded a value on an axis where sites
+legitimately differ**, so adopting it forced a visual change, so the site stayed hand-rolled and got
+written down as "bespoke". There were only three such axes. Giving each scenario its missing axis as a
+modifier turned the whole list into mechanical, visually-neutral migrations:
 
-**Roadblocks — deliberately kept bespoke (do NOT force onto the utils):**
-- **Rich empty state** — `ImageTable` `.empty-state` (+ `.empty-icon/-title/-hint/-cta`): a full icon +
-  title + hint + CTA block with generous padding. `.cc-empty` is the plain column; a rich `<EmptyState>`
-  variant could wrap it later, but it's the one genuinely rich case — leave it.
-- **Absolute-positioned overlay empty** — `UmapView` `.uv-empty` (`position:absolute; inset:0`): not a
-  flow block; `.cc-empty` doesn't apply.
-- **Tiny / italic micro-empties** — `ChainQcNode` `.qc-empty` (9px italic), `PopulationManager`
-  `.pm-chip-empty` (10px italic), `CropPanel`/`ChainQcNode` italic hints: sub-`--cc-fs-xs` sizes +
-  italic are intentional dense-context chrome; `.cc-muted` (0.75rem, non-italic) would enlarge them.
+| Axis | Was baked in | Now |
+|---|---|---|
+| Density | one font size per util | `.cc-muted/-readout/-eyebrow` + `-dense` (≈10px) / `-micro` (≈9px) |
+| Surface | `.cc-card` = surface-1 | `.cc-card` (border+radius) + `.cc-card-2` (raised) |
+| Layout | `.cc-empty` = padded centred column | + `-inline` / `-overlay` / `-lg` |
+
+Two measurement errors had kept the picture wrong:
+
+1. **The size audit only counted `rem`.** There are ~430 `rem` *and* ~149 `px` font-size declarations,
+   and they are the same scale in two spellings: `12px` **is** `--cc-fs-sm`, `11px` **is** `--cc-fs-xs`,
+   and `10px`/`9px` are two tiers *below the old floor*. So the "tiny/italic micro-empties" were never
+   exceptions — they were exactly the two missing steps. Added `--cc-fs-2xs` / `--cc-fs-3xs`.
+   The tell: `CollapsibleSection` — the *canonical* component — hand-rolled its own eyebrow (uppercase +
+   600 + 0.06em + dim) at `0.65rem`, below `--cc-fs-xs`. The reference implementation could not adopt the
+   vocabulary it was meant to model. It does now.
+2. **The card count conflated cards with controls.** Of the "~29 panel/card blocks", nearly all are small
+   *controls* (search wraps, mini/gear buttons, tabs, pills, segmented rows, native inputs) whose canonical
+   form is the control — `.cc-btn`, `ChipSelect`, the global `select`/`input` base — not `.cc-card`. The
+   genuine card population is a handful. Radius was never the blocker either: `0.3rem`→`0.25rem` is **0.8px**.
+   Surface was, and `.cc-card-2` covers it. **There is no card sweep to do** — the leftovers are the
+   icon/mini-button question the entry below already parks.
+
+Migrated on the back of that (each visually equivalent unless noted):
+`ChainQcNode` `.qc-empty` · `PopulationManager` `.pm-chip-empty` · `UmapView` `.uv-empty` (overlay) +
+`.uv-pop-head` (eyebrow; now 600-weight, the one intended change) · `ImageTable` `.empty-state` (rich) ·
+`GatePlotPanel` `.gate-empty` (inline empty *wearing card chrome* — the composite case) ·
+`CollapsibleSection` `.cs-label` · `NotebooksModule` `.nb-empty` · `ClaudeOverviewDialog` `.co-entry`
+(`.cc-card-2`) · `CropPanel` `.crop-hint` · `CopyDialog` `.copy-hint`.
+
+**Still deliberately bespoke:**
 - **`HintCallout.vue`** is a full component (icon + dismiss), not a text scenario — leave it.
 - **`ChainModule`** empties/hints (`.live-empty`, `.canvas-empty`, `.no-chains-hint`, palette hints):
   several are richer (icons, multi-line CTAs) inside the whiteboard; adopt opportunistically, not swept.
+- **Accent-coloured readouts** (`.pt-val` and friends) — a readout that is *deliberately* accent or
+  `--cc-text` rather than dim. Prominence, not density; `.cc-readout-strong` covers the common case.
+- **Per-site italic and geometry.** `font-style: italic` marks provisional/advisory prose in ~20 places;
+  it is emphasis, not a tier, and stays a one-line scoped rule (as do width/margin/flex/padding).
+
+### Correctness find — dead design tokens (the actually-broken thing)
+
+Measuring the above turned up **16 references to 4 tokens `style.css` never declares**. An undeclared
+`--cc-*` doesn't warn: the declaration is invalid at computed-value time and drops to `unset`.
+- 13 × `--cc-text-muted` — the `, #888` fallback *masked* it, freezing a hard-coded grey instead of
+  `--cc-text-dim` `#7d8590`. (This is why the earlier sweep only caught "several": the fallbacks hid them.)
+- 2 × `--cc-font-mono` (the token is `--cc-mono`) — silently fell back to bare `monospace`.
+- 1 × `--cc-surface-3` — never existed.
+- 2 × fallback-less `background: var(--cc-surface)` in `LabLogPanel`. Worst case: on a `<select>` the
+  invalid **shorthand** dropped `background-image` too, killing the global custom caret — that dropdown
+  rendered transparent *and* arrowless.
+
+All fixed, and `frontend/src/utils/cssTokens.ts` + `cssTokens.test.ts` now fail the suite on any
+reference to an undeclared custom property (`vite.config.ts` sets `test.css: true`, without which Vitest
+stubs `style.css` to `''` and the guard would pass vacuously). **Add the token, never a fallback.**
+The guard was later widened from `--cc-*` to **all** `--*` properties — and immediately found a 17th
+site, `SpatialContactHeatmap`'s `var(--text-muted, #888)`, which had been hiding behind the prefix
+filter. Component-local declarations count as valid, including inline `:style="{ '--foo': … }"` for
+dynamic values (`--gate-font`, `--sk`, `--sep-thick`, `--pct` are all legitimately set that way).
+
+### Enforcement — the ratchet (2026-07-25)
+
+The mandatory-lookup clause in `CLAUDE.md` and the catalog in `docs/UI.md` are review-time discipline,
+and this project's history *is* the record of that discipline failing across fresh context windows. So
+the scenarios are now machine-checked: `utils/cssScenarios.ts` + `cssScenarios.test.ts` detect a scoped
+rule that spells out a utility's defining declarations, and hold a **per-file baseline that may shrink
+and must never grow**. ~130 rules remain in 45 files; new divergence fails immediately, and the backlog
+drains as files get touched. This decouples "stop the drift" from "finish the sweep" — which is what had
+stalled the whole exercise.
+
+Precision was chosen over recall, deliberately, because the allow-list a noisy check would force is
+where this kind of thing rots. Three matchers were dropped or tightened during calibration:
+- **`card` — dropped entirely.** `surface + 1px border + radius` is the shape of a card, an input, a
+  chip, a badge *and* an icon-button; ~60% of matches wanted `.cc-btn`/`ChipSelect`/the global input
+  base, not `.cc-card`. Nothing in scoped CSS distinguishes them. Review-time rule only.
+- **Controls excluded from the text matchers.** A dim colour + a size also describes every ghost/icon
+  button (`.action-btn`, `.icon-btn`, `.ra-btn`, …), whose canonical form is `.cc-btn-ghost`.
+- **`empty` narrowed to rules that re-declare the colour.** `.foo-empty p { margin: 0; font-size: 0.8rem }`
+  is styling its own contents, not re-implementing the scenario.
+
+Calibration took the count from 310 → 262 → 155 → 130. **The first three figures were wrong**, and so
+was the "~80" estimated from class-name greps (`*-hint`/`*-sub`/`*-val`) — most muted text has no such
+word in its class name. That is the fourth miscount in this saga; the lesson is that every count here
+should come from a committed detector, not a grep.
+
+### Raw sizes and radii — done, and it was never churn
+
+This was written off twice as "churn: touches every file for no behavioural gain". That was wrong, and
+the reasoning was inconsistent: the argument for adding `--cc-fs-2xs/3xs` was *"the scale should have the
+steps the app actually uses"*, and it simply wasn't applied to the middle of the scale. Worse, the ratchet
+had been built with the largest category carved out of it, so those values would have kept growing.
+
+Measuring settled it — **33 distinct font-size spellings, of which 98% (541/553) were already within
+0.5px of an existing token.** 33 spellings of 5 values. The "it's a visual change" objection was about
+sub-pixel shifts. So both scales were derived from the distribution and everything was tokenised:
+
+- `--cc-fs-lg: 0.9rem` added (a real 9-use cluster one step above body).
+- Radius scale went 2 steps → 5: `xs/sm/md/lg/pill`, and **`--cc-radius-sm` was retuned `0.25rem`→`0.3rem`**
+  because 4.8px is the modal radius (33 uses) — that halved the worst-case shift from 1.6px to 0.8px. Only
+  one site consumed the old value.
+- **~770 declarations tokenised** across 83 files. `findRawValues` + its test now fail on any literal.
+- Exempt by rule: display type (>15px), pill radii, `0`, and `em` (container-relative by design —
+  `ViewLegend` scales with the export). One inline-documented exception: `ChainQcNode` `.qc-bar`'s 1px
+  radius, where the 3px token would round a 4px-wide bar into a blob.
+
+Two blind spots surfaced while finishing, both now covered: the detector and the sweep only looked inside
+`<style>` blocks, so four **inline `style="font-size:…"`** icon sizes were invisible; and the `muted`
+matcher keyed on a *literal* size, so tokenising a rule would have silently un-flagged it —
+`color: dim` + `font-size: var(--cc-fs-sm)` is still `.cc-muted` spelled longhand.
+
+**Residual risk (needs eyes in a browser).** ~139 declarations shifted by ~0.48px, which is up to **4%
+relative** at these sizes. Absolute shift is imperceptible, but a +4% label in a tightly-fitted fixed-width
+element could newly wrap or ellipsize. Most likely spots: the chain whiteboard node footers (8px → 8.96px,
+in a 120px-min node) and the dense table/readout rows.
+
+Migrated on top of the earlier batch: the **three byte-identical overlay-empty triples** in
+`ClusterHeatmapPanel` / `ClusterHmmStatesPanel` / `ClusterHmmTransitionsPanel` (the same rule as
+`UmapView`'s, copy-pasted four times) · `ClusterHeatmapPanel` `.feat-empty` · `ClusterPlots` `.cp-empty` ·
+`SpatialContactHeatmap` `.ch-empty`/`.ch-meta` · and the **six** hand-rolled eyebrows in `ChainModule`
+(sizes 0.6/0.65/0.68rem, weights 600/700, tracking 0.06/0.07/0.08 — all one role). Those four files are
+now fully clean. The eyebrow unification is the one visible change: weight and tracking normalise.
 
 ## Convention going forward
 

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -85,8 +85,8 @@ const statusTip: Record<string, string> = {
   cursor: pointer;
   color: var(--cc-text-dim);
   padding: 0.25rem 0.4rem;
-  border-radius: 0.3rem;
-  font-size: 0.9rem;
+  border-radius: var(--cc-radius-sm);
+  font-size: var(--cc-fs-lg);
   margin-left: -0.3rem;
 }
 .nav-toggle:hover { background: var(--cc-surface-2); color: var(--cc-text); }
@@ -105,14 +105,14 @@ const statusTip: Record<string, string> = {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 500;
   padding: 0.2rem 0.65rem;
-  border-radius: 999px;
+  border-radius: var(--cc-radius-pill);
   cursor: default;
   white-space: nowrap;
 }
-.dot { width: 7px; height: 7px; border-radius: 50%; }
+.dot { width: 7px; height: 7px; border-radius: var(--cc-radius-pill); }
 
 .ws-badge.connected    { background: #14532d33; color: #86efac; }
 .ws-badge.connected .dot { background: #4ade80; box-shadow: 0 0 5px #4ade80; }
@@ -127,17 +127,17 @@ const statusTip: Record<string, string> = {
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   padding: 0.2rem 0.4rem 0.2rem 0.6rem;
-  border-radius: 999px;
+  border-radius: var(--cc-radius-pill);
   cursor: pointer;
   white-space: nowrap;
   background: color-mix(in srgb, var(--cc-accent) 22%, transparent);
   color: var(--cc-accent);
 }
 .update-badge:hover { background: color-mix(in srgb, var(--cc-accent) 34%, transparent); }
-.update-badge .pi-arrow-circle-up { font-size: 0.8rem; }
+.update-badge .pi-arrow-circle-up { font-size: var(--cc-fs-md); }
 .update-x {
   display: inline-flex;
   background: none;
@@ -146,8 +146,8 @@ const statusTip: Record<string, string> = {
   color: inherit;
   opacity: 0.7;
   padding: 0 0.1rem;
-  border-radius: 0.25rem;
+  border-radius: var(--cc-radius-xs);
 }
 .update-x:hover { opacity: 1; }
-.update-x .pi { font-size: 0.6rem; }
+.update-x .pi { font-size: var(--cc-fs-2xs); }
 </style>

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -291,10 +291,10 @@ function isNavDisabled(item: NavItem): boolean {
   gap: 0.4rem;
   min-width: 0;
 }
-.proj-icon { font-size: 0.85rem; color: var(--cc-accent); flex-shrink: 0; }
+.proj-icon { font-size: var(--cc-fs-md); color: var(--cc-accent); flex-shrink: 0; }
 .proj-text { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 .proj-name {
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   font-weight: 600;
   color: var(--cc-text);
   white-space: nowrap;
@@ -303,7 +303,7 @@ function isNavDisabled(item: NavItem): boolean {
   cursor: default;
 }
 .proj-type {
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   color: var(--cc-text-dim);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -314,8 +314,8 @@ function isNavDisabled(item: NavItem): boolean {
   cursor: pointer;
   color: var(--cc-text-dim);
   padding: 0.15rem 0.3rem;
-  border-radius: 0.2rem;
-  font-size: 0.75rem;
+  border-radius: var(--cc-radius-xs);
+  font-size: var(--cc-fs-sm);
   flex-shrink: 0;
 }
 .proj-menu-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
@@ -325,12 +325,12 @@ function isNavDisabled(item: NavItem): boolean {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 500;
   color: var(--cc-accent);
   background: #a78bfa14;
   border: 1px dashed #a78bfa55;
-  border-radius: 0.35rem;
+  border-radius: var(--cc-radius-sm);
   padding: 0.35rem 0.6rem;
   cursor: pointer;
   transition: background 0.12s;
@@ -346,7 +346,7 @@ function isNavDisabled(item: NavItem): boolean {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -355,7 +355,7 @@ function isNavDisabled(item: NavItem): boolean {
   transition: color 0.1s;
 }
 .group-heading:hover { color: var(--cc-text); }
-.group-chevron { font-size: 0.55rem; opacity: 0.6; }
+.group-chevron { font-size: var(--cc-fs-3xs); opacity: 0.6; }
 /* Viewer controls: a prominent call-to-action (it drives most napari controls, so it must stand out
    from the dim nav headings — a bordered, filled button with a title + subtitle). */
 .viewer-cta {
@@ -368,7 +368,7 @@ function isNavDisabled(item: NavItem): boolean {
   padding: 0.5rem 0.6rem;
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-border);
-  border-radius: 0.4rem;
+  border-radius: var(--cc-radius-md);
   cursor: pointer;
   color: var(--cc-text);
   text-align: left;
@@ -379,10 +379,10 @@ function isNavDisabled(item: NavItem): boolean {
 .viewer-cta:hover { border-color: #16a34a; background: #14261a; }
 .viewer-cta.viewer-on { background: #0f3d24; border-color: var(--cc-viewer); color: #bbf7d0; }
 .viewer-cta-icon { font-size: 0.95rem; color: var(--cc-viewer); flex-shrink: 0; }
-.viewer-cta-title { flex: 1; min-width: 0; font-size: 0.78rem; font-weight: 700; }
-.viewer-cta-state { font-size: 0.8rem; opacity: 0.75; flex-shrink: 0; }
+.viewer-cta-title { flex: 1; min-width: 0; font-size: var(--cc-fs-sm); font-weight: 700; }
+.viewer-cta-state { font-size: var(--cc-fs-md); opacity: 0.75; flex-shrink: 0; }
 /* badge: Claude added a lab-log note while the panel was closed */
-.lablog-badge { font-size: 0.8rem; color: var(--cc-accent); flex-shrink: 0; margin-left: 0.2rem; }
+.lablog-badge { font-size: var(--cc-fs-md); color: var(--cc-accent); flex-shrink: 0; margin-left: 0.2rem; }
 .lablog-cta.lablog-unseen { border-color: var(--cc-accent); }
 /* Lab log CTA: a neutral/whiteish variant so it reads as its own thing, distinct from the coloured
    Viewer control. Overrides the .viewer-cta base (defined above → these win on equal specificity). */
@@ -400,9 +400,9 @@ function isNavDisabled(item: NavItem): boolean {
   align-items: center;
   gap: 0.55rem;
   padding: 0.45rem 0.85rem;
-  border-radius: 0.35rem;
+  border-radius: var(--cc-radius-sm);
   margin: 0 0.35rem;
-  font-size: 0.82rem;
+  font-size: var(--cc-fs-md);
   font-weight: 500;
   color: var(--cc-text-dim);
   text-decoration: none;
@@ -421,20 +421,20 @@ function isNavDisabled(item: NavItem): boolean {
 }
 .nav-item.disabled { opacity: 0.4; cursor: not-allowed; }
 
-.nav-icon  { font-size: 0.85rem; flex-shrink: 0; }
+.nav-icon  { font-size: var(--cc-fs-md); flex-shrink: 0; }
 .nav-label { flex: 1; }
 
 .soon-badge {
-  font-size: 0.6rem;
+  font-size: var(--cc-fs-2xs);
   font-weight: 700;
   padding: 0.05rem 0.3rem;
-  border-radius: 0.2rem;
+  border-radius: var(--cc-radius-xs);
   background: var(--cc-surface-2);
   color: var(--cc-text-dim);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.lock-badge { font-size: 0.68rem; color: var(--cc-text-dim); opacity: 0.7; }
+.lock-badge { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); opacity: 0.7; }
 
 /* ── Footer: quick app controls, pinned to the bottom ──────────────────────── */
 .sidebar-footer {
@@ -457,10 +457,10 @@ function isNavDisabled(item: NavItem): boolean {
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-border);
   color: var(--cc-text-dim);
-  border-radius: 0.35rem;
+  border-radius: var(--cc-radius-sm);
   padding: 0.35rem 0.55rem;
   cursor: pointer;
-  font-size: 0.85rem;
+  font-size: var(--cc-fs-md);
   text-decoration: none;            /* Settings is a RouterLink (<a>) — no underline */
   transition: background 0.12s, color 0.12s;
 }

--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -68,7 +68,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
 .cc-modal {
   background: var(--cc-surface-1);
   border: 1px solid var(--cc-border);
-  border-radius: 0.6rem;
+  border-radius: var(--cc-radius-lg);
   max-width: 96vw; max-height: 90vh;
   display: flex; flex-direction: column;
   overflow: hidden;
@@ -81,13 +81,13 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
   flex-shrink: 0;
 }
 .cc-modal-title {
-  flex: 1; font-size: 0.9rem; font-weight: 600; color: var(--cc-text);
+  flex: 1; font-size: var(--cc-fs-lg); font-weight: 600; color: var(--cc-text);
   display: flex; gap: 0.45rem; align-items: center;
 }
 .cc-modal-close {
   background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.8rem;
-  padding: 0.2rem 0.4rem; border-radius: 0.25rem;
+  color: var(--cc-text-dim); font-size: var(--cc-fs-md);
+  padding: 0.2rem 0.4rem; border-radius: var(--cc-radius-xs);
 }
 .cc-modal-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 

--- a/frontend/src/components/CcToggle.vue
+++ b/frontend/src/components/CcToggle.vue
@@ -27,7 +27,7 @@ defineProps<{ label?: string; disabled?: boolean }>()
 .cc-toggle-input { display: none; }
 .cc-toggle-track {
   width: 32px; height: 17px;
-  border-radius: 999px;
+  border-radius: var(--cc-radius-pill);
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-border);
   position: relative;
@@ -41,11 +41,11 @@ defineProps<{ label?: string; disabled?: boolean }>()
 .cc-toggle-thumb {
   position: absolute;
   width: 11px; height: 11px;
-  border-radius: 50%;
+  border-radius: var(--cc-radius-pill);
   background: #fff;
   top: 2px; left: 2px;
   transition: left 0.15s;
 }
 .cc-toggle-input:checked ~ .cc-toggle-track .cc-toggle-thumb { left: 17px; }
-.cc-toggle-label { font-size: 0.8rem; color: var(--cc-text); }
+.cc-toggle-label { font-size: var(--cc-fs-md); color: var(--cc-text); }
 </style>

--- a/frontend/src/components/ChainLiveLabel.vue
+++ b/frontend/src/components/ChainLiveLabel.vue
@@ -23,7 +23,7 @@ defineProps<{
 
 <style scoped>
 .live-label {
-  font-size: 10px;
+  font-size: var(--cc-fs-2xs);
   color: var(--cc-text-dim, #8b8ca7);
   white-space: nowrap;
   pointer-events: none;
@@ -57,7 +57,7 @@ defineProps<{
   text-overflow: ellipsis;
 }
 .live-label-sub {
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   font-family: monospace;
   opacity: 0.7;
 }

--- a/frontend/src/components/ChainLiveNode.vue
+++ b/frontend/src/components/ChainLiveNode.vue
@@ -75,9 +75,9 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
 .live-node {
   background: var(--cc-surface-1, #1e1b2e);
   border: 1.5px solid #3f3f46;
-  border-radius: 5px;
+  border-radius: var(--cc-radius-sm);
   padding: 5px 9px;
-  font-size: 11px;
+  font-size: var(--cc-fs-xs);
   min-width: 110px;
   cursor: pointer;              /* clickable: pick as the resume-from node */
   position: relative;
@@ -96,13 +96,13 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
 .restart-badge {
   position: absolute;
   top: -8px; left: 6px;
-  font-size: 8px;
+  font-size: var(--cc-fs-3xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--cc-surface-1, #1e1b2e);
   background: var(--cc-accent, #a78bfa);
-  border-radius: 3px;
+  border-radius: var(--cc-radius-xs);
   padding: 1px 4px;
   z-index: 1;
 }
@@ -122,12 +122,12 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
   gap: 0.25rem;
   margin: -5px -9px 5px;
   padding: 3px 9px;
-  border-radius: 3px 3px 0 0;
-  font-size: 9px;
+  border-radius: var(--cc-radius-xs) 3px 0 0;
+  font-size: var(--cc-fs-3xs);
 }
 
 .live-status-label {
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;
@@ -135,13 +135,13 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
 
 .live-elapsed {
   margin-left: auto;
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   font-family: monospace;
   opacity: 0.8;
 }
 
 .live-fn {
-  font-size: 11px;
+  font-size: var(--cc-fs-xs);
   font-weight: 600;
   color: var(--cc-text, #e2e2f0);
   white-space: nowrap;
@@ -154,12 +154,12 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
   margin-top: 3px;
 }
 .live-variant {
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   font-family: var(--cc-mono, monospace);
   font-weight: 600;
   color: var(--cc-accent, #a78bfa);
   background: color-mix(in srgb, var(--cc-accent, #a78bfa) 18%, transparent);
-  border-radius: 3px;
+  border-radius: var(--cc-radius-xs);
   padding: 1px 4px;
 }
 </style>

--- a/frontend/src/components/ChainPicnicNode.vue
+++ b/frontend/src/components/ChainPicnicNode.vue
@@ -32,7 +32,7 @@ defineProps<{
       <span class="policy-val">{{ data.barrier_policy }}</span>
     </div>
     <div v-if="data.resource_pool" class="node-pool">
-      <i class="pi pi-server" style="font-size:0.6rem" />
+      <i class="pi pi-server" style="font-size:var(--cc-fs-2xs)" />
       {{ data.resource_pool }}
     </div>
 
@@ -44,9 +44,9 @@ defineProps<{
 .chain-picnic-node {
   background: #1c1505;
   border: 2px solid #f59e0b;
-  border-radius: 6px;
+  border-radius: var(--cc-radius-md);
   padding: 7px 11px;
-  font-size: 12px;
+  font-size: var(--cc-fs-sm);
   min-width: 140px;
   cursor: pointer;
   position: relative;
@@ -63,12 +63,12 @@ defineProps<{
   margin-bottom: 0.25rem;
 }
 .picnic-diamond {
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   color: #f59e0b;
   line-height: 1;
 }
 .picnic-badge {
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;
@@ -76,7 +76,7 @@ defineProps<{
 }
 
 .node-label {
-  font-size: 12px;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   color: #fef3c7;
   white-space: nowrap;
@@ -85,7 +85,7 @@ defineProps<{
   max-width: 160px;
 }
 .node-fn {
-  font-size: 10px;
+  font-size: var(--cc-fs-2xs);
   color: #d97706;
   font-family: monospace;
   margin-top: 2px;
@@ -101,12 +101,12 @@ defineProps<{
   margin-top: 4px;
 }
 .policy-label {
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   color: #92400e;
   font-weight: 600;
 }
 .policy-val {
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   color: #f59e0b;
   font-family: monospace;
 }
@@ -114,7 +114,7 @@ defineProps<{
   display: flex;
   align-items: center;
   gap: 3px;
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   color: #f97316;
   margin-top: 3px;
 }

--- a/frontend/src/components/ChainQcNode.vue
+++ b/frontend/src/components/ChainQcNode.vue
@@ -38,7 +38,7 @@ const fmt = (n?: number) => n == null ? '—' : n.toLocaleString()
     <div class="qc-count">{{ fmt(data.total) }} <span class="qc-unit">cells</span></div>
     <div class="qc-spark">
       <span v-for="(h, i) in bars" :key="i" class="qc-bar" :style="{ height: h + 'px' }" />
-      <span v-if="!bars.length" class="qc-empty">no data</span>
+      <span v-if="!bars.length" class="qc-empty cc-empty-inline cc-muted-micro">no data</span>
     </div>
     <div class="qc-foot">{{ data.imageCount ?? 0 }} img · expand</div>
   </div>
@@ -48,20 +48,21 @@ const fmt = (n?: number) => n == null ? '—' : n.toLocaleString()
 .qc-node {
   background: var(--cc-surface-1, #1e1b2e);
   border: 1px dashed var(--cc-accent, #a78bfa);
-  border-radius: 6px;
+  border-radius: var(--cc-radius-md);
   padding: 5px 9px;
   min-width: 120px;
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--cc-fs-xs);
 }
 .qc-head { display: flex; align-items: center; gap: 5px; color: var(--cc-accent, #a78bfa); }
-.qc-head .pi { font-size: 0.7rem; }
-.qc-name { font-size: 9px; font-weight: 700; font-family: var(--cc-mono, monospace); letter-spacing: 0.04em; }
-.qc-spin { margin-left: auto; font-size: 0.6rem; opacity: 0.7; }
-.qc-count { font-size: 15px; font-weight: 700; color: var(--cc-text, #e2e2f0); margin: 2px 0; }
-.qc-unit { font-size: 9px; font-weight: 400; color: var(--cc-text-dim, #8b8ca7); }
+.qc-head .pi { font-size: var(--cc-fs-xs); }
+.qc-name { font-size: var(--cc-fs-3xs); font-weight: 700; font-family: var(--cc-mono, monospace); letter-spacing: 0.04em; }
+.qc-spin { margin-left: auto; font-size: var(--cc-fs-2xs); opacity: 0.7; }
+.qc-count { font-size: var(--cc-fs-lg); font-weight: 700; color: var(--cc-text, #e2e2f0); margin: 2px 0; }
+.qc-unit { font-size: var(--cc-fs-3xs); font-weight: 400; color: var(--cc-text-dim, #8b8ca7); }
 .qc-spark { display: flex; align-items: flex-end; gap: 2px; height: 24px; }
+/* 1px is deliberate and off-scale: --cc-radius-xs (3px) on a 4px-wide bar rounds it to a blob */
 .qc-bar { width: 4px; background: var(--cc-accent, #a78bfa); opacity: 0.7; border-radius: 1px; }
-.qc-empty { font-size: 9px; color: var(--cc-text-dim, #8b8ca7); font-style: italic; }
-.qc-foot { font-size: 8px; color: var(--cc-text-dim, #8b8ca7); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2px; }
+.qc-empty { font-style: italic; }   /* + .cc-empty-inline .cc-muted-micro (row/colour/9px tier) */
+.qc-foot { font-size: var(--cc-fs-3xs); color: var(--cc-text-dim, #8b8ca7); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2px; }
 </style>

--- a/frontend/src/components/ChainStartNode.vue
+++ b/frontend/src/components/ChainStartNode.vue
@@ -32,7 +32,7 @@ defineProps<{ id: string; selected: boolean }>()
 .start-dot {
   width: 34px;
   height: 34px;
-  border-radius: 50%;
+  border-radius: var(--cc-radius-pill);
   background: var(--cc-text, #e2e2f0);
   border: 3px solid var(--cc-accent, #a78bfa);
   box-shadow: 0 0 0 2px transparent;
@@ -42,7 +42,7 @@ defineProps<{ id: string; selected: boolean }>()
   box-shadow: 0 0 0 3px var(--cc-accent, #a78bfa);
 }
 .start-label {
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;

--- a/frontend/src/components/ChainTaskNode.vue
+++ b/frontend/src/components/ChainTaskNode.vue
@@ -26,7 +26,7 @@ defineProps<{
     <div class="node-label">{{ data.label || data.fn }}</div>
     <div class="node-fn">{{ data.fn }}</div>
     <div v-if="data.resource_pool" class="node-pool">
-      <i class="pi pi-server" style="font-size:0.6rem" />
+      <i class="pi pi-server" style="font-size:var(--cc-fs-2xs)" />
       {{ data.resource_pool }}
     </div>
 
@@ -38,9 +38,9 @@ defineProps<{
 .chain-task-node {
   background: var(--cc-surface-1, #1e1b2e);
   border: 1.5px solid var(--cc-accent, #a78bfa);
-  border-radius: 6px;
+  border-radius: var(--cc-radius-md);
   padding: 7px 11px;
-  font-size: 12px;
+  font-size: var(--cc-fs-sm);
   min-width: 140px;
   cursor: pointer;
   position: relative;
@@ -63,13 +63,13 @@ defineProps<{
 .scope-dot {
   width: 6px;
   height: 6px;
-  border-radius: 50%;
+  border-radius: var(--cc-radius-pill);
   background: var(--cc-accent, #a78bfa);
   flex-shrink: 0;
 }
 .incremental .scope-dot { background: #60a5fa; }
 .scope-label {
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;
@@ -77,7 +77,7 @@ defineProps<{
 }
 
 .node-label {
-  font-size: 12px;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   color: var(--cc-text, #e2e2f0);
   white-space: nowrap;
@@ -86,7 +86,7 @@ defineProps<{
   max-width: 160px;
 }
 .node-fn {
-  font-size: 10px;
+  font-size: var(--cc-fs-2xs);
   color: var(--cc-text-dim, #8b8ca7);
   font-family: monospace;
   margin-top: 2px;
@@ -99,7 +99,7 @@ defineProps<{
   display: flex;
   align-items: center;
   gap: 3px;
-  font-size: 9px;
+  font-size: var(--cc-fs-3xs);
   color: #f97316;
   margin-top: 4px;
 }

--- a/frontend/src/components/ChipSelect.vue
+++ b/frontend/src/components/ChipSelect.vue
@@ -140,7 +140,7 @@ function activeStyle(o: ChipOption, on: boolean): Record<string, string> | undef
   display: inline-flex; align-items: center; gap: 0.3rem;
   color: var(--cc-text-dim); cursor: pointer;
   border: 1px solid var(--cc-border); background: var(--cc-surface-2);
-  font-size: 0.7rem; white-space: nowrap;
+  font-size: var(--cc-fs-xs); white-space: nowrap;
   transition: background 0.1s, color 0.1s, border-color 0.1s;
 }
 .chip:hover:not(.disabled) { color: var(--cc-text); border-color: var(--cc-accent); }
@@ -149,18 +149,18 @@ function activeStyle(o: ChipOption, on: boolean): Record<string, string> | undef
 .chip.drag { cursor: grab; }
 .chip.drag:active { cursor: grabbing; }
 .chip-badge {
-  font-size: 0.62rem; font-variant-numeric: tabular-nums; line-height: 1;
-  padding: 0.05rem 0.28rem; border-radius: 999px;
+  font-size: var(--cc-fs-2xs); font-variant-numeric: tabular-nums; line-height: 1;
+  padding: 0.05rem 0.28rem; border-radius: var(--cc-radius-pill);
   background: color-mix(in srgb, currentColor 22%, transparent);
 }
 
 /* ── pill dialect: wrapping capsules ── */
 .chip-select.pill { flex-wrap: wrap; gap: 0.25rem; }
-.pill .chip { padding: 0.15rem 0.55rem; border-radius: 999px; }
+.pill .chip { padding: 0.15rem 0.55rem; border-radius: var(--cc-radius-pill); }
 
 /* ── segmented dialect: one joined row (the old `.seg`) ── */
-.chip-select.segmented { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
-.segmented .chip { border: none; border-radius: 0; padding: 4px 8px; font-size: 12px; }
+.chip-select.segmented { display: inline-flex; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); overflow: hidden; }
+.segmented .chip { border: none; border-radius: 0; padding: 4px 8px; font-size: var(--cc-fs-sm); }
 .segmented .chip + .chip { border-left: 1px solid var(--cc-border); }
 .segmented .chip:hover:not(.disabled) { border-color: transparent; }
 </style>

--- a/frontend/src/components/ClaudeOverviewDialog.vue
+++ b/frontend/src/components/ClaudeOverviewDialog.vue
@@ -17,7 +17,7 @@ defineEmits<{ (e: 'close'): void }>()
   <BaseModal title="What Claude can do here" icon="pi-sparkles" width="620px" @close="$emit('close')">
     <!-- two entry points, side by side: the how-to -->
     <div class="co-entries">
-      <div v-for="e in CLAUDE_ENTRY_POINTS" :key="e.name" class="co-entry">
+      <div v-for="e in CLAUDE_ENTRY_POINTS" :key="e.name" class="co-entry cc-card cc-card-2">
         <div class="co-entry-head"><i :class="['pi', e.icon]" /> {{ e.name }}</div>
         <p class="co-entry-what">{{ e.what }}</p>
         <ol class="co-steps">
@@ -48,19 +48,17 @@ defineEmits<{ (e: 'close'): void }>()
 
 <style scoped>
 .co-entries { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 18px; }
-.co-entry {
-  border: 1px solid var(--cc-border); border-radius: 8px; padding: 14px 16px;
-  background: var(--cc-surface-2);
-}
+/* a raised card ON the dialog's surface-1 body — the surface-2 variant of .cc-card */
+.co-entry { padding: 14px 16px; }
 .co-entry-head { font-weight: 600; color: var(--cc-text); display: flex; align-items: center; gap: 6px; }
 .co-entry-head .pi { color: var(--cc-accent); }
-.co-entry-what { margin: 8px 0 10px; color: var(--cc-text-dim); font-size: 0.85rem; line-height: 1.4; }
-.co-steps { margin: 0; padding-left: 18px; color: var(--cc-text); font-size: 0.82rem; line-height: 1.55; }
+.co-entry-what { margin: 8px 0 10px; color: var(--cc-text-dim); font-size: var(--cc-fs-md); line-height: 1.4; }
+.co-steps { margin: 0; padding-left: 18px; color: var(--cc-text); font-size: var(--cc-fs-md); line-height: 1.55; }
 
 .co-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
-.co-cell { border: 1px solid var(--cc-border); border-radius: 8px; padding: 12px 14px; }
+.co-cell { border: 1px solid var(--cc-border); border-radius: var(--cc-radius-lg); padding: 12px 14px; }
 .co-cell-head { font-weight: 600; display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
-.co-cell ul { margin: 0; padding-left: 18px; font-size: 0.8rem; line-height: 1.55; color: var(--cc-text); }
+.co-cell ul { margin: 0; padding-left: 18px; font-size: var(--cc-fs-md); line-height: 1.55; color: var(--cc-text); }
 .co-cell.tone-good .co-cell-head { color: #56d364; }
 .co-cell.tone-good .co-cell-head .pi { color: #56d364; }
 .co-cell.tone-neutral .co-cell-head .pi { color: var(--cc-accent); }
@@ -68,10 +66,10 @@ defineEmits<{ (e: 'close'): void }>()
 .co-cell.tone-muted .co-cell-head { color: var(--cc-text-dim); }
 
 .co-examples { margin-top: 18px; }
-.co-examples-label { display: block; font-size: 0.78rem; color: var(--cc-text-dim); margin-bottom: 6px; }
+.co-examples-label { display: block; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin-bottom: 6px; }
 .co-chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .co-chip {
-  font-size: 0.78rem; color: var(--cc-text); background: var(--cc-surface-2);
-  border: 1px solid var(--cc-border); border-radius: 999px; padding: 3px 10px;
+  font-size: var(--cc-fs-sm); color: var(--cc-text); background: var(--cc-surface-2);
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-pill); padding: 3px 10px;
 }
 </style>

--- a/frontend/src/components/CohortCheckButton.vue
+++ b/frontend/src/components/CohortCheckButton.vue
@@ -95,21 +95,21 @@ async function check() {
 .cohort-check { display: inline-flex; align-items: center; gap: 0.35rem; }
 .cohort-run {
   display: inline-flex; align-items: center; gap: 0.25rem;
-  font-size: 0.72rem; color: var(--cc-text-muted, var(--cc-text));
+  font-size: var(--cc-fs-sm); color: var(--cc-text-dim);
 }
 .cohort-run select {
-  font-size: 0.72rem; padding: 0.15rem 0.3rem; border-radius: 0.3rem;
+  font-size: var(--cc-fs-sm); padding: 0.15rem 0.3rem; border-radius: var(--cc-radius-sm);
   color: var(--cc-text); background: var(--cc-surface-2); border: 1px solid var(--cc-border); cursor: pointer;
 }
 .cohort-run select:disabled { opacity: 0.6; cursor: default; }
 .cohort-check-btn {
   display: inline-flex; align-items: center; gap: 0.3rem;
-  font-size: 0.72rem; padding: 0.25rem 0.55rem; border-radius: 0.3rem; cursor: pointer;
+  font-size: var(--cc-fs-sm); padding: 0.25rem 0.55rem; border-radius: var(--cc-radius-sm); cursor: pointer;
   color: var(--cc-text); background: var(--cc-surface-2); border: 1px solid var(--cc-border);
 }
 .cohort-check-btn:hover:not(:disabled) { border-color: var(--cc-accent); }
 .cohort-check-btn:disabled { opacity: 0.6; cursor: default; }
-.cohort-check-btn .pi { font-size: 0.72rem; }
+.cohort-check-btn .pi { font-size: var(--cc-fs-sm); }
 /* amber when the last check flagged an outlier — the cross-image detail is in the lab log */
 .cohort-check-btn.warn { color: var(--cc-sev-warn); border-color: var(--cc-sev-warn); background: rgba(250, 178, 25, 0.1); }
 .cohort-check-btn.warn:hover:not(:disabled) { border-color: var(--cc-sev-warn); }

--- a/frontend/src/components/CollapsibleSection.vue
+++ b/frontend/src/components/CollapsibleSection.vue
@@ -33,7 +33,7 @@ watch(open, v => {
     <button class="cs-toggle" @click="open = !open"
       v-tooltip.right="open ? `Collapse ${label}` : `Expand ${label}`">
       <i :class="['pi', open ? 'pi-chevron-up' : 'pi-chevron-down']" />
-      <span class="cs-label">{{ label }}</span>
+      <span class="cs-label cc-eyebrow">{{ label }}</span>
     </button>
     <!-- with a real max-height the body scrolls itself; with max-height:none it must NOT be a scroll
          container (overflow-y:auto would still make it the sticky scrollport, so a `position:sticky`
@@ -63,20 +63,17 @@ watch(open, v => {
   border: none;
   cursor: pointer;
   color: var(--cc-text-dim);
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   text-align: left;
   transition: background 0.1s, color 0.1s;
   flex-shrink: 0;
 }
 .cs-toggle:hover { background: var(--cc-surface-2); color: var(--cc-text); }
-.cs-toggle .pi  { font-size: 0.65rem; }
+.cs-toggle .pi  { font-size: var(--cc-fs-2xs); }
 
-.cs-label {
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-size: 0.65rem;
-}
+/* the heading IS the eyebrow scenario — colour/weight/tracking/case/size all come from .cc-eyebrow,
+   which this component previously hand-rolled (and at a size the scale had no step for) */
+.cs-label { color: inherit; }
 
 .cs-body {
   overflow-y: auto;

--- a/frontend/src/components/ConfirmDeleteButton.vue
+++ b/frontend/src/components/ConfirmDeleteButton.vue
@@ -48,8 +48,8 @@ defineEmits<{ confirm: [] }>()
 /* compact, self-contained danger icon button (dim by default → danger on hover → solid danger when
    armed), so it reads the same in every toolbar/row/footer. */
 .cc-del { display: inline-flex; align-items: center; gap: 5px; background: none;
-  border: 1px solid transparent; border-radius: 5px; color: var(--cc-text-dim); cursor: pointer;
-  padding: 4px 6px; font-size: 12px; line-height: 1; }
+  border: 1px solid transparent; border-radius: var(--cc-radius-sm); color: var(--cc-text-dim); cursor: pointer;
+  padding: 4px 6px; font-size: var(--cc-fs-sm); line-height: 1; }
 .cc-del:hover:not(:disabled) { color: var(--cc-danger); background: var(--cc-surface-2); }
 .cc-del.armed { color: #fff; background: var(--cc-danger); border-color: var(--cc-danger); }
 .cc-del:disabled { opacity: 0.35; cursor: not-allowed; }

--- a/frontend/src/components/CopyDialog.vue
+++ b/frontend/src/components/CopyDialog.vue
@@ -102,7 +102,7 @@ function copyImage() {
              @keydown.enter="copyImage" autofocus />
     </div>
 
-    <p class="copy-hint">
+    <p class="copy-hint cc-muted">
       Duplicates the chosen version as a new image; derived data (segmentations, populations, gating) is
       dropped. Runs in the background — the copy appears when it finishes.
     </p>
@@ -118,12 +118,12 @@ function copyImage() {
 
 <style scoped>
 .copy-row { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.55rem; }
-.copy-lbl { color: var(--cc-text-muted, #888); font-size: 0.72rem; width: 4rem; flex-shrink: 0; }
+.copy-lbl { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); width: 4rem; flex-shrink: 0; }
 .copy-select, .copy-name-input { flex: 1 1 auto; }
-.copy-hint { font-size: 0.68rem; color: var(--cc-text-muted, #888); font-style: italic; margin: 0.3rem 0 0; }
+.copy-hint { font-size: var(--cc-fs-xs); font-style: italic; margin: 0.3rem 0 0; }   /* + .cc-muted (colour) */
 .copy-version-tag {
-  margin-left: 0.4rem; padding: 0.05rem 0.4rem; border-radius: 0.5rem;
-  font-size: 0.62rem; font-weight: 600; vertical-align: middle;
+  margin-left: 0.4rem; padding: 0.05rem 0.4rem; border-radius: var(--cc-radius-lg);
+  font-size: var(--cc-fs-2xs); font-weight: 600; vertical-align: middle;
   color: var(--cc-accent, #a855f7);
   background: color-mix(in srgb, var(--cc-accent, #a855f7) 15%, transparent);
 }

--- a/frontend/src/components/CropDialog.vue
+++ b/frontend/src/components/CropDialog.vue
@@ -53,11 +53,11 @@ function defaultValueName(): string {
 
 <style scoped>
 .crop-version-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem; }
-.crop-version-lbl { color: var(--cc-text-muted, #888); font-size: 0.7rem; }
+.crop-version-lbl { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
 .crop-version-select { flex: 0 1 auto; }
 .crop-version-tag {
-  margin-left: 0.4rem; padding: 0.05rem 0.4rem; border-radius: 0.5rem;
-  font-size: 0.62rem; font-weight: 600; vertical-align: middle;
+  margin-left: 0.4rem; padding: 0.05rem 0.4rem; border-radius: var(--cc-radius-lg);
+  font-size: var(--cc-fs-2xs); font-weight: 600; vertical-align: middle;
   color: var(--cc-accent, #a855f7);
   background: color-mix(in srgb, var(--cc-accent, #a855f7) 15%, transparent);
 }

--- a/frontend/src/components/CropPanel.vue
+++ b/frontend/src/components/CropPanel.vue
@@ -160,9 +160,9 @@ function save() {
           Cancel
         </button>
       </div>
-      <span class="crop-hint">{{ rect ? 'Drag to redraw the rectangle, set z/t, then Save.' : 'Drag a rectangle over the structure to crop.' }}</span>
+      <span class="crop-hint cc-muted">{{ rect ? 'Drag to redraw the rectangle, set z/t, then Save.' : 'Drag a rectangle over the structure to crop.' }}</span>
     </template>
-    <div v-else class="crop-hint">Loading crop preview…</div>
+    <div v-else class="crop-hint cc-muted">Loading crop preview…</div>
   </div>
 </template>
 
@@ -172,15 +172,15 @@ function save() {
    version's MIP by an INTEGER factor to a ≤512px long side, so different native dims render at different
    pixel sizes. width:100% pins the width; only the true aspect ratio (height) varies between versions. */
 .crop-view { position: relative; display: block; width: 100%; line-height: 0; cursor: crosshair; touch-action: none; user-select: none; }
-.crop-img { display: block; width: 100%; height: auto; border: 1px solid var(--cc-border, #2a2a2a); border-radius: 0.3rem; background: #000; }
-.crop-placeholder { display: flex; align-items: center; justify-content: center; width: 100%; min-height: 8rem; color: var(--cc-text-muted, #888); }
+.crop-img { display: block; width: 100%; height: auto; border: 1px solid var(--cc-border, #2a2a2a); border-radius: var(--cc-radius-sm); background: #000; }
+.crop-placeholder { display: flex; align-items: center; justify-content: center; width: 100%; min-height: 8rem; color: var(--cc-text-dim); }
 .crop-rect { position: absolute; border: 1.5px solid var(--cc-accent, #a855f7); background: color-mix(in srgb, var(--cc-accent, #a855f7) 12%, transparent); pointer-events: none; }
-.crop-loading { position: absolute; top: 0.3rem; right: 0.3rem; color: var(--cc-accent); font-size: 0.8rem; }
+.crop-loading { position: absolute; top: 0.3rem; right: 0.3rem; color: var(--cc-accent); font-size: var(--cc-fs-md); }
 .crop-row { display: flex; align-items: center; gap: 0.4rem; }
 .crop-row input[type=range] { flex: 1 1 auto; }
-.crop-lbl { color: var(--cc-text-muted, #888); font-size: 0.7rem; width: 2.6rem; }
-.crop-tval { font-size: 0.62rem; color: var(--cc-text); width: 4.2rem; text-align: right; font-variant-numeric: tabular-nums; }
+.crop-lbl { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); width: 2.6rem; }
+.crop-tval { font-size: var(--cc-fs-2xs); color: var(--cc-text); width: 4.2rem; text-align: right; font-variant-numeric: tabular-nums; }
 .crop-actions { display: flex; gap: 0.4rem; }
-.crop-hint { font-size: 0.68rem; color: var(--cc-text-muted, #888); font-style: italic; }
-.crop-err { font-size: 0.7rem; color: #f85149; }
+.crop-hint { font-size: var(--cc-fs-xs); font-style: italic; }   /* + .cc-muted (colour) */
+.crop-err { font-size: var(--cc-fs-xs); color: #f85149; }
 </style>

--- a/frontend/src/components/ErrorConsole.vue
+++ b/frontend/src/components/ErrorConsole.vue
@@ -166,7 +166,7 @@ const filterOptions = computed<ChipOption[]>(() =>
   display: flex;
   align-items: center;
   gap: 0.3rem;
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   color: var(--cc-text-dim);
   background: none;
@@ -195,7 +195,7 @@ const filterOptions = computed<ChipOption[]>(() =>
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   flex: 1;
   overflow: hidden;
   white-space: nowrap;
@@ -208,7 +208,7 @@ const filterOptions = computed<ChipOption[]>(() =>
 
 .lvl-dot {
   width: 6px; height: 6px;
-  border-radius: 50%;
+  border-radius: var(--cc-radius-pill);
   flex-shrink: 0;
 }
 .bar-last.error .lvl-dot { background: #ef4444; }
@@ -221,10 +221,10 @@ const filterOptions = computed<ChipOption[]>(() =>
 .unread-badge {
   background: #7f1d1d;
   color: #fca5a5;
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   font-weight: 700;
   padding: 0.1rem 0.45rem;
-  border-radius: 999px;
+  border-radius: var(--cc-radius-pill);
   min-width: 1.4em;
   text-align: center;
 }
@@ -259,8 +259,8 @@ const filterOptions = computed<ChipOption[]>(() =>
   cursor: pointer;
   color: var(--cc-text-dim);
   padding: 0.2rem 0.4rem;
-  border-radius: 0.25rem;
-  font-size: 0.8rem;
+  border-radius: var(--cc-radius-xs);
+  font-size: var(--cc-fs-md);
 }
 .icon-btn:hover:not(:disabled) { background: var(--cc-surface-2); color: var(--cc-text); }
 .icon-btn:disabled { opacity: 0.35; cursor: not-allowed; }
@@ -270,7 +270,7 @@ const filterOptions = computed<ChipOption[]>(() =>
   flex: 1;
   overflow-y: auto;
   font-family: var(--cc-mono);
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   padding: 0.25rem 0;
 }
 
@@ -294,10 +294,10 @@ const filterOptions = computed<ChipOption[]>(() =>
 .lvl {
   font-weight: 700;
   text-transform: uppercase;
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   flex-shrink: 0;
   padding: 0.05rem 0.35rem;
-  border-radius: 0.2rem;
+  border-radius: var(--cc-radius-xs);
 }
 .error .lvl { background: #7f1d1d; color: #fca5a5; }
 .warn  .lvl { background: #78350f; color: #fcd34d; }
@@ -307,17 +307,17 @@ const filterOptions = computed<ChipOption[]>(() =>
 .error .msg { color: #fca5a5; }
 .warn  .msg { color: #fcd34d; }
 
-.expand-icon { color: var(--cc-text-dim); font-size: 0.65rem; flex-shrink: 0; }
+.expand-icon { color: var(--cc-text-dim); font-size: var(--cc-fs-2xs); flex-shrink: 0; }
 
 .detail {
   width: 100%;
   margin: 0.35rem 0 0.2rem;
   padding: 0.5rem 0.75rem;
   background: var(--cc-surface-1);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   border-left: 2px solid var(--cc-border);
   color: var(--cc-text-dim);
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   white-space: pre-wrap;
   word-break: break-all;
   overflow-x: auto;
@@ -327,6 +327,6 @@ const filterOptions = computed<ChipOption[]>(() =>
   padding: 1.5rem;
   text-align: center;
   color: var(--cc-text-dim);
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
 }
 </style>

--- a/frontend/src/components/FileBrowser.vue
+++ b/frontend/src/components/FileBrowser.vue
@@ -282,7 +282,7 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
   display: flex; align-items: center; gap: 0.15rem;
   padding: 0.4rem 1rem;
   border-bottom: 1px solid var(--cc-border);
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   background: var(--cc-surface-1);
   flex-shrink: 0;
   flex-wrap: wrap;
@@ -294,19 +294,19 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
   border-bottom: 1px solid var(--cc-border);
   background: var(--cc-surface-1);
 }
-.fb-sc-icon { font-size: 0.7rem; color: var(--cc-text-dim); margin-right: 0.1rem; }
+.fb-sc-icon { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); margin-right: 0.1rem; }
 .fb-shortcut {
   background: var(--cc-surface-2); border: 1px solid var(--cc-border); cursor: pointer;
-  color: var(--cc-text); font-size: 0.72rem;
-  padding: 0.12rem 0.5rem; border-radius: 0.9rem;
+  color: var(--cc-text); font-size: var(--cc-fs-sm);
+  padding: 0.12rem 0.5rem; border-radius: var(--cc-radius-pill);
 }
 .fb-shortcut:hover { border-color: var(--cc-accent); color: var(--cc-accent); }
 
 .crumb-sep { color: var(--cc-text-dim); }
 .crumb {
   background: none; border: none; cursor: pointer;
-  color: var(--cc-accent); font-size: 0.75rem;
-  padding: 0.1rem 0.25rem; border-radius: 0.2rem;
+  color: var(--cc-accent); font-size: var(--cc-fs-sm);
+  padding: 0.1rem 0.25rem; border-radius: var(--cc-radius-xs);
 }
 .crumb:hover { background: var(--cc-surface-2); }
 
@@ -314,14 +314,14 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 
 .fb-state {
   display: flex; align-items: center; gap: 0.5rem;
-  padding: 2rem; color: var(--cc-text-dim); font-size: 0.82rem;
+  padding: 2rem; color: var(--cc-text-dim); font-size: var(--cc-fs-md);
 }
 .fb-state.error { color: #fca5a5; flex-direction: column; align-items: flex-start; }
 
 /* table */
-.fb-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+.fb-table { width: 100%; border-collapse: collapse; font-size: var(--cc-fs-md); }
 .fb-table thead th {
-  text-align: left; font-size: 0.68rem; font-weight: 600;
+  text-align: left; font-size: var(--cc-fs-xs); font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.06em;
   color: var(--cc-text-dim);
   padding: 0.4rem 0.75rem;
@@ -346,18 +346,18 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 .non-image { opacity: 0.4; cursor: default; }
 .row-selected { background: #a78bfa14; }
 
-.row-icon { font-size: 0.8rem; margin-right: 0.4rem; }
+.row-icon { font-size: var(--cc-fs-md); margin-right: 0.4rem; }
 .dir-row  .row-icon { color: #fcd34d; }
 .image-row .row-icon { color: var(--cc-accent); }
 
 .col-name { display: table-cell; }
 .row-name { vertical-align: middle; }
-.dim { color: var(--cc-text-dim); font-size: 0.75rem; }
+.dim { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
 
 .fb-empty { text-align: center; padding: 2rem; }   /* + .cc-muted */
 
 /* footer */
-.sel-count { font-size: 0.78rem; color: var(--cc-text); flex: 1; }
+.sel-count { font-size: var(--cc-fs-sm); color: var(--cc-text); flex: 1; }
 .footer-actions { display: flex; gap: 0.4rem; }
 /* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/components/FloatingPanel.vue
+++ b/frontend/src/components/FloatingPanel.vue
@@ -105,7 +105,7 @@ function endGesture() {
   flex-direction: column;
   background: var(--cc-surface-1);          /* solid — floats over content, must not be see-through */
   border: 1px solid var(--cc-border);
-  border-radius: 0.5rem;
+  border-radius: var(--cc-radius-lg);
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
   overflow: hidden;
   min-width: 220px;
@@ -121,10 +121,10 @@ function endGesture() {
   user-select: none;
   flex-shrink: 0;
 }
-.fp-icon { font-size: 0.8rem; color: var(--cc-accent); flex-shrink: 0; }
+.fp-icon { font-size: var(--cc-fs-md); color: var(--cc-accent); flex-shrink: 0; }
 .fp-title {
   flex: 1;
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -143,11 +143,11 @@ function endGesture() {
   background: none;
   color: var(--cc-text-dim);
   cursor: pointer;
-  border-radius: 0.25rem;
-  font-size: 0.72rem;
+  border-radius: var(--cc-radius-xs);
+  font-size: var(--cc-fs-sm);
   flex-shrink: 0;
 }
-.fp-btn:hover { color: var(--cc-text); background: var(--cc-surface-3, rgba(255, 255, 255, 0.06)); }
+.fp-btn:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 .fp-body { flex: 1; overflow: auto; min-height: 0; }
 .fp-resize {
   position: absolute;

--- a/frontend/src/components/HintCallout.vue
+++ b/frontend/src/components/HintCallout.vue
@@ -34,11 +34,11 @@ function dismiss() {
   background: color-mix(in srgb, var(--cc-accent) 12%, var(--cc-surface-1));
   border-bottom: 1px solid var(--cc-border);
   border-left: 2px solid var(--cc-accent);
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   color: var(--cc-text);
   flex-shrink: 0;
 }
-.hint-icon { color: var(--cc-accent); font-size: 0.85rem; flex-shrink: 0; }
+.hint-icon { color: var(--cc-accent); font-size: var(--cc-fs-md); flex-shrink: 0; }
 .hint-text { flex: 1; }
 .hint-x {
   background: none;
@@ -46,9 +46,9 @@ function dismiss() {
   cursor: pointer;
   color: var(--cc-text-dim);
   padding: 0.15rem 0.3rem;
-  border-radius: 0.25rem;
+  border-radius: var(--cc-radius-xs);
   flex-shrink: 0;
 }
 .hint-x:hover { background: var(--cc-surface-2); color: var(--cc-text); }
-.hint-x .pi { font-size: 0.7rem; }
+.hint-x .pi { font-size: var(--cc-fs-xs); }
 </style>

--- a/frontend/src/components/ImageMetadataDialog.vue
+++ b/frontend/src/components/ImageMetadataDialog.vue
@@ -149,45 +149,45 @@ async function copy(key: string, value: string) {
 <style scoped>
 /* Shell (overlay/box/header/footer) lives in BaseModal; only dialog-specific styles here. */
 .md-body { display: flex; flex-direction: column; gap: 1rem; }   /* padding from BaseModal */
-.md-name { margin: 0; font-size: 0.85rem; font-weight: 600; color: var(--cc-text); }
+.md-name { margin: 0; font-size: var(--cc-fs-md); font-weight: 600; color: var(--cc-text); }
 
 .md-section { display: flex; flex-direction: column; gap: 0.4rem; }
 .md-h {
-  margin: 0; font-size: 0.68rem; font-weight: 600; text-transform: uppercase;
+  margin: 0; font-size: var(--cc-fs-xs); font-weight: 600; text-transform: uppercase;
   letter-spacing: 0.04em; color: var(--cc-text-dim);
 }
 
 .md-grid {
   display: grid; grid-template-columns: max-content 1fr;
-  gap: 0.25rem 1rem; font-size: 0.8rem; align-items: baseline;
+  gap: 0.25rem 1rem; font-size: var(--cc-fs-md); align-items: baseline;
 }
 .md-k { color: var(--cc-text-dim); white-space: nowrap; }
 .md-v { color: var(--cc-text); word-break: break-word; }
-.md-mono, .md-v.md-mono { font-family: var(--cc-font-mono, monospace); font-size: 0.74rem; }
+.md-mono, .md-v.md-mono { font-family: var(--cc-mono); font-size: var(--cc-fs-sm); }
 
 .md-path { display: flex; align-items: flex-start; gap: 0.4rem; }
 .md-code {
-  flex: 1; min-width: 0; font-family: var(--cc-font-mono, monospace); font-size: 0.74rem;
+  flex: 1; min-width: 0; font-family: var(--cc-mono); font-size: var(--cc-fs-sm);
   color: var(--cc-text); background: var(--cc-surface-2); border: 1px solid var(--cc-border);
-  border-radius: 0.3rem; padding: 0.3rem 0.45rem; word-break: break-all;
+  border-radius: var(--cc-radius-sm); padding: 0.3rem 0.45rem; word-break: break-all;
 }
 .md-copy {
   flex-shrink: 0; background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); padding: 0.25rem 0.35rem; border-radius: 0.25rem; font-size: 0.75rem;
+  color: var(--cc-text-dim); padding: 0.25rem 0.35rem; border-radius: var(--cc-radius-xs); font-size: var(--cc-fs-sm);
 }
 .md-copy:hover { color: var(--cc-text); background: var(--cc-surface-2); }
-.md-none { margin: 0; font-size: 0.78rem; color: var(--cc-text-dim); font-style: italic; }
+.md-none { margin: 0; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); font-style: italic; }
 
 .md-chips { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 0.3rem; counter-reset: ch; }
 .md-chip {
-  font-size: 0.74rem; color: var(--cc-text);
+  font-size: var(--cc-fs-sm); color: var(--cc-text);
   background: var(--cc-surface-2); border: 1px solid var(--cc-border);
-  border-radius: 999px; padding: 0.12rem 0.5rem;
+  border-radius: var(--cc-radius-pill); padding: 0.12rem 0.5rem;
 }
 .md-chip::before { counter-increment: ch; content: counter(ch) '· '; color: var(--cc-text-dim); }
 
 .md-file { display: flex; align-items: baseline; gap: 0.5rem; }
-.md-file-vn { flex-shrink: 0; font-size: 0.74rem; color: var(--cc-text-dim); min-width: 6rem; }
+.md-file-vn { flex-shrink: 0; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); min-width: 6rem; }
 
-.md-note-text { margin: 0; font-size: 0.8rem; color: var(--cc-text); white-space: pre-wrap; }
+.md-note-text { margin: 0; font-size: var(--cc-fs-md); color: var(--cc-text); white-space: pre-wrap; }
 </style>

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -634,7 +634,7 @@ onUnmounted(stopResize)
     <button class="cc-btn cc-btn-ghost" @click="moveUid = null">Cancel</button>
   </div>
 
-  <div v-if="images.length === 0" class="empty-state">
+  <div v-if="images.length === 0" class="cc-empty cc-empty-lg">
     <i class="pi pi-images empty-icon" />
     <p class="empty-title">No images yet</p>
     <p class="empty-hint">Import your first image to get started.<br>
@@ -959,16 +959,14 @@ onUnmounted(stopResize)
 .delete-confirm {
   display: flex; align-items: center; gap: 0.6rem;
   padding: 0.5rem 1rem; background: #7f1d1d22;
-  border-bottom: 1px solid #7f1d1d55; font-size: 0.82rem; flex-shrink: 0;
+  border-bottom: 1px solid #7f1d1d55; font-size: var(--cc-fs-md); flex-shrink: 0;
 }
 
-.empty-state {
-  display: flex; flex-direction: column; align-items: center; justify-content: center;
-  padding: 4rem 2rem; gap: 0.5rem; color: var(--cc-text-dim);
-}
+/* the one genuinely RICH empty state (icon + title + hint + CTA); the chrome comes from
+   .cc-empty .cc-empty-lg, only the icon/title/hint/CTA details are local */
 .empty-icon  { font-size: 2.5rem; margin-bottom: 0.5rem; opacity: 0.3; }
 .empty-title { font-size: 0.95rem; font-weight: 600; color: var(--cc-text); margin: 0; }
-.empty-hint  { font-size: 0.8rem; margin: 0; text-align: center; }
+.empty-hint  { font-size: var(--cc-fs-md); margin: 0; text-align: center; }
 .empty-cta   { margin-top: 0.85rem; }
 
 /* ── Table ───────────────────────────────────────────────────────────────────── */
@@ -978,12 +976,12 @@ onUnmounted(stopResize)
   width: max-content;
   min-width: 100%;
   border-collapse: collapse;
-  font-size: 0.82rem;
+  font-size: var(--cc-fs-md);
 }
 
 .image-table thead th {
   text-align: left;
-  font-size: 0.7rem; font-weight: 600;
+  font-size: var(--cc-fs-xs); font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.06em;
   color: var(--cc-text-dim);
   padding: 0.5rem 0.75rem;
@@ -1000,14 +998,14 @@ onUnmounted(stopResize)
 }
 .th-sort:hover { color: var(--cc-text); }
 .th-sort.active { color: var(--cc-text); }
-.sort-ico { font-size: 0.6rem; opacity: 0.3; transition: opacity 0.1s, color 0.1s; }
+.sort-ico { font-size: var(--cc-fs-2xs); opacity: 0.3; transition: opacity 0.1s, color 0.1s; }
 .th-sort:hover .sort-ico { opacity: 0.7; }
 .th-sort.active .sort-ico { opacity: 1; color: var(--cc-accent); }
 
 .select-flagged-btn {
   background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.72rem; padding: 0.1rem 0.3rem;
-  margin-left: 0.3rem; border-radius: 0.2rem; vertical-align: middle;
+  color: var(--cc-text-dim); font-size: var(--cc-fs-sm); padding: 0.1rem 0.3rem;
+  margin-left: 0.3rem; border-radius: var(--cc-radius-xs); vertical-align: middle;
 }
 .select-flagged-btn:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 .select-flagged-btn.active { color: #fbbf24; }
@@ -1098,7 +1096,7 @@ th:hover .resize-handle::after { opacity: 1; }
    palette); the shape-distinct triangle icon carries the meaning, colour is secondary. */
 .warn-icon-btn {
   flex-shrink: 0; background: none; border: none; cursor: pointer;
-  color: var(--cc-sev-warn); font-size: 0.75rem; padding: 0.1rem; line-height: 1;
+  color: var(--cc-sev-warn); font-size: var(--cc-fs-sm); padding: 0.1rem; line-height: 1;
 }
 .warn-icon-btn:hover { filter: brightness(1.2); }
 
@@ -1106,22 +1104,22 @@ th:hover .resize-handle::after { opacity: 1; }
    warning icon). Uses the canonical severity tokens. */
 .qc-badge {
   flex-shrink: 0; display: inline-flex; align-items: center; gap: 0.2rem;
-  font-size: 0.6rem; font-weight: 700; letter-spacing: 0.04em;
-  padding: 0.05rem 0.3rem; border-radius: 0.25rem; cursor: help;
+  font-size: var(--cc-fs-2xs); font-weight: 700; letter-spacing: 0.04em;
+  padding: 0.05rem 0.3rem; border-radius: var(--cc-radius-xs); cursor: help;
   border: 1px solid transparent;
 }
-.qc-badge .pi { font-size: 0.62rem; }
+.qc-badge .pi { font-size: var(--cc-fs-2xs); }
 .qc-badge.warn { color: var(--cc-sev-warn); background: color-mix(in srgb, var(--cc-sev-warn) 15%, transparent); border-color: color-mix(in srgb, var(--cc-sev-warn) 40%, transparent); }
 .qc-badge.info { color: var(--cc-text-dim); background: var(--cc-surface-2); border-color: var(--cc-border); }
 
 /* excluded badge — persistent "this image is excluded" pill; carries the note as its tooltip */
 .excl-badge {
   flex-shrink: 0; display: inline-flex; align-items: center; gap: 0.2rem;
-  font-size: 0.6rem; font-weight: 700; letter-spacing: 0.04em;
-  padding: 0.05rem 0.3rem; border-radius: 0.25rem; cursor: help;
+  font-size: var(--cc-fs-2xs); font-weight: 700; letter-spacing: 0.04em;
+  padding: 0.05rem 0.3rem; border-radius: var(--cc-radius-xs); cursor: help;
   color: #fca5a5; background: #7f1d1d33; border: 1px solid #7f1d1d66;
 }
-.excl-badge .pi { font-size: 0.62rem; }
+.excl-badge .pi { font-size: var(--cc-fs-2xs); }
 
 /* include/exclude toggle: hidden until row hover like the other row actions, but ALWAYS visible on
    an excluded row so there's an obvious way back */
@@ -1131,18 +1129,18 @@ th:hover .resize-handle::after { opacity: 1; }
 /* exclusion note — editable reason under the uid, only on excluded rows */
 .note-row { display: flex; align-items: center; margin-top: 0.15rem; }
 .note-text {
-  font-size: 0.68rem; color: var(--cc-text-dim); cursor: text;
+  font-size: var(--cc-fs-xs); color: var(--cc-text-dim); cursor: text;
   display: inline-flex; align-items: center; gap: 0.25rem;
-  border-radius: 3px; padding: 0 2px;
+  border-radius: var(--cc-radius-xs); padding: 0 2px;
 }
 .note-text:hover { background: var(--cc-surface-2); outline: 1px dashed var(--cc-border); }
-.note-text .pi { font-size: 0.62rem; }
+.note-text .pi { font-size: var(--cc-fs-2xs); }
 
 /* row-hover actions after the name: the "open editor" page icon + copy-UID — same look, one class */
 .row-icon-btn {
   flex-shrink: 0; background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.72rem; padding: 0.1rem 0.2rem;
-  border-radius: 0.2rem; line-height: 1;
+  color: var(--cc-text-dim); font-size: var(--cc-fs-sm); padding: 0.1rem 0.2rem;
+  border-radius: var(--cc-radius-xs); line-height: 1;
   opacity: 0; transition: opacity 0.1s, color 0.1s, background 0.1s;
 }
 .image-row:hover .row-icon-btn { opacity: 1; }
@@ -1153,10 +1151,10 @@ th:hover .resize-handle::after { opacity: 1; }
 .row-icon-btn:disabled:hover { color: var(--cc-text-dim); background: none; }
 
 /* editable attribute cell: click to edit; subtle hover affordance */
-.attr-cell { cursor: text; border-radius: 3px; padding: 0 2px; }
+.attr-cell { cursor: text; border-radius: var(--cc-radius-xs); padding: 0 2px; }
 .attr-cell:hover { background: var(--cc-surface-2); outline: 1px dashed var(--cc-border); }
 .attr-edit { width: 100%; box-sizing: border-box; font: inherit; padding: 1px 3px;
-  border: 1px solid var(--cc-accent); border-radius: 3px; background: var(--cc-surface-1); color: var(--cc-text); }
+  border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); color: var(--cc-text); }
 
 .uid-row {
   display: flex;
@@ -1170,15 +1168,15 @@ th:hover .resize-handle::after { opacity: 1; }
 .runlog-cog.on { color: var(--cc-text); background: var(--cc-surface-2); opacity: 1; }
 /* inner layout only — TeleportPopover provides surface/border/shadow/position */
 .runlog-pop { min-width: 15rem; max-height: 16rem; overflow-y: auto; padding: 6px 8px; }
-.runlog-hd { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--cc-text-dim); margin-bottom: 4px; }
-.runlog-empty { font-size: 0.7rem; color: var(--cc-text-dim); }
-.runlog-row { display: flex; align-items: baseline; gap: 6px; padding: 2px 0; font-size: 0.7rem; }
+.runlog-hd { font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.05em; color: var(--cc-text-dim); margin-bottom: 4px; }
+.runlog-empty { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.runlog-row { display: flex; align-items: baseline; gap: 6px; padding: 2px 0; font-size: var(--cc-fs-xs); }
 .runlog-fun { font-weight: 600; color: var(--cc-text); font-family: var(--cc-mono); }
-.runlog-vn { color: var(--cc-accent); font-size: 0.62rem; }
+.runlog-vn { color: var(--cc-accent); font-size: var(--cc-fs-2xs); }
 .runlog-at { margin-left: auto; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; white-space: nowrap; }
 .img-uid {
   font-family: var(--cc-mono);
-  font-size: 0.68rem;
+  font-size: var(--cc-fs-xs);
   color: var(--cc-text-dim);
   letter-spacing: 0.03em;
   overflow: hidden;
@@ -1193,9 +1191,9 @@ th:hover .resize-handle::after { opacity: 1; }
 .run-tag {
   display: inline-flex; align-items: baseline; gap: 0.3rem; flex-shrink: 0;
   max-width: 60%;
-  padding: 0.05rem 0.4rem; border-radius: 0.25rem;
+  padding: 0.05rem 0.4rem; border-radius: var(--cc-radius-xs);
   border: 1px solid transparent;
-  font-size: 0.64rem; line-height: 1.5;
+  font-size: var(--cc-fs-2xs); line-height: 1.5;
 }
 .run-tag-mod { font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; flex-shrink: 0; }
 .run-tag-fun { opacity: 0.85; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -1206,8 +1204,8 @@ th:hover .resize-handle::after { opacity: 1; }
 
 .status-badge {
   display: inline-flex; align-items: center; gap: 0.35rem;
-  font-size: 0.7rem; font-weight: 600; padding: 0.15rem 0.5rem;
-  border-radius: 999px; text-transform: uppercase; letter-spacing: 0.04em;
+  font-size: var(--cc-fs-xs); font-weight: 600; padding: 0.15rem 0.5rem;
+  border-radius: var(--cc-radius-pill); text-transform: uppercase; letter-spacing: 0.04em;
 }
 .st-pending  { background: #27272a;    color: #71717a; }
 .st-queued   { background: #2d1b69;    color: #c4b5fd; }
@@ -1216,7 +1214,7 @@ th:hover .resize-handle::after { opacity: 1; }
 .st-failed   { background: #7f1d1d44;  color: #fca5a5; }
 
 .spinner {
-  width: 7px; height: 7px; border-radius: 50%;
+  width: 7px; height: 7px; border-radius: var(--cc-radius-pill);
   border: 1.5px solid #93c5fd44; border-top-color: #93c5fd;
   animation: spin 0.7s linear infinite; flex-shrink: 0;
 }
@@ -1226,8 +1224,8 @@ th:hover .resize-handle::after { opacity: 1; }
 
 .viewer-btn {
   background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.8rem;
-  padding: 0.2rem 0.3rem; border-radius: 0.25rem;
+  color: var(--cc-text-dim); font-size: var(--cc-fs-md);
+  padding: 0.2rem 0.3rem; border-radius: var(--cc-radius-xs);
   opacity: 0; transition: opacity 0.12s, color 0.12s, background 0.12s; line-height: 1;
 }
 .image-row:hover .viewer-btn { opacity: 0.6; }
@@ -1240,8 +1238,8 @@ th:hover .resize-handle::after { opacity: 1; }
 
 .action-btn {
   background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.75rem;
-  padding: 0.2rem 0.4rem; border-radius: 0.25rem;
+  color: var(--cc-text-dim); font-size: var(--cc-fs-sm);
+  padding: 0.2rem 0.4rem; border-radius: var(--cc-radius-xs);
   opacity: 0; transition: opacity 0.1s, background 0.1s;
 }
 .image-row:hover .action-btn { opacity: 1; }
@@ -1253,7 +1251,7 @@ th:hover .resize-handle::after { opacity: 1; }
 .move-bar {
   display: flex; align-items: center; gap: 0.6rem;
   padding: 0.5rem 1rem; background: var(--cc-surface-1);
-  border-bottom: 1px solid var(--cc-border); font-size: 0.82rem; flex-shrink: 0;
+  border-bottom: 1px solid var(--cc-border); font-size: var(--cc-fs-md); flex-shrink: 0;
 }
 .move-select { min-width: 160px; }
 .move-name-input { width: 180px; border-color: var(--cc-accent); }
@@ -1267,8 +1265,8 @@ th:hover .resize-handle::after { opacity: 1; }
 .actions-menu { display: flex; flex-direction: column; min-width: 200px; padding: 0.25rem; }
 .actions-item {
   display: flex; align-items: center; gap: 0.55rem;
-  width: 100%; padding: 0.4rem 0.6rem; border: none; border-radius: 4px;
-  background: none; color: var(--cc-text); font-size: 0.82rem; text-align: left; cursor: pointer;
+  width: 100%; padding: 0.4rem 0.6rem; border: none; border-radius: var(--cc-radius-xs);
+  background: none; color: var(--cc-text); font-size: var(--cc-fs-md); text-align: left; cursor: pointer;
 }
 .actions-item:hover:not(:disabled) { background: var(--cc-surface-2); }
 .actions-item:disabled { opacity: 0.4; cursor: not-allowed; }

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -387,28 +387,28 @@ async function dismissEntry(entry: LabLogEntry) {
 </template>
 
 <style scoped>
-.ll { display: flex; flex-direction: column; height: 100%; font-size: 0.8rem; }
+.ll { display: flex; flex-direction: column; height: 100%; font-size: var(--cc-fs-md); }
 
 .ll-compose { padding: 0.5rem; border-bottom: 1px solid var(--cc-border); flex-shrink: 0; }
 .ll-compose.correcting { background: rgba(210, 153, 34, 0.08); }
 .ll-correcting {
   display: flex; align-items: center; gap: 0.35rem;
-  font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.04em;
+  font-size: var(--cc-fs-xs); text-transform: uppercase; letter-spacing: 0.04em;
   color: #d29922; margin-bottom: 0.3rem;
 }
 .ll-input {
   width: 100%; resize: vertical; box-sizing: border-box;
   background: var(--cc-surface-2); color: var(--cc-text);
-  border: 1px solid var(--cc-border); border-radius: 0.35rem;
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm);
   padding: 0.4rem 0.5rem; font: inherit; line-height: 1.35;
 }
 .ll-input:focus { outline: none; border-color: var(--cc-accent); }
 .ll-input:disabled { opacity: 0.6; }
 .ll-compose-row { display: flex; align-items: center; justify-content: space-between; margin-top: 0.35rem; }
-.ll-hint { font-size: 0.66rem; color: var(--cc-text-dim); }
+.ll-hint { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
 .ll-save {
   border: 1px solid var(--cc-accent); background: var(--cc-accent); color: #fff;
-  border-radius: 0.35rem; padding: 0.22rem 0.6rem; font-size: 0.72rem; cursor: pointer;
+  border-radius: var(--cc-radius-sm); padding: 0.22rem 0.6rem; font-size: var(--cc-fs-sm); cursor: pointer;
 }
 .ll-save:disabled { opacity: 0.5; cursor: default; }
 
@@ -423,7 +423,7 @@ async function dismissEntry(entry: LabLogEntry) {
 .ll-capture {
   display: inline-flex; align-items: center; gap: 0.3rem;
   border: 1px solid var(--cc-border); background: var(--cc-surface-2); color: var(--cc-text);
-  border-radius: 0.35rem; padding: 0.2rem 0.5rem; font-size: 0.7rem; cursor: pointer;
+  border-radius: var(--cc-radius-sm); padding: 0.2rem 0.5rem; font-size: var(--cc-fs-xs); cursor: pointer;
 }
 .ll-capture:hover:not(:disabled) { border-color: #8b949e; }
 /* brief "copied" flash on the Chat-to-Claude button (replaces the toast) */
@@ -431,33 +431,35 @@ async function dismissEntry(entry: LabLogEntry) {
 .ll-capture:disabled { opacity: 0.5; cursor: default; }
 .ll-help {
   display: inline-flex; align-items: center; border: none; background: none;
-  color: var(--cc-text-dim); cursor: pointer; padding: 0.2rem; font-size: 0.85rem;
+  color: var(--cc-text-dim); cursor: pointer; padding: 0.2rem; font-size: var(--cc-fs-md);
 }
 .ll-help:hover { color: var(--cc-accent); }
-.ll-auto { display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.7rem; color: var(--cc-text-dim); cursor: pointer; }
+.ll-auto { display: inline-flex; align-items: center; gap: 0.25rem; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); cursor: pointer; }
 .ll-model {
-  font-size: 0.66rem; color: var(--cc-text-dim); cursor: pointer; padding: 0.05rem 0.2rem;
-  background: var(--cc-surface); border: 1px solid var(--cc-border); border-radius: 3px;
+  font-size: var(--cc-fs-xs); color: var(--cc-text-dim); cursor: pointer; padding: 0.05rem 0.2rem;
+  /* background-COLOR, not the shorthand: the global `select` rule paints the custom caret via
+     background-image, and a shorthand here would reset it to none (leaving an arrowless select). */
+  background-color: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs);
 }
 /* capture status: floats to the far right of the whole bar (direct toolbar child) */
-.ll-note { font-size: 0.66rem; color: var(--cc-text-dim); margin-left: auto; }
+.ll-note { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); margin-left: auto; }
 /* token readout sits inline within the Claude group (no auto-margin — it's not a toolbar child) */
-.ll-tokens { font-size: 0.66rem; color: var(--cc-text-dim); }
+.ll-tokens { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
 .ll-clearctx {
   border: none; background: transparent; color: var(--cc-text-dim);
-  font-size: 0.66rem; cursor: pointer; text-decoration: underline; padding: 0;
+  font-size: var(--cc-fs-xs); cursor: pointer; text-decoration: underline; padding: 0;
 }
 .ll-clearctx:hover { color: var(--cc-text); }
 /* setup hint — install/login guidance when Claude Code is missing or not authenticated */
 .ll-setup {
   flex-shrink: 0; border-bottom: 1px solid var(--cc-border);
   background: var(--cc-surface-2); padding: 0.4rem 0.6rem;
-  font-size: 0.68rem; color: var(--cc-text-dim); line-height: 1.5;
+  font-size: var(--cc-fs-xs); color: var(--cc-text-dim); line-height: 1.5;
 }
 .ll-setup strong { color: var(--cc-text); }
 .ll-setup code {
-  font-size: 0.64rem; padding: 0 0.2rem; border-radius: 3px;
-  background: var(--cc-surface); border: 1px solid var(--cc-border);
+  font-size: var(--cc-fs-2xs); padding: 0 0.2rem; border-radius: var(--cc-radius-xs);
+  background: var(--cc-surface-1); border: 1px solid var(--cc-border);
 }
 .ll-setup a { margin-left: 0.3rem; color: var(--cc-accent); white-space: nowrap; }
 /* Claude activity log — collapsible; each Ask-Claude pass with its verdict, cost + outcome */
@@ -466,22 +468,22 @@ async function dismissEntry(entry: LabLogEntry) {
   background: var(--cc-surface-2); padding: 0.3rem 0.6rem; max-height: 11rem; overflow-y: auto;
 }
 .ll-activity > summary {
-  font-size: 0.66rem; color: var(--cc-text-dim); cursor: pointer; user-select: none;
+  font-size: var(--cc-fs-xs); color: var(--cc-text-dim); cursor: pointer; user-select: none;
 }
 .ll-pass { margin-top: 0.35rem; padding-left: 0.4rem; border-left: 2px solid var(--cc-border); }
 .ll-pass.appended { border-left-color: var(--cc-accent); }
 .ll-pass.failed   { border-left-color: #f85149; }
-.ll-pass-head { display: flex; align-items: baseline; gap: 0.35rem; font-size: 0.64rem; }
+.ll-pass-head { display: flex; align-items: baseline; gap: 0.35rem; font-size: var(--cc-fs-2xs); }
 .ll-pass-trig { display: inline-flex; align-items: center; gap: 0.2rem; font-weight: 600; color: var(--cc-accent); }
-.ll-pass-trig .pi { font-size: 0.6rem; }
+.ll-pass-trig .pi { font-size: var(--cc-fs-2xs); }
 .ll-pass-meta { color: var(--cc-text-dim); }
 .ll-pass-at   { margin-left: auto; color: var(--cc-text-dim); opacity: 0.8; }
-.ll-pass-note { font-size: 0.7rem; color: var(--cc-text); line-height: 1.4; white-space: pre-wrap; margin-top: 0.1rem; }
+.ll-pass-note { font-size: var(--cc-fs-xs); color: var(--cc-text); line-height: 1.4; white-space: pre-wrap; margin-top: 0.1rem; }
 
-.ll-error { padding: 0.4rem 0.6rem; color: #f85149; font-size: 0.72rem; }
+.ll-error { padding: 0.4rem 0.6rem; color: #f85149; font-size: var(--cc-fs-sm); }
 
 .ll-list { flex: 1; overflow-y: auto; padding: 0.4rem 0.5rem 0.6rem; }
-.ll-empty { color: var(--cc-text-dim); text-align: center; padding: 1.2rem 0.5rem; font-size: 0.74rem; }
+.ll-empty { color: var(--cc-text-dim); text-align: center; padding: 1.2rem 0.5rem; font-size: var(--cc-fs-sm); }
 
 .ll-entry {
   border-left: 3px solid var(--cc-border);
@@ -501,13 +503,13 @@ async function dismissEntry(entry: LabLogEntry) {
 .k-cecelia .ll-author { color: #8b949e; }
 
 .ll-entry-head { display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.2rem; }
-.ll-author { font-weight: 700; font-size: 0.72rem; }
-.ll-date { color: var(--cc-text-dim); font-size: 0.68rem; }
+.ll-author { font-weight: 700; font-size: var(--cc-fs-sm); }
+.ll-date { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
 /* per-entry actions: hidden until hover (thumbs prefill a note — they carry no persisted state) */
 .ll-actions { margin-left: auto; display: inline-flex; align-items: center; gap: 0.15rem; visibility: hidden; }
 .ll-entry:hover .ll-actions { visibility: visible; }
 .ll-thumb {
-  border: none; background: none; cursor: pointer; font-size: 0.8rem; line-height: 1;
+  border: none; background: none; cursor: pointer; font-size: var(--cc-fs-md); line-height: 1;
   padding: 0 0.1rem; opacity: 0.8; filter: grayscale(0.5);
 }
 .ll-thumb:hover { opacity: 1; filter: none; }
@@ -516,7 +518,7 @@ async function dismissEntry(entry: LabLogEntry) {
 
 .ll-link {
   border: none; background: none; color: var(--cc-text-dim);
-  cursor: pointer; font-size: 0.68rem; padding: 0; text-decoration: underline;
+  cursor: pointer; font-size: var(--cc-fs-xs); padding: 0; text-decoration: underline;
 }
 .ll-link:hover { color: var(--cc-text); }
 </style>

--- a/frontend/src/components/LegacyMigrateDialog.vue
+++ b/frontend/src/components/LegacyMigrateDialog.vue
@@ -235,29 +235,29 @@ async function confirmImport() {
 
 <style scoped>
 .lm { display: flex; flex-direction: column; gap: 0.75rem; color: var(--cc-text); }
-.lm-lead { margin: 0; font-size: 0.9rem; color: var(--cc-text-dim); }
+.lm-lead { margin: 0; font-size: var(--cc-fs-lg); color: var(--cc-text-dim); }
 .lm-donebox { padding: 0.5rem 0.25rem; }
 .lm-doneline { margin: 0 0 0.4rem; font-size: 1rem; color: var(--cc-text); }
 .lm-doneline .pi-check-circle { color: #4ade80; margin-right: 0.35rem; }
 .lm-path { display: flex; gap: 0.5rem; }
 .lm-input {
-  flex: 1; padding: 0.4rem 0.6rem; font-size: 0.9rem;
-  border: 1px solid var(--cc-border); border-radius: 6px;
+  flex: 1; padding: 0.4rem 0.6rem; font-size: var(--cc-fs-lg);
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md);
   background: var(--cc-surface-1); color: var(--cc-text);
 }
 .lm-input::placeholder { color: var(--cc-text-dim); }
-.lm-rscript { font-size: 0.8rem; }
-.lm-error { color: #f87171; margin: 0; font-size: 0.85rem; }
-.lm-summary { margin: 0; font-size: 0.9rem; color: var(--cc-text); }
-.lm-tablewrap { max-height: 46vh; overflow: auto; border: 1px solid var(--cc-border); border-radius: 6px; }
-.lm-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; color: var(--cc-text); }
+.lm-rscript { font-size: var(--cc-fs-md); }
+.lm-error { color: #f87171; margin: 0; font-size: var(--cc-fs-md); }
+.lm-summary { margin: 0; font-size: var(--cc-fs-lg); color: var(--cc-text); }
+.lm-tablewrap { max-height: 46vh; overflow: auto; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); }
+.lm-table { width: 100%; border-collapse: collapse; font-size: var(--cc-fs-md); color: var(--cc-text); }
 .lm-table th, .lm-table td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--cc-border); vertical-align: top; }
 .lm-table thead th { position: sticky; top: 0; background: var(--cc-surface-1); font-weight: 600; color: var(--cc-text-dim); }
 .lm-table tr.off { opacity: 0.45; }
 .lm-name { font-weight: 500; }
-.cc-muted { color: var(--cc-text-dim); font-size: 0.78rem; }
-.lm-warn { color: #fbbf24; font-size: 0.78rem; margin-top: 0.15rem; }
-.lm-tag { display: inline-block; margin: 0.1rem 0.2rem 0.1rem 0; padding: 0.05rem 0.4rem; border-radius: 4px; font-size: 0.76rem; }
+.cc-muted { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
+.lm-warn { color: #fbbf24; font-size: var(--cc-fs-sm); margin-top: 0.15rem; }
+.lm-tag { display: inline-block; margin: 0.1rem 0.2rem 0.1rem 0; padding: 0.05rem 0.4rem; border-radius: var(--cc-radius-xs); font-size: var(--cc-fs-sm); }
 .lm-tag.ok { background: #16653433; color: #4ade80; }
 .lm-tag.off-tag { background: var(--cc-surface-2); color: var(--cc-text-dim); text-decoration: line-through; }
 </style>

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -543,7 +543,7 @@ const visibleUids = computed<string[]>(() =>
   transition: background 0.12s, color 0.12s;
 }
 .right-handle:hover { background: var(--cc-surface-2); color: var(--cc-text); }
-.right-handle .pi { font-size: 0.7rem; }
+.right-handle .pi { font-size: var(--cc-fs-xs); }
 /* drag strip on the panel's left edge to resize (col-resize); thin, highlights on hover */
 .right-resizer { flex-shrink: 0; width: 5px; cursor: col-resize; background: transparent; transition: background 0.12s; }
 .right-resizer:hover { background: var(--cc-accent); }
@@ -560,7 +560,7 @@ const visibleUids = computed<string[]>(() =>
 }
 
 .image-count {
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   display: flex;
   align-items: center;
@@ -569,18 +569,18 @@ const visibleUids = computed<string[]>(() =>
 .excluded-note { color: var(--cc-sev-warn); }
 
 .filter-badge {
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   padding: 0.1rem 0.45rem;
-  border-radius: 999px;
+  border-radius: var(--cc-radius-pill);
   background: #2d1b69;
   color: #c4b5fd;
 }
 
 .no-set-hint {
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   font-style: italic;
 }
@@ -609,7 +609,7 @@ const visibleUids = computed<string[]>(() =>
   gap: 0.3rem;
   padding: 0.2rem 0.5rem;
   border: 1px solid var(--cc-border);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   background: var(--cc-surface-1);
   cursor: pointer;
   color: var(--cc-text-dim);
@@ -617,11 +617,11 @@ const visibleUids = computed<string[]>(() =>
 }
 .filter-toggle:hover { color: var(--cc-text); border-color: #484f58; }
 .filter-toggle.active { color: #c4b5fd; border-color: #7c3aed; }
-.filter-toggle .pi { font-size: 0.7rem; }
-.filter-toggle .filter-caret { font-size: 0.55rem; opacity: 0.7; }
+.filter-toggle .pi { font-size: var(--cc-fs-xs); }
+.filter-toggle .filter-caret { font-size: var(--cc-fs-3xs); opacity: 0.7; }
 
 .filter-label {
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -641,7 +641,7 @@ const visibleUids = computed<string[]>(() =>
   display: flex;
   align-items: center;
   gap: 0.3rem;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   cursor: pointer;
   user-select: none;
@@ -654,15 +654,15 @@ const visibleUids = computed<string[]>(() =>
 .proc-row .filter-key { min-width: 104px; }
 .proc-controls { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
 .proc-select {
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   padding: 0.15rem 0.4rem;
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   background: var(--cc-surface-1);
   border: 1px solid var(--cc-border);
   color: var(--cc-text);
   max-width: 240px;
 }
-.proc-mode { display: flex; align-items: center; gap: 0.55rem; font-size: 0.75rem; color: var(--cc-text-dim); }
+.proc-mode { display: flex; align-items: center; gap: 0.55rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
 .proc-mode label { display: inline-flex; align-items: center; gap: 0.25rem; cursor: pointer; }
 .proc-mode.disabled { opacity: 0.4; }
 .proc-mode input { cursor: pointer; }
@@ -677,7 +677,7 @@ const visibleUids = computed<string[]>(() =>
 }
 
 .filter-key {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   color: var(--cc-text-dim);
   min-width: 80px;
@@ -709,7 +709,7 @@ const visibleUids = computed<string[]>(() =>
   padding: 2rem 1rem;
   gap: 0.4rem;
   color: var(--cc-text-dim);
-  font-size: 0.85rem;
+  font-size: var(--cc-fs-md);
 }
 .no-set p { margin: 0; }
 </style>

--- a/frontend/src/components/NotebookTable.vue
+++ b/frontend/src/components/NotebookTable.vue
@@ -333,14 +333,14 @@ defineExpose({ refresh })
 <style scoped>
 .nbt-add { display: flex; align-items: center; gap: .5rem; margin-bottom: .75rem; }
 .nbt-add input { flex: 0 1 240px; }
-.nbt-table { width: 100%; border-collapse: collapse; font-size: .9rem; }
+.nbt-table { width: 100%; border-collapse: collapse; font-size: var(--cc-fs-lg); }
 .nbt-table th, .nbt-table td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--cc-border, #2a2a2a); }
-.nbt-table th { color: var(--cc-text-muted, #888); font-weight: 600; }
+.nbt-table th { color: var(--cc-text-dim); font-weight: 600; }
 .nbt-name { white-space: nowrap; }
 .nbt-desc input { width: 100%; }
 .nbt-editable { cursor: text; }
-.nbt-muted { color: var(--cc-text-muted, #888); font-style: italic; }
-.nbt-ver { white-space: nowrap; color: var(--cc-text-muted, #888); }
+.nbt-muted { color: var(--cc-text-dim); font-style: italic; }
+.nbt-ver { white-space: nowrap; color: var(--cc-text-dim); }
 .nbt-actions-h { text-align: right; }
 .nbt-actions { display: flex; gap: .3rem; justify-content: flex-end; }
 .nbt-actions .cc-btn { padding: .25rem .45rem; }
@@ -348,13 +348,13 @@ defineExpose({ refresh })
 .nbt-active { color: #58a6ff; }
 .nbt-empty { text-align: center; padding: 1rem; }   /* + .cc-muted */
 .nbt-history-row td { background: var(--cc-surface-2, rgba(255,255,255,0.03)); }
-.nbt-history { display: flex; align-items: center; flex-wrap: wrap; gap: .5rem; font-size: .85rem; }
-.nbt-hist-label { color: var(--cc-text-muted, #888); }
+.nbt-history { display: flex; align-items: center; flex-wrap: wrap; gap: .5rem; font-size: var(--cc-fs-md); }
+.nbt-hist-label { color: var(--cc-text-dim); }
 .nbt-hist-sep { flex: 1 1 auto; }   /* push Prune to the far end, away from the Restore control */
-.nbt-snap { display: inline-flex; align-items: center; gap: .25rem; border: 1px solid var(--cc-border, #333); border-radius: 6px; padding: .1rem .1rem .1rem .5rem; }
+.nbt-snap { display: inline-flex; align-items: center; gap: .25rem; border: 1px solid var(--cc-border, #333); border-radius: var(--cc-radius-md); padding: .1rem .1rem .1rem .5rem; }
 .nbt-snap-ver { font-variant-numeric: tabular-nums; }
 .nbt-snap .cc-btn { padding: .15rem .4rem; }
-.nb-badge { font-size: .72rem; padding: .1rem .45rem; border-radius: 999px; border: 1px solid var(--cc-border, #333); }
+.nb-badge { font-size: var(--cc-fs-sm); padding: .1rem .45rem; border-radius: var(--cc-radius-pill); border: 1px solid var(--cc-border, #333); }
 .nb-badge.scope-project { color: #58a6ff; border-color: #58a6ff55; }
 .nb-badge.scope-example { color: #888; }
 </style>

--- a/frontend/src/components/PackagesDialog.vue
+++ b/frontend/src/components/PackagesDialog.vue
@@ -112,27 +112,27 @@ function copyAll() {
 
 <style scoped>
 .pk-toolbar { display: flex; gap: 0.5rem; align-items: center; padding: 0.6rem 1rem; border-bottom: 1px solid var(--cc-border); flex-shrink: 0; }
-.search-wrap { flex: 1; display: flex; align-items: center; gap: 0.4rem; background: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: 0.35rem; padding: 0.25rem 0.5rem; }
-.search-wrap .pi-search { font-size: 0.75rem; color: var(--cc-text-dim); }
-.search-input { flex: 1; background: none; border: none; outline: none; color: var(--cc-text); font-size: 0.8rem; }
-.mini-btn { display: flex; align-items: center; gap: 0.3rem; font-size: 0.75rem; padding: 0.3rem 0.6rem; border-radius: 0.35rem; border: 1px solid var(--cc-border); background: var(--cc-surface-2); color: var(--cc-text-dim); cursor: pointer; white-space: nowrap; }
+.search-wrap { flex: 1; display: flex; align-items: center; gap: 0.4rem; background: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); padding: 0.25rem 0.5rem; }
+.search-wrap .pi-search { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.search-input { flex: 1; background: none; border: none; outline: none; color: var(--cc-text); font-size: var(--cc-fs-md); }
+.mini-btn { display: flex; align-items: center; gap: 0.3rem; font-size: var(--cc-fs-sm); padding: 0.3rem 0.6rem; border-radius: var(--cc-radius-sm); border: 1px solid var(--cc-border); background: var(--cc-surface-2); color: var(--cc-text-dim); cursor: pointer; white-space: nowrap; }
 .mini-btn:hover:not(:disabled) { color: var(--cc-text); }
 .mini-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
-.grp-head { display: flex; align-items: baseline; gap: 0.5rem; font-size: 0.8rem; font-weight: 600; color: var(--cc-text); margin: 0.85rem 0 0.4rem; position: sticky; top: 0; background: var(--cc-surface-1); padding: 0.2rem 0; }
+.grp-head { display: flex; align-items: baseline; gap: 0.5rem; font-size: var(--cc-fs-md); font-weight: 600; color: var(--cc-text); margin: 0.85rem 0 0.4rem; position: sticky; top: 0; background: var(--cc-surface-1); padding: 0.2rem 0; }
 .grp-head:first-child { margin-top: 0.2rem; }
-.grp-sub { font-size: 0.68rem; font-weight: 400; color: var(--cc-text-dim); }
-.grp-count { margin-left: auto; font-size: 0.7rem; color: var(--cc-text-dim); background: var(--cc-surface-2); border-radius: 999px; padding: 0.05rem 0.5rem; }
+.grp-sub { font-size: var(--cc-fs-xs); font-weight: 400; color: var(--cc-text-dim); }
+.grp-count { margin-left: auto; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); background: var(--cc-surface-2); border-radius: var(--cc-radius-pill); padding: 0.05rem 0.5rem; }
 
 .pkg-grid { display: grid; grid-template-columns: 1fr auto auto; gap: 0.1rem 0.75rem; align-items: baseline; }
-.pk-name { font-size: 0.78rem; color: var(--cc-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.pk-ver { font-size: 0.74rem; color: var(--cc-text-dim); }
-.pk-kind { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.03em; color: var(--cc-text-dim); min-width: 3.2rem; }
+.pk-name { font-size: var(--cc-fs-sm); color: var(--cc-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pk-ver { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.pk-kind { font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.03em; color: var(--cc-text-dim); min-width: 3.2rem; }
 .pk-kind.conda { color: #34d399; }
 .pk-kind.pypi  { color: #60a5fa; }
 
 .mono { font-variant-numeric: tabular-nums; }
-.state-line { display: flex; align-items: center; gap: 0.4rem; font-size: 0.78rem; color: var(--cc-text-dim); margin: 0.4rem 0; }
+.state-line { display: flex; align-items: center; gap: 0.4rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin: 0.4rem 0; }
 .state-line.err  { color: #f87171; }
 .state-line.warn { color: #fbbf24; }
 .state-line.dim  { grid-column: 1 / -1; }

--- a/frontend/src/components/PhysicalSizeDialog.vue
+++ b/frontend/src/components/PhysicalSizeDialog.vue
@@ -327,24 +327,24 @@ async function fillFlagged() {
 
 <style scoped>
 /* Shell (overlay/box/header/footer) lives in BaseModal; only dialog-specific styles remain here. */
-.info-dot { font-size: 0.72rem; color: var(--cc-text-dim); cursor: default; }
+.info-dot { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); cursor: default; }
 .pp-form { padding: 1rem 1.25rem; display: flex; flex-direction: column; gap: 0.75rem; }
 
-.focus-name { margin: 0; font-size: 0.82rem; font-weight: 600; color: var(--cc-text); }
+.focus-name { margin: 0; font-size: var(--cc-fs-md); font-weight: 600; color: var(--cc-text); }
 
 .warn-line {
   display: flex; align-items: center; gap: 0.4rem; margin: 0;
-  font-size: 0.78rem; color: #fcd34d;
+  font-size: var(--cc-fs-sm); color: #fcd34d;
   background: #7c2d1244; border: 1px solid #92400e55;
-  border-radius: 0.3rem; padding: 0.35rem 0.55rem; cursor: help;
+  border-radius: var(--cc-radius-sm); padding: 0.35rem 0.55rem; cursor: help;
 }
 
 /* Informational (not an error): downstream artifacts need a re-run after a calibration change. */
 .rerun-line {
   display: flex; align-items: center; gap: 0.4rem; margin: 0;
-  font-size: 0.78rem; color: var(--cc-text-dim);
+  font-size: var(--cc-fs-sm); color: var(--cc-text-dim);
   background: var(--cc-surface-2); border: 1px solid var(--cc-border);
-  border-radius: 0.3rem; padding: 0.35rem 0.55rem; cursor: help;
+  border-radius: var(--cc-radius-sm); padding: 0.35rem 0.55rem; cursor: help;
 }
 
 .toggle-row { gap: 0.35rem; }
@@ -353,7 +353,7 @@ async function fillFlagged() {
 .dims-row.excluded { opacity: 0.4; }
 .dim-label {
   flex-shrink: 0; width: 1.2rem; text-align: right;
-  font-size: 0.75rem; font-weight: 600; color: var(--cc-text-dim);
+  font-size: var(--cc-fs-sm); font-weight: 600; color: var(--cc-text-dim);
 }
 .field-input { flex: 1; min-width: 0; }
 .field-input.warn { border-color: #f59e0b !important; background: #7c2d1222; }

--- a/frontend/src/components/PoolThrottle.vue
+++ b/frontend/src/components/PoolThrottle.vue
@@ -97,26 +97,26 @@ onUnmounted(() => { if (timer) clearInterval(timer) })
 
 <style scoped>
 .pt-root { width: 260px; padding: 0.6rem 0.7rem; }
-.pt-head { font-size: 0.78rem; font-weight: 600; color: var(--cc-text); margin-bottom: 0.5rem; }
+.pt-head { font-size: var(--cc-fs-sm); font-weight: 600; color: var(--cc-text); margin-bottom: 0.5rem; }
 .pt-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem 0.9rem; }
 .pt-cell { display: flex; flex-direction: column; gap: 0.15rem; }
 .pt-cell-head { display: flex; justify-content: space-between; align-items: baseline; }
-.pt-label { font-size: 0.76rem; color: var(--cc-text); }
-.pt-val { font-size: 0.78rem; font-variant-numeric: tabular-nums; color: var(--cc-accent, var(--cc-text)); }
+.pt-label { font-size: var(--cc-fs-sm); color: var(--cc-text); }
+.pt-val { font-size: var(--cc-fs-sm); font-variant-numeric: tabular-nums; color: var(--cc-accent, var(--cc-text)); }
 .pt-slider { width: 100%; accent-color: var(--cc-accent); cursor: pointer; }
 .pt-slider:disabled { opacity: 0.5; cursor: default; }
 
 /* live occupancy readout under each slider — dim when idle, brightens when the pool is busy */
 .pt-occ {
   display: flex; justify-content: space-between; align-items: baseline; gap: 0.3rem;
-  font-size: 0.64rem; color: var(--cc-text-dim); font-variant-numeric: tabular-nums;
+  font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); font-variant-numeric: tabular-nums;
 }
 .pt-occ.busy { color: var(--cc-text); }
 .pt-occ.busy .pt-occ-n { color: var(--cc-accent); font-weight: 600; }
 .pt-occ-sep { opacity: 0.5; margin: 0 1px; }
 .pt-occ-q { color: var(--cc-accent); }
-.pt-bar { height: 3px; border-radius: 2px; background: var(--cc-surface-2); overflow: hidden; margin-top: 2px; }
+.pt-bar { height: 3px; border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); overflow: hidden; margin-top: 2px; }
 .pt-bar-fill { height: 100%; background: var(--cc-accent); transition: width 0.3s; }
 
-.pt-hint { font-size: 0.68rem; color: var(--cc-text-dim); margin: 0.55rem 0 0; }
+.pt-hint { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); margin: 0.55rem 0 0; }
 </style>

--- a/frontend/src/components/ProjectPanel.vue
+++ b/frontend/src/components/ProjectPanel.vue
@@ -501,7 +501,7 @@ const typeColour: Record<ProjectType, string> = {
 }
 .pp-tab {
   background: none; border: none; cursor: pointer;
-  font-size: 0.8rem; font-weight: 500;
+  font-size: var(--cc-fs-md); font-weight: 500;
   color: var(--cc-text-dim);
   padding: 0.55rem 1rem;
   display: flex; align-items: center; gap: 0.4rem;
@@ -518,14 +518,14 @@ const typeColour: Record<ProjectType, string> = {
   display: flex; flex-direction: column; align-items: center;
   justify-content: center; gap: 0.75rem;
   padding: 3rem 1rem;
-  color: var(--cc-text-dim); font-size: 0.85rem;
+  color: var(--cc-text-dim); font-size: var(--cc-fs-md);
 }
 .pp-empty p { margin: 0; }
 
 /* project table */
-.proj-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+.proj-table { width: 100%; border-collapse: collapse; font-size: var(--cc-fs-md); }
 .proj-table thead th {
-  text-align: left; font-size: 0.68rem; font-weight: 600;
+  text-align: left; font-size: var(--cc-fs-xs); font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.06em;
   color: var(--cc-text-dim);
   padding: 0.4rem 0.75rem;
@@ -542,7 +542,7 @@ const typeColour: Record<ProjectType, string> = {
 /* small square row-action button (export, cancel) — matches ConfirmDeleteButton's footprint */
 .pp-row-btn {
   background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); padding: 0.2rem 0.3rem; border-radius: 0.25rem;
+  color: var(--cc-text-dim); padding: 0.2rem 0.3rem; border-radius: var(--cc-radius-xs);
   transition: color 0.1s, background 0.1s;
 }
 .pp-row-btn:hover:not(:disabled) { color: var(--cc-accent); background: var(--cc-surface-2); }
@@ -555,37 +555,37 @@ const typeColour: Record<ProjectType, string> = {
 }
 /* live export/import progress — standalone below the footer, so it needs its own top separator */
 .pp-io-live { border-top: 1px solid var(--cc-border); }
-.pp-io-hint { margin: 0; font-size: 0.72rem; }
-.pp-io-hint .pi { font-size: 0.7rem; }
-.pp-conflict { padding: 1rem 1.25rem; font-size: 0.85rem; color: var(--cc-text); }
+.pp-io-hint { margin: 0; font-size: var(--cc-fs-sm); }
+.pp-io-hint .pi { font-size: var(--cc-fs-xs); }
+.pp-conflict { padding: 1rem 1.25rem; font-size: var(--cc-fs-md); color: var(--cc-text); }
 .pp-conflict p { margin: 0 0 0.6rem; }
-.pp-conflict code { font-family: var(--cc-mono); font-size: 0.75rem; background: var(--cc-surface-2); padding: 0.05rem 0.3rem; border-radius: 0.2rem; }
-.pp-conflict-opts { margin: 0; padding-left: 1.1rem; color: var(--cc-text-dim); font-size: 0.8rem; }
+.pp-conflict code { font-family: var(--cc-mono); font-size: var(--cc-fs-sm); background: var(--cc-surface-2); padding: 0.05rem 0.3rem; border-radius: var(--cc-radius-xs); }
+.pp-conflict-opts { margin: 0; padding-left: 1.1rem; color: var(--cc-text-dim); font-size: var(--cc-fs-md); }
 .pp-conflict-opts li { margin: 0.2rem 0; }
 
-.pp-io-dest { display: flex; gap: 0.4rem; align-items: center; font-size: 0.75rem; flex-wrap: wrap; }
+.pp-io-dest { display: flex; gap: 0.4rem; align-items: center; font-size: var(--cc-fs-sm); flex-wrap: wrap; }
 .pp-io-destpath {
-  font-family: var(--cc-mono); font-size: 0.7rem; color: var(--cc-text);
-  background: var(--cc-surface-2); padding: 0.1rem 0.35rem; border-radius: 0.2rem;
+  font-family: var(--cc-mono); font-size: var(--cc-fs-xs); color: var(--cc-text);
+  background: var(--cc-surface-2); padding: 0.1rem 0.35rem; border-radius: var(--cc-radius-xs);
   max-width: 60%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   margin-right: auto;   /* push the Change button to the row's right edge (aligns with Import below) */
 }
 .pp-io-import { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }
-.pp-io-select { flex: 1 1 180px; font-size: 0.78rem; }
-.pp-io-path { flex: 2 1 180px; font-size: 0.78rem; }
+.pp-io-select { flex: 1 1 180px; font-size: var(--cc-fs-sm); }
+.pp-io-path { flex: 2 1 180px; font-size: var(--cc-fs-sm); }
 .pp-io-status {
   display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
-  font-size: 0.75rem; color: var(--cc-text-dim);
+  font-size: var(--cc-fs-sm); color: var(--cc-text-dim);
 }
 .pp-io-label { color: var(--cc-text); font-weight: 500; }
-.pp-io-state { text-transform: uppercase; font-size: 0.62rem; font-weight: 700; letter-spacing: 0.05em; }
+.pp-io-state { text-transform: uppercase; font-size: var(--cc-fs-2xs); font-weight: 700; letter-spacing: 0.05em; }
 .pp-io-status.done  .pp-io-state { color: #34d399; }
 .pp-io-status.failed .pp-io-state, .pp-io-status.cancelled .pp-io-state { color: #fca5a5; }
-.pp-io-bar { flex: 0 0 90px; height: 4px; border-radius: 2px; background: var(--cc-surface-2); overflow: hidden; }
+.pp-io-bar { flex: 0 0 90px; height: 4px; border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); overflow: hidden; }
 .pp-io-fill { height: 100%; background: var(--cc-accent); transition: width 0.2s; }
 .pp-io-log {
   flex: 1 1 100%; min-width: 0;
-  font-family: var(--cc-mono); font-size: 0.68rem; opacity: 0.75;
+  font-family: var(--cc-mono); font-size: var(--cc-fs-xs); opacity: 0.75;
   white-space: normal; word-break: break-all; user-select: text;   /* show full path, selectable */
 }
 
@@ -601,37 +601,37 @@ const typeColour: Record<ProjectType, string> = {
 
 .proj-name { color: var(--cc-text); font-weight: 500; margin-right: 0.4rem; }
 .open-badge {
-  font-size: 0.62rem; font-weight: 700; text-transform: uppercase;
-  padding: 0.05rem 0.35rem; border-radius: 0.2rem;
+  font-size: var(--cc-fs-2xs); font-weight: 700; text-transform: uppercase;
+  padding: 0.05rem 0.35rem; border-radius: var(--cc-radius-xs);
   background: #a78bfa22; color: var(--cc-accent);
   border: 1px solid #a78bfa44;
 }
-.type-badge { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; }
-.dim { color: var(--cc-text-dim); font-size: 0.78rem; }
+.type-badge { font-size: var(--cc-fs-sm); font-weight: 600; text-transform: uppercase; }
+.dim { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
 
 /* form */
 .pp-form { padding: 1.25rem 1.5rem; display: flex; flex-direction: column; gap: 1.25rem; }
 
 .form-row { display: flex; flex-direction: column; gap: 0.35rem; }
 .form-label {
-  font-size: 0.78rem; font-weight: 600;
+  font-size: var(--cc-fs-sm); font-weight: 600;
   color: var(--cc-text); cursor: default;
 }
 /* visual styling from the global form base (style.css) */
 .form-input.input-error { border-color: #ef4444; }
 .form-input::placeholder { color: var(--cc-text-dim); }
 
-.field-error { font-size: 0.75rem; color: #fca5a5; }
+.field-error { font-size: var(--cc-fs-sm); color: #fca5a5; }
 .field-hint {
-  font-size: 0.72rem; color: var(--cc-text-dim);
+  font-size: var(--cc-fs-sm); color: var(--cc-text-dim);
   display: flex; align-items: center; gap: 0.3rem;
 }
 .dir-hint {
   font-family: var(--cc-mono);
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   background: var(--cc-surface-2);
   padding: 0.1rem 0.35rem;
-  border-radius: 0.2rem;
+  border-radius: var(--cc-radius-xs);
   color: var(--cc-text);
 }
 
@@ -646,8 +646,8 @@ const typeColour: Record<ProjectType, string> = {
 
 /* buttons use the global .cc-btn utilities (style.css) */
 .pp-danger-note {
-  color: #fca5a5; font-size: 0.78rem; display: flex; gap: 0.4rem; align-items: flex-start;
-  margin-top: 0.6rem; padding: 0.4rem 0.55rem; border-radius: 0.3rem;
+  color: #fca5a5; font-size: var(--cc-fs-sm); display: flex; gap: 0.4rem; align-items: flex-start;
+  margin-top: 0.6rem; padding: 0.4rem 0.55rem; border-radius: var(--cc-radius-sm);
   background: #b91c1c1a; border: 1px solid #b91c1c44;
 }
 </style>

--- a/frontend/src/components/RangeSlider.vue
+++ b/frontend/src/components/RangeSlider.vue
@@ -79,21 +79,21 @@ function onTrackDown(e: PointerEvent) {
   position: absolute;
   left: 0; right: 0;
   height: 3px;
-  border-radius: 2px;
+  border-radius: var(--cc-radius-xs);
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-border);
 }
 .rs-fill {
   position: absolute;
   height: 3px;
-  border-radius: 2px;
+  border-radius: var(--cc-radius-xs);
   background: var(--cc-accent);
 }
 .rs-thumb {
   position: absolute;
   width: 11px;
   height: 11px;
-  border-radius: 50%;
+  border-radius: var(--cc-radius-pill);
   background: var(--cc-accent);
   border: 1px solid var(--cc-bg);
   transform: translateX(-50%);

--- a/frontend/src/components/SetBar.vue
+++ b/frontend/src/components/SetBar.vue
@@ -177,7 +177,7 @@ async function deleteSet() {
 .set-selector { display: flex; align-items: center; gap: 0.5rem; }
 .set-uid {
   font-family: var(--cc-mono);
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   color: var(--cc-text-dim);
   letter-spacing: 0.03em;
 }
@@ -186,14 +186,14 @@ async function deleteSet() {
   border: none;
   cursor: pointer;
   color: var(--cc-text-dim);
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   padding: 0.2rem 0.35rem;
-  border-radius: 0.25rem;
+  border-radius: var(--cc-radius-xs);
   line-height: 1;
 }
 .set-uid-copy:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 .set-label {
-  font-size: 0.75rem; font-weight: 600; color: var(--cc-text-dim);
+  font-size: var(--cc-fs-sm); font-weight: 600; color: var(--cc-text-dim);
   text-transform: uppercase; letter-spacing: 0.06em; cursor: default;
 }
 /* visual styling from the global form base (style.css) */
@@ -201,6 +201,6 @@ async function deleteSet() {
 .set-select:disabled { opacity: 0.4; cursor: not-allowed; }
 .set-name-input { width: 180px; border-color: var(--cc-accent); }
 .spacer { flex: 1; }
-.confirm-text { font-size: 0.82rem; color: var(--cc-text-dim); }
+.confirm-text { font-size: var(--cc-fs-md); color: var(--cc-text-dim); }
 /* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/components/StillOverlay.vue
+++ b/frontend/src/components/StillOverlay.vue
@@ -55,7 +55,7 @@ const barY = computed(() => ey.value - my.value - barH.value)
 /* timestamp: white with a dark outline (four text-shadows ≈ SVG paint-order stroke) so it reads on any
    background, matching the channel legend's on-image styling (.is-legend). */
 .ovl-ts { position: absolute; top: 5px; left: 6px; color: #fff; font-weight: 700; line-height: 1;
-  font-family: system-ui, sans-serif; font-size: 11px;
+  font-family: system-ui, sans-serif; font-size: var(--cc-fs-xs);
   text-shadow: -1px -1px 0 rgba(0,0,0,0.85), 1px -1px 0 rgba(0,0,0,0.85),
                -1px 1px 0 rgba(0,0,0,0.85), 1px 1px 0 rgba(0,0,0,0.85); }
 /* white with a dark outline so it reads on any background (like napari's overlays) */

--- a/frontend/src/components/SwatchSelect.vue
+++ b/frontend/src/components/SwatchSelect.vue
@@ -43,21 +43,21 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDoc))
 <style scoped>
 .ss { position: relative; min-width: 150px; }
 .ss-btn { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left;
-  font-size: 0.8rem; color: var(--cc-text); background: var(--cc-surface-2);
-  border: 1px solid var(--cc-border); border-radius: 0.4rem; padding: 0.32rem 0.5rem; cursor: pointer; }
+  font-size: var(--cc-fs-md); color: var(--cc-text); background: var(--cc-surface-2);
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); padding: 0.32rem 0.5rem; cursor: pointer; }
 .ss-btn:hover { border-color: #484f58; }
 .ss.open .ss-btn { border-color: var(--cc-accent); }
 .ss-lbl { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ss-caret { font-size: 0.6rem; opacity: 0.6; }
+.ss-caret { font-size: var(--cc-fs-2xs); opacity: 0.6; }
 /* swatch — same size/shape as .cby-swatch */
-.ss-sw { width: 0.8rem; height: 0.8rem; border-radius: 2px; flex-shrink: 0; border: 1px solid var(--cc-border); }
+.ss-sw { width: 0.8rem; height: 0.8rem; border-radius: var(--cc-radius-xs); flex-shrink: 0; border: 1px solid var(--cc-border); }
 .ss-sw.none { background: repeating-linear-gradient(45deg, transparent, transparent 2px, var(--cc-text-dim) 2px, var(--cc-text-dim) 3px); }
 .ss-menu { position: absolute; z-index: 40; left: 0; right: 0; top: calc(100% + 2px); margin: 0; padding: 3px;
   list-style: none; max-height: 220px; overflow: auto; background: var(--cc-surface-1);
-  border: 1px solid var(--cc-border); border-radius: 0.4rem; box-shadow: 0 6px 18px rgba(0,0,0,0.4); }
-.ss-opt { display: flex; align-items: center; gap: 6px; padding: 0.28rem 0.4rem; border-radius: 0.3rem;
-  font-size: 0.8rem; cursor: pointer; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); box-shadow: 0 6px 18px rgba(0,0,0,0.4); }
+.ss-opt { display: flex; align-items: center; gap: 6px; padding: 0.28rem 0.4rem; border-radius: var(--cc-radius-sm);
+  font-size: var(--cc-fs-md); cursor: pointer; }
 .ss-opt:hover { background: var(--cc-surface-2); }
 .ss-opt.sel { color: var(--cc-text); }
-.ss-check { font-size: 0.6rem; color: var(--cc-accent); }
+.ss-check { font-size: var(--cc-fs-2xs); color: var(--cc-accent); }
 </style>

--- a/frontend/src/components/TeleportPopover.vue
+++ b/frontend/src/components/TeleportPopover.vue
@@ -94,7 +94,7 @@ onBeforeUnmount(() => {
   z-index: 1000;
   background: var(--cc-surface-1);
   border: 1px solid var(--cc-border);
-  border-radius: 6px;
+  border-radius: var(--cc-radius-md);
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
   color: var(--cc-text);
 }

--- a/frontend/src/components/ViewLegend.vue
+++ b/frontend/src/components/ViewLegend.vue
@@ -33,5 +33,5 @@ withDefaults(defineProps<{ sections: LegendSection[]; swatch?: number; vertical?
 /* vertical: one item per line (channel names stacked), left-aligned */
 .vl-items.vertical { flex-direction: column; flex-wrap: nowrap; align-items: flex-start; gap: 1px; }
 .vl-item { display: inline-flex; align-items: center; gap: 4px; font-size: 0.9em; white-space: nowrap; }
-.vl-swatch { border-radius: 2px; flex-shrink: 0; border: 1px solid rgba(128, 128, 128, 0.4); }
+.vl-swatch { border-radius: var(--cc-radius-xs); flex-shrink: 0; border: 1px solid rgba(128, 128, 128, 0.4); }
 </style>

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -774,18 +774,18 @@ onUnmounted(() => {
   gap: 0.35rem;
   padding: 0.28rem 0.4rem;
   border: 1px solid var(--cc-warn);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   background: color-mix(in srgb, var(--cc-warn) 14%, transparent);
   color: var(--cc-warn);
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
 }
 .viewer-stale-txt { flex: 1; min-width: 0; }
 .viewer-stale-btn {
   flex-shrink: 0;
-  font-size: 0.66rem;
+  font-size: var(--cc-fs-xs);
   font-weight: 600;
   padding: 0.15rem 0.45rem;
-  border-radius: 0.25rem;
+  border-radius: var(--cc-radius-xs);
   border: 1px solid var(--cc-warn);
   background: none;
   color: var(--cc-warn);
@@ -799,9 +799,9 @@ onUnmounted(() => {
   gap: 0.35rem;
   min-width: 0;
 }
-.viewer-eye { font-size: 0.72rem; color: #f97316; flex-shrink: 0; }
+.viewer-eye { font-size: var(--cc-fs-sm); color: #f97316; flex-shrink: 0; }
 .viewer-name {
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text);
   white-space: nowrap;
   overflow: hidden;
@@ -809,31 +809,31 @@ onUnmounted(() => {
 }
 
 /* visual styling from the global form base (style.css) */
-.viewer-select { width: 100%; font-size: 0.72rem; }
+.viewer-select { width: 100%; font-size: var(--cc-fs-sm); }
 /* colour-by dropdown: full width on its own line (the sidebar is narrow, so inline it clipped) */
-.opt-colourby { font-size: 0.7rem; width: 100%; min-width: 0; }
+.opt-colourby { font-size: var(--cc-fs-xs); width: 100%; min-width: 0; }
 /* movie recording params — one compact row: fps slider · res slider · record button */
 .movie-row { display: flex; align-items: center; gap: 0.3rem; }
-.movie-lbl { font-size: 0.6rem; color: var(--cc-text-dim); flex-shrink: 0; text-transform: uppercase; letter-spacing: 0.04em; }
+.movie-lbl { font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); flex-shrink: 0; text-transform: uppercase; letter-spacing: 0.04em; }
 .movie-range { flex: 1; min-width: 2.5rem; accent-color: #7c3aed; }
-.movie-val { font-size: 0.64rem; color: var(--cc-text); width: 1.4rem; text-align: right; flex-shrink: 0; font-variant-numeric: tabular-nums; }
+.movie-val { font-size: var(--cc-fs-2xs); color: var(--cc-text); width: 1.4rem; text-align: right; flex-shrink: 0; font-variant-numeric: tabular-nums; }
 .movie-rec { margin-left: 0.1rem; }
 .movie-title-row { margin-top: 0.25rem; }
 .movie-title-toggle { display: inline-flex; align-items: center; gap: 0.25rem; cursor: pointer; text-transform: none; letter-spacing: 0; }
-.movie-note { flex: 2; min-width: 3rem; font-size: 0.64rem; padding: 1px 4px;
-  border: 1px solid var(--cc-border); border-radius: 3px; background: var(--cc-surface-1); color: var(--cc-text); }
+.movie-note { flex: 2; min-width: 3rem; font-size: var(--cc-fs-2xs); padding: 1px 4px;
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); color: var(--cc-text); }
 
 /* colour-by legend: value → swatch (a population's colour where one matches, else default) */
 .cby-legend { display: flex; flex-wrap: wrap; gap: 0.15rem 0.5rem; margin-top: 0.25rem; }
-.cby-item { display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.66rem; color: var(--cc-text-dim); }
-.cby-swatch { width: 0.7rem; height: 0.7rem; border-radius: 2px; flex-shrink: 0; border: 1px solid var(--cc-border); }
+.cby-item { display: inline-flex; align-items: center; gap: 0.25rem; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.cby-swatch { width: 0.7rem; height: 0.7rem; border-radius: var(--cc-radius-xs); flex-shrink: 0; border: 1px solid var(--cc-border); }
 /* editable swatch: a native colour input squeezed to swatch size (categories with no population) */
 .cby-swatch-edit { padding: 0; cursor: pointer; background: none; -webkit-appearance: none; appearance: none; }
 .cby-swatch-edit::-webkit-color-swatch-wrapper { padding: 0; }
-.cby-swatch-edit::-webkit-color-swatch { border: none; border-radius: 2px; }
-.cby-swatch-edit::-moz-color-swatch { border: none; border-radius: 2px; }
+.cby-swatch-edit::-webkit-color-swatch { border: none; border-radius: var(--cc-radius-xs); }
+.cby-swatch-edit::-moz-color-swatch { border: none; border-radius: var(--cc-radius-xs); }
 .cby-reset {
-  font-size: 0.6rem; color: var(--cc-text-dim); background: none; border: none; cursor: pointer;
+  font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); background: none; border: none; cursor: pointer;
   padding: 0 0.2rem; text-decoration: underline; align-self: center;
 }
 .cby-reset:hover { color: var(--cc-text); }
@@ -852,7 +852,7 @@ onUnmounted(() => {
 /* the top section (View) sits flush against the panel top — no leading divider */
 .viewer-section.first { padding-top: 0; border-top: none; }
 .viewer-section-title {
-  font-size: 0.6rem;
+  font-size: var(--cc-fs-2xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -860,7 +860,7 @@ onUnmounted(() => {
 }
 
 .viewer-hint {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
 }
 
@@ -876,12 +876,12 @@ onUnmounted(() => {
   min-width: 0;
 }
 .viewer-label-icon {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-accent);
   flex-shrink: 0;
 }
 .viewer-label-name {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   flex: 1;
   white-space: nowrap;
@@ -912,12 +912,12 @@ onUnmounted(() => {
   justify-content: center;
   width: 1.8rem;
   height: 1.8rem;
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   border: 1px solid var(--cc-border);
   background: var(--cc-surface-2);
   color: var(--cc-text-dim);
   cursor: pointer;
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   line-height: 1;
   transition: background 0.1s, color 0.1s, border-color 0.1s;
   flex-shrink: 0;
@@ -927,7 +927,7 @@ onUnmounted(() => {
 .opt-btn.active:hover { background: #3b2382; }
 
 .opt-text {
-  font-size: 0.6rem;
+  font-size: var(--cc-fs-2xs);
   font-weight: 700;
   letter-spacing: 0.03em;
   line-height: 1;

--- a/frontend/src/components/canvas/CanvasPanel.vue
+++ b/frontend/src/components/canvas/CanvasPanel.vue
@@ -134,7 +134,7 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
 <style scoped>
 /* free-floating, draggable + resizable box */
 .panel { position: absolute; display: flex; flex-direction: column; border: 1px solid var(--cc-border);
-  border-radius: 6px; background: var(--cc-surface-1); overflow: hidden; box-shadow: 0 4px 18px rgba(0,0,0,0.35);
+  border-radius: var(--cc-radius-md); background: var(--cc-surface-1); overflow: hidden; box-shadow: 0 4px 18px rgba(0,0,0,0.35);
   width: 460px; height: 440px; min-width: 340px; min-height: 320px; resize: both; z-index: 5;
   transition: border-color 0.12s, box-shadow 0.12s; }
 .panel.active { border-color: var(--cc-selected); box-shadow: 0 0 0 1px var(--cc-selected), 0 6px 22px rgba(0,0,0,0.45); z-index: 6; }
@@ -147,13 +147,13 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
 .panel-head { display: flex; align-items: center; gap: 8px; padding: 5px 8px; cursor: move;
   border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2); }
 /* min-width:0 lets the title shrink; the text span truncates so it never shoves the head buttons */
-.panel-title { display: inline-flex; align-items: center; gap: 5px; font-weight: 700; font-size: 12px;
+.panel-title { display: inline-flex; align-items: center; gap: 5px; font-weight: 700; font-size: var(--cc-fs-sm);
   letter-spacing: 0.02em; user-select: none; min-width: 0; }
 .panel-title-txt { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
-.drag-icon { font-size: 10px; opacity: 0.55; flex: none; }
+.drag-icon { font-size: var(--cc-fs-2xs); opacity: 0.55; flex: none; }
 /* docked panels: the drag icon IS the reorder handle (in-flow in the header → aligned with the other
    buttons, no absolute overlay to collide with the pin). Its native dragstart bubbles to the board slot. */
-.drag-icon.grip { cursor: grab; font-size: 12px; opacity: 0.7; padding: 2px; margin: -2px 0; }
+.drag-icon.grip { cursor: grab; font-size: var(--cc-fs-sm); opacity: 0.7; padding: 2px; margin: -2px 0; }
 .drag-icon.grip:active { cursor: grabbing; }
 .panel-spacer { flex: 1; }
 /* main region below the head: the anchor for the auto-hide control overlays (position: relative) and
@@ -170,8 +170,8 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
 .panel-foot.inflow { border-top: 1px solid var(--cc-border); background: var(--cc-surface-2); flex-shrink: 0; }
 .ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
 .panel-btn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-1); color: var(--cc-text-dim);
-  cursor: pointer; font-size: 0.7rem; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1); color: var(--cc-text-dim);
+  cursor: pointer; font-size: var(--cc-fs-xs); }
 .panel-btn:hover { color: var(--cc-text); border-color: #484f58; }
 .panel-btn.on { color: var(--cc-text); border-color: var(--cc-accent); }
 .panel-remove:hover { color: #f87171; border-color: #f87171; }

--- a/frontend/src/components/canvas/CanvasZoomControl.vue
+++ b/frontend/src/components/canvas/CanvasZoomControl.vue
@@ -23,12 +23,12 @@ const pct = () => Math.round(props.zoom * 100)
 
 <style scoped>
 .cz { display: inline-flex; align-items: center; gap: 4px; border: 1px solid var(--cc-border);
-  border-radius: 5px; padding: 1px 4px; background: var(--cc-surface-2); }
+  border-radius: var(--cc-radius-sm); padding: 1px 4px; background: var(--cc-surface-2); }
 .cz-btn { display: inline-flex; align-items: center; justify-content: center; width: 1.4rem; height: 1.4rem;
-  background: transparent; color: var(--cc-text-dim); border: none; cursor: pointer; font-size: 0.72rem; }
+  background: transparent; color: var(--cc-text-dim); border: none; cursor: pointer; font-size: var(--cc-fs-sm); }
 .cz-btn:hover { color: var(--cc-text); }
 .cz-range { width: 6rem; }
 .cz-val { min-width: 2.6rem; text-align: center; background: transparent; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 11px; font-variant-numeric: tabular-nums; }
+  color: var(--cc-text-dim); font-size: var(--cc-fs-xs); font-variant-numeric: tabular-nums; }
 .cz-val:hover { color: var(--cc-text); }
 </style>

--- a/frontend/src/components/canvas/InteractivePanel.vue
+++ b/frontend/src/components/canvas/InteractivePanel.vue
@@ -57,10 +57,10 @@ defineExpose({ exportImage, exportSvg })
 </template>
 
 <style scoped>
-.ip-missing { padding: 1rem; color: var(--cc-text-dim); font-size: 0.85rem; }
+.ip-missing { padding: 1rem; color: var(--cc-text-dim); font-size: var(--cc-fs-md); }
 .ip-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: 0.7rem; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
+  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
 .ip-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
-.ip-export { font-size: 12px; max-width: 7rem; }
+.ip-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 </style>

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -568,34 +568,34 @@ defineExpose({ capturePage, collectCsvs })
 <style scoped>
 .layout-canvas { display: flex; flex-direction: column; }
 .lc-empty { padding: 20px; }   /* + .cc-muted */
-.lc-bar { display: flex; flex-direction: column; gap: 6px; padding: 8px 4px; font-size: 12px; flex-shrink: 0; }
+.lc-bar { display: flex; flex-direction: column; gap: 6px; padding: 8px 4px; font-size: var(--cc-fs-sm); flex-shrink: 0; }
 .lc-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 /* sits right after the sliders (NOT pushed to the far right) so it doesn't shift when the compare
    dropdown changes width (e.g. "by attribute" adds selects) */
 .lc-right { display: flex; align-items: center; gap: 10px; }
-.lc-lbl { color: var(--cc-text-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+.lc-lbl { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); text-transform: uppercase; letter-spacing: 0.04em; }
 .lc-sep { width: 1px; height: 1.4rem; background: var(--cc-border); }
 .lc-nm { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .lc-nm input[type="range"] { width: 5rem; }
 .lc-clust { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim);
-  padding: 2px 8px; border: 1px solid var(--cc-border); border-radius: 6px; }
-.lc-clust select { font-size: 11px; }
+  padding: 2px 8px; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); }
+.lc-clust select { font-size: var(--cc-fs-xs); }
 /* ⚙ grid-size / height popover */
 .lc-opts { position: relative; display: inline-flex; }
 .lc-gear { display: inline-flex; align-items: center; justify-content: center; width: 1.7rem; height: 1.6rem;
-  border: 1px solid var(--cc-border); border-radius: 5px; background: var(--cc-surface-2); color: var(--cc-text-dim);
-  cursor: pointer; font-size: 0.72rem; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-2); color: var(--cc-text-dim);
+  cursor: pointer; font-size: var(--cc-fs-sm); }
 .lc-gear:hover, .lc-gear.on { color: var(--cc-text); border-color: #7c3aed; }
-.lc-custom { font-size: 11px; padding: 0.22rem 0.55rem; }
+.lc-custom { font-size: var(--cc-fs-xs); padding: 0.22rem 0.55rem; }
 .lc-custom.on { color: var(--cc-text); border-color: #7c3aed; }
 /* inner layout only — TeleportPopover provides surface/border/shadow/position */
 .lc-pop { min-width: 13rem; display: flex; flex-direction: column; gap: 8px; padding: 10px; }
-.lc-pop-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--cc-text-dim); }
+.lc-pop-row { display: flex; align-items: center; gap: 8px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
 .lc-pop-row span:first-child { width: 3rem; }
 .lc-pop-row input[type="range"] { flex: 1; }
 .lc-val { min-width: 0.9rem; text-align: center; font-weight: 700; color: var(--cc-text); }
 .lc-compare { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim);
-  padding: 2px 8px; border: 1px solid var(--cc-border); border-radius: 6px; }
+  padding: 2px 8px; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); }
 .lc-x { opacity: 0.6; }
 .lc-pool { display: flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 /* the board sizes to its grid (rowHeight × rows); the page's panel-scroll handles overflow */
@@ -605,11 +605,11 @@ defineExpose({ capturePage, collectCsvs })
 .lc-canvas-wrap { flex: 1; min-width: 0; overflow: auto; }
 .lc-zoom { display: block; }
 .lc-grid { flex: 1; display: grid; gap: 8px; padding: 4px; overflow: hidden; }
-.lc-slot { position: relative; border: 1px dashed var(--cc-border); border-radius: 6px; overflow: hidden;
+.lc-slot { position: relative; border: 1px dashed var(--cc-border); border-radius: var(--cc-radius-md); overflow: hidden;
   display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--cc-bg); }
 /* per-slot title (figure caption): a plain-looking, centred, editable line above the plot */
 .lc-slot-cap { flex: 0 0 auto; width: 100%; box-sizing: border-box; border: none; background: transparent;
-  color: var(--cc-text); font-size: 12px; font-weight: 600; text-align: center; padding: 3px 6px 1px; }
+  color: var(--cc-text); font-size: var(--cc-fs-sm); font-weight: 600; text-align: center; padding: 3px 6px 1px; }
 .lc-slot-cap::placeholder { color: var(--cc-text-dim); font-weight: 400; opacity: 0.55; }
 .lc-slot-cap:focus { outline: none; background: var(--cc-surface-2); }
 /* the plot area fills the rest of the slot (was the slot itself before the caption was added) */
@@ -623,7 +623,7 @@ defineExpose({ capturePage, collectCsvs })
 /* reorder drag handle now lives IN the panel header (CanvasPanel docked drag icon); its native
    dragstart bubbles to .lc-slot (@dragstart above). No absolute overlay grip here anymore. */
 .lc-add { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; }
-.lc-add-hint { color: var(--cc-text-dim); font-size: 11px; opacity: 0.6; }
+.lc-add-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); opacity: 0.6; }
 /* stick to the top of the scroll viewport so the pop manager stays reachable as the (tall) board
    scrolls past — otherwise you must scroll back up to change the selection. align-self so the sticky
    box hugs the top of the flex row; its own overflow-y scrolls a manager taller than the viewport. */

--- a/frontend/src/components/canvas/PlateBuilder.vue
+++ b/frontend/src/components/canvas/PlateBuilder.vue
@@ -92,23 +92,23 @@ function apply() { emit('apply', buildPlate(cols.value, rows.value, spans.value)
 <style scoped>
 .pb { display: flex; flex-direction: column; gap: 8px; width: 15rem; }
 .pb-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.pb-num { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: var(--cc-text-dim); }
-.pb-num input { width: 3rem; font-size: 12px; padding: 2px 4px; }
-.pb-hint { flex-basis: 100%; font-size: 10px; color: var(--cc-text-dim); opacity: 0.75; }
+.pb-num { display: inline-flex; align-items: center; gap: 4px; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.pb-num input { width: 3rem; font-size: var(--cc-fs-sm); padding: 2px 4px; }
+.pb-hint { flex-basis: 100%; font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); opacity: 0.75; }
 /* the plate canvas: an A4-portrait-ish aspect so the preview reads like a page */
 .pb-grid { position: relative; display: grid; gap: 3px; aspect-ratio: 0.78; width: 100%;
-  padding: 3px; background: var(--cc-border); border-radius: 5px; user-select: none; touch-action: none; }
-.pb-cell { background: var(--cc-surface-2); border-radius: 3px; cursor: crosshair; }
+  padding: 3px; background: var(--cc-border); border-radius: var(--cc-radius-sm); user-select: none; touch-action: none; }
+.pb-cell { background: var(--cc-surface-2); border-radius: var(--cc-radius-xs); cursor: crosshair; }
 .pb-cell:hover { background: var(--cc-surface-1); }
 /* a merged span: one contiguous block over the cells it covers (spanning a grid-area covers the
    internal gaps automatically); pointer-events none so a click passes through to the cell to split */
-.pb-span { pointer-events: none; z-index: 2; border-radius: 3px;
+.pb-span { pointer-events: none; z-index: 2; border-radius: var(--cc-radius-xs);
   background: color-mix(in srgb, var(--cc-accent) 30%, var(--cc-surface-2));
   border: 1px solid var(--cc-accent); }
 /* live drag highlight */
-.pb-drag { pointer-events: none; z-index: 3; border-radius: 3px;
+.pb-drag { pointer-events: none; z-index: 3; border-radius: var(--cc-radius-xs);
   background: color-mix(in srgb, var(--cc-accent) 22%, transparent); border: 1px dashed var(--cc-accent); }
 .pb-foot { display: flex; align-items: center; gap: 6px; }
-.pb-count { font-size: 11px; color: var(--cc-text-dim); }
+.pb-count { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
 .pb-spacer { flex: 1; }
 </style>

--- a/frontend/src/components/canvas/PlotOptions.vue
+++ b/frontend/src/components/canvas/PlotOptions.vue
@@ -127,15 +127,15 @@ const has = (s: string) => props.sections.includes(s as 'layout')
 <style scoped>
 .po { display: flex; flex-direction: column; }
 .po-toggle { display: flex; align-items: center; gap: 6px; width: 100%; background: none; border: none;
-  color: var(--cc-text-dim); cursor: pointer; padding: 6px 8px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+  color: var(--cc-text-dim); cursor: pointer; padding: 6px 8px; font-size: var(--cc-fs-xs); text-transform: uppercase; letter-spacing: 0.05em; }
 .po-toggle:hover { color: var(--cc-text); }
 .po-body { padding: 4px 10px 10px; display: flex; flex-direction: column; gap: 8px; }
-.po-row { display: flex; align-items: center; gap: 8px; color: var(--cc-text-dim); font-size: 11px; }
+.po-row { display: flex; align-items: center; gap: 8px; color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
 .po-row > span:first-child { flex: 1; }
 .po-row input[type="range"] { flex: 1; max-width: 110px; }
 .po-val { width: 2.2rem; text-align: right; font-variant-numeric: tabular-nums; }
-.po-sel { font-size: 11px; max-width: 7rem; }
-.po-txt { font-size: 11px; width: 4rem; padding: 1px 4px; }
+.po-sel { font-size: var(--cc-fs-xs); max-width: 7rem; }
+.po-txt { font-size: var(--cc-fs-xs); width: 4rem; padding: 1px 4px; }
 .po-txt.wide { width: 100%; }
 .po-col { flex-direction: column; align-items: stretch; gap: 3px; }
 .po-col > span:first-child { flex: none; }

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -339,7 +339,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
                   :style="popClusterIds(p).includes(id) ? { background: p.colour, borderColor: p.colour, color: '#111' } : {}"
                   v-tooltip.bottom="clusterOwner(id) && clusterOwner(id)?.path !== p.path ? `In “${clusterOwner(id)?.name}”` : ''"
                   @click.stop="!readonly && toggleCluster(p, id)">{{ id }}</button>
-          <span v-if="!props.clusterIds.length" class="pm-chip-empty">no clusters at this suffix</span>
+          <span v-if="!props.clusterIds.length" class="pm-chip-empty cc-empty-inline cc-muted-dense">no clusters at this suffix</span>
         </div>
       </template>
 
@@ -420,20 +420,20 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
 .pm-row:hover { background: var(--cc-surface-2); }
 .pm-row.active { background: color-mix(in srgb, var(--cc-accent) 22%, transparent); }
 .pm-row.transient { font-style: italic; background: color-mix(in srgb, #22d3ee 8%, transparent); }
-.pm-napari { width: 16px; text-align: center; font-size: 13px; }
-.pm-swatch { width: 16px; height: 16px; padding: 0; border: 1px solid var(--cc-border); border-radius: 3px; cursor: pointer; flex-shrink: 0; }
+.pm-napari { width: 16px; text-align: center; font-size: var(--cc-fs-md); }
+.pm-swatch { width: 16px; height: 16px; padding: 0; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); cursor: pointer; flex-shrink: 0; }
 .pm-swatch:disabled { cursor: default; opacity: 0.7; }
 /* colour picker popover (Cecelia palette + native custom) — TeleportPopover gives surface/border */
 .pm-colours { display: flex; flex-direction: column; gap: 8px; padding: 8px; }
 .pm-colours-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 5px; }
-.pm-colour-chip { width: 22px; height: 22px; border: 1px solid var(--cc-border); border-radius: 4px; cursor: pointer; padding: 0; }
+.pm-colour-chip { width: 22px; height: 22px; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); cursor: pointer; padding: 0; }
 .pm-colour-chip:hover { transform: scale(1.08); }
 .pm-colour-chip.on { outline: 2px solid var(--cc-text); outline-offset: 1px; }
 .pm-colour-custom { display: flex; align-items: center; justify-content: space-between; gap: 8px;
-  font-size: 12px; color: var(--cc-text-dim); border-top: 1px solid var(--cc-border); padding-top: 6px; }
+  font-size: var(--cc-fs-sm); color: var(--cc-text-dim); border-top: 1px solid var(--cc-border); padding-top: 6px; }
 .pm-colour-custom input { width: 28px; height: 20px; padding: 0; border: none; background: none; cursor: pointer; }
 .pm-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.pm-rename { flex: 1; background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-accent); border-radius: 3px; padding: 1px 4px; }
+.pm-rename { flex: 1; background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); padding: 1px 4px; }
 .pm-stat { color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
 .pm-stat small { opacity: 0.7; margin-left: 3px; }
 .pm-icon { background: none; border: none; color: var(--cc-text-dim); cursor: pointer; padding: 2px; }
@@ -443,8 +443,8 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
 
 /* ── cluster mode: add-pop bar + per-pop cluster-ID toggle chips ── */
 .pm-add { padding: 6px 8px; border-bottom: 1px solid var(--cc-border); }
-.pm-add-btn { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; padding: 4px 9px;
-  border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-2);
+.pm-add-btn { display: inline-flex; align-items: center; gap: 5px; font-size: var(--cc-fs-xs); padding: 4px 9px;
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-2);
   color: var(--cc-text); cursor: pointer; }
 .pm-add-btn:hover { border-color: #7c3aed; color: #c4b5fd; }
 .pm-add-btn:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -452,29 +452,29 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
 .pm-ff { display: flex; flex-direction: column; gap: 5px; padding: 6px 8px; border-bottom: 1px solid var(--cc-border);
   background: var(--cc-surface-1); }
 .pm-ff-head { display: flex; gap: 5px; align-items: center; }
-.pm-ff-name { flex: 1; font-size: 11px; padding: 3px 6px; border: 1px solid var(--cc-border); border-radius: 4px;
+.pm-ff-name { flex: 1; font-size: var(--cc-fs-xs); padding: 3px 6px; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs);
   background: var(--cc-surface-2); color: var(--cc-text); }
-.pm-ff-colour { width: 24px; height: 24px; padding: 0; border: 1px solid var(--cc-border); border-radius: 4px;
+.pm-ff-colour { width: 24px; height: 24px; padding: 0; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs);
   background: none; cursor: pointer; }
-.pm-ff-row, .pm-ff-cond { display: flex; gap: 4px; align-items: center; font-size: 11px; color: var(--cc-text-dim); }
-.pm-ff-cond select, .pm-ff-row select, .pm-ff-vals { font-size: 11px; padding: 2px 4px; border: 1px solid var(--cc-border);
-  border-radius: 3px; background: var(--cc-surface-2); color: var(--cc-text); }
+.pm-ff-row, .pm-ff-cond { display: flex; gap: 4px; align-items: center; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.pm-ff-cond select, .pm-ff-row select, .pm-ff-vals { font-size: var(--cc-fs-xs); padding: 2px 4px; border: 1px solid var(--cc-border);
+  border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); color: var(--cc-text); }
 .pm-ff-measure { flex: 1; min-width: 0; }
 .pm-ff-fun { width: 48px; }
 .pm-ff-vals { width: 64px; }
 .pm-ff-actions { display: flex; justify-content: space-between; align-items: center; }
-.pm-ff-cond-add { background: none; border: none; color: var(--cc-text-dim); font-size: 11px; cursor: pointer; padding: 2px; }
+.pm-ff-cond-add { background: none; border: none; color: var(--cc-text-dim); font-size: var(--cc-fs-xs); cursor: pointer; padding: 2px; }
 .pm-ff-cond-add:hover { color: var(--cc-text); }
-.pm-ff-title { font-size: 11px; font-weight: 600; color: var(--cc-text); }
+.pm-ff-title { font-size: var(--cc-fs-xs); font-weight: 600; color: var(--cc-text); }
 .pm-ff-spacer { flex: 1; }
-.pm-ff-cancel { background: none; border: none; color: var(--cc-text-dim); font-size: 11px; cursor: pointer; padding: 4px 6px; }
+.pm-ff-cancel { background: none; border: none; color: var(--cc-text-dim); font-size: var(--cc-fs-xs); cursor: pointer; padding: 4px 6px; }
 .pm-ff-cancel:hover { color: var(--cc-text); }
-.pm-filter-badge { font-size: 10px; color: #8b5cf6; margin-left: 2px; opacity: 0.8; }
+.pm-filter-badge { font-size: var(--cc-fs-2xs); color: #8b5cf6; margin-left: 2px; opacity: 0.8; }
 button.pm-filter-badge { border: none; background: none; cursor: pointer; padding: 2px; }
 button.pm-filter-badge:hover { opacity: 1; }
 .pm-clusters { display: flex; flex-wrap: wrap; gap: 3px; padding: 2px 8px 6px; border-bottom: 1px solid var(--cc-border); }
-.pm-chip { min-width: 1.4rem; height: 1.4rem; padding: 0 4px; font-size: 11px; line-height: 1;
-  border: 1px solid var(--cc-border); border-radius: 3px; background: var(--cc-surface-1);
+.pm-chip { min-width: 1.4rem; height: 1.4rem; padding: 0 4px; font-size: var(--cc-fs-xs); line-height: 1;
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-1);
   color: var(--cc-text-dim); cursor: pointer; font-variant-numeric: tabular-nums; transition: background 0.1s, color 0.1s, border-color 0.1s; }
 .pm-chip:hover { border-color: #7c3aed; color: var(--cc-text); }
 .pm-chip.on { font-weight: 700; }
@@ -482,15 +482,15 @@ button.pm-filter-badge:hover { opacity: 1; }
 .pm-chip.ro { cursor: default; }
 .pm-chip.ro:hover { border-color: var(--cc-border); color: var(--cc-text-dim); }
 .pm-chip.ro.on:hover { color: #111; }
-.pm-chip-empty { font-size: 10px; color: var(--cc-text-dim); font-style: italic; }
+.pm-chip-empty { font-style: italic; }   /* + .cc-empty-inline .cc-muted-dense (row/colour/10px tier) */
 
 /* segmented toggle (axis option in the #options slot; the shell owns the footer scope toggle) */
 .pm-seg { margin-left: auto; }
 .seg-btn {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 1.8rem; height: 1.8rem; border-radius: 0.3rem;
+  width: 1.8rem; height: 1.8rem; border-radius: var(--cc-radius-sm);
   border: 1px solid var(--cc-border); background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: 0.8rem; transition: background 0.1s, color 0.1s, border-color 0.1s;
+  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-md); transition: background 0.1s, color 0.1s, border-color 0.1s;
 }
 .seg-btn:hover { color: var(--cc-text); border-color: #484f58; }
 .seg-btn.active { background: #2d1b69; border-color: #7c3aed; color: #c4b5fd; }
@@ -498,16 +498,16 @@ button.pm-filter-badge:hover { opacity: 1; }
 /* ── extra options ── */
 .pm-opts { border-top: 1px solid var(--cc-border); }
 .pm-opts-toggle { display: flex; align-items: center; gap: 6px; width: 100%; background: none; border: none;
-  color: var(--cc-text-dim); cursor: pointer; padding: 6px 8px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+  color: var(--cc-text-dim); cursor: pointer; padding: 6px 8px; font-size: var(--cc-fs-xs); text-transform: uppercase; letter-spacing: 0.05em; }
 .pm-opts-toggle:hover { color: var(--cc-text); }
 .pm-opts-body { padding: 4px 10px 10px; display: flex; flex-direction: column; gap: 8px; }
 /* small section heading: ──── plot ──── */
 .pm-opt-head { display: flex; align-items: center; gap: 6px; margin-top: 2px;
-  color: var(--cc-text-dim); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; }
+  color: var(--cc-text-dim); font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.08em; }
 .pm-opt-head::before, .pm-opt-head::after { content: ""; flex: 1; height: 1px; background: var(--cc-border); }
 .pm-opt-head:first-child { margin-top: 0; }
 .pm-opt-row { display: flex; align-items: center; gap: 8px; }
-.pm-opt-label { color: var(--cc-text-dim); font-size: 11px; flex: 1; }
+.pm-opt-label { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); flex: 1; }
 .pm-opt-row input[type="range"] { flex: 1; max-width: 110px; }
-.pm-opt-val { color: var(--cc-text-dim); font-size: 11px; width: 1.8rem; text-align: right; font-variant-numeric: tabular-nums; }
+.pm-opt-val { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); width: 1.8rem; text-align: right; font-variant-numeric: tabular-nums; }
 </style>

--- a/frontend/src/components/canvas/PopulationPanelShell.vue
+++ b/frontend/src/components/canvas/PopulationPanelShell.vue
@@ -85,8 +85,8 @@ function onHeaderDown(e: MouseEvent) { if (!props.docked) startDrag(e) }
 .pop-manager {
   position: absolute; z-index: 20; width: 300px;
   background: var(--cc-surface-1); border: 1px solid var(--cc-border);
-  border-radius: 6px; box-shadow: 0 6px 24px rgba(0,0,0,0.4);
-  font-size: 12px; color: var(--cc-text); user-select: none;
+  border-radius: var(--cc-radius-md); box-shadow: 0 6px 24px rgba(0,0,0,0.4);
+  font-size: var(--cc-fs-sm); color: var(--cc-text); user-select: none;
 }
 /* docked: in-flow rail (no float/drag/shadow), fills its container column */
 .pop-manager.docked { position: static; z-index: auto; width: 100%; box-shadow: none; }
@@ -94,7 +94,7 @@ function onHeaderDown(e: MouseEvent) { if (!props.docked) startDrag(e) }
 .pm-header {
   display: flex; align-items: center; gap: 6px; padding: 6px 8px;
   cursor: move; border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2);
-  border-radius: 6px 6px 0 0;
+  border-radius: var(--cc-radius-md) 6px 0 0;
 }
 .pm-title { font-weight: 600; }
 .pm-count { color: var(--cc-text-dim); margin-left: auto; }

--- a/frontend/src/components/canvas/SeriesPicker.vue
+++ b/frontend/src/components/canvas/SeriesPicker.vue
@@ -64,16 +64,16 @@ const depthOf = (path: string) => Math.max(0, path.split('/').length - 2)
 .pm-empty { padding: 12px; }   /* + .cc-muted */
 .pm-group-head {
   padding: 5px 8px; background: var(--cc-surface-2); color: var(--cc-text-dim);
-  font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em;
+  font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.06em;
   border-bottom: 1px solid var(--cc-border); position: sticky; top: 0; z-index: 1;
 }
 .pm-row { display: flex; align-items: center; gap: 6px; padding: 4px 8px 4px 12px; cursor: pointer; border-bottom: 1px solid var(--cc-border); }
 .pm-row:hover { background: var(--cc-surface-2); }
 .pm-row.active { background: color-mix(in srgb, var(--cc-accent) 22%, transparent); }
-.pm-swatch { width: 14px; height: 14px; border-radius: 3px; flex-shrink: 0; border: 1px solid rgba(255,255,255,0.2); }
+.pm-swatch { width: 14px; height: 14px; border-radius: var(--cc-radius-xs); flex-shrink: 0; border: 1px solid rgba(255,255,255,0.2); }
 .pm-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.pm-tag { font-size: 9px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-text-dim);
-  border: 1px solid var(--cc-border); border-radius: 3px; padding: 0 3px; flex-shrink: 0; }
+.pm-tag { font-size: var(--cc-fs-3xs); text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-text-dim);
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); padding: 0 3px; flex-shrink: 0; }
 .pm-icon { background: none; border: none; color: var(--cc-text-dim); cursor: pointer; padding: 2px; }
 .pm-icon:hover { color: var(--cc-text); }
 .pm-icon.lit { color: var(--cc-accent); }

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -200,19 +200,19 @@ watch(segPops, () => {
 <style scoped>
 .summary-canvas { display: flex; flex-direction: column; height: 100%; min-height: 80vh; }
 .sc-empty { padding: 20px; }   /* + .cc-muted */
-.sc-bar { display: flex; align-items: center; gap: 12px; padding: 8px 4px; font-size: 12px; flex-shrink: 0; flex-wrap: wrap; }
+.sc-bar { display: flex; align-items: center; gap: 12px; padding: 8px 4px; font-size: var(--cc-fs-sm); flex-shrink: 0; flex-wrap: wrap; }
 .sc-bar label { display: flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .sc-add { min-width: 8rem; }
 /* compare cluster: one tight group so the mode + attribute selects read as a unit */
 .sc-compare { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim);
-  padding: 2px 8px; border: 1px solid var(--cc-border); border-radius: 6px; }
-.sc-lbl { font-size: 11px; opacity: 0.8; }
+  padding: 2px 8px; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); }
+.sc-lbl { font-size: var(--cc-fs-xs); opacity: 0.8; }
 .sc-cmp { min-width: 8rem; }
 .sc-attr { min-width: 5.5rem; max-width: 8rem; }   /* short attribute names — no need for 9rem */
 .sc-x { opacity: 0.6; }
-.sc-hint { color: var(--cc-text-dim); font-size: 11px; opacity: 0.7; margin-left: auto; }
-.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
-.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 5px 9px; cursor: pointer; font-size: 12px; }
+.sc-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); opacity: 0.7; margin-left: auto; }
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 5px 9px; cursor: pointer; font-size: var(--cc-fs-sm); }
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button:hover { color: var(--cc-text); }
 .seg button.on { color: var(--cc-accent); background: var(--cc-surface-1); }

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -657,14 +657,14 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
 </template>
 
 <style scoped>
-.sp-measure { font-size: 12px; max-width: 12rem; }
-.sp-chart { font-size: 12px; max-width: 8rem; }
-.sp-export { font-size: 12px; max-width: 7rem; }
+.sp-measure { font-size: var(--cc-fs-sm); max-width: 12rem; }
+.sp-chart { font-size: var(--cc-fs-sm); max-width: 8rem; }
+.sp-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 
 /* compact icon buttons (options / duplicate) */
 .sp-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: 0.7rem; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
+  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
 .sp-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
 .sp-iconbtn.on { color: var(--cc-text); border-color: var(--cc-accent); }
 
@@ -672,9 +672,9 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
 .sp-explode-wrap { position: relative; display: inline-flex; }
 .sp-explode-pop { position: absolute; bottom: calc(100% + 6px); right: 0; z-index: 30;
   min-width: 13rem; max-height: 60vh; overflow-y: auto; padding: 8px;
-  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 0.4rem;
-  box-shadow: 0 6px 18px rgba(0,0,0,0.35); font-size: 12px; }
-.sp-explode-hd { color: var(--cc-text-dim); font-size: 11px; margin-bottom: 6px; }
+  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md);
+  box-shadow: 0 6px 18px rgba(0,0,0,0.35); font-size: var(--cc-fs-sm); }
+.sp-explode-hd { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); margin-bottom: 6px; }
 .sp-explode-row { display: flex; align-items: center; gap: 6px; padding: 2px 0; color: var(--cc-text); cursor: pointer; }
 .sp-explode-ft { display: flex; justify-content: flex-end; gap: 6px; margin-top: 8px; }
 
@@ -687,10 +687,10 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
 /* inner layout only — TeleportPopover provides surface/border/shadow/position */
 .sp-pop { min-width: 11rem; display: flex; flex-direction: column; gap: 6px; padding: 8px; }
 .sp-pop-row { display: flex; align-items: center; justify-content: space-between; gap: 8px;
-  font-size: 12px; color: var(--cc-text-dim); }
-.sp-pop-row select { font-size: 12px; max-width: 7rem; }
-.sp-pop-row input[type="number"] { width: 3.6rem; font-size: 12px; padding: 2px 4px; }
+  font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.sp-pop-row select { font-size: var(--cc-fs-sm); max-width: 7rem; }
+.sp-pop-row input[type="number"] { width: 3.6rem; font-size: var(--cc-fs-sm); padding: 2px 4px; }
 .sp-body { position: relative; flex: 1; min-height: 200px; padding: 8px; overflow: hidden; }
-.sp-msg { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--cc-text-dim); font-size: 12px; text-align: center; padding: 12px; }
+.sp-msg { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); text-align: center; padding: 12px; }
 .sp-err { color: var(--cc-danger, #f87171); }
 </style>

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -251,34 +251,34 @@ function exportBoard(kind: string) {
 }
 .tab {
   display: inline-flex; align-items: center; gap: 6px;
-  padding: 5px 10px; font-size: 12px; cursor: pointer; user-select: none;
+  padding: 5px 10px; font-size: var(--cc-fs-sm); cursor: pointer; user-select: none;
   color: var(--cc-text-dim); background: var(--cc-surface-1);
   border: 1px solid var(--cc-border); border-bottom: none;
-  border-radius: 6px 6px 0 0; max-width: 16rem;
+  border-radius: var(--cc-radius-md) 6px 0 0; max-width: 16rem;
 }
 .tab:hover { color: var(--cc-text); }
 .tab.active { color: var(--cc-text); background: var(--cc-bg); border-color: #7c3aed; }
 .tab-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.tab-edit { font-size: 12px; width: 8rem; background: var(--cc-surface-2); color: var(--cc-text);
-  border: 1px solid #7c3aed; border-radius: 3px; padding: 1px 4px; }
+.tab-edit { font-size: var(--cc-fs-sm); width: 8rem; background: var(--cc-surface-2); color: var(--cc-text);
+  border: 1px solid #7c3aed; border-radius: var(--cc-radius-xs); padding: 1px 4px; }
 .tab-close {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 1rem; height: 1rem; border: none; border-radius: 3px;
-  background: transparent; color: var(--cc-text-dim); cursor: pointer; font-size: 0.6rem;
+  width: 1rem; height: 1rem; border: none; border-radius: var(--cc-radius-xs);
+  background: transparent; color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-2xs);
 }
 .tab-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 .tab-add {
   display: inline-flex; align-items: center; justify-content: center;
   width: 1.8rem; border: none; background: transparent; color: var(--cc-text-dim);
-  cursor: pointer; font-size: 0.75rem; margin-left: 2px;
+  cursor: pointer; font-size: var(--cc-fs-sm); margin-left: 2px;
 }
 .tab-add:hover { color: var(--cc-text); }
 .tab-pdf { display: inline-flex; align-items: center; gap: 5px; margin-left: auto; margin-bottom: 2px;
-  padding: 3px 10px; font-size: 11px; border: 1px solid var(--cc-border); border-radius: 5px;
+  padding: 3px 10px; font-size: var(--cc-fs-xs); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm);
   background: var(--cc-surface-1); color: var(--cc-text-dim); cursor: pointer; }
 .tab-pdf:hover:not(:disabled) { color: var(--cc-text); border-color: #7c3aed; }
 .tab-pdf:disabled { opacity: 0.5; cursor: default; }
 /* info hint for the figure-export format choice */
-.tab-info { align-self: center; margin-left: 4px; margin-bottom: 2px; font-size: 12px; color: var(--cc-text-dim); cursor: help; }
+.tab-info { align-self: center; margin-left: 4px; margin-bottom: 2px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); cursor: help; }
 .tab-info:hover { color: var(--cc-text); }
 </style>

--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -305,7 +305,7 @@ const corrFont = (r: number | null | undefined) => `${Math.round(13 + Math.abs(r
 /* light theme for PDF export: dark ink on white */
 .gm-grid.cc-light { --cc-text: #111; --cc-text-dim: #555; --cc-border: #c9ccd1; --cc-bg: #fff; --cc-surface-2: #f0f0f3; }
 .gm-cell { display: flex; flex-direction: column; min-height: 0; border: 1px solid var(--cc-border);
-  border-radius: 5px; overflow: hidden; background: var(--cc-bg); }
+  border-radius: var(--cc-radius-sm); overflow: hidden; background: var(--cc-bg); }
 /* montage plot area is SQUARE — but the SQUARE is the DOTS (.panel-plot in GateScatterCell), not this
    outer box: the capture's axis padding is asymmetric (room for the rotated y-name + the x-name below),
    so squaring the OUTER box made the dots taller than wide ("flow plots elongate on export"). We size
@@ -330,13 +330,13 @@ const corrFont = (r: number | null | undefined) => `${Math.round(13 + Math.abs(r
   flex: none; aspect-ratio: 1; min-height: 0; width: min(100%, calc(100cqh - 82px)); }
 /* diagonal label cell (matrix): channel name centred, matches the tile square */
 .gm-diag { align-items: center; justify-content: center; aspect-ratio: 1; background: var(--cc-surface-2);
-  color: var(--cc-text); font-weight: 700; font-size: 12px; padding: 4px; text-align: center; word-break: break-word; }
+  color: var(--cc-text); font-weight: 700; font-size: var(--cc-fs-sm); padding: 4px; text-align: center; word-break: break-word; }
 /* upper-triangle correlation cell (ggpairs): "Corr" label + the value, text scaled by |r| */
 .gm-corr { align-items: center; justify-content: center; aspect-ratio: 1; gap: 2px; border-color: var(--cc-border); }
-.gm-corr-k { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--cc-text-dim); }
+.gm-corr-k { font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.05em; color: var(--cc-text-dim); }
 .gm-corr-v { font-weight: 700; color: var(--cc-text); font-variant-numeric: tabular-nums; line-height: 1; }
-.gm-title { flex-shrink: 0; font-size: 11px; font-weight: 700; padding: 3px 6px; color: var(--cc-text-dim);
+.gm-title { flex-shrink: 0; font-size: var(--cc-fs-xs); font-weight: 700; padding: 3px 6px; color: var(--cc-text-dim);
   border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .gm-loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--cc-text-dim); aspect-ratio: 1; }
-.gm-msg { grid-column: 1 / -1; padding: 16px; color: var(--cc-text-dim); font-size: 13px; }
+.gm-msg { grid-column: 1 / -1; padding: 16px; color: var(--cc-text-dim); font-size: var(--cc-fs-md); }
 </style>

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -317,5 +317,5 @@ defineExpose({ exportImage, exportSvg, hiRes, getHost: () => hostEl.value,
 /* vertical text via writing-mode (rotate's origin offsets by half the text width → overlap) */
 .axis-y { position: absolute; left: -66px; top: 50%; transform: translateY(-50%) rotate(180deg);
   writing-mode: vertical-rl; white-space: nowrap; font-size: calc(var(--gate-font, 11px) + 2px); font-weight: 600; color: var(--cc-text); }
-.panel-loading { position: absolute; top: 4px; right: 6px; font-size: 11px; color: var(--cc-text-dim); }
+.panel-loading { position: absolute; top: 4px; right: 6px; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
 </style>

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -230,19 +230,19 @@ defineExpose({ exportImage, exportSvg })
 /* position: relative so the overlaid .gs-bar (.cc-panel-controls) anchors to the plot box, not the panel */
 .gs-view { position: relative; display: flex; flex-direction: column; height: 100%; min-height: 0; }
 .gs-bar { display: flex; align-items: center; gap: 6px; padding: 6px 8px; flex-wrap: wrap;
-  font-size: 12px; }
-.gs-bar select { font-size: 12px; max-width: 9rem; }
+  font-size: var(--cc-fs-sm); }
+.gs-bar select { font-size: var(--cc-fs-sm); max-width: 9rem; }
 /* ⚙ options popover (hierarchy toggle). margin-left:auto pins the gear to the far right so the popover —
    anchored right:0 — always opens LEFTWARD into the panel and is never clipped at the left edge. */
 .gs-opts { position: relative; display: inline-flex; margin-left: auto; }
 .gs-gear { background: var(--cc-surface-2); color: var(--cc-text-dim); border: 1px solid var(--cc-border);
-  border-radius: 5px; padding: 4px 8px; cursor: pointer; font-size: 12px; }
+  border-radius: var(--cc-radius-sm); padding: 4px 8px; cursor: pointer; font-size: var(--cc-fs-sm); }
 .gs-gear.on { background: var(--cc-accent); color: #fff; border-color: var(--cc-accent); }
 /* inner layout only — TeleportPopover provides surface/border/shadow/position */
 .gs-pop { width: 13rem; display: flex; flex-direction: column; gap: 8px; padding: 10px; }
-.gs-check { display: flex; align-items: center; gap: 6px; color: var(--cc-text); font-size: 12px; }
-.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
-.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 4px 8px; cursor: pointer; font-size: 12px; }
+.gs-check { display: flex; align-items: center; gap: 6px; color: var(--cc-text); font-size: var(--cc-fs-sm); }
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 4px 8px; cursor: pointer; font-size: var(--cc-fs-sm); }
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button.on { background: var(--cc-accent); color: #fff; }
 </style>

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -377,25 +377,25 @@ defineExpose({ exportImage })
 .is-view { position: relative; display: flex; flex-direction: column; height: 100%; min-height: 0; }
 /* angle/width live in a ⚙ popover (below), so the bar stays short and never wraps */
 .is-bar { display: flex; align-items: center; gap: 8px; padding: 6px 8px; flex-wrap: wrap;
-  font-size: 12px; }
+  font-size: var(--cc-fs-sm); }
 .is-opts { position: relative; display: inline-flex; }
 .is-gear { display: inline-flex; align-items: center; justify-content: center; width: 1.7rem; height: 1.6rem;
-  border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-2); color: var(--cc-text-dim);
-  cursor: pointer; font-size: 0.72rem; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); color: var(--cc-text-dim);
+  cursor: pointer; font-size: var(--cc-fs-sm); }
 .is-gear:hover, .is-gear.on { color: var(--cc-text); border-color: #7c3aed; }
 /* inner layout only — the teleported TeleportPopover shell provides surface/border/shadow/position */
 .is-pop { display: flex; flex-direction: column; gap: 6px; padding: 8px 10px; }
 .is-val { min-width: 1.2rem; text-align: right; font-weight: 700; color: var(--cc-text); }
-.is-err { color: #fca5a5; font-size: 11px; }
-.is-slider { display: inline-flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: 11px; }
+.is-err { color: #fca5a5; font-size: var(--cc-fs-xs); }
+.is-slider { display: inline-flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
 .is-slider input[type="range"] { width: 4.5rem; }
-.is-check { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim); font-size: 11px; }
+.is-check { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
 /* view legend (shared <ViewLegend>): overlaid bottom-left of the frame (z above the auto-hide toolbar
    like the caption/actions); included in the PDF export (not hidden while capturing). The container
    sets the on-image styling (white text, shadow, dark chip); ViewLegend inherits color + font-size. */
-.is-legend { position: absolute; bottom: 6px; left: 6px; padding: 3px 5px; border-radius: 3px;
+.is-legend { position: absolute; bottom: 6px; left: 6px; padding: 3px 5px; border-radius: var(--cc-radius-xs);
   background: rgba(0,0,0,0.45); pointer-events: none; z-index: 7;
-  color: #fff; font-size: 10px; font-weight: 600; text-shadow: 0 1px 2px rgba(0,0,0,0.85); }
+  color: #fff; font-size: var(--cc-fs-2xs); font-weight: 600; text-shadow: 0 1px 2px rgba(0,0,0,0.85); }
 .is-strip { flex: 1; min-height: 0; display: flex; padding: 6px; gap: 0; overflow: auto; }
 .is-strip.col { flex-direction: column; }
 /* straight: no box around each frame — just a thin rule BETWEEN frames */
@@ -416,7 +416,7 @@ defineExpose({ exportImage })
    Cecelia-drawn scale bar) will let frames go edge-to-edge again without losing the annotations. */
 .is-img { flex: 1; width: 100%; object-fit: contain; min-height: 0; }
 .is-capture { flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px;
-  border: 1px dashed var(--cc-border); background: transparent; color: var(--cc-text-dim); cursor: pointer; font-size: 12px; }
+  border: 1px dashed var(--cc-border); background: transparent; color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-sm); }
 .is-capture:hover { color: var(--cc-text); border-color: #7c3aed; }
 /* per-frame actions (zoom-to-source / recapture / remove): BOTTOM-left, revealed on cell hover.
    They used to sit TOP-right (z-index 7) — but that's exactly where the CanvasPanel's OWN controls
@@ -432,14 +432,14 @@ defineExpose({ exportImage })
    old dark translucent pills: solid surface + border, purple accent on hover. Sit over the image, so a
    solid surface reads cleanly. */
 .is-mini { width: 1.5rem; height: 1.5rem; display: inline-flex; align-items: center; justify-content: center;
-  border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-2); color: var(--cc-text-dim);
-  cursor: pointer; font-size: 0.7rem; transition: color 0.1s, border-color 0.1s, background 0.1s; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); color: var(--cc-text-dim);
+  cursor: pointer; font-size: var(--cc-fs-xs); transition: color 0.1s, border-color 0.1s, background 0.1s; }
 .is-mini:hover { color: var(--cc-text); border-color: #7c3aed; background: var(--cc-surface-1); }
 .is-mini:disabled { opacity: 0.5; cursor: not-allowed; }
 /* while capturing for the PDF: hide the per-frame buttons (and empty-frame capture prompts) so the
    exported strip is just the images */
 .is-strip.capturing .is-mini, .is-strip.capturing .is-capture { display: none; }
 .is-btn { display: inline-flex; align-items: center; gap: 4px; background: var(--cc-surface-2); color: var(--cc-text-dim);
-  border: 1px solid var(--cc-border); border-radius: 4px; padding: 3px 8px; cursor: pointer; font-size: 11px; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); padding: 3px 8px; cursor: pointer; font-size: var(--cc-fs-xs); }
 .is-btn:hover { color: var(--cc-text); }
 </style>

--- a/frontend/src/components/plots/PlotChart.vue
+++ b/frontend/src/components/plots/PlotChart.vue
@@ -102,19 +102,19 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null; node?.remove(); node = null
 <style scoped>
 /* white plot ground (theme_classic) — fills the panel body. position:relative anchors the legend
    overlay. color:#111 so any HTML text (legend) is dark on the white ground (not the app's light grey). */
-.plot-host { position: relative; width: 100%; height: 100%; background: white; border-radius: 3px; overflow: hidden; color: #111; }
+.plot-host { position: relative; width: 100%; height: 100%; background: white; border-radius: var(--cc-radius-xs); overflow: hidden; color: #111; }
 .plot-host :deep(svg) { display: block; }
 /* legend drawn as an absolute overlay (top-right) so it never eats height / clips the x-axis.
    colour is set inline by PlotChart (theme ink); descendants inherit it (force inherit so Plot's
    own swatch styles don't override the dark-theme ink). */
 .plot-host :deep(.plot-legend-overlay) {
   position: absolute; top: 4px; right: 6px; display: flex; flex-wrap: wrap; gap: 2px 10px;
-  max-width: 58%; justify-content: flex-end; border-radius: 3px; padding: 1px 4px;
+  max-width: 58%; justify-content: flex-end; border-radius: var(--cc-radius-xs); padding: 1px 4px;
 }
 .plot-host :deep(.plot-legend-overlay *) { color: inherit !important; }
 /* title overlay (top-left), theme ink set inline */
 .plot-host :deep(.plot-title-overlay) {
-  position: absolute; top: 4px; left: 8px; max-width: 60%; font-weight: 600; font-size: 12px;
+  position: absolute; top: 4px; left: 8px; max-width: 60%; font-weight: 600; font-size: var(--cc-fs-sm);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 </style>

--- a/frontend/src/components/plots/PlotSpinner.vue
+++ b/frontend/src/components/plots/PlotSpinner.vue
@@ -36,13 +36,13 @@ defineProps<{ label?: string }>()
 .plot-spinner__wheel {
   width: 26px;
   height: 26px;
-  border-radius: 50%;
+  border-radius: var(--cc-radius-pill);
   border: 2.5px solid var(--cc-border);
   border-top-color: var(--cc-accent);
   animation: plot-spinner-rot 0.7s linear infinite;
 }
 .plot-spinner__label {
-  font-size: 11px;
+  font-size: var(--cc-fs-xs);
   color: var(--cc-text-dim);
 }
 @keyframes plot-spinner-rot { to { transform: rotate(360deg); } }

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -625,7 +625,7 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
             <div class="uv-pop">
               <div v-if="!popGroups.length" class="uv-pop-empty cc-muted">No populations in the clustered segmentations.</div>
               <template v-for="grp in popGroups" :key="grp.valueName">
-                <div v-if="grp.populations.length" class="uv-pop-head">{{ grp.valueName }}</div>
+                <div v-if="grp.populations.length" class="uv-pop-head cc-eyebrow cc-eyebrow-dense">{{ grp.valueName }}</div>
                 <div v-for="p in grp.populations" :key="p.popType + grp.valueName + p.path"
                      class="uv-pop-row" :class="{ on: isPopOn(grp.valueName, p.path, p.popType) }"
                      @click="togglePop(grp.valueName, p.path, p.popType)">
@@ -660,7 +660,7 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
             <span v-for="(t, ti) in facetTitles" :key="'f'+ti" class="uv-facet-title"
                   :style="{ left: t.x + 'px', top: t.y + 'px', fontSize: labelFont + 'px', color: legendInk }">{{ t.label }}</span>
           </template>
-          <div v-else class="uv-empty">
+          <div v-else class="uv-empty cc-empty cc-empty-overlay">
             <i :class="['pi', loading ? 'pi-spin pi-spinner' : 'pi-chart-scatter']" />
             <p>{{ loading ? 'Loading…' : (err || 'Select clustered image(s) to view the UMAP.') }}</p>
           </div>
@@ -680,42 +680,42 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
 <style scoped>
 /* position: relative so the overlaid .uv-ctrl (.cc-panel-controls) anchors to the plot box */
 .uv { position: relative; display: flex; flex-direction: column; flex: 1; min-height: 0; }
-.uv-ctrl { display: flex; align-items: center; gap: 8px; padding: 4px 6px; font-size: 12px; color: var(--cc-text-dim); }
+.uv-ctrl { display: flex; align-items: center; gap: 8px; padding: 4px 6px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
 /* active (ticked) label toggle: filled accent so it's clearly on/off */
 .uv-ctrl .cc-btn.on { background: var(--cc-accent); border-color: var(--cc-accent); color: #fff; }
 .uv-spacer { flex: 1; }
 .uv-count { font-variant-numeric: tabular-nums; }
 /* colour & facet options popover (inner layout only — TeleportPopover gives surface/border/shadow) */
 .uv-opts { width: 15rem; display: flex; flex-direction: column; gap: 8px; padding: 10px; }
-.uv-opt { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12px; color: var(--cc-text-dim); }
-.uv-opt select { font-size: 12px; padding: 2px 4px; max-width: 8.5rem; }
-.uv-opt-sep { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--cc-text-dim);
+.uv-opt { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.uv-opt select { font-size: var(--cc-fs-sm); padding: 2px 4px; max-width: 8.5rem; }
+.uv-opt-sep { font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.06em; color: var(--cc-text-dim);
   border-top: 1px solid var(--cc-border); padding-top: 6px; margin-top: 2px; }
 /* population checklist (inside the options popover) */
-.uv-pop { max-height: 14rem; overflow-y: auto; border: 1px solid var(--cc-border); border-radius: 5px; }
+.uv-pop { max-height: 14rem; overflow-y: auto; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); }
 .uv-pop-empty { padding: 10px; }   /* + .cc-muted */
-.uv-pop-head { padding: 4px 8px; background: var(--cc-surface-2); color: var(--cc-text-dim);
-  font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; position: sticky; top: 0; }
-.uv-pop-row { display: flex; align-items: center; gap: 6px; padding: 4px 8px; cursor: pointer; font-size: 12px; color: var(--cc-text); }
+/* + .cc-eyebrow .cc-eyebrow-dense (case/tracking/weight/colour at the 10px tier) */
+.uv-pop-head { padding: 4px 8px; background: var(--cc-surface-2); position: sticky; top: 0; }
+.uv-pop-row { display: flex; align-items: center; gap: 6px; padding: 4px 8px; cursor: pointer; font-size: var(--cc-fs-sm); color: var(--cc-text); }
 .uv-pop-row:hover { background: var(--cc-surface-2); }
 .uv-pop-row.on { color: var(--cc-accent); }
 .uv-pop-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.uv-pop-tag { font-size: 9px; text-transform: uppercase; color: var(--cc-text-dim); border: 1px solid var(--cc-border); border-radius: 3px; padding: 0 3px; }
+.uv-pop-tag { font-size: var(--cc-fs-3xs); text-transform: uppercase; color: var(--cc-text-dim); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); padding: 0 3px; }
 .uv-body { display: flex; flex: 1; min-height: 0; gap: 8px; padding: 0 6px 6px; }
 /* .uv-square (SquarePlot) provides the centred 1:1 box; .uv-plot fills it and carries the ground/frame */
-.uv-plot { position: absolute; inset: 0; background: #0d0b1a; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
+.uv-plot { position: absolute; inset: 0; background: #0d0b1a; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); overflow: hidden; }
 .uv-canvas { position: absolute; inset: 0; width: 100%; height: 100%; }
 .uv-label { position: absolute; transform: translate(-50%, -50%); pointer-events: none; font-weight: 700;
-  color: #111; background: rgba(255,255,255,0.9); border: 1px solid rgba(0,0,0,0.55); border-radius: 3px; padding: 0 4px; line-height: 1.4; z-index: 2; }
+  color: #111; background: rgba(255,255,255,0.9); border: 1px solid rgba(0,0,0,0.55); border-radius: var(--cc-radius-xs); padding: 0 4px; line-height: 1.4; z-index: 2; }
 /* small-multiples facet title: centred at the top of each cell (positioned in CSS px from facetTitles) */
 .uv-facet-title { position: absolute; transform: translateX(-50%); pointer-events: none; z-index: 2;
-  font-size: 10px; font-weight: 700; white-space: nowrap; }
-.uv-empty { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; color: var(--cc-text-dim); text-align: center; padding: 1rem; }
+  font-size: var(--cc-fs-2xs); font-weight: 700; white-space: nowrap; }
+.uv-empty { padding: 1rem; }   /* + .cc-empty .cc-empty-overlay (stretched over the plot box) */
 .uv-empty .pi { font-size: 1.4rem; opacity: 0.6; }
-.uv-empty p { margin: 0; font-size: 0.8rem; max-width: 22rem; }
-.uv-legend { width: 9.5rem; flex-shrink: 0; overflow-y: auto; border: 1px solid var(--cc-border); border-radius: 5px; padding: 5px; }
-.leg-row { display: flex; align-items: center; gap: 5px; padding: 1px 2px; font-size: 11px; }
-.leg-dot { width: 0.65rem; height: 0.65rem; border-radius: 50%; flex-shrink: 0; }
+.uv-empty p { margin: 0; font-size: var(--cc-fs-md); max-width: 22rem; }
+.uv-legend { width: 9.5rem; flex-shrink: 0; overflow-y: auto; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); padding: 5px; }
+.leg-row { display: flex; align-items: center; gap: 5px; padding: 1px 2px; font-size: var(--cc-fs-xs); }
+.leg-dot { width: 0.65rem; height: 0.65rem; border-radius: var(--cc-radius-pill); flex-shrink: 0; }
 /* legend ink is themed inline on .uv-legend (light on dark ground, dark on light) so it stays
    legible in the exported PNG; children inherit it. */
 .leg-lbl { flex: 1; color: inherit; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -372,26 +372,26 @@ async function render() {
 .anim-head h1 { font-size: 1.1rem; margin: 0 0 0.2rem; }
 .anim-sub { max-width: 46rem; margin: 0; }   /* + .cc-muted */
 .anim-head-ctl { display: flex; align-items: center; gap: 0.9rem; flex-shrink: 0; }
-.anim-fps { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.4rem; }
+.anim-fps { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.4rem; }
 .anim-range { width: 5rem; accent-color: var(--cc-accent); }
-.anim-num { font-size: 0.72rem; color: var(--cc-text); font-variant-numeric: tabular-nums; min-width: 1.2rem; }
-.anim-title-toggle { font-size: 0.72rem; color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.35rem; cursor: pointer; }
-.anim-note { font-size: 0.72rem; width: 9rem; padding: 2px 6px; border: 1px solid var(--cc-border);
-  border-radius: 4px; background: var(--cc-surface-1); color: var(--cc-text); }
+.anim-num { font-size: var(--cc-fs-sm); color: var(--cc-text); font-variant-numeric: tabular-nums; min-width: 1.2rem; }
+.anim-title-toggle { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.35rem; cursor: pointer; }
+.anim-note { font-size: var(--cc-fs-sm); width: 9rem; padding: 2px 6px; border: 1px solid var(--cc-border);
+  border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); color: var(--cc-text); }
 .anim-toolbar { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.9rem; }
-.anim-img { font-size: 0.78rem; font-weight: 600; color: var(--cc-text); margin-right: 0.2rem; }
-.anim-sync { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; color: var(--cc-text-dim); cursor: pointer; }
+.anim-img { font-size: var(--cc-fs-sm); font-weight: 600; color: var(--cc-text); margin-right: 0.2rem; }
+.anim-sync { display: inline-flex; align-items: center; gap: 0.3rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); cursor: pointer; }
 
 /* clean matrix (not a bordered table): sticky row labels, colour-coded toggle dots, rounded thumbs */
-.anim-timeline { overflow-x: auto; border: 1px solid var(--cc-border); border-radius: 0.6rem;
+.anim-timeline { overflow-x: auto; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-lg);
   background: var(--cc-surface-1); padding: 0.6rem 0.7rem 0.8rem; }
 .tl { border-collapse: separate; border-spacing: 0; }
-.tl-rowhead { position: sticky; left: 0; background: var(--cc-surface-1); text-align: left; font-size: 0.72rem;
+.tl-rowhead { position: sticky; left: 0; background: var(--cc-surface-1); text-align: left; font-size: var(--cc-fs-sm);
   color: var(--cc-text); padding: 0.25rem 0.9rem 0.25rem 0.1rem; max-width: 11rem; overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap; z-index: 1; }
 .tl-corner { min-width: 7rem; }
 .tl-col { padding: 0 0.35rem 0.4rem; vertical-align: top; text-align: center; }
-.tl-thumb { position: relative; width: 96px; height: 96px; background: #000; border-radius: 0.5rem;
+.tl-thumb { position: relative; width: 96px; height: 96px; background: #000; border-radius: var(--cc-radius-lg);
   overflow: hidden; border: 1px solid var(--cc-border); transition: box-shadow 0.12s, border-color 0.12s; }
 .tl-thumb img { width: 100%; height: 100%; object-fit: contain; }
 .tl-thumb { cursor: grab; }
@@ -400,28 +400,28 @@ async function render() {
 /* selected keyframe = the highlighted box → amber ring (--cc-selected), matching the plot panels'
    selected state. "edited" is a separate flag (the badge), not a ring. */
 .tl-thumb.selected { border-color: var(--cc-selected); box-shadow: 0 0 0 2px color-mix(in srgb, var(--cc-selected) 55%, transparent); }
-.tl-badge { position: absolute; top: 4px; right: 4px; font-size: 0.55rem; font-weight: 700; text-transform: uppercase;
-  letter-spacing: 0.04em; color: #1f1400; background: var(--cc-warn); padding: 1px 5px; border-radius: 999px; }
-.tl-time { font-size: 0.6rem; color: var(--cc-text-dim); text-align: center; margin-top: 0.15rem; font-variant-numeric: tabular-nums; }
+.tl-badge { position: absolute; top: 4px; right: 4px; font-size: var(--cc-fs-3xs); font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.04em; color: #1f1400; background: var(--cc-warn); padding: 1px 5px; border-radius: var(--cc-radius-pill); }
+.tl-time { font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); text-align: center; margin-top: 0.15rem; font-variant-numeric: tabular-nums; }
 .tl-colctl { display: flex; align-items: center; justify-content: center; gap: 0.1rem; margin-top: 0.3rem; }
-.tl-kf { font-size: 0.66rem; color: var(--cc-text-dim); min-width: 0.9rem; text-align: center; }
+.tl-kf { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); min-width: 0.9rem; text-align: center; }
 .tl-ico { display: inline-flex; border: none; background: none; color: var(--cc-text-dim); cursor: pointer;
-  padding: 0.15rem; font-size: 0.62rem; border-radius: 0.25rem; }
+  padding: 0.15rem; font-size: var(--cc-fs-2xs); border-radius: var(--cc-radius-xs); }
 .tl-ico:hover:not(:disabled) { color: var(--cc-text); background: var(--cc-surface-2); }
 .tl-ico:disabled { opacity: 0.3; cursor: default; }
 .tl-dur { display: flex; align-items: center; justify-content: center; gap: 0.3rem; margin-top: 0.3rem; }
 .tl-durrange { width: 68px; accent-color: var(--cc-accent); }
-.tl-durval { font-size: 0.62rem; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; min-width: 1.8rem; text-align: left; }
-.tl-group .tl-rowhead { font-size: 0.58rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+.tl-durval { font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); font-variant-numeric: tabular-nums; min-width: 1.8rem; text-align: left; }
+.tl-group .tl-rowhead { font-size: var(--cc-fs-3xs); font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
   color: var(--cc-text-dim); padding-top: 0.7rem; padding-bottom: 0.2rem; }
 .tl-row:hover .tl-cell, .tl-row:hover .tl-rowhead { background: rgba(255, 255, 255, 0.03); }
 .tl-cell { text-align: center; padding: 0.22rem 0.35rem; }
-.tl-dot { width: 15px; height: 15px; border-radius: 50%; border: 1.5px solid var(--cc-border);
+.tl-dot { width: 15px; height: 15px; border-radius: var(--cc-radius-pill); border: 1.5px solid var(--cc-border);
   background: transparent; cursor: pointer; padding: 0; transition: transform 0.1s; }
 .tl-dot:hover { transform: scale(1.18); }
 .tl-dot.on { border-style: solid; }         /* on: filled with the layer colour (set inline) */
 .tl-absent { color: var(--cc-text-dim); opacity: 0.35; }
-.tl-cam { font-size: 0.68rem; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
+.tl-cam { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
 
 /* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -1071,7 +1071,7 @@ onActivated(async () => {
     <!-- ── Live view ──────────────────────────────────────────────────────── -->
     <div v-if="activeTab === 'live'" class="chain-live">
       <div class="live-toolbar">
-        <label class="live-label">Run</label>
+        <label class="live-label cc-eyebrow">Run</label>
         <select
           v-if="runOptions.length"
           class="chain-select live-run-select"
@@ -1263,7 +1263,7 @@ onActivated(async () => {
               :key="cat.name"
               class="palette-category"
             >
-              <div class="palette-cat-heading">{{ cat.name }}</div>
+              <div class="palette-cat-heading cc-eyebrow cc-eyebrow-dense">{{ cat.name }}</div>
               <div
                 v-for="def in cat.defs"
                 :key="def.fun_name"
@@ -1296,7 +1296,7 @@ onActivated(async () => {
 
         <!-- ── Run table ──────────────────────────────────────────────────── -->
         <div class="run-table-section">
-          <div class="run-section-heading">Run</div>
+          <div class="run-section-heading cc-eyebrow cc-eyebrow-dense">Run</div>
 
           <select
             v-if="project.sets.length"
@@ -1396,7 +1396,7 @@ onActivated(async () => {
       <template v-if="selectedNode">
 
         <div class="config-header">
-          <div class="config-title">{{ selectedNode.type === 'start' ? 'Start node' : 'Node' }}</div>
+          <div class="config-title cc-eyebrow">{{ selectedNode.type === 'start' ? 'Start node' : 'Node' }}</div>
           <ConfirmDeleteButton
             title="Remove this node and its connections from the chain."
             armed-title="Click again to remove this node"
@@ -1411,15 +1411,15 @@ onActivated(async () => {
         <template v-else>
         <!-- Identity -->
         <div class="config-section">
-          <label class="config-label">ID</label>
+          <label class="config-label cc-eyebrow">ID</label>
           <div class="config-value mono">{{ selectedNode.id }}</div>
-          <label class="config-label" style="margin-top:0.5rem">Function</label>
+          <label class="config-label cc-eyebrow" style="margin-top:0.5rem">Function</label>
           <div class="config-value mono">{{ selectedNode.data.fn }}</div>
         </div>
 
         <!-- Scope -->
         <div class="config-section">
-          <label class="config-label">Scope</label>
+          <label class="config-label cc-eyebrow">Scope</label>
           <select
             class="config-select"
             :value="selectedNode.data.scope"
@@ -1432,7 +1432,7 @@ onActivated(async () => {
           </select>
 
           <template v-if="selectedNode.data.scope === 'set'">
-            <label class="config-label" style="margin-top:0.5rem">Barrier policy</label>
+            <label class="config-label cc-eyebrow" style="margin-top:0.5rem">Barrier policy</label>
             <select
               class="config-select"
               :value="selectedNode.data.barrier_policy"
@@ -1445,7 +1445,7 @@ onActivated(async () => {
             </select>
           </template>
 
-          <label class="config-label" style="margin-top:0.5rem">Resource pool</label>
+          <label class="config-label cc-eyebrow" style="margin-top:0.5rem">Resource pool</label>
           <select
             class="config-select"
             :value="selectedNode.data.resource_pool"
@@ -1461,7 +1461,7 @@ onActivated(async () => {
 
         <!-- Params -->
         <div class="config-section" v-if="selectedTaskDef && selectedTaskDef.params.length">
-          <div class="config-section-heading">Parameters</div>
+          <div class="config-section-heading cc-eyebrow">Parameters</div>
           <div class="config-params">
             <ParamRenderer
               v-for="p in selectedTaskDef.params"
@@ -1531,14 +1531,7 @@ onActivated(async () => {
   flex-shrink: 0;
 }
 
-.live-label {
-  font-size: 0.68rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--cc-text-dim);
-  flex-shrink: 0;
-}
+.live-label { flex-shrink: 0; }   /* + .cc-eyebrow */
 
 /* Live toolbar: keep the run selector tight (it otherwise stretches full width via .chain-select
    flex:1) with the copy button right beside it. */
@@ -1571,18 +1564,18 @@ onActivated(async () => {
 }
 .qc-expand-card {
   width: 96%; height: 94%;
-  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 0.5rem;
+  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-lg);
   display: flex; flex-direction: column; overflow: hidden;
 }
 .qc-expand-head {
   display: flex; align-items: center; justify-content: space-between;
   padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--cc-border);
-  font-size: 0.8rem; font-weight: 600; color: var(--cc-text);
+  font-size: var(--cc-fs-md); font-weight: 600; color: var(--cc-text);
 }
 .qc-expand-body { flex: 1; min-height: 0; overflow: auto; }
 
 .live-hint {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   font-style: italic;
 }
@@ -1601,7 +1594,7 @@ onActivated(async () => {
   justify-content: center;
   gap: 0.5rem;
   color: var(--cc-text-dim);
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   font-style: italic;
 }
 
@@ -1652,10 +1645,10 @@ onActivated(async () => {
 .chain-select {
   flex: 1;
   min-width: 0;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-border);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   color: var(--cc-text);
   padding: 0.25rem 0.4rem;
   cursor: pointer;
@@ -1664,7 +1657,7 @@ onActivated(async () => {
 
 .no-chains-hint {
   flex: 1;
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   font-style: italic;
 }
@@ -1674,12 +1667,12 @@ onActivated(async () => {
   align-items: center;
   justify-content: center;
   width: 26px; height: 26px;
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   border: 1px solid var(--cc-border);
   background: var(--cc-surface-2);
   color: var(--cc-text-dim);
   cursor: pointer;
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   flex-shrink: 0;
   transition: background 0.1s, color 0.1s;
 }
@@ -1700,10 +1693,10 @@ onActivated(async () => {
 .new-chain-input {
   flex: 1;
   min-width: 0;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-accent);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   color: var(--cc-text);
   padding: 0.2rem 0.4rem;
   outline: none;
@@ -1717,24 +1710,17 @@ onActivated(async () => {
 
 .palette-category { margin-bottom: 0.25rem; }
 
-.palette-cat-heading {
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--cc-text-dim);
-  padding: 0.5rem 0.65rem 0.2rem;
-}
+.palette-cat-heading { padding: 0.5rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-eyebrow-dense */
 
 .palette-item {
   display: flex;
   align-items: center;
   gap: 0.35rem;
   padding: 0.3rem 0.65rem;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   cursor: grab;
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   margin: 0 0.3rem;
   transition: background 0.1s, color 0.1s;
   user-select: none;
@@ -1746,7 +1732,7 @@ onActivated(async () => {
 .palette-item:active { cursor: grabbing; }
 
 .drag-grip {
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   opacity: 0.4;
   flex-shrink: 0;
 }
@@ -1757,13 +1743,13 @@ onActivated(async () => {
 }
 
 .palette-hint {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   font-style: italic;
   padding: 0.75rem 0.65rem;
 }
 .palette-soon {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   font-style: italic;
   padding: 0.75rem 0.65rem;
@@ -1775,7 +1761,7 @@ onActivated(async () => {
   gap: 0.4rem;
 }
 .palette-retry-btn {
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   padding: 0.1rem 0.3rem;
   flex-shrink: 0;
 }
@@ -1799,7 +1785,7 @@ onActivated(async () => {
   align-items: center;
   gap: 0.5rem;
   color: var(--cc-text-dim);
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   font-style: italic;
 }
 .canvas-empty i { font-size: 2rem; opacity: 0.25; }
@@ -1809,7 +1795,7 @@ onActivated(async () => {
   bottom: 0.5rem;
   left: 50%;
   transform: translateX(-50%);
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   color: var(--cc-text-dim);
   opacity: 0.5;
   pointer-events: none;
@@ -1839,7 +1825,7 @@ onActivated(async () => {
   gap: 0.5rem;
   padding: 2rem 1rem;
   color: var(--cc-text-dim);
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   font-style: italic;
   text-align: center;
 }
@@ -1852,57 +1838,36 @@ onActivated(async () => {
   border-bottom: 1px solid var(--cc-border);
   flex-shrink: 0;
 }
-.config-title {
-  font-size: 0.68rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--cc-text-dim);
-}
+/* .config-title is purely the eyebrow scenario → .cc-eyebrow */
 
 .config-section {
   padding: 0.65rem 0.75rem;
   border-bottom: 1px solid var(--cc-border);
 }
-.config-label {
-  display: block;
-  font-size: 0.68rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--cc-text-dim);
-  margin-bottom: 0.25rem;
-}
+.config-label { display: block; margin-bottom: 0.25rem; }   /* + .cc-eyebrow */
 .config-value {
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text);
   word-break: break-all;
 }
-.config-value.mono { font-family: var(--cc-mono, monospace); font-size: 0.7rem; }
+.config-value.mono { font-family: var(--cc-mono, monospace); font-size: var(--cc-fs-xs); }
 
 .config-select, .config-input {
   width: 100%;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-border);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   color: var(--cc-text);
   padding: 0.28rem 0.5rem;
 }
 .config-select:focus, .config-input:focus { outline: 1px solid var(--cc-accent); border-color: var(--cc-accent); }
 .config-input::placeholder { color: var(--cc-text-dim); font-style: italic; }
 
-.config-section-heading {
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--cc-text-dim);
-  margin-bottom: 0.35rem;
-}
+.config-section-heading { margin-bottom: 0.35rem; }   /* + .cc-eyebrow */
 .config-params { display: flex; flex-direction: column; }
 .no-params-hint {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   font-style: italic;
 }
@@ -1917,14 +1882,7 @@ onActivated(async () => {
   background: var(--cc-bg);
 }
 
-.run-section-heading {
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--cc-text-dim);
-  padding: 0.45rem 0.65rem 0.2rem;
-}
+.run-section-heading { padding: 0.45rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-eyebrow-dense */
 
 .run-set-select {
   margin: 0 0.45rem 0.3rem;
@@ -1965,7 +1923,7 @@ onActivated(async () => {
 .run-row-all:hover { background: var(--cc-surface-2); }
 
 .run-check-icon {
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   color: var(--cc-accent);
   flex-shrink: 0;
   width: 14px;
@@ -1975,19 +1933,19 @@ onActivated(async () => {
 .run-row-all .run-check-icon { color: var(--cc-accent); }
 
 .run-all-label {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   color: var(--cc-text-dim);
   flex: 1;
 }
 .run-sel-count {
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   font-family: var(--cc-mono);
   color: var(--cc-accent);
 }
 
 .run-img-name {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   white-space: nowrap;
   overflow: hidden;
@@ -2003,9 +1961,9 @@ onActivated(async () => {
   margin: 0 0.45rem 0.5rem;
   width: calc(100% - 0.9rem);
   padding: 0.35rem 0.5rem;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   border: 1px solid #10b981;
   background: #0c1a0e;
   color: #6ee7b7;

--- a/frontend/src/modules/MoviesModule.vue
+++ b/frontend/src/modules/MoviesModule.vue
@@ -231,10 +231,10 @@ function movieTime(mtime: number): string {
 .mov-head h1 { margin: 0; font-size: 1.15rem; }
 .mov-sub { margin: 0.2rem 0 0; max-width: 46rem; }   /* + .cc-muted (colour/size) */
 .mov-head-ctl { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
-.mov-ctl { display: flex; align-items: center; gap: 0.35rem; font-size: 0.78rem; color: var(--cc-text-dim); }
+.mov-ctl { display: flex; align-items: center; gap: 0.35rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
 .mov-select {
   background: var(--cc-surface-2); color: var(--cc-text); border: 1px solid var(--cc-border);
-  border-radius: var(--cc-radius-sm); padding: 0.15rem 0.35rem; font-size: 0.78rem;
+  border-radius: var(--cc-radius-sm); padding: 0.15rem 0.35rem; font-size: var(--cc-fs-sm);
 }
 .mov-range { width: 6rem; }
 .mov-num { min-width: 2.2rem; }   /* + .cc-readout (tabular-nums/colour/size) */
@@ -248,10 +248,10 @@ function movieTime(mtime: number): string {
 .mov-stage { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 0.5rem; }
 .mov-viewport {
   flex: 1; min-height: 0; display: flex; overflow: auto;
-  background: #000; border: 1px solid var(--cc-border); border-radius: 0.4rem;
+  background: #000; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md);
 }
 .mov-video { margin: auto; display: block; flex-shrink: 0; }
-.mov-caption { font-size: 0.8rem; color: var(--cc-text); word-break: break-all; }
+.mov-caption { font-size: var(--cc-fs-md); color: var(--cc-text); word-break: break-all; }
 
 /* Playlist */
 .mov-list { width: 18rem; flex-shrink: 0; overflow-y: auto; padding: 0.35rem; }   /* + .cc-card (surface/border/radius) */
@@ -259,12 +259,12 @@ function movieTime(mtime: number): string {
 .mov-item {
   display: flex; align-items: center; gap: 0.5rem; width: 100%; text-align: left;
   background: none; border: none; cursor: pointer; color: var(--cc-text-dim);
-  padding: 0.45rem 0.5rem; border-radius: 0.35rem; transition: background 0.12s, color 0.12s;
+  padding: 0.45rem 0.5rem; border-radius: var(--cc-radius-sm); transition: background 0.12s, color 0.12s;
 }
 .mov-item:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 .mov-item.active { background: var(--cc-surface-2); color: var(--cc-text); }
-.mov-item-ico { font-size: 0.85rem; flex-shrink: 0; color: var(--cc-accent); }
+.mov-item-ico { font-size: var(--cc-fs-md); flex-shrink: 0; color: var(--cc-accent); }
 .mov-item-body { display: flex; flex-direction: column; min-width: 0; }
-.mov-item-name { font-size: 0.8rem; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.mov-item-meta { font-size: 0.68rem; color: var(--cc-text-dim); }
+.mov-item-name { font-size: var(--cc-fs-md); font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mov-item-meta { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
 </style>

--- a/frontend/src/modules/NotebooksModule.vue
+++ b/frontend/src/modules/NotebooksModule.vue
@@ -141,7 +141,7 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
       </p>
     </header>
 
-    <div v-if="!hasProject" class="nb-empty">
+    <div v-if="!hasProject" class="nb-empty cc-empty-inline">
       <i class="pi pi-lock" /> Open or create a project first.
     </div>
 
@@ -225,18 +225,18 @@ onUnmounted(() => { stopPoll(); stopBuildPoll() })
 .notebooks-page { padding: 1.25rem 1.5rem; max-width: 980px; }
 .nb-header h1 { display: flex; align-items: center; gap: .5rem; margin: 0 0 .25rem; font-size: 1.4rem; }
 .nb-sub { margin: 0 0 1rem; max-width: 640px; }   /* + .cc-muted */
-.nb-empty { display: flex; align-items: center; gap: .5rem; color: var(--cc-text-muted, #888); padding: 2rem 0; }
+.nb-empty { padding: 2rem 0; }   /* + .cc-empty-inline (row/gap/colour) */
 .nb-section { margin-bottom: 1.5rem; }
 .nb-section h2 { font-size: 1.05rem; margin: 0 0 .5rem; }
 .nb-server-row { display: flex; align-items: center; gap: 1rem; }
-.nb-status { display: inline-flex; align-items: center; gap: .4rem; font-size: .9rem; }
+.nb-status { display: inline-flex; align-items: center; gap: .4rem; font-size: var(--cc-fs-lg); }
 .nb-status.is-running .pi { color: #3fb950; }
-.nb-status.is-stopped .pi, .nb-status.is-unknown .pi { color: var(--cc-text-muted, #888); }
+.nb-status.is-stopped .pi, .nb-status.is-unknown .pi { color: var(--cc-text-dim); }
 .nb-hint { margin: .5rem 0 0; }   /* + .cc-muted */
-.nb-error { color: #f0883e; font-size: .85rem; margin: .5rem 0 0; display: flex; align-items: center; gap: .4rem; }
+.nb-error { color: #f0883e; font-size: var(--cc-fs-md); margin: .5rem 0 0; display: flex; align-items: center; gap: .4rem; }
 .nb-note {
   display: flex; align-items: flex-start; gap: .55rem; margin: .75rem 0 0; padding: .65rem .8rem;
-  font-size: .85rem; line-height: 1.4; border-radius: 6px;
+  font-size: var(--cc-fs-md); line-height: 1.4; border-radius: var(--cc-radius-md);
   color: var(--cc-text, #cdd9e5); background: rgba(88, 166, 255, .08); border: 1px solid rgba(88, 166, 255, .25);
 }
 .nb-note .pi { margin-top: .1rem; color: #58a6ff; }

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -599,7 +599,7 @@ async function switchWt(path: string) {
                @update:model-value="settings.napariDiscreteGpu = $event; toggleGpu()"
                v-tooltip.right="'Render napari on the discrete GPU (hybrid graphics). Restarts napari to apply. Linux only.'">
           Use discrete GPU for napari
-          <i v-if="gpuBusy" class="pi pi-spin pi-cog" style="font-size:0.7rem;" />
+          <i v-if="gpuBusy" class="pi pi-spin pi-cog" style="font-size:var(--cc-fs-xs);" />
         </CcToggle>
         <span v-if="!gpuSupported" class="field-hint">
           Only configurable on Linux — on this system the GPU is selected by the OS/driver.
@@ -768,7 +768,7 @@ async function switchWt(path: string) {
 }
 
 .section-title {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -791,7 +791,7 @@ async function switchWt(path: string) {
 
 .field-label {
   display: block;
-  font-size: 0.76rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   color: var(--cc-text);
   margin-bottom: 0.3rem;
@@ -806,11 +806,11 @@ async function switchWt(path: string) {
 /* visual styling from the global form base (style.css) */
 .field-input { flex: 1; }
 .field-input[readonly] { color: var(--cc-text-dim); cursor: default; }
-.field-input.mono { font-family: var(--cc-mono); font-size: 0.74rem; }
+.field-input.mono { font-family: var(--cc-mono); font-size: var(--cc-fs-sm); }
 
 .field-hint {
   display: block;
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   color: var(--cc-text-dim);
   margin-top: 0.25rem;
 }
@@ -820,12 +820,12 @@ async function switchWt(path: string) {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.2rem 0.6rem;
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   margin: 0.4rem 0 0.6rem;
 }
 .stor-line strong { justify-self: end; }
 .stor-reclaim { margin-top: 0.5rem; }
-.stor-reclaim-head { font-size: 0.82rem; margin-bottom: 0.35rem; }
+.stor-reclaim-head { font-size: var(--cc-fs-md); margin-bottom: 0.35rem; }
 .stor-reclaim-head .field-hint { display: inline; margin-left: 0.35rem; }
 .stor-list {
   list-style: none;
@@ -838,7 +838,7 @@ async function switchWt(path: string) {
   display: flex;
   align-items: baseline;
   gap: 0.5rem;
-  font-size: 0.76rem;
+  font-size: var(--cc-fs-sm);
   padding: 0.1rem 0;
 }
 .stor-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -849,9 +849,9 @@ async function switchWt(path: string) {
   display: flex;
   align-items: center;
   gap: 0.3rem;
-  font-size: 0.76rem;
+  font-size: var(--cc-fs-sm);
   padding: 0.35rem 0.7rem;
-  border-radius: 0.35rem;
+  border-radius: var(--cc-radius-sm);
   border: 1px solid var(--cc-accent);
   background: var(--cc-accent);
   color: #fff;
@@ -867,9 +867,9 @@ async function switchWt(path: string) {
   border: none;
   cursor: pointer;
   color: var(--cc-text-dim);
-  font-size: 0.82rem;
+  font-size: var(--cc-fs-md);
   padding: 0.3rem 0.4rem;
-  border-radius: 0.25rem;
+  border-radius: var(--cc-radius-xs);
   flex-shrink: 0;
 }
 .icon-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
@@ -878,7 +878,7 @@ async function switchWt(path: string) {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.82rem;
+  font-size: var(--cc-fs-md);
   color: var(--cc-text);
   cursor: pointer;
   user-select: none;
@@ -888,25 +888,25 @@ async function switchWt(path: string) {
 .toggle-row.disabled input { cursor: not-allowed; }
 
 .no-project {
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   color: var(--cc-text-dim);
 }
 
 /* system control panel: aligned grid — name · status pill · port · actions */
 .svc-row { display: grid; grid-template-columns: 8rem 7rem 3.5rem 1fr; align-items: center;
   column-gap: 0.6rem; margin-bottom: 0.55rem; }
-.svc-name { font-size: 0.8rem; color: var(--cc-text); }
-.wt-select { font-size: 0.8rem; padding: 2px 6px; max-width: 18rem; }
-.svc-pill { justify-self: start; display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.72rem;
-  color: var(--cc-text-dim); padding: 0.1rem 0.55rem; border: 1px solid var(--cc-border); border-radius: 999px;
+.svc-name { font-size: var(--cc-fs-md); color: var(--cc-text); }
+.wt-select { font-size: var(--cc-fs-md); padding: 2px 6px; max-width: 18rem; }
+.svc-pill { justify-self: start; display: inline-flex; align-items: center; gap: 0.35rem; font-size: var(--cc-fs-sm);
+  color: var(--cc-text-dim); padding: 0.1rem 0.55rem; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-pill);
   white-space: nowrap; }
-.svc-pill .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--cc-text-dim); }
+.svc-pill .dot { width: 7px; height: 7px; border-radius: var(--cc-radius-pill); background: var(--cc-text-dim); }
 .svc-pill.ok .dot   { background: #22c55e; }
 .svc-pill.warn .dot { background: #f59e0b; }
 .svc-pill.idle .dot { background: var(--cc-text-dim); }
-.svc-tag { font-size: 0.62rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
-  color: var(--cc-accent); border: 1px solid var(--cc-accent); border-radius: 3px; padding: 0 0.3rem; }
-.svc-port { justify-self: start; font-family: var(--cc-mono); font-size: 0.68rem; color: var(--cc-text-dim); }
+.svc-tag { font-size: var(--cc-fs-2xs); font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--cc-accent); border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); padding: 0 0.3rem; }
+.svc-port { justify-self: start; font-family: var(--cc-mono); font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
 .svc-actions { display: flex; gap: 0.4rem; justify-content: flex-end; }
 .save-btn.ghost { background: transparent; color: var(--cc-text-dim); border-color: var(--cc-border); }
 .save-btn.ghost:not(:disabled):hover { color: var(--cc-text); }
@@ -917,16 +917,16 @@ async function switchWt(path: string) {
   display: grid;
   grid-template-columns: max-content 1fr;
   gap: 0.3rem 0.9rem;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text);
 }
 .diag-grid > span:nth-child(odd) { color: var(--cc-text-dim); }
-.mono { font-family: var(--cc-mono); font-size: 0.74rem; word-break: break-all; }
-.field-hint code, .diag-grid code { font-family: var(--cc-mono); font-size: 0.72rem; }
+.mono { font-family: var(--cc-mono); font-size: var(--cc-fs-sm); word-break: break-all; }
+.field-hint code, .diag-grid code { font-family: var(--cc-mono); font-size: var(--cc-fs-sm); }
 /* stale-process flag: amber value + a small chip (problem short; the action is in the tooltip) */
 .diag-stale { color: var(--cc-warn); }
-.diag-stale-note { margin-left: 0.4rem; font-size: 0.68rem; color: var(--cc-warn); white-space: nowrap; cursor: default; }
-.diag-stale-note .pi { font-size: 0.66rem; }
+.diag-stale-note { margin-left: 0.4rem; font-size: var(--cc-fs-xs); color: var(--cc-warn); white-space: nowrap; cursor: default; }
+.diag-stale-note .pi { font-size: var(--cc-fs-xs); }
 
 /* debug console */
 .repl-log {
@@ -934,7 +934,7 @@ async function switchWt(path: string) {
   overflow: auto;
   margin: 0.6rem 0;
   border: 1px solid var(--cc-border);
-  border-radius: 0.35rem;
+  border-radius: var(--cc-radius-sm);
   background: var(--cc-surface-1);
   padding: 0.4rem 0.6rem;
 }
@@ -942,25 +942,25 @@ async function switchWt(path: string) {
 .patch-row { padding: 0.5rem 0; border-bottom: 1px solid var(--cc-border); }
 .patch-row:last-child { border-bottom: none; }
 .patch-head { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.25rem; }
-.patch-title { font-size: 0.82rem; font-weight: 600; color: var(--cc-text); flex: 1; }
+.patch-title { font-size: var(--cc-fs-md); font-weight: 600; color: var(--cc-text); flex: 1; }
 .patch-actions { display: flex; align-items: center; gap: 0.4rem; flex-shrink: 0; }
 .patch-run { margin-top: 0.4rem; }
-.patch-bar { height: 4px; border-radius: 2px; background: var(--cc-surface-2); overflow: hidden; margin-bottom: 0.35rem; }
+.patch-bar { height: 4px; border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); overflow: hidden; margin-bottom: 0.35rem; }
 .patch-bar span { display: block; height: 100%; background: var(--cc-accent); transition: width 0.2s; }
-.patch-log { max-height: 200px; font-family: var(--cc-mono); font-size: 0.72rem; color: var(--cc-text); white-space: pre-wrap; }
+.patch-log { max-height: 200px; font-family: var(--cc-mono); font-size: var(--cc-fs-sm); color: var(--cc-text); white-space: pre-wrap; }
 
 .repl-entry { padding: 0.35rem 0; border-bottom: 1px solid var(--cc-border); }
 .repl-entry:last-child { border-bottom: none; }
-.repl-code { font-family: var(--cc-mono); font-size: 0.74rem; color: var(--cc-accent); white-space: pre-wrap; }
+.repl-code { font-family: var(--cc-mono); font-size: var(--cc-fs-sm); color: var(--cc-accent); white-space: pre-wrap; }
 .repl-out, .repl-val, .repl-err {
-  margin: 0.2rem 0 0; font-family: var(--cc-mono); font-size: 0.72rem;
+  margin: 0.2rem 0 0; font-family: var(--cc-mono); font-size: var(--cc-fs-sm);
   white-space: pre-wrap; word-break: break-word;
 }
 .repl-out { color: var(--cc-text-dim); }
 .repl-val { color: var(--cc-text); }
 .repl-err { color: var(--cc-danger, #f87171); }
 .repl-input {
-  width: 100%; resize: vertical; font-family: var(--cc-mono); font-size: 0.76rem;
-  padding: 0.5rem; border-radius: 0.35rem;
+  width: 100%; resize: vertical; font-family: var(--cc-mono); font-size: var(--cc-fs-sm);
+  padding: 0.5rem; border-radius: var(--cc-radius-sm);
 }
 </style>

--- a/frontend/src/modules/SetupModule.vue
+++ b/frontend/src/modules/SetupModule.vue
@@ -125,7 +125,7 @@ async function waitForBackend(timeoutMs = 60000) {
   max-width: calc(100vw - 2rem);
   background: var(--cc-surface-1);
   border: 1px solid var(--cc-border);
-  border-radius: 12px;
+  border-radius: var(--cc-radius-lg);
   padding: 2rem;
   display: flex;
   flex-direction: column;
@@ -134,12 +134,12 @@ async function waitForBackend(timeoutMs = 60000) {
 .setup-logo { font-size: 2.5rem; line-height: 1; }
 .setup-title { margin: 0.5rem 0 0; font-size: 1.4rem; font-weight: 600; }
 .setup-sub { margin: 0 0 1rem; }   /* + .cc-muted */
-.setup-label { font-size: 0.8rem; color: var(--cc-text-dim); margin-bottom: 0.15rem; }
+.setup-label { font-size: var(--cc-fs-md); color: var(--cc-text-dim); margin-bottom: 0.15rem; }
 .setup-input { width: 100%; font-family: var(--cc-mono, monospace); }
 .setup-hint {
   min-height: 1.2rem;
   margin: 0.15rem 0 0.5rem;
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   color: var(--cc-text-dim);
   display: flex;
   align-items: center;

--- a/frontend/src/modules/TasksModule.vue
+++ b/frontend/src/modules/TasksModule.vue
@@ -257,7 +257,7 @@ const FILTERS: ChipOption[] = [
   background: var(--cc-surface-1);
 }
 .tm-title {
-  font-size: 0.82rem;
+  font-size: var(--cc-fs-md);
   font-weight: 600;
   color: var(--cc-text);
   flex-shrink: 0;
@@ -270,7 +270,7 @@ const FILTERS: ChipOption[] = [
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   cursor: pointer;
   flex-shrink: 0;
@@ -285,7 +285,7 @@ const FILTERS: ChipOption[] = [
   width: 1.7rem;
   height: 1.7rem;
   border: 1px solid var(--cc-border);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   background: none;
   color: var(--cc-text-dim);
   cursor: pointer;
@@ -315,7 +315,7 @@ const FILTERS: ChipOption[] = [
 }
 .tm-empty {
   padding: 2rem 1rem;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   text-align: center;
   background: var(--cc-bg);
@@ -342,22 +342,22 @@ const FILTERS: ChipOption[] = [
   border-radius: 0 2px 2px 0;
 }
 
-.row-icon { font-size: 0.82rem; flex-shrink: 0; }
+.row-icon { font-size: var(--cc-fs-md); flex-shrink: 0; }
 /* status icon colour is inline from TASK_STATUS (lib/taskStatus.ts) */
 
 .row-body  { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 0.1rem; }
 .row-top   { display: flex; align-items: center; gap: 0.35rem; min-width: 0; }
 .mod-pill  {
-  font-size: 0.6rem;
+  font-size: var(--cc-fs-2xs);
   font-weight: 700;
   padding: 0.05rem 0.3rem;
-  border-radius: 0.2rem;
+  border-radius: var(--cc-radius-xs);
   flex-shrink: 0;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 .row-label {
-  font-size: 0.76rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 500;
   color: var(--cc-text);
   white-space: nowrap;
@@ -365,15 +365,15 @@ const FILTERS: ChipOption[] = [
   text-overflow: ellipsis;
   flex: 1;
 }
-.row-seq { font-size: 0.62rem; font-family: var(--cc-mono); color: var(--cc-text-dim); margin-right: 0.2rem; }
+.row-seq { font-size: var(--cc-fs-2xs); font-family: var(--cc-mono); color: var(--cc-text-dim); margin-right: 0.2rem; }
 .chain-pill {
   display: inline-flex;
   align-items: center;
   gap: 0.2rem;
-  font-size: 0.58rem;
+  font-size: var(--cc-fs-3xs);
   font-weight: 700;
   padding: 0.05rem 0.3rem;
-  border-radius: 0.2rem;
+  border-radius: var(--cc-radius-xs);
   background: #a78bfa22;
   color: #a78bfa;
   flex-shrink: 0;
@@ -384,11 +384,11 @@ const FILTERS: ChipOption[] = [
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }
-.chain-pill .pi { font-size: 0.55rem; flex-shrink: 0; }
-.chain-pill.sm { font-size: 0.62rem; padding: 0.1rem 0.4rem; max-width: 10rem; }
+.chain-pill .pi { font-size: var(--cc-fs-3xs); flex-shrink: 0; }
+.chain-pill.sm { font-size: var(--cc-fs-2xs); padding: 0.1rem 0.4rem; max-width: 10rem; }
 .log-title-row { display: flex; align-items: center; gap: 0.4rem; min-width: 0; }
-.row-elapsed { font-size: 0.65rem; font-family: var(--cc-mono); color: var(--cc-text-dim); flex-shrink: 0; }
-.row-image { font-size: 0.68rem; color: var(--cc-text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.row-elapsed { font-size: var(--cc-fs-2xs); font-family: var(--cc-mono); color: var(--cc-text-dim); flex-shrink: 0; }
+.row-image { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 .row-actions {
   display: flex;
@@ -415,7 +415,7 @@ const FILTERS: ChipOption[] = [
   justify-content: center;
   gap: 0.5rem;
   color: var(--cc-text-dim);
-  font-size: 0.82rem;
+  font-size: var(--cc-fs-md);
 }
 .log-empty .pi { font-size: 1.5rem; opacity: 0.3; }
 
@@ -428,13 +428,13 @@ const FILTERS: ChipOption[] = [
   flex-shrink: 0;
   background: var(--cc-surface-1);
 }
-.log-status-icon { font-size: 0.9rem; flex-shrink: 0; }
+.log-status-icon { font-size: var(--cc-fs-lg); flex-shrink: 0; }
 /* log-status-icon colour is inline from TASK_STATUS (lib/taskStatus.ts) */
 
 .log-title-block { flex: 1; min-width: 0; display: flex; flex-direction: column; }
-.log-title { font-size: 0.82rem; font-weight: 600; color: var(--cc-text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.log-image { font-size: 0.7rem; color: var(--cc-text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.log-elapsed { font-size: 0.7rem; font-family: var(--cc-mono); color: var(--cc-text-dim); flex-shrink: 0; }
+.log-title { font-size: var(--cc-fs-md); font-weight: 600; color: var(--cc-text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.log-image { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.log-elapsed { font-size: var(--cc-fs-xs); font-family: var(--cc-mono); color: var(--cc-text-dim); flex-shrink: 0; }
 .log-actions { display: flex; gap: 0.15rem; flex-shrink: 0; }
 
 .log-progress {
@@ -455,7 +455,7 @@ const FILTERS: ChipOption[] = [
   margin: 0;
   padding: 0.75rem 1rem;
   font-family: var(--cc-mono);
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   background: var(--cc-console-bg, var(--cc-bg));
   white-space: pre-wrap;
@@ -469,9 +469,9 @@ const FILTERS: ChipOption[] = [
   border: none;
   cursor: pointer;
   color: var(--cc-text-dim);
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   padding: 0.2rem 0.3rem;
-  border-radius: 0.2rem;
+  border-radius: var(--cc-radius-xs);
 }
 .ra-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 .ra-btn.danger:hover { background: #7f1d1d55; color: #fca5a5; }

--- a/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
+++ b/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
@@ -335,36 +335,36 @@ async function previewOpen() {
 
 <style scoped>
 .bm { display: flex; flex-direction: column; gap: 7px; flex: 1; min-width: 0; padding: 2px; }
-.bm-hint { color: var(--cc-text-dim); font-size: 0.78rem; margin: 2px 0; }
-.bm-busy { display: flex; align-items: center; gap: 8px; padding: 6px 9px; border-radius: 6px;
+.bm-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); margin: 2px 0; }
+.bm-busy { display: flex; align-items: center; gap: 8px; padding: 6px 9px; border-radius: var(--cc-radius-md);
   background: color-mix(in srgb, var(--cc-warn) 16%, transparent); border: 1px solid var(--cc-warn);
-  color: var(--cc-text); font-size: 0.8rem; }
-.bm-sec { border: 1px solid var(--cc-border); border-radius: 6px; padding: 6px 8px; background: var(--cc-surface-1); }
-.bm-sec h4 { display: flex; align-items: baseline; margin: 0 0 4px; font-size: 0.8rem; font-weight: 700; }
-.bm-mini { min-width: 0; padding: 0.2rem 1.4rem 0.2rem 0.4rem; font-size: 0.72rem; }
-.bm-sub { font-weight: 400; color: var(--cc-text-dim); font-size: 0.72rem; margin-left: 6px; }
-.bm-link { float: right; font-size: 0.7rem; color: var(--cc-accent); background: none; border: none;
+  color: var(--cc-text); font-size: var(--cc-fs-md); }
+.bm-sec { border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); padding: 6px 8px; background: var(--cc-surface-1); }
+.bm-sec h4 { display: flex; align-items: baseline; margin: 0 0 4px; font-size: var(--cc-fs-md); font-weight: 700; }
+.bm-mini { min-width: 0; padding: 0.2rem 1.4rem 0.2rem 0.4rem; font-size: var(--cc-fs-sm); }
+.bm-sub { font-weight: 400; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); margin-left: 6px; }
+.bm-link { float: right; font-size: var(--cc-fs-xs); color: var(--cc-accent); background: none; border: none;
   cursor: pointer; padding: 0; display: inline-flex; align-items: center; gap: 3px; }
 .bm-link:hover:not(:disabled) { text-decoration: underline; }
 .bm-link:disabled { opacity: 0.4; cursor: not-allowed; }
 .bm-row { display: flex; align-items: center; gap: 8px; margin: 3px 0; }
-.bm-ch { flex: 1; font-size: 0.8rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bm-ch { flex: 1; font-size: var(--cc-fs-md); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .bm-row select, .bm-sec > select { min-width: 150px; }
-.bm-chk { display: flex; align-items: center; gap: 6px; font-size: 0.8rem; margin: 3px 0; cursor: pointer; }
+.bm-chk { display: flex; align-items: center; gap: 6px; font-size: var(--cc-fs-md); margin: 3px 0; cursor: pointer; }
 .bm-chk.inline { display: inline-flex; margin-right: 10px; }
 .bm-inset { display: flex; align-items: center; gap: 6px; margin: 5px 0 1px; }
 /* range inputs default to a fixed intrinsic width (~129px) and don't shrink, so two on one row
    (fps + res) overflow the sidebar. Let them flex down to share the available width. */
 .bm-inset input[type="range"] { flex: 1; min-width: 0; }
-.bm-lbl { font-size: 0.72rem; color: var(--cc-text-dim); }
-.bm-val { font-size: 0.72rem; min-width: 1.6rem; }
+.bm-lbl { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.bm-val { font-size: var(--cc-fs-sm); min-width: 1.6rem; }
 .bm-attrs { margin-top: 6px; display: flex; flex-direction: column; gap: 4px; }
-.bm-preview { font-size: 0.76rem; color: var(--cc-text-dim); margin: 6px 0 0; word-break: break-all; }
+.bm-preview { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin: 6px 0 0; word-break: break-all; }
 .bm-preview b { color: var(--cc-text); }
 .bm-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 .bm-title-row { display: flex; align-items: center; gap: 0.5rem; }
 .bm-title-toggle { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; flex-shrink: 0; font-weight: 600; }
 .bm-title-range { flex: 1; min-width: 3rem; accent-color: var(--cc-accent); }
 .bm-note { width: 100%; box-sizing: border-box; font: inherit; padding: 3px 6px; margin-top: 5px;
-  border: 1px solid var(--cc-border); border-radius: 4px; background: var(--cc-surface-1); color: var(--cc-text); }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); color: var(--cc-text); }
 </style>

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -139,7 +139,7 @@ defineExpose({ exportImage, getCsv, exportSvg })
           <label v-for="f in featureOptions" :key="f" class="feat-row">
             <input type="checkbox" :checked="features.includes(f)" @change="toggleFeature(f)" /> {{ label(f) }}
           </label>
-          <p v-if="!featureOptions.length" class="feat-empty">No recorded features — re-run clustering, or this run predates feature tracking.</p>
+          <p v-if="!featureOptions.length" class="feat-empty cc-muted">No recorded features — re-run clustering, or this run predates feature tracking.</p>
         </div>
       </details>
       <select v-model="heatmapScale" class="hm-sel"
@@ -165,7 +165,7 @@ defineExpose({ exportImage, getCsv, exportSvg })
     </template>
     <div class="hm-body">
       <PlotChart v-if="heatmap" ref="plotRef" :data="heatmap" :opts="opts" />
-      <div v-else class="hm-empty">
+      <div v-else class="hm-empty cc-empty cc-empty-overlay">
         <i :class="['pi', loading ? 'pi-spin pi-spinner' : 'pi-table']" />
         <p>{{ loading ? 'Loading…' : (err || 'Pick features to build the cluster heatmap.') }}</p>
       </div>
@@ -174,22 +174,23 @@ defineExpose({ exportImage, getCsv, exportSvg })
 </template>
 
 <style scoped>
-.feat { position: relative; font-size: 12px; }
-.feat summary { cursor: pointer; color: var(--cc-text-dim); list-style: none; padding: 2px 6px; border: 1px solid var(--cc-border); border-radius: 4px; }
+.feat { position: relative; font-size: var(--cc-fs-sm); }
+.feat summary { cursor: pointer; color: var(--cc-text-dim); list-style: none; padding: 2px 6px; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); }
 .feat[open] summary { color: var(--cc-text); }
 .feat-list { position: absolute; z-index: 10; top: 1.7rem; left: 0; min-width: 12rem; max-height: 16rem; overflow-y: auto;
-  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 5px; padding: 5px; box-shadow: 0 4px 14px rgba(0,0,0,0.4); }
+  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); padding: 5px; box-shadow: 0 4px 14px rgba(0,0,0,0.4); }
 .feat-row { display: flex; align-items: center; gap: 5px; padding: 2px 3px; color: var(--cc-text); white-space: nowrap; }
-.feat-empty { color: var(--cc-text-dim); font-size: 11px; margin: 4px; }
-.hm-sel { font-size: 12px; margin-left: 6px; }
-.hm-chk { display: inline-flex; align-items: center; gap: 3px; font-size: 12px; color: var(--cc-text-dim); margin-left: 6px; cursor: pointer; }
+.feat-empty { font-size: var(--cc-fs-xs); margin: 4px; }   /* + .cc-muted (colour) */
+.hm-sel { font-size: var(--cc-fs-sm); margin-left: 6px; }
+.hm-chk { display: inline-flex; align-items: center; gap: 3px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin-left: 6px; cursor: pointer; }
 .hm-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: 0.7rem; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
+  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
 .hm-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
-.hm-export { font-size: 12px; max-width: 7rem; }
+.hm-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 .hm-body { display: flex; flex: 1; min-height: 0; padding: 6px; }
-.hm-empty { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; color: var(--cc-text-dim); text-align: center; padding: 1rem; }
+/* + .cc-empty .cc-empty-overlay (was a byte-identical copy of the same overlay empty in UmapView + the two HMM panels) */
+.hm-empty { padding: 1rem; }
 .hm-empty .pi { font-size: 1.4rem; opacity: 0.6; }
-.hm-empty p { margin: 0; font-size: 0.8rem; max-width: 22rem; }
+.hm-empty p { margin: 0; font-size: var(--cc-fs-md); max-width: 22rem; }
 </style>

--- a/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
@@ -191,7 +191,7 @@ defineExpose({ exportImage, getCsv })
     </template>
     <div class="hmm-body">
       <div v-show="rows.length" ref="host" class="hmm-host" :style="{ background: hostBg }" />
-      <div v-if="!rows.length" class="hmm-empty">
+      <div v-if="!rows.length" class="hmm-empty cc-empty cc-empty-overlay">
         <i :class="['pi', loading ? 'pi-spin pi-spinner' : 'pi-chart-bar']" />
         <p>{{ loading ? 'Loading…' : (err || 'No HMM states to show.') }}</p>
       </div>
@@ -201,21 +201,22 @@ defineExpose({ exportImage, getCsv })
 
 <style scoped>
 .hmm-body { display: flex; flex: 1; min-height: 0; padding: 6px; }
-.hmm-host { position: relative; flex: 1; min-height: 0; background: white; border-radius: 3px; overflow: hidden; }
+.hmm-host { position: relative; flex: 1; min-height: 0; background: white; border-radius: var(--cc-radius-xs); overflow: hidden; }
 .hmm-host :deep(svg) { display: block; }
 /* themed legend/title overlays (float over the plot, theme ink) — see plots/overlays.ts */
 .hmm-host :deep(.plot-legend-overlay) { position: absolute; top: 4px; right: 6px; display: flex; flex-wrap: wrap;
-  gap: 2px 10px; max-width: 62%; justify-content: flex-end; border-radius: 3px; padding: 1px 4px; }
+  gap: 2px 10px; max-width: 62%; justify-content: flex-end; border-radius: var(--cc-radius-xs); padding: 1px 4px; }
 .hmm-host :deep(.plot-legend-overlay *) { color: inherit !important; }
 .hmm-host :deep(.plot-title-overlay) { position: absolute; top: 4px; left: 8px; max-width: 70%; font-weight: 600;
-  font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.cc-sel { font-size: 12px; }
+  font-size: var(--cc-fs-sm); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cc-sel { font-size: var(--cc-fs-sm); }
 .hmm-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: 0.7rem; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
+  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
 .hmm-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
-.hmm-export { font-size: 12px; max-width: 7rem; }
-.hmm-empty { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; color: var(--cc-text-dim); text-align: center; padding: 1rem; }
+.hmm-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
+/* + .cc-empty .cc-empty-overlay (was a byte-identical copy of the same overlay empty in UmapView + ClusterHeatmapPanel) */
+.hmm-empty { padding: 1rem; }
 .hmm-empty .pi { font-size: 1.4rem; opacity: 0.6; }
-.hmm-empty p { margin: 0; font-size: 0.8rem; max-width: 22rem; }
+.hmm-empty p { margin: 0; font-size: var(--cc-fs-md); max-width: 22rem; }
 </style>

--- a/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
@@ -198,7 +198,7 @@ defineExpose({ exportImage, getCsv })
     </template>
     <div class="hmm-body">
       <div v-show="rows.length" ref="host" class="hmm-host" :style="{ background: hostBg }" />
-      <div v-if="!rows.length" class="hmm-empty">
+      <div v-if="!rows.length" class="hmm-empty cc-empty cc-empty-overlay">
         <i :class="['pi', loading ? 'pi-spin pi-spinner' : 'pi-circle']" />
         <p>{{ loading ? 'Loading…' : (err || 'No HMM transitions to show.') }}</p>
       </div>
@@ -208,23 +208,24 @@ defineExpose({ exportImage, getCsv })
 
 <style scoped>
 .hmm-body { display: flex; flex: 1; min-height: 0; padding: 6px; }
-.hmm-host { position: relative; flex: 1; min-height: 0; background: white; border-radius: 3px; overflow: hidden; }
+.hmm-host { position: relative; flex: 1; min-height: 0; background: white; border-radius: var(--cc-radius-xs); overflow: hidden; }
 .hmm-host :deep(svg) { display: block; }
 /* vertical colour ramp in the right margin (max at top, 0 at bottom) */
 .hmm-host :deep(.hmm-vlegend) { position: absolute; top: 50%; right: 5px; transform: translateY(-50%);
-  display: flex; flex-direction: column; align-items: center; gap: 3px; font-size: 10px; line-height: 1; }
-.hmm-host :deep(.hmm-vlegend .vl-ramp) { width: 11px; height: 90px; border-radius: 2px; border: 1px solid rgba(128,128,128,0.4);
+  display: flex; flex-direction: column; align-items: center; gap: 3px; font-size: var(--cc-fs-2xs); line-height: 1; }
+.hmm-host :deep(.hmm-vlegend .vl-ramp) { width: 11px; height: 90px; border-radius: var(--cc-radius-xs); border: 1px solid rgba(128,128,128,0.4);
   background: linear-gradient(to top, #ffffcc, #ffeda0, #fed976, #feb24c, #fd8d3c, #fc4e2a, #e31a1c, #b10026); }
 .hmm-host :deep(.hmm-vlegend .vl-cap) { font-weight: 600; }
 .hmm-host :deep(.plot-title-overlay) { position: absolute; top: 4px; left: 8px; max-width: 70%; font-weight: 600;
-  font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.cc-sel { font-size: 12px; }
+  font-size: var(--cc-fs-sm); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cc-sel { font-size: var(--cc-fs-sm); }
 .hmm-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: 0.3rem; background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: 0.7rem; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
+  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
 .hmm-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
-.hmm-export { font-size: 12px; max-width: 7rem; }
-.hmm-empty { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; color: var(--cc-text-dim); text-align: center; padding: 1rem; }
+.hmm-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
+/* + .cc-empty .cc-empty-overlay (was a byte-identical copy of the same overlay empty in UmapView + ClusterHeatmapPanel) */
+.hmm-empty { padding: 1rem; }
 .hmm-empty .pi { font-size: 1.4rem; opacity: 0.6; }
-.hmm-empty p { margin: 0; font-size: 0.8rem; max-width: 22rem; }
+.hmm-empty p { margin: 0; font-size: var(--cc-fs-md); max-width: 22rem; }
 </style>

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -187,7 +187,7 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
 
 <template>
   <div class="cluster-plots">
-    <div v-if="!imageUids.length" class="cp-empty">Select clustered image(s) above to explore clusters.</div>
+    <div v-if="!imageUids.length" class="cp-empty cc-empty-inline">Select clustered image(s) above to explore clusters.</div>
     <template v-else>
       <div class="cp-bar">
         <label>clustering
@@ -268,20 +268,20 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
 
 <style scoped>
 .cluster-plots { display: flex; flex-direction: column; height: 100%; min-height: 80vh; }
-.cp-empty { padding: 20px; color: var(--cc-text-dim); }
-.cp-bar { display: flex; align-items: center; gap: 14px; padding: 8px 4px; font-size: 12px; flex-shrink: 0; }
+.cp-empty { padding: 20px; }   /* + .cc-empty-inline (row/colour) */
+.cp-bar { display: flex; align-items: center; gap: 14px; padding: 8px 4px; font-size: var(--cc-fs-sm); flex-shrink: 0; }
 .cp-bar label { display: flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .cp-bar select { min-width: 7rem; }
-.cp-hint { color: var(--cc-text-dim); font-size: 11px; opacity: 0.7; }
+.cp-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); opacity: 0.7; }
 .cp-members { display: flex; align-items: flex-start; gap: 6px; margin: 0 4px 6px; padding: 6px 9px;
-  font-size: 11px; color: #fcd34d; background: #78350f22; border: 1px solid #b4530933; border-radius: 5px; }
+  font-size: var(--cc-fs-xs); color: #fcd34d; background: #78350f22; border: 1px solid #b4530933; border-radius: var(--cc-radius-sm); }
 .cp-members .pi { margin-top: 1px; }
-.cp-fix { flex-shrink: 0; margin-left: auto; align-self: center; font-size: 11px; padding: 3px 9px;
-  border: 1px solid #b45309; border-radius: 4px; background: #78350f44; color: #fcd34d; cursor: pointer; white-space: nowrap; }
+.cp-fix { flex-shrink: 0; margin-left: auto; align-self: center; font-size: var(--cc-fs-xs); padding: 3px 9px;
+  border: 1px solid #b45309; border-radius: var(--cc-radius-xs); background: #78350f44; color: #fcd34d; cursor: pointer; white-space: nowrap; }
 .cp-fix:hover { background: #78350f88; }
-.cp-add { font-size: 12px; padding: 4px 8px; }
-.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
-.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 5px 9px; cursor: pointer; font-size: 12px; }
+.cp-add { font-size: var(--cc-fs-sm); padding: 4px 8px; }
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 5px 9px; cursor: pointer; font-size: var(--cc-fs-sm); }
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button:hover { color: var(--cc-text); }
 .seg button.on { color: var(--cc-accent); background: var(--cc-surface-1); }

--- a/frontend/src/modules/gate/GatePairsPanel.vue
+++ b/frontend/src/modules/gate/GatePairsPanel.vue
@@ -198,42 +198,42 @@ function exportAs(kind: string) {
 </template>
 
 <style scoped>
-.ro-tag { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-text-dim);
-  border: 1px solid var(--cc-border); border-radius: 3px; padding: 1px 5px; }
+.ro-tag { font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-text-dim);
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); padding: 1px 5px; }
 /* heavy-matrix warning strip (brief; numbers + the fix live in the tooltip) */
-.pairs-warn { display: flex; align-items: center; gap: 6px; padding: 4px 10px; font-size: 11px;
+.pairs-warn { display: flex; align-items: center; gap: 6px; padding: 4px 10px; font-size: var(--cc-fs-xs);
   color: var(--cc-warn, #f59e0b); background: color-mix(in srgb, var(--cc-warn, #f59e0b) 12%, transparent);
   border-bottom: 1px solid var(--cc-border); cursor: help; }
 .ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
 /* axis controls now live in the auto-hide overlay (#actions) — full line below the icon tools */
-.panel-ctrl { flex-basis: 100%; display: flex; flex-direction: column; gap: 6px; font-size: 12px; }
+.panel-ctrl { flex-basis: 100%; display: flex; flex-direction: column; gap: 6px; font-size: var(--cc-fs-sm); }
 .ax-row { display: flex; align-items: center; gap: 6px; }
 .ax-lbl { width: 2.6rem; color: var(--cc-text-dim); flex-shrink: 0; }
 .ax-chan { width: 12rem; flex: none; }
 .tsel { width: 5.5rem; flex-shrink: 0; }
 /* amber: some channels' range can't use the chosen transform → those tiles auto-shown on linear */
 .tsel.tsel-amber { border-color: #f59e0b; color: #f59e0b; }
-.ax-warn { color: #f59e0b; font-size: 0.7rem; flex-shrink: 0; cursor: help; }
+.ax-warn { color: #f59e0b; font-size: var(--cc-fs-xs); flex-shrink: 0; cursor: help; }
 /* channel multiselect popover */
 .chan-pick { position: relative; flex: 1; min-width: 0; }
 .chan-btn { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 6px;
   background: var(--cc-surface-2); color: var(--cc-text); border: 1px solid var(--cc-border);
-  border-radius: 5px; padding: 3px 8px; cursor: pointer; font-size: 12px; }
+  border-radius: var(--cc-radius-sm); padding: 3px 8px; cursor: pointer; font-size: var(--cc-fs-sm); }
 .chan-btn.on { border-color: var(--cc-accent); }
 /* inner layout only — TeleportPopover provides surface/border/shadow/position */
 .chan-pop { width: 15rem; max-width: 80vw; padding: 6px; }
 .chan-pop-head { display: flex; align-items: center; justify-content: space-between; padding: 2px 4px 6px;
-  color: var(--cc-text-dim); font-size: 11px; border-bottom: 1px solid var(--cc-border); }
-.chan-clear { background: none; border: none; color: var(--cc-accent); cursor: pointer; font-size: 11px; }
+  color: var(--cc-text-dim); font-size: var(--cc-fs-xs); border-bottom: 1px solid var(--cc-border); }
+.chan-clear { background: none; border: none; color: var(--cc-accent); cursor: pointer; font-size: var(--cc-fs-xs); }
 .chan-clear:disabled { color: var(--cc-text-dim); cursor: default; }
 .chan-list { max-height: 220px; overflow-y: auto; padding: 4px 0; }
 .chan-item { display: flex; align-items: center; gap: 6px; padding: 3px 4px; cursor: pointer; color: var(--cc-text); }
 .chan-item:hover { background: var(--cc-surface-2); }
 .chan-item.disabled { color: var(--cc-text-dim); cursor: default; }
-.chan-cap { padding: 5px 4px 2px; font-size: 10px; color: var(--cc-text-dim); border-top: 1px solid var(--cc-border); }
-.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
-.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 3px 8px; cursor: pointer; font-size: 12px; }
+.chan-cap { padding: 5px 4px 2px; font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); border-top: 1px solid var(--cc-border); }
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 3px 8px; cursor: pointer; font-size: var(--cc-fs-sm); }
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button.on { background: var(--cc-accent); color: #fff; }
-.gp-export { font-size: 12px; max-width: 7rem; }
+.gp-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 </style>

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -392,7 +392,7 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
                      :view-tick="viewTick" :loading="loading"
                      @draw="onDraw" @edit="onEdit" @cancel="mode = 'off'">
       <!-- untracked segmentation on a track plot: nothing to show, point the user at tracking -->
-      <div v-if="notTracked" class="gate-empty">
+      <div v-if="notTracked" class="gate-empty cc-empty-inline cc-card">
         <i class="pi pi-share-alt" />
         <span>Not tracked yet — run tracking on this segmentation first.</span>
       </div>
@@ -416,39 +416,38 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
    this component's scoped styles). */
 /* axis controls now live in the auto-hide overlay (#actions); take a full line below the icon tools
    (flex-basis:100% within the flex-wrap overlay), one row per axis so they don't wrap awkwardly */
-.panel-ctrl { flex-basis: 100%; display: flex; flex-direction: column; gap: 6px; font-size: 12px; }
+.panel-ctrl { flex-basis: 100%; display: flex; flex-direction: column; gap: 6px; font-size: var(--cc-fs-sm); }
 .ax-row { display: flex; align-items: center; gap: 6px; }
 .ax-lbl { width: 1.8rem; color: var(--cc-text-dim); flex-shrink: 0; }
 /* fixed widths so the controls don't stretch when the plot is resized */
 .ax-chan { width: 9rem; flex: none; }
 .ax-row .tsel { flex-shrink: 0; }
-.panel-ctrl label { display: flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: 12px; }
+.panel-ctrl label { display: flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
 /* fixed widths so the bar doesn't reflow when the selected option text changes; the rest
    (background, border, chevron, focus) comes from the global form base in style.css */
-.panel-ctrl select { width: 8rem; font-size: 12px; padding-top: 2px; padding-bottom: 2px; }
+.panel-ctrl select { width: 8rem; font-size: var(--cc-fs-sm); padding-top: 2px; padding-bottom: 2px; }
 .panel-ctrl select.tsel { width: 5.5rem; }
 /* amber: this axis' preferred transform was auto-linearised because the measure's range can't use it */
 .panel-ctrl select.tsel.tsel-amber { border-color: #f59e0b; color: #f59e0b; }
-.ax-warn { color: #f59e0b; font-size: 0.7rem; flex-shrink: 0; cursor: help; }
+.ax-warn { color: #f59e0b; font-size: var(--cc-fs-xs); flex-shrink: 0; cursor: help; }
 .panel-ctrl select:focus { outline: none; border-color: var(--cc-accent); }
 .ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
-.gp-export { font-size: 12px; max-width: 7rem; }
+.gp-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 /* the plot body (scatter/layers/gate + ticks/axes + PNG export) lives in GateScatterCell now. */
 .panel-name { position: absolute; top: 4px; left: 4px; display: flex; align-items: center; gap: 5px;
-  background: var(--cc-surface-1); border: 1px solid var(--cc-accent); border-radius: 4px; padding: 4px 6px; font-size: 11px; }
-.panel-name input { background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-border); border-radius: 3px; padding: 1px 5px; width: 90px; }
+  background: var(--cc-surface-1); border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); padding: 4px 6px; font-size: var(--cc-fs-xs); }
+.panel-name input { background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); padding: 1px 5px; width: 90px; }
 .panel-name input.name-invalid { border-color: var(--cc-danger, #ef4444); }
-.name-hint { color: var(--cc-danger, #ef4444); font-size: 10px; max-width: 150px; line-height: 1.2; }
+.name-hint { color: var(--cc-danger, #ef4444); font-size: var(--cc-fs-2xs); max-width: 150px; line-height: 1.2; }
 /* subtle draw-mode affordance (top-right of the plot); mirrors .panel-name but muted and non-interactive */
 /* inline affordance beside the pop selector (was overlaid on the plot, which obscured gating) */
 .gate-hint { margin-left: 2px; pointer-events: none; display: inline-flex; align-items: center; gap: 4px;
-  font-size: 10px; color: var(--cc-text-dim); white-space: nowrap; }
+  font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); white-space: nowrap; }
 
-/* centred empty-state over the plot: track-grained pop type on an untracked segmentation */
+/* centred empty-state over the plot: track-grained pop type on an untracked segmentation.
+   + .cc-empty-inline .cc-card — an inline empty wearing card chrome; only the centring is local */
 .gate-empty { position: absolute; inset: 0; margin: auto; width: max-content; height: max-content;
-  display: flex; align-items: center; gap: 6px; padding: 8px 12px; pointer-events: none;
-  background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: 6px;
-  font-size: 12px; color: var(--cc-text-dim); }
-.gate-hint kbd { font: inherit; background: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: 3px;
+  padding: 8px 12px; pointer-events: none; font-size: var(--cc-fs-sm); }
+.gate-hint kbd { font: inherit; background: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs);
   padding: 0 3px; color: var(--cc-text); }
 </style>

--- a/frontend/src/modules/gate/GatingCopyDialog.vue
+++ b/frontend/src/modules/gate/GatingCopyDialog.vue
@@ -128,17 +128,17 @@ async function copy() {
 
 <style scoped>
 .cg-body { display: flex; flex-direction: column; gap: 0.7rem; }   /* padding from BaseModal */
-.cg-warn { display: flex; align-items: center; gap: 0.4rem; margin: 0; font-size: 0.78rem; color: #fcd34d;
-  background: #7c2d1244; border: 1px solid #92400e55; border-radius: 0.3rem; padding: 0.4rem 0.55rem; line-height: 1.35; }
+.cg-warn { display: flex; align-items: center; gap: 0.4rem; margin: 0; font-size: var(--cc-fs-sm); color: #fcd34d;
+  background: #7c2d1244; border: 1px solid #92400e55; border-radius: var(--cc-radius-sm); padding: 0.4rem 0.55rem; line-height: 1.35; }
 .cg-empty { margin: 0; }   /* + .cc-muted */
-.cg-all { font-size: 0.75rem; color: var(--cc-text-dim); display: flex; align-items: center; gap: 0.4rem; cursor: pointer; }
+.cg-all { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); display: flex; align-items: center; gap: 0.4rem; cursor: pointer; }
 .cg-list { display: flex; flex-direction: column; gap: 0.15rem; max-height: 240px; overflow: auto;
-  border: 1px solid var(--cc-border); border-radius: 0.35rem; padding: 0.4rem 0.5rem; }
-.cg-item { display: flex; align-items: center; gap: 0.5rem; font-size: 0.82rem; color: var(--cc-text); cursor: pointer; padding: 0.15rem 0; }
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); padding: 0.4rem 0.5rem; }
+.cg-item { display: flex; align-items: center; gap: 0.5rem; font-size: var(--cc-fs-md); color: var(--cc-text); cursor: pointer; padding: 0.15rem 0; }
 .cg-item input, .cg-all input, .cg-layout input { accent-color: var(--cc-accent); cursor: pointer; }
 .cg-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cg-layout { display: flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; color: var(--cc-text); cursor: pointer; }
-.cg-missing { display: flex; flex-direction: column; gap: 0.2rem; font-size: 0.72rem; color: var(--cc-text-dim);
+.cg-layout { display: flex; align-items: center; gap: 0.4rem; font-size: var(--cc-fs-md); color: var(--cc-text); cursor: pointer; }
+.cg-missing { display: flex; flex-direction: column; gap: 0.2rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim);
   border-top: 1px solid var(--cc-border); padding-top: 0.5rem; }
 .cg-missing-head { display: flex; align-items: center; gap: 0.35rem; color: #f59e0b; }
 .cg-missing-names { padding-left: 1.1rem; word-break: break-word; }

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -294,13 +294,13 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
 /* fill all available height so the plot workspace isn't capped */
 .gating-plots { display: flex; flex-direction: column; height: 100%; min-height: 80vh; }
 .gp-empty { padding: 20px; }   /* + .cc-muted */
-.gp-bar { display: flex; align-items: center; gap: 14px; padding: 8px 4px; font-size: 12px; flex-shrink: 0; }
+.gp-bar { display: flex; align-items: center; gap: 14px; padding: 8px 4px; font-size: var(--cc-fs-sm); flex-shrink: 0; }
 .gp-bar label { display: flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .gp-bar select { min-width: 9rem; }   /* visual styling from the global form base */
-.gp-hint { color: var(--cc-text-dim); font-size: 11px; opacity: 0.7; }
+.gp-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); opacity: 0.7; }
 /* window-arrange segmented icons */
-.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: 5px; overflow: hidden; }
-.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 5px 9px; cursor: pointer; font-size: 12px; }
+.seg { display: inline-flex; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); overflow: hidden; }
+.seg button { background: var(--cc-surface-2); color: var(--cc-text-dim); border: none; padding: 5px 9px; cursor: pointer; font-size: var(--cc-fs-sm); }
 .seg button + button { border-left: 1px solid var(--cc-border); }
 .seg button:hover { color: var(--cc-text); }
 .seg button.on { background: var(--cc-accent); color: #fff; }
@@ -308,7 +308,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
 .seg button:disabled:hover { color: var(--cc-text-dim); }
 /* z-slice window stepper (shown only in slice mode) */
 .zwin { display: flex; align-items: center; gap: 2px; color: var(--cc-text-dim); }
-.zwin input { width: 3.2rem; font-size: 12px; padding: 3px 4px; }
+.zwin input { width: 3.2rem; font-size: var(--cc-fs-sm); padding: 3px 4px; }
 /* free-floating plot workspace: panels + manager are absolutely positioned within */
 .gp-canvas { position: relative; flex: 1; min-height: 70vh; }
 /* the scaled workspace fills the canvas (offsetParent for the floating plot panels); transform inline */

--- a/frontend/src/modules/metadata/MetadataPanel.vue
+++ b/frontend/src/modules/metadata/MetadataPanel.vue
@@ -532,14 +532,14 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 .panel-section.disabled { opacity: 0.45; pointer-events: none; }
 
 .section-title {
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;
   color: var(--cc-text-dim);
 }
 .section-hint {
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   margin: 0;
   line-height: 1.5;
@@ -563,9 +563,9 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 .field-textarea {
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-border);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   color: var(--cc-text);
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   padding: 0.35rem 0.5rem;
   resize: vertical;
   font-family: var(--cc-mono);
@@ -583,7 +583,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
   display: flex;
   align-items: center;
   gap: 0.3rem;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   cursor: pointer;
 }
@@ -592,29 +592,29 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 .builder-toggle {
   display: inline-flex; align-items: center; gap: 0.3rem;
   background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.75rem; padding: 0.1rem 0;
+  color: var(--cc-text-dim); font-size: var(--cc-fs-sm); padding: 0.1rem 0;
   margin-top: 0.15rem;
 }
 .builder-toggle:hover { color: var(--cc-text); }
 .builder-toggle:disabled { opacity: 0.4; cursor: not-allowed; }
-.builder-toggle .pi { font-size: 0.6rem; }
+.builder-toggle .pi { font-size: var(--cc-fs-2xs); }
 
 .builder {
   display: flex; flex-direction: column; gap: 0.4rem;
   margin-top: 0.35rem; padding: 0.5rem;
-  border: 1px solid var(--cc-border); border-radius: 0.3rem;
+  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm);
   background: var(--cc-surface-1);
 }
 .builder.disabled { opacity: 0.5; pointer-events: none; }
 /* fixed label width + flexible controls → every select/input lines up down the builder */
-.builder-label { font-size: 0.75rem; color: var(--cc-text-dim); flex: 0 0 5rem; white-space: nowrap; }
+.builder-label { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); flex: 0 0 5rem; white-space: nowrap; }
 .builder .field-input { flex: 1 1 0; min-width: 0; }
 .builder .builder-custom { flex: 0 0 3.5rem; }
 
-.builder-hint { font-size: 0.72rem; color: var(--cc-text-dim); margin: 0; line-height: 1.4; }
+.builder-hint { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin: 0; line-height: 1.4; }
 
 /* single preview for the regex field (typed or built) */
-.regex-preview { display: flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; min-width: 0; }
+.regex-preview { display: flex; align-items: center; gap: 0.3rem; font-size: var(--cc-fs-sm); min-width: 0; }
 .preview-src {
   color: var(--cc-text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   flex: 1; min-width: 0;
@@ -628,7 +628,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 .warn-count {
   display: inline-flex; align-items: center; justify-content: center;
   min-width: 1.1rem; height: 1.1rem; padding: 0 0.3rem;
-  border-radius: 999px; font-size: 0.65rem; font-weight: 700;
+  border-radius: var(--cc-radius-pill); font-size: var(--cc-fs-2xs); font-weight: 700;
   background: #7c2d1244; color: #fcd34d;
 }
 

--- a/frontend/src/modules/spatial/SpatialContactHeatmap.vue
+++ b/frontend/src/modules/spatial/SpatialContactHeatmap.vue
@@ -57,17 +57,18 @@ useDataRefresh(() => props.imageUids, load)   // refetch when a spatial task fin
           <option v-for="s in resp.suffixes" :key="s" :value="s">{{ s }}</option>
         </select>
       </label>
-      <span v-if="resp" class="ch-meta">{{ resp.nCells }} cells · {{ resp.nEdges }} contacts</span>
+      <span v-if="resp" class="ch-meta cc-readout">{{ resp.nCells }} cells · {{ resp.nEdges }} contacts</span>
     </div>
     <PlotChart v-if="data" :data="data" :opts="opts" />
-    <div v-else-if="loading" class="ch-empty">Loading…</div>
-    <div v-else class="ch-empty">No contact statistics — run “Contact statistics” for this image first.</div>
+    <div v-else-if="loading" class="ch-empty cc-empty-inline">Loading…</div>
+    <div v-else class="ch-empty cc-empty-inline">No contact statistics — run “Contact statistics” for this image first.</div>
   </div>
 </template>
 
 <style scoped>
 .contact-heatmap { display: flex; flex-direction: column; gap: 0.5rem; }
-.ch-controls { display: flex; align-items: center; gap: 1rem; font-size: 0.85rem; }
-.ch-meta { color: var(--text-muted, #888); }
-.ch-empty { padding: 1rem; color: var(--text-muted, #888); font-size: 0.9rem; }
+.ch-controls { display: flex; align-items: center; gap: 1rem; font-size: var(--cc-fs-md); }
+/* + .cc-readout / .cc-empty-inline — both previously read a `--text-muted` token that has never
+   existed in this app (the real one is --cc-text-dim), so both silently rendered the #888 fallback */
+.ch-empty { padding: 1rem; font-size: var(--cc-fs-lg); }
 </style>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -52,15 +52,24 @@
 
   /* Corner radius scale — collapses the ~8 ad-hoc radii (0.2/0.25/0.3/0.35/0.4…) to two steps.
      -sm = small controls/chips/inputs; -md = cards/panels/dialogs. Use these, not a raw rem. */
-  --cc-radius-sm: 0.25rem;
-  --cc-radius-md: 0.4rem;
+  --cc-radius-xs:   0.2rem;   /* ≈  3px — chips, swatches, inline code, micro chrome */
+  --cc-radius-sm:   0.3rem;   /* ≈  5px — buttons, inputs, small controls */
+  --cc-radius-md:   0.4rem;   /* ≈  6px — cards, panels, dialogs */
+  --cc-radius-lg:   0.5rem;   /* =  8px — large dialogs / prominent surfaces */
+  --cc-radius-pill: 999px;    /* fully rounded — pills and dots */
 
-  /* Small-text scale — collapses the ~10 ad-hoc sizes (0.6–0.85rem) to three steps for the
-     "secondary text" scenarios (labels, hints, readouts, meta). Body stays 13px; these are for
-     de-emphasised chrome. Use with `.cc-muted` etc., not a raw rem. */
-  --cc-fs-xs: 0.68rem;
-  --cc-fs-sm: 0.75rem;
-  --cc-fs-md: 0.82rem;
+  /* Small-text scale for the "secondary text" scenarios (labels, hints, readouts, meta). Body stays
+     13px; these are for de-emphasised chrome. Use with `.cc-muted` etc., not a raw rem.
+     The two smallest steps exist because dense chrome (whiteboard nodes, chip rows, list headers)
+     genuinely sits below the -xs floor, and the codebase spells the same scale in px as well as rem
+     — 12px IS -sm, 11px IS -xs. Without -2xs/-3xs those sites could not adopt the scenario utilities
+     without growing, which is exactly why they were stranded as "bespoke". */
+  --cc-fs-3xs: 0.56rem;   /* ≈  9px — micro labels inside dense nodes/chips */
+  --cc-fs-2xs: 0.62rem;   /* ≈ 10px — dense chrome, list headers */
+  --cc-fs-xs:  0.68rem;   /* ≈ 11px */
+  --cc-fs-sm:  0.75rem;   /* =  12px */
+  --cc-fs-md:  0.82rem;
+  --cc-fs-lg:  0.9rem;    /* ≈ 14px — the one step ABOVE body: dialog prose, prominent hints */
 }
 
 /* ── Reset / base ──────────────────────────────────────────────────────────── */
@@ -70,7 +79,7 @@
 body {
   margin: 0;
   font-family: system-ui, 'Segoe UI', Roboto, sans-serif;
-  font-size: 13px;
+  font-size: var(--cc-fs-md);
   line-height: 1.5;
   background: #0f1117;
   color: #e6edf3;
@@ -86,18 +95,18 @@ body {
 
 ::-webkit-scrollbar        { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track  { background: transparent; }
-::-webkit-scrollbar-thumb  { background: #30363d; border-radius: 3px; }
+::-webkit-scrollbar-thumb  { background: #30363d; border-radius: var(--cc-radius-xs); }
 ::-webkit-scrollbar-thumb:hover { background: #484f58; }
 
 /* ── PrimeVue tooltip overrides ────────────────────────────────────────────── */
 
 .p-tooltip .p-tooltip-text {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   padding: 0.3rem 0.6rem;
   background: #21262d;
   border: 1px solid #30363d;
   color: #e6edf3;
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   max-width: 280px;
   line-height: 1.45;
 }
@@ -110,10 +119,10 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 500;
   padding: 0.28rem 0.65rem;
-  border-radius: 0.35rem;
+  border-radius: var(--cc-radius-sm);
   border: 1px solid transparent;
   cursor: pointer;
   transition: filter 0.1s, background 0.1s, color 0.1s;
@@ -159,30 +168,58 @@ body {
    of styling each site ad-hoc. Compose them; add only layout (width/margin/flex) in scoped CSS.
    See docs/UI.md → "UX primitive catalog" and docs/todo/UX_PRIMITIVES_PLAN.md. */
 
-/* Secondary / de-emphasised text — hints, subtitles, captions, meta lines. */
+/* Each scenario below is `base class + optional modifier`, and the modifiers exist for one reason:
+   the axis a site legitimately varies on. Bake that axis into the base and adoption forces a visual
+   change, so the site stays hand-rolled — which is how the "kept bespoke" list in
+   UX_PRIMITIVES_PLAN.md accumulated. The axes are DENSITY (-dense/-micro, for dense chrome),
+   SURFACE (-2) and LAYOUT (-inline/-overlay/-lg). Per-site emphasis (italic) and geometry
+   (width/margin/flex) still belong in scoped CSS. */
+
+/* Secondary / de-emphasised text — hints, subtitles, captions, meta lines. -dense/-micro drop to the
+   two smallest tiers for dense contexts (chip rows, whiteboard nodes) without changing the role. */
 .cc-muted { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
+.cc-muted-dense { font-size: var(--cc-fs-2xs); }
+.cc-muted-micro { font-size: var(--cc-fs-3xs); }
 
 /* Empty / placeholder state — "nothing here yet" message. Centred, muted, padded; drop an icon /
-   title / CTA inside for the rich variant (it's a flex column). */
+   title / CTA inside for the rich variant (it's a flex column).
+   Layout modifiers, because the same scenario appears in three shapes:
+     -inline  a one-line placeholder in a row of chrome (no padding, no centring block)
+     -overlay stretched over a plot/canvas that has its own box rather than a flow block
+     -lg      a full-page empty with generous breathing room (icon + title + hint + CTA) */
 .cc-empty {
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 0.4rem; padding: 2rem 1rem;
   color: var(--cc-text-dim); font-size: var(--cc-fs-md); text-align: center;
 }
+.cc-empty-inline {
+  display: inline-flex; flex-direction: row; align-items: center; justify-content: flex-start;
+  gap: 0.4rem; padding: 0; text-align: left; color: var(--cc-text-dim);
+}
+.cc-empty-overlay { position: absolute; inset: 0; }
+.cc-empty-lg { padding: 4rem 2rem; gap: 0.5rem; }
 
 /* Numeric value readout shown beside a control/metric (slider values, counts, occupancy). Default is
-   muted; add .cc-readout-strong for a prominent count (same scenario, higher prominence). */
+   muted; add .cc-readout-strong for a prominent count (same scenario, higher prominence), or
+   .cc-readout-dense for an inline readout in dense chrome. */
 .cc-readout { font-variant-numeric: tabular-nums; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
 .cc-readout-strong { color: var(--cc-text); font-weight: 600; }
+.cc-readout-dense { font-size: var(--cc-fs-2xs); }
 
-/* Eyebrow / section label — small uppercase dim heading above a group of controls. */
+/* Eyebrow / section label — small uppercase dim heading above a group of controls. -dense for the
+   sticky list/table headers, which sit a tier smaller. */
 .cc-eyebrow {
   font-size: var(--cc-fs-xs); font-weight: 600; letter-spacing: 0.06em;
   text-transform: uppercase; color: var(--cc-text-dim);
 }
+.cc-eyebrow-dense { font-size: var(--cc-fs-2xs); }
 
-/* Surface / container chrome — a card/panel body (surface-1 + hairline border + md radius). */
+/* Surface / container chrome — a card/panel body (hairline border + md radius). Surface is the axis:
+   the base is the recessed surface-1, `.cc-card-2` the raised surface-2 (a card sitting ON a
+   surface-1 panel). Radius is NOT an axis — the ad-hoc radii differ by well under a pixel at this
+   scale, so -sm/-md are the only two steps worth having. */
 .cc-card { background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); }
+.cc-card-2 { background: var(--cc-surface-2); }
 
 /* ── Form controls — modern, consistent base for ALL native inputs ─────────── */
 /* Applies app-wide so bare <select>/<input> look the same everywhere. Components  */
@@ -192,11 +229,11 @@ select,
 input[type="text"], input[type="number"], input[type="search"],
 input[type="password"], input[type="email"], textarea {
   font: inherit;
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   color: var(--cc-text);
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-border);
-  border-radius: 0.4rem;
+  border-radius: var(--cc-radius-md);
   padding: 0.32rem 0.6rem;
   transition: border-color 0.12s, box-shadow 0.12s;
   outline: none;

--- a/frontend/src/tasks/ParamRenderer.vue
+++ b/frontend/src/tasks/ParamRenderer.vue
@@ -579,7 +579,7 @@ const pct = computed(() => {
     <!-- fallback -->
     <div v-else class="picker-placeholder"
       v-tooltip.right="`${param.type} — populated from image metadata`">
-      <i class="pi pi-spinner pi-spin" style="font-size:0.7rem" />
+      <i class="pi pi-spinner pi-spin" style="font-size:var(--cc-fs-xs)" />
       {{ param.type }}
     </div>
   </div>
@@ -682,7 +682,7 @@ const pct = computed(() => {
 .param-row:last-child { border-bottom: none; }
 
 .param-label {
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 500;
   color: var(--cc-text-dim);
   display: flex;
@@ -690,7 +690,7 @@ const pct = computed(() => {
   gap: 0.3rem;
   cursor: default;
 }
-.tip-icon { font-size: 0.65rem; opacity: 0.6; }
+.tip-icon { font-size: var(--cc-fs-2xs); opacity: 0.6; }
 
 /* slider */
 .slider-wrap {
@@ -702,7 +702,7 @@ const pct = computed(() => {
   flex: 1;
   appearance: none;
   height: 4px;
-  border-radius: 2px;
+  border-radius: var(--cc-radius-xs);
   background: linear-gradient(to right,
     var(--cc-accent) 0%, var(--cc-accent) var(--pct, 0%),
     var(--cc-surface-2) var(--pct, 0%), var(--cc-surface-2) 100%);
@@ -712,13 +712,13 @@ const pct = computed(() => {
 .slider::-webkit-slider-thumb {
   appearance: none;
   width: 13px; height: 13px;
-  border-radius: 50%;
+  border-radius: var(--cc-radius-pill);
   background: var(--cc-accent);
   cursor: pointer;
   box-shadow: 0 0 4px #a78bfa55;
 }
 .slider-val {
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   font-family: var(--cc-mono);
   color: var(--cc-text);
   min-width: 28px;
@@ -742,7 +742,7 @@ const pct = computed(() => {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   color: var(--cc-text-dim);
   text-transform: uppercase;
@@ -756,35 +756,35 @@ const pct = computed(() => {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   background: var(--cc-surface-2);
   border: 1px dashed var(--cc-border);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   padding: 0.35rem 0.5rem;
 }
 
 /* channel selection */
 .channel-select-wrap { width: 100%; }
 .channel-empty {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   font-style: italic;
   padding: 0.2rem 0;
 }
 /* motion-dims selector + recommendation note (gap keeps the note off the dropdown) */
 .motion-dims { display: flex; flex-direction: column; gap: 0.4rem; width: 100%; }
-.md-note { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; color: var(--cc-text-dim); }
-.md-note .pi { font-size: 0.72rem; }
+.md-note { display: inline-flex; align-items: center; gap: 0.3rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.md-note .pi { font-size: var(--cc-fs-sm); }
 .md-note.warn { color: #fbbf24; }
 /* traffic-light flag: how usable is the z-axis (ok real 3D · warn borderline · fail jitter). A
    shape-distinct severity icon (canonical severity model) — colour is never the sole cue. */
-.md-flag { font-size: 0.72rem; flex: none; }
+.md-flag { font-size: var(--cc-fs-sm); flex: none; }
 
 .col-group { margin-bottom: 0.4rem; }
 .col-group:last-child { margin-bottom: 0; }
 .col-group-title {
-  font-size: 0.62rem;
+  font-size: var(--cc-fs-2xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -803,7 +803,7 @@ const pct = computed(() => {
   padding: 0.45rem 0 0.3rem;
 }
 .group-title {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   color: var(--cc-text-dim);
   text-transform: uppercase;
@@ -814,17 +814,17 @@ const pct = computed(() => {
   align-items: center;
   justify-content: center;
   width: 18px; height: 18px;
-  border-radius: 50%;
+  border-radius: var(--cc-radius-pill);
   border: 1px solid var(--cc-border);
   background: var(--cc-surface-2);
   color: var(--cc-text-dim);
   cursor: pointer;
-  font-size: 0.6rem;
+  font-size: var(--cc-fs-2xs);
   transition: background 0.1s, border-color 0.1s;
 }
 .group-add-btn:hover { background: var(--cc-accent); border-color: var(--cc-accent); color: #fff; }
 .group-empty {
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   font-style: italic;
   padding: 0.3rem 0;
@@ -832,7 +832,7 @@ const pct = computed(() => {
 .group-entry {
   margin-bottom: 0.4rem;
   border: 1px solid var(--cc-border);
-  border-radius: 0.3rem;
+  border-radius: var(--cc-radius-sm);
   overflow: hidden;
 }
 .group-entry-hdr {
@@ -844,7 +844,7 @@ const pct = computed(() => {
   border-bottom: 1px solid var(--cc-border);
 }
 .group-entry-num {
-  font-size: 0.68rem;
+  font-size: var(--cc-fs-xs);
   font-weight: 700;
   font-family: var(--cc-mono);
   color: var(--cc-accent);
@@ -854,12 +854,12 @@ const pct = computed(() => {
   align-items: center;
   justify-content: center;
   width: 14px; height: 14px;
-  border-radius: 50%;
+  border-radius: var(--cc-radius-pill);
   border: none;
   background: none;
   color: var(--cc-text-dim);
   cursor: pointer;
-  font-size: 0.55rem;
+  font-size: var(--cc-fs-3xs);
   transition: color 0.1s;
 }
 .group-remove-btn:hover { color: #f87171; }
@@ -876,7 +876,7 @@ const pct = computed(() => {
   border: none;
   border-top: 1px solid var(--cc-border);
   cursor: pointer;
-  font-size: 0.68rem;
+  font-size: var(--cc-fs-xs);
   font-weight: 600;
   color: var(--cc-text-dim);
   text-transform: uppercase;
@@ -884,7 +884,7 @@ const pct = computed(() => {
   text-align: left;
 }
 .group-section-toggle:hover { color: var(--cc-text); }
-.group-section-toggle .pi { font-size: 0.6rem; }
+.group-section-toggle .pi { font-size: var(--cc-fs-2xs); }
 
 .group-section-body {
   padding-left: 0.4rem;

--- a/frontend/src/tasks/TaskList.vue
+++ b/frontend/src/tasks/TaskList.vue
@@ -188,14 +188,14 @@ function elapsed(t: TaskEntry) {
 }
 
 .task-empty {
-  font-size: 0.75rem;
+  font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim);
   text-align: center;
   padding: 1.5rem 0.5rem;
 }
 
 .task-item {
-  border-radius: 0.4rem;
+  border-radius: var(--cc-radius-md);
   border: 1px solid var(--cc-border);
   overflow: hidden;
   background: var(--cc-surface-1);
@@ -212,12 +212,12 @@ function elapsed(t: TaskEntry) {
   padding: 0.4rem 0.6rem;
 }
 
-.task-icon { font-size: 0.85rem; flex-shrink: 0; }
+.task-icon { font-size: var(--cc-fs-md); flex-shrink: 0; }
 /* status icon colour is inline from TASK_STATUS (lib/taskStatus.ts) */
 
 .task-info { display: flex; flex-direction: column; flex: 1; min-width: 0; }
 .task-label {
-  font-size: 0.78rem;
+  font-size: var(--cc-fs-sm);
   font-weight: 600;
   color: var(--cc-text);
   white-space: nowrap;
@@ -228,19 +228,19 @@ function elapsed(t: TaskEntry) {
   gap: 0.3rem;
 }
 .task-seq {
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   font-family: var(--cc-mono);
   font-weight: 700;
   color: var(--cc-text-dim);
   flex-shrink: 0;
 }
 .chain-badge {
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   color: #a78bfa;
   flex-shrink: 0;
 }
 .task-image {
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   color: var(--cc-text-dim);
   white-space: nowrap;
   overflow: hidden;
@@ -251,17 +251,17 @@ function elapsed(t: TaskEntry) {
 }
 .task-uid {
   font-family: var(--cc-mono);
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   color: var(--cc-text-dim);
   opacity: 0.6;
   flex-shrink: 0;
   background: var(--cc-surface-2);
   padding: 0 0.25rem;
-  border-radius: 0.2rem;
+  border-radius: var(--cc-radius-xs);
 }
 
 .task-elapsed {
-  font-size: 0.68rem;
+  font-size: var(--cc-fs-xs);
   font-family: var(--cc-mono);
   color: var(--cc-text-dim);
   flex-shrink: 0;
@@ -271,8 +271,8 @@ function elapsed(t: TaskEntry) {
 
 .icon-btn {
   background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: 0.72rem;
-  padding: 0.2rem 0.3rem; border-radius: 0.2rem;
+  color: var(--cc-text-dim); font-size: var(--cc-fs-sm);
+  padding: 0.2rem 0.3rem; border-radius: var(--cc-radius-xs);
 }
 .icon-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 .icon-btn.danger:hover { background: #7f1d1d55; color: #fca5a5; }
@@ -283,7 +283,7 @@ function elapsed(t: TaskEntry) {
   border: none;
   cursor: pointer;
   color: #4ade80;
-  font-size: 0.8rem;
+  font-size: var(--cc-fs-md);
   padding: 0 0.15rem 0 0;
   flex-shrink: 0;
   line-height: 1;
@@ -305,7 +305,7 @@ function elapsed(t: TaskEntry) {
 
 .task-log {
   font-family: var(--cc-mono);
-  font-size: 0.68rem;
+  font-size: var(--cc-fs-xs);
   color: var(--cc-text-dim);
   background: var(--cc-console-bg);
   padding: 0.5rem 0.6rem;
@@ -316,5 +316,5 @@ function elapsed(t: TaskEntry) {
   word-break: break-all;
   border-top: 1px solid var(--cc-border);
 }
-.dim { color: var(--cc-text-dim); font-size: 0.72rem; }
+.dim { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
 </style>

--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -458,9 +458,9 @@ const { width: sidebarWidth, onResizeStart } =
   border: none;
   cursor: pointer;
   color: var(--cc-text-dim);
-  font-size: 0.72rem;
+  font-size: var(--cc-fs-sm);
   padding: 0.15rem 0.3rem;
-  border-radius: 0.2rem;
+  border-radius: var(--cc-radius-xs);
 }
 .clear-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 .clear-btn.danger:hover { background: #7f1d1d55; color: #fca5a5; }
@@ -491,7 +491,7 @@ const { width: sidebarWidth, onResizeStart } =
   margin-top: 0.5rem;
 }
 .pool-label {
-  font-size: 0.7rem;
+  font-size: var(--cc-fs-xs);
   color: var(--cc-text-dim);
   white-space: nowrap;
   flex-shrink: 0;
@@ -505,7 +505,7 @@ const { width: sidebarWidth, onResizeStart } =
   height: 1.55rem;
   flex-shrink: 0;
   border: 1px solid var(--cc-border);
-  border-radius: 0.25rem;
+  border-radius: var(--cc-radius-xs);
   background: var(--cc-surface-2);
   color: var(--cc-text-dim);
   cursor: pointer;
@@ -515,7 +515,7 @@ const { width: sidebarWidth, onResizeStart } =
 .pool-throttle.active { background: var(--cc-accent); border-color: var(--cc-accent); color: #fff; }
 
 .section-heading {
-  font-size: 0.65rem;
+  font-size: var(--cc-fs-2xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -528,9 +528,9 @@ const { width: sidebarWidth, onResizeStart } =
   width: 100%;
   background: var(--cc-surface-2);
   border: 1px solid var(--cc-border);
-  border-radius: 0.35rem;
+  border-radius: var(--cc-radius-sm);
   color: var(--cc-text);
-  font-size: 0.82rem;
+  font-size: var(--cc-fs-md);
   padding: 0.35rem 0.5rem;
   cursor: pointer;
 }
@@ -541,11 +541,11 @@ const { width: sidebarWidth, onResizeStart } =
 
 .fn-meta { display: flex; gap: 0.3rem; margin-top: 0.4rem; }
 .env-badge {
-  font-size: 0.62rem;
+  font-size: var(--cc-fs-2xs);
   font-weight: 600;
   text-transform: uppercase;
   padding: 0.1rem 0.4rem;
-  border-radius: 0.2rem;
+  border-radius: var(--cc-radius-xs);
   background: var(--cc-surface-2);
   color: var(--cc-text-dim);
   border: 1px solid var(--cc-border);
@@ -567,10 +567,10 @@ const { width: sidebarWidth, onResizeStart } =
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  font-size: 0.82rem;
+  font-size: var(--cc-fs-md);
   font-weight: 600;
   padding: 0.55rem;
-  border-radius: 0.4rem;
+  border-radius: var(--cc-radius-md);
   border: none;
   background: var(--cc-accent);
   color: #fff;

--- a/frontend/src/utils/cssScenarios.test.ts
+++ b/frontend/src/utils/cssScenarios.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import {
+  styleBlocks, cssRules, scenarioFor, findReimplementedScenarios, findRawValues,
+} from './cssScenarios'
+
+describe('styleBlocks', () => {
+  it('extracts every style block of an SFC, and passes plain CSS through', () => {
+    expect(styleBlocks('<template>x</template><style scoped>.a{}</style>')).toEqual(['.a{}'])
+    expect(styleBlocks('<style>.a{}</style><style scoped>.b{}</style>')).toEqual(['.a{}', '.b{}'])
+    expect(styleBlocks('.plain { color: red }')).toEqual(['.plain { color: red }'])
+  })
+})
+
+describe('cssRules', () => {
+  it('splits selectors from bodies', () => {
+    expect(cssRules('.a { color: red; } .b, .c { top: 0 }')).toEqual([
+      { selector: '.a', body: ' color: red; ' },
+      { selector: '.b, .c', body: ' top: 0 ' },
+    ])
+  })
+
+  it('does not let a comment leak into the next selector', () => {
+    expect(cssRules('/* note */ .a { top: 0 }').map(r => r.selector)).toEqual(['.a'])
+  })
+
+  it('descends into at-rules instead of treating them as one rule', () => {
+    expect(cssRules('@media (max-width: 5px) { .a { top: 0 } }').map(r => r.selector)).toEqual(['.a'])
+  })
+})
+
+describe('scenarioFor', () => {
+  const of = (selector: string, body: string) => scenarioFor({ selector, body })
+
+  it('names the canonical utility a rule re-implements', () => {
+    expect(of('.x-hint', 'color: var(--cc-text-dim); font-size: 0.7rem;')).toBe('muted')
+    expect(of('.x-empty', 'color: var(--cc-text-dim); padding: 1rem;')).toBe('empty')
+    expect(of('.x-head', 'text-transform: uppercase; letter-spacing: 0.06em; color: var(--cc-text-dim);'))
+      .toBe('eyebrow')
+  })
+
+  it('ignores rules that already take colour from a utility', () => {
+    expect(of('.x-hint', 'font-size: var(--cc-fs-xs); font-style: italic;')).toBeNull()
+    expect(of('.x-empty p', 'margin: 0; font-size: 0.8rem;')).toBeNull()
+  })
+
+  // Using the scale tokens is necessary but not sufficient: this rule is still `.cc-muted` longhand.
+  it('still flags a re-declaration built from tokens', () => {
+    expect(of('.x', 'color: var(--cc-text-dim); font-size: var(--cc-fs-sm);')).toBe('muted')
+  })
+
+  // A dim colour + a size also describes every ghost/icon button, whose canonical form is
+  // `.cc-btn-ghost` rather than `.cc-muted`. Flagging those would send readers to the wrong utility.
+  it('does not flag controls', () => {
+    expect(of('.x-btn', 'color: var(--cc-text-dim); font-size: 0.7rem;')).toBeNull()
+    expect(of('.x-thing', 'color: var(--cc-text-dim); font-size: 0.7rem; cursor: pointer;')).toBeNull()
+    expect(of('.x-thing', 'color: var(--cc-text-dim); font-size: 0.7rem; background: #000;')).toBeNull()
+  })
+})
+
+// ── The ratchet ───────────────────────────────────────────────────────────────────────────────────
+//
+// ~130 rules still hand-roll a scenario that `docs/UI.md` has a utility for. Migrating them all at once
+// would be a churn diff across 45 files, and the plan explicitly warns off that. But the thing actually
+// worth preventing is NEW divergence, and that doesn't require the backlog to be empty first — it
+// requires the count to never rise. So: a per-file baseline that may shrink and must never grow.
+//
+// Touching a file in this list? Migrate its rules and lower the number. Adding a file? Use the utility
+// instead. The failure message tells you which.
+const BASELINE: Record<string, number> = {
+  'components/AppSidebar.vue': 2,
+  'components/ClaudeOverviewDialog.vue': 2,
+  'components/CohortCheckButton.vue': 1,
+  'components/CopyDialog.vue': 1,
+  'components/CropDialog.vue': 1,
+  'components/CropPanel.vue': 1,
+  'components/ErrorConsole.vue': 3,
+  'components/FileBrowser.vue': 3,
+  'components/ImageMetadataDialog.vue': 3,
+  'components/ImageTable.vue': 3,
+  'components/LabLogPanel.vue': 5,
+  'components/LegacyMigrateDialog.vue': 2,
+  'components/ModuleLayout.vue': 5,
+  'components/PackagesDialog.vue': 5,
+  'components/PhysicalSizeDialog.vue': 1,
+  'components/PoolThrottle.vue': 2,
+  'components/ProjectPanel.vue': 5,
+  'components/SetBar.vue': 2,
+  'components/ViewerPanel.vue': 5,
+  'components/canvas/InteractivePanel.vue': 1,
+  'components/canvas/LayoutCanvas.vue': 3,
+  'components/canvas/PlateBuilder.vue': 3,
+  'components/canvas/PlotOptions.vue': 1,
+  'components/canvas/PopulationManager.vue': 4,
+  'components/canvas/SummaryCanvas.vue': 1,
+  'components/canvas/SummaryPanel.vue': 3,
+  'components/plots/GateMontage.vue': 2,
+  'components/plots/GateScatterCell.vue': 3,
+  'components/plots/ImageStripView.vue': 2,
+  'components/plots/PlotSpinner.vue': 1,
+  'components/plots/UmapView.vue': 2,
+  'modules/AnimationModule.vue': 6,
+  'modules/ChainModule.vue': 11,
+  'modules/MoviesModule.vue': 2,
+  'modules/SettingsModule.vue': 3,
+  'modules/SetupModule.vue': 2,
+  'modules/TasksModule.vue': 6,
+  'modules/batchmovies/BatchMoviesPanel.vue': 4,
+  'modules/cluster/ClusterPlots.vue': 1,
+  'modules/gate/GatePlotPanel.vue': 2,
+  'modules/gate/GatingPlots.vue': 1,
+  'modules/metadata/MetadataPanel.vue': 4,
+  'tasks/ParamRenderer.vue': 5,
+  'tasks/TaskList.vue': 5,
+  'tasks/TaskRunner.vue': 2,
+}
+
+const RAW = import.meta.glob('/src/**/*.{vue,css}', {
+  query: '?raw', import: 'default', eager: true,
+}) as Record<string, string>
+
+describe('hand-rolled UX scenarios', () => {
+  it('never increase — see docs/UI.md for the canonical utility', () => {
+    const sources = Object.entries(RAW)
+      .filter(([path]) => path !== '/src/style.css')          // style.css DEFINES the utilities
+      .map(([path, text]) => ({ path: path.replace('/src/', ''), text }))
+
+    expect(sources.length).toBeGreaterThan(100)               // the glob resolved
+
+    const counts: Record<string, number> = {}
+    for (const hit of findReimplementedScenarios(sources)) {
+      counts[hit.path] = (counts[hit.path] ?? 0) + 1
+    }
+
+    const regressions: string[] = []
+    const improvements: string[] = []
+    for (const path of new Set([...Object.keys(BASELINE), ...Object.keys(counts)])) {
+      const was = BASELINE[path] ?? 0
+      const now = counts[path] ?? 0
+      if (now > was) regressions.push(`${path}: ${was} → ${now} (use the utility, don't re-declare it)`)
+      if (now < was) improvements.push(`${path}: ${was} → ${now} (lower the BASELINE entry)`)
+    }
+
+    expect(regressions).toEqual([])
+    // Improvements fail too, on purpose: an un-updated baseline silently stops ratcheting.
+    expect(improvements).toEqual([])
+  })
+})
+
+describe('raw sizes and radii', () => {
+  // Unlike the scenario backlog above, this one is DONE: the ~770 literal font-sizes and radii are all
+  // on the scales now, so the bar is an exact list rather than a shrinking count. One documented
+  // exception survives — see the inline comment at that line for why it is genuinely off-scale.
+  const ALLOWED = [
+    'components/ChainQcNode.vue | .qc-bar | border-radius: 1px',
+  ]
+
+  it('are always scale tokens', () => {
+    const sources = Object.entries(RAW).map(([path, text]) => ({ path: path.replace('/src/', ''), text }))
+    const found = findRawValues(sources).map(r => `${r.path} | ${r.selector} | ${r.decl}`)
+    expect(found.sort()).toEqual(ALLOWED.sort())
+  })
+})

--- a/frontend/src/utils/cssScenarios.ts
+++ b/frontend/src/utils/cssScenarios.ts
@@ -1,0 +1,174 @@
+// Re-implemented-scenario detector.
+//
+// `docs/UI.md` says: use `.cc-muted` / `.cc-empty` / `.cc-eyebrow` / `.cc-card` rather than declaring
+// the same role again in scoped CSS. That rule was only ever enforced by review — and review across
+// fresh context windows is exactly what kept failing (see docs/todo/UX_PRIMITIVES_PLAN.md). So the
+// scenarios are detectable here instead: a scoped rule that spells out the *defining* declarations of
+// a canonical utility IS that utility, hand-rolled.
+//
+// Deliberately narrow. Each matcher keys on the combination that makes the role unambiguous, not on a
+// single property — plenty of rules legitimately set only a colour or only a size. False positives are
+// worse than misses here, because the allow-list they'd force is where this kind of check rots.
+
+// NOT linted: `card`. Measured it — `surface + 1px border + radius` is the shape of at least five
+// different roles (card, input, chip, badge, icon-button), and scoped CSS carries nothing that tells
+// them apart; ~60% of the matches wanted `.cc-btn`/`ChipSelect`/the global input base rather than
+// `.cc-card`. A check that wrong either gets ignored or grows an allow-list that stops meaning
+// anything, so card chrome stays a review-time rule in docs/UI.md.
+export type Scenario = 'muted' | 'empty' | 'eyebrow'
+
+export interface CssRule {
+  selector: string
+  body:     string
+}
+
+/** Contents of every `<style>` block in an SFC (or the whole text for a plain .css file). */
+export function styleBlocks(text: string): string[] {
+  if (!text.includes('<style')) return [text]
+  const out: string[] = []
+  for (const m of text.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)) out.push(m[1])
+  return out
+}
+
+/**
+ * Split CSS into `{selector, body}` rules. Bodies that themselves contain a block (`@media`,
+ * `@supports`) are recursed into, so rules nested in an at-rule are still seen.
+ */
+export function cssRules(css: string): CssRule[] {
+  const out: CssRule[] = []
+  // Block comments only — `//` is not a CSS comment, and stripping it would eat `url(//…)`.
+  css = css.replace(/\/\*[\s\S]*?\*\//g, ' ')
+  let selStart = 0, depth = 0, bodyStart = -1
+
+  for (let i = 0; i < css.length; i++) {
+    const ch = css[i]
+    if (ch === '{') {
+      if (depth === 0) bodyStart = i
+      depth++
+    } else if (ch === '}') {
+      depth--
+      if (depth === 0) {
+        const selector = css.slice(selStart, bodyStart).trim()
+        const body     = css.slice(bodyStart + 1, i)
+        if (body.includes('{')) out.push(...cssRules(body))   // at-rule wrapper
+        else if (selector && !selector.startsWith('@')) out.push({ selector, body })
+        selStart = i + 1
+      }
+    }
+  }
+  return out
+}
+
+const has = (body: string, re: RegExp) => re.test(body)
+
+const DIM_COLOUR   = /color:\s*var\(--cc-text-dim\)/
+// ANY font-size, token-valued included: `color: dim` + `font-size: var(--cc-fs-sm)` is still
+// `.cc-muted` spelled out longhand. Using the scale tokens is necessary, not sufficient.
+const ANY_SIZE     = /font-size:/
+const UPPERCASE    = /text-transform:\s*uppercase/
+const TRACKING     = /letter-spacing:/
+
+// A dim colour + a size also describes every ghost/icon BUTTON in the app — whose canonical form is
+// `.cc-btn-ghost`, not `.cc-muted`. So the text scenarios only fire on rules that are purely text:
+// nothing interactive, no box chrome, and not a control-shaped selector.
+const INTERACTIVE  = /cursor:|background(-color)?:|border(-\w+)?:|transition:|:hover|appearance:/
+const CONTROL_NAME = /(btn|button|toggle|tab|chip|input|select|gear|caret|swatch)\b/i
+
+const isTextOnly = (rule: CssRule) =>
+  !INTERACTIVE.test(rule.body) && !CONTROL_NAME.test(rule.selector)
+
+/**
+ * Which canonical utility this rule re-implements, if any.
+ *
+ * - muted   dim colour + a hard-coded size = `.cc-muted` (+ a density modifier)
+ * - empty   an `*-empty*` selector re-declaring the dim colour = `.cc-empty*`
+ * - eyebrow uppercase + tracking + dim = `.cc-eyebrow`
+ *
+ * All three key on the dim colour, because that is what actually marks a rule as *owning* the role.
+ * A child rule inside an adopted empty (`.foo-empty p { margin: 0; font-size: 0.8rem }`) is styling
+ * its own contents, not re-implementing the scenario, and must not be flagged.
+ */
+export function scenarioFor(rule: CssRule): Scenario | null {
+  const { selector, body } = rule
+  if (!isTextOnly(rule) || !has(body, DIM_COLOUR)) return null
+
+  if (has(body, UPPERCASE) && has(body, TRACKING)) return 'eyebrow'
+  if (/-empty|empty-/.test(selector))              return 'empty'
+  if (has(body, ANY_SIZE))                         return 'muted'
+  return null
+}
+
+// ── Raw values ────────────────────────────────────────────────────────────────────────────────────
+
+/** A literal `font-size` / `border-radius` where a scale token exists. */
+export interface RawValue {
+  path:     string
+  selector: string
+  decl:     string
+}
+
+// Above this the value is display type / a bespoke geometry, not a step on the small-text scale.
+const DISPLAY_PX = 15.0
+
+const toPx = (v: number, unit: string) => (unit === 'rem' ? v * 16 : v)
+
+/**
+ * Literal sizes and radii still hand-written in scoped CSS. The scales in `style.css` carry every tier
+ * the app actually uses, so a literal here is a value that won't track the system — the same class of
+ * defect as a dead token, just silent instead of broken.
+ *
+ * Exempt: display type (> 15px), pill radii (>= 100), `0`, and `em` — an `em` size is deliberately
+ * relative to its container (a legend that scales with the export), which is the opposite of a
+ * hand-written constant, and a fixed token would break it.
+ */
+export function findRawValues(sources: Array<{ path: string, text: string }>): RawValue[] {
+  const out: RawValue[] = []
+  const LITERAL = /(font-size|border-radius):\s*([0-9.]+)(rem|px|em|%)/g
+
+  const keep = (prop: string, num: number, unit: string) =>
+    !(num === 0 || unit === '%' || unit === 'em' || num >= 100) &&
+    !(prop === 'font-size' && toPx(num, unit) > DISPLAY_PX)
+
+  for (const { path, text } of sources) {
+    for (const block of styleBlocks(text)) {
+      for (const rule of cssRules(block)) {
+        for (const m of rule.body.matchAll(LITERAL)) {
+          if (keep(m[1], parseFloat(m[2]), m[3])) out.push({ path, selector: rule.selector, decl: m[0] })
+        }
+      }
+    }
+    // Inline `style="font-size:0.7rem"` in the TEMPLATE is just as hand-rolled, and lives outside every
+    // <style> block — a blind spot that hid four icon sizes. Inline declarations can reference the
+    // tokens too (they inherit from :root), so there's no reason to exempt them.
+    const template = text.replace(/<style[^>]*>[\s\S]*?<\/style>/g, ' ')
+    for (const m of template.matchAll(LITERAL)) {
+      if (keep(m[1], parseFloat(m[2]), m[3])) out.push({ path, selector: '(inline style)', decl: m[0] })
+    }
+  }
+  return out
+}
+
+export interface ScenarioHit {
+  path:     string
+  selector: string
+  scenario: Scenario
+}
+
+/** Every rule across the given sources that re-implements a canonical scenario. */
+export function findReimplementedScenarios(
+  sources: Array<{ path: string, text: string }>,
+): ScenarioHit[] {
+  const out: ScenarioHit[] = []
+  for (const { path, text } of sources) {
+    for (const block of styleBlocks(text)) {
+      for (const rule of cssRules(block)) {
+        const scenario = scenarioFor(rule)
+        if (scenario) out.push({ path, selector: rule.selector, scenario })
+      }
+    }
+  }
+  return out
+}
+
+/** Stable `path::selector` key, for comparing against an allow-list. */
+export const hitKey = (h: ScenarioHit) => `${h.path}::${h.selector}`

--- a/frontend/src/utils/cssTokens.test.ts
+++ b/frontend/src/utils/cssTokens.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { definedTokens, referencedTokens, findDeadTokenRefs } from './cssTokens'
+
+describe('definedTokens', () => {
+  it('collects declarations and ignores references', () => {
+    const css = ':root { --cc-text: #fff; --cc-fs-sm: 0.75rem; }\n.x { color: var(--cc-text); }'
+    expect(definedTokens(css)).toEqual(new Set(['--cc-text', '--cc-fs-sm']))
+  })
+
+  it('ignores declarations inside comments', () => {
+    expect(definedTokens('/* --cc-ghost: 1px; */ :root { --cc-real: 2px; }'))
+      .toEqual(new Set(['--cc-real']))
+  })
+})
+
+describe('referencedTokens', () => {
+  it('records whether a reference carries a fallback', () => {
+    expect(referencedTokens('a { color: var(--cc-a); background: var(--cc-b, #888); }')).toEqual([
+      { token: '--cc-a', hasFallback: false },
+      { token: '--cc-b', hasFallback: true },
+    ])
+  })
+
+  it('ignores token-shaped text in CSS, HTML and line comments', () => {
+    expect(referencedTokens('/* var(--cc-x) */')).toEqual([])
+    expect(referencedTokens('<!-- var(--cc-*) would be undefined -->')).toEqual([])
+    expect(referencedTokens('// e.g. var(--cc-text-muted, #888)')).toEqual([])
+  })
+
+  it('does not let a URL swallow the rest of its line', () => {
+    expect(referencedTokens('/* see https://x.dev */ a { color: var(--cc-a); }'))
+      .toEqual([{ token: '--cc-a', hasFallback: false }])
+    expect(referencedTokens('a { background: url(https://x.dev/i.png) var(--cc-b); }'))
+      .toEqual([{ token: '--cc-b', hasFallback: false }])
+  })
+
+  it('only considers our own prefix', () => {
+    expect(referencedTokens('a { color: var(--p-primary-color); }')).toEqual([])
+  })
+})
+
+describe('findDeadTokenRefs', () => {
+  it('flags a reference the stylesheet never declares, fallback or not', () => {
+    const dead = findDeadTokenRefs(':root { --cc-text-dim: #7d8590; }', [
+      { path: 'ok.vue',      text: 'a { color: var(--cc-text-dim); }' },
+      { path: 'masked.vue',  text: 'a { color: var(--cc-text-muted, #888); }' },
+      { path: 'broken.vue',  text: 'a { background: var(--cc-surface); }' },
+    ])
+    expect(dead).toEqual([
+      { path: 'masked.vue', token: '--cc-text-muted', hasFallback: true },
+      { path: 'broken.vue', token: '--cc-surface',    hasFallback: false },
+    ])
+  })
+})
+
+// ── The real check: no component may reference a token style.css doesn't declare ──────────────────
+
+// Sources are pulled in with Vite's raw glob rather than node's fs, so this test needs no
+// @types/node and the tier stays fs-free (see docs/DEV.md → Tests).
+const RAW = import.meta.glob('/src/**/*.{vue,ts,css}', {
+  query: '?raw', import: 'default', eager: true,
+}) as Record<string, string>
+
+describe('the app stylesheet', () => {
+  it('declares every --cc-* token the sources reference', () => {
+    const sources = Object.entries(RAW)
+      .filter(([path]) => !path.endsWith('.test.ts'))
+      .map(([path, text]) => ({ path, text }))
+
+    expect(sources.length).toBeGreaterThan(100)   // the glob resolved; not a vacuous pass
+
+    const dead = findDeadTokenRefs(RAW['/src/style.css'], sources)
+    // Reported as readable lines so a failure names the file and token directly.
+    expect(dead.map(d => `${d.path}: ${d.token}`)).toEqual([])
+  })
+})

--- a/frontend/src/utils/cssTokens.ts
+++ b/frontend/src/utils/cssTokens.ts
@@ -1,0 +1,81 @@
+// Design-token integrity check.
+//
+// Every `--cc-*` custom property is declared once in `style.css` (the design system) and referenced
+// from scoped component CSS. A reference to a token that was never declared is silently broken: the
+// declaration becomes "invalid at computed-value time", so the property falls back to its `unset`
+// value rather than to anything sensible. With a fallback (`var(--cc-text-muted, #888)`) that shows
+// up as a slightly-wrong hard-coded colour that never tracks the theme; WITHOUT one it drops the
+// property entirely — e.g. `background: var(--cc-surface)` on a `<select>` reset both the fill and
+// the global custom-caret background-image, leaving an arrowless, transparent dropdown.
+//
+// Neither failure mode throws, so nothing catches it at build time. Hence this checker, run over the
+// real sources by `cssTokens.test.ts`. Only `--cc-*` is checked — `--p-*` (PrimeVue) and other
+// vendor tokens are declared outside our stylesheet.
+
+// PrimeVue declares its own `--p-*` tokens in vendor CSS we don't parse, so they're out of scope.
+const VENDOR = /^--p-/
+
+/**
+ * Strip block, HTML and line comments — token-shaped text in prose or in a commented-out line is not
+ * a live reference. Line comments are matched only when `//` isn't preceded by `:`, so a `https://`
+ * URL doesn't truncate the rest of its line.
+ */
+export function stripComments(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+}
+
+/**
+ * Token names DECLARED in a source, i.e. appearing on the left of `--foo: value`.
+ *
+ * Scans the whole file, not just its `<style>` block, because a component may legitimately declare a
+ * custom property inline for a dynamic value — `:style="{ '--gate-font': \`${fontSize}px\` }"` — and
+ * those are real declarations. Hence the optional quote before the colon.
+ */
+export function definedTokens(css: string): Set<string> {
+  const out = new Set<string>()
+  for (const m of stripComments(css).matchAll(/(--[A-Za-z0-9_-]+)['"`]?\s*:/g)) out.add(m[1])
+  return out
+}
+
+export interface TokenRef {
+  token:       string
+  hasFallback: boolean
+}
+
+/** Token names REFERENCED via `var(--foo)` / `var(--foo, fallback)`. */
+export function referencedTokens(text: string): TokenRef[] {
+  const out: TokenRef[] = []
+  for (const m of stripComments(text).matchAll(/var\(\s*(--[A-Za-z0-9_-]+)\s*(,?)/g)) {
+    if (!VENDOR.test(m[1])) out.push({ token: m[1], hasFallback: m[2] === ',' })
+  }
+  return out
+}
+
+export interface DeadTokenRef extends TokenRef {
+  path: string
+}
+
+/**
+ * References to custom properties that nothing declares — neither the global stylesheet nor the
+ * referencing file itself (a component-local token, static or inline, is perfectly valid).
+ *
+ * @param styleCss  contents of the stylesheet that owns the global tokens (`style.css`)
+ * @param sources   every file that may reference tokens (including the stylesheet itself)
+ */
+export function findDeadTokenRefs(
+  styleCss: string,
+  sources: Array<{ path: string, text: string }>,
+): DeadTokenRef[] {
+  const global = definedTokens(styleCss)
+  const out: DeadTokenRef[] = []
+  for (const { path, text } of sources) {
+    const local = definedTokens(text)
+    for (const ref of referencedTokens(text)) {
+      if (!global.has(ref.token) && !local.has(ref.token)) out.push({ path, ...ref })
+    }
+  }
+  return out
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,14 @@
-import { defineConfig } from 'vite'
+// defineConfig comes from vitest/config (not vite) so the `test` block below typechecks; the Vite
+// build behaviour is identical.
+import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
   plugins: [vue()],
+  // Vitest stubs CSS imports to '' by default, which would make the design-token guard in
+  // utils/cssTokens.test.ts read an empty style.css and pass vacuously. No test mounts components,
+  // so processing CSS costs nothing else.
+  test: { css: true },
   server: {
     proxy: {
       '/ws': {


### PR DESCRIPTION
Unblocks the stalled adoption sweep in `docs/todo/UX_PRIMITIVES_PLAN.md`, and closes the raw-values category entirely.

Every "roadblock" recorded in that plan had **one cause**: the utility hard-coded a value on an axis where sites legitimately differ, so adopting it forced a visual change, so the site stayed hand-rolled and got written down as permanently bespoke. Fixing the axes turned the whole list into mechanical migrations.

## Correctness — the part that was actually broken

**17 references to 5 custom properties that nothing declares.** These don't warn: the declaration is invalid at computed-value time and drops to `unset`.

- 13× `--cc-text-muted` — the `, #888` fallback **masked** it, freezing a hard-coded grey that never tracks the theme. (This is why an earlier sweep only caught "several".)
- 1× `--text-muted`, hiding behind the `--cc-` prefix filter until the guard was widened
- 2× `--cc-font-mono` (the token is `--cc-mono`) → bare `monospace`
- 1× `--cc-surface-3` — never existed
- 2× fallback-less `background: var(--cc-surface)` in `LabLogPanel`. **Worst case:** on a `<select>` the invalid *shorthand* also reset `background-image`, killing the global custom caret — that dropdown rendered transparent *and* arrowless.

## Vocabulary — one modifier axis per scenario

| Axis | Was baked in | Now |
|---|---|---|
| Density | one font size per util | `.cc-muted/-readout/-eyebrow` + `-dense`/`-micro` (+ `--cc-fs-2xs/3xs`) |
| Surface | `.cc-card` = surface-1 | `.cc-card` + `.cc-card-2` |
| Layout | `.cc-empty` = padded centred column | + `-inline` / `-overlay` / `-lg` |

Migrated the sites the plan had declared bespoke — including **three byte-identical overlay-empty triples** in the cluster panels (a 4th copy of `UmapView`'s) and **six** hand-rolled eyebrows in `ChainModule` at 0.6/0.65/0.68rem, weight 600/700, tracking 0.06/0.07/0.08: one role, six spellings. `CollapsibleSection` — the canonical component — had been hand-rolling its own eyebrow at a size the scale had no step for.

## Raw values — ~770 declarations tokenised across 83 files

Both scales derived from the measured distribution rather than guessed: **33 distinct font-size spellings, 98% of them already within 0.5px of an existing step.** Fonts now 6 steps, radii 2 → 5 (`xs/sm/md/lg/pill`). `--cc-radius-sm` retuned `0.25rem`→`0.3rem` because 4.8px is the modal radius (33 uses), halving the worst-case shift from 1.6px to 0.8px — one site consumed the old value.

Exempt by rule: display type (>15px), pill radii, `0`, and `em` (container-relative by design — `ViewLegend` scales with the export). One inline-documented exception: `ChainQcNode` `.qc-bar`'s 1px radius, where the token would round a 4px-wide bar into a blob.

## Enforcement — what stops this recurring

The mandatory-lookup clause in `CLAUDE.md` is review-time discipline, and this project's history is the record of that discipline failing across fresh context windows. So it's machine-checked now:

- **`utils/cssTokens.ts`** — fails on a reference to an undeclared custom property. All `--*`, not just `--cc-*`; inline `:style="{ '--foo': … }"` counts as a valid declaration.
- **`utils/cssScenarios.ts`** — fails on a scoped rule that re-implements a utility (per-file baseline that **may shrink, never grow**), and on any literal `font-size`/`border-radius`, including inline `style=`.

`vite.config.ts` sets `test.css: true` — Vitest otherwise stubs `style.css` to `''`, which would have made the token guard pass vacuously.

**Card chrome is deliberately not checked.** Measured: `surface + border + radius` is equally a card, input, chip, badge and icon-button, and ~60% of matches wanted `.cc-btn`/`ChipSelect`. A check that wrong forces an allow-list that stops meaning anything. It stays a review-time rule — and it's the one category left with no enforcement.

## Verification

`vue-tsc -b` clean · 358 tests pass (52 files) · `npm run build` clean. Both guards were confirmed to bite by injecting violations.

## Reservations

- **Not run in a browser.** ~139 declarations shifted ~0.48px — imperceptible absolutely, but up to **4% relative**, so a tightly-fitted label could newly wrap or ellipsize. Most likely: chain whiteboard node footers (8px → 8.96px in a 120px-min node) and dense table rows.
- `--cc-radius-sm` is a token *semantics* change, not just an adoption.
- Both guards fail on *improvement* too (lower a count without updating the baseline → red). Intentional, so the baseline can't go stale, but it's friction.
- The ~770 tokenisations were script-generated; I verified the aggregate and spot-checked, not all 770 individually.
- `docs/todo/UX_PRIMITIVES_PLAN.md` also records the process failure: the item count went 310 → 262 → 155 → 130 during calibration, and the earlier "~80" and "48 ad-hoc spinners" figures were both wrong. Every count in that doc now comes from a committed detector rather than a grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
