### PR TITLE
Icon buttons: one primitive for 116 hand-rolled sites

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -15,7 +15,8 @@ primitives still being extracted lives in `docs/todo/UX_PRIMITIVES_PLAN.md`.
 
 | Need | Use | Never |
 |------|-----|-------|
-| Button | `.cc-btn` + `-primary`/`-ghost`/`-danger`/`-danger-ghost` (`style.css`) | scoped `.btn-sm`/`.btn-primary` in a component |
+| Button | `.cc-btn` + `-primary`/`-ghost`/`-bare`/`-danger`/`-danger-ghost` (`style.css`) | scoped `.btn-sm`/`.btn-primary` in a component |
+| Icon-only button | `.cc-btn` + `-bare`\|`-ghost` + `-icon` (+ `-micro`/`-dense`/`-lg`) | a per-file `.icon-btn`/`.opt-btn`/`.gear` class |
 | On/off option (applies on flip) | `components/CcToggle.vue` | a native checkbox styled as a switch |
 | Select from a list (multi/single) | native `<input type="checkbox">`, or `ChipSelect` for chips | a column of toggle switches |
 | Chips / segmented picker | `components/ChipSelect.vue` | hand-rolled pill/`.seg` rows |
@@ -53,6 +54,12 @@ of them were already within 0.5px of a step), and 15 radius spellings onto 5. `-
 `font-size`/`border-radius` anywhere — scoped CSS **or** an inline `style=` — now fails
 `utils/cssScenarios.test.ts`. Exempt by rule: display type (>15px), pill radii, `0`, and `em` (which is
 deliberately container-relative, e.g. `ViewLegend` scaling with the export).
+
+**Icon buttons are a fixed square**, so a toolbar row lines up regardless of glyph width — that's why
+`-icon` is a modifier rather than per-site padding (48 sites had each discovered they needed a fixed box,
+at nine different sizes). `-bare` is transparent/dim-until-hover, `-ghost` is its boxed counterpart; tone
+comes from `-danger-ghost` or a scoped `color` for the one-offs (the napari viewer green). A `<button>`
+whose whole content is an icon and which doesn't use `.cc-btn` fails `utils/cssScenarios.test.ts`.
 
 **Re-implementing a scenario is a test failure, not a style opinion.** `utils/cssScenarios.test.ts`
 detects a scoped rule that spells out a canonical utility's defining declarations — a dim colour plus a

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -82,9 +82,46 @@ Remaining — incremental adoption only (no forced sweeps):
   **per-row disclosure** in a list — `TaskList`, `ErrorConsole` — worth naming if a third site appears.)
 - [ ] **Opportunistic muted-text / card / readout adoption.** Replace scoped `.*-empty` / `.*-val` /
   subtitle / surface blocks with the semantic utils as files are touched — NOT a dedicated sweep.
-- [ ] **Not recommended as sweeps:** single-value range wrapper (base already accent-themed; readout now
-  covered by `.cc-readout`; sliders are layout-entangled and some commit on release) and icon-only
-  buttons (~90, mostly intentional — different sizes/hover-reveal/viewer-green). Governed by the rule.
+- [ ] **Not recommended as a sweep:** single-value range wrapper (base already accent-themed; readout now
+  covered by `.cc-readout`; sliders are layout-entangled and some commit on release). Governed by the rule.
+- [ ] **`.seg` segmented controls** — three **byte-identical** hand-rolled copies (`SummaryCanvas`,
+  `ClusterPlots`, `GatingPlots`) of a `.seg button {…}` block that should be `ChipSelect`. Surfaced by
+  the icon-button check and allow-listed there, because it's a component swap (`v-model`), not a class
+  swap. The only remaining hand-rolled buttons in the app.
+
+### Icon-only buttons — done (2026-07-25)
+
+Long parked here as *"~90, mostly intentional — different sizes/hover-reveal/viewer-green"*. Measured,
+that was half wrong: **116 icon-only buttons carrying 60 distinct class names, but only TWO shapes**
+(boxed `surface+border`, 45; bare `transparent`, 50) **and four size tiers**. Colour was not an axis at
+all — 96 of 99 resolvable base rules were `--cc-text-dim`; the danger/viewer tones live in modifier
+classes. So the divergence was 60 spellings of 2×4.
+
+Canonical form hangs off the existing button vocabulary rather than a new family, since `.cc-btn-ghost`
+already had exactly the right colour behaviour and 4 sites already spelled it that way:
+
+```
+<button class="cc-btn cc-btn-bare  cc-btn-icon">              bare
+<button class="cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense"> boxed, dense
+```
+
+- `.cc-btn-bare` — transparent, no border, dim until hover. The app's most common button.
+- `.cc-btn-icon` — a fixed **square** (`1.5rem`), so toolbar rows align regardless of glyph width. This
+  is the reason it's a modifier and not per-site padding: 48 sites had independently discovered they
+  needed a fixed box, at **nine** different sizes.
+- Size steps `-micro`/`-dense`/`-lg` on the same density axis as the text scale (measured tiers).
+
+**103 sites across 35 files migrated**, 45 bespoke classes collapsed (−415 lines). Hover-reveal
+(`opacity: 0` + a parent `:hover` rule) and one-off tones are preserved as scoped CSS — they were the
+genuinely intentional part. `findHandRolledIconButtons` + its test now fail on any icon-only `<button>`
+not built from `.cc-btn`, with the ten `.seg` buttons pinned by path.
+
+Three defects in my own migration script, all caught by inspecting output rather than by the green
+tests: an anchored selector regex silently skipped 11 classes whose rule was preceded by a comment; the
+splice consumed the leading whitespace **and any preceding comment**, gluing rules onto one line; and
+the button scan matched `<button class="footer-btn">` inside `ConfirmButton`'s usage-example doc
+comment. Also resolved: three surviving `.foo .pi { font-size }` child rules that would have overridden
+the primitive's size — they render identically but weren't actually unified.
 
 **Healthy / no action:** Modals (`BaseModal`), popovers (`TeleportPopover`), tabs (`TabbedCanvas`),
 chips (`ChipSelect`), colour dropdown (`SwatchSelect`).

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -30,7 +30,7 @@ const statusTip: Record<string, string> = {
 
 <template>
   <header class="app-header">
-    <button class="nav-toggle" @click="settings.sidebarCollapsed = !settings.sidebarCollapsed"
+    <button class="nav-toggle cc-btn cc-btn-bare cc-btn-icon cc-btn-lg" @click="settings.sidebarCollapsed = !settings.sidebarCollapsed"
       v-tooltip.bottom="settings.sidebarCollapsed ? 'Show menu' : 'Hide menu'"
       :aria-label="settings.sidebarCollapsed ? 'Show menu' : 'Hide menu'">
       <i class="pi pi-bars" />
@@ -46,7 +46,7 @@ const statusTip: Record<string, string> = {
             : `Update available — ${appCtl.updateLatest}. Open Settings to install.`">
       <i class="pi pi-arrow-circle-up" />
       Update{{ appCtl.updateLatest ? ' ' + appCtl.updateLatest : '' }}
-      <button class="update-x" @click.stop="appCtl.dismissUpdate()"
+      <button class="update-x cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" @click.stop="appCtl.dismissUpdate()"
               v-tooltip.bottom="'Remind me later'" aria-label="Dismiss update notice">
         <i class="pi pi-times" />
       </button>
@@ -76,19 +76,7 @@ const statusTip: Record<string, string> = {
   z-index: 100;
 }
 
-.nav-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--cc-text-dim);
-  padding: 0.25rem 0.4rem;
-  border-radius: var(--cc-radius-sm);
-  font-size: var(--cc-fs-lg);
-  margin-left: -0.3rem;
-}
+.nav-toggle { margin-left: -0.3rem; }   /* + cc-btn cc-btn-bare cc-btn-icon cc-btn-lg */
 .nav-toggle:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 
 .logo {
@@ -138,16 +126,6 @@ const statusTip: Record<string, string> = {
 }
 .update-badge:hover { background: color-mix(in srgb, var(--cc-accent) 34%, transparent); }
 .update-badge .pi-arrow-circle-up { font-size: var(--cc-fs-md); }
-.update-x {
-  display: inline-flex;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: inherit;
-  opacity: 0.7;
-  padding: 0 0.1rem;
-  border-radius: var(--cc-radius-xs);
-}
+.update-x { color: inherit; opacity: 0.7; }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .update-x:hover { opacity: 1; }
-.update-x .pi { font-size: var(--cc-fs-2xs); }
 </style>

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -147,7 +147,7 @@ function isNavDisabled(item: NavItem): boolean {
             <span class="proj-type">{{ projectMeta.current.type }}</span>
           </div>
           <!-- no manual save: the /analysis boards autosave; everything else persists on edit -->
-          <button class="proj-menu-btn" @click="showPanel = true"
+          <button class="proj-menu-btn cc-btn cc-btn-bare cc-btn-icon" @click="showPanel = true"
             v-tooltip.right="'Switch project or create a new one.'">
             <i class="pi pi-ellipsis-h" />
           </button>
@@ -229,23 +229,23 @@ function isNavDisabled(item: NavItem): boolean {
          Settings is an app preference, not a pipeline step, so it sits apart from the module nav
          and opposite the destructive/lifecycle controls. -->
     <div class="sidebar-footer">
-      <RouterLink to="/settings" class="footer-btn"
+      <RouterLink to="/settings" class="footer-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg"
                   v-tooltip.right="'Settings — project name, ID, and interface preferences'">
         <i class="pi pi-sliders-h" />
       </RouterLink>
       <div class="footer-ctl">
         <ConfirmButton @confirm="appCtl.quit()" v-slot="{ armed, arm, confirm, cancel }">
-          <button v-if="!armed" class="footer-btn danger" :disabled="appCtl.busy" @click="arm"
+          <button v-if="!armed" class="footer-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg danger" :disabled="appCtl.busy" @click="arm"
                   v-tooltip.right="'Quit Cecelia — stop napari, notebooks and the backend'">
             <i class="pi pi-power-off" />
           </button>
           <template v-else>
-            <button class="footer-btn danger" @click="confirm"
+            <button class="footer-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg danger" @click="confirm"
                     v-tooltip.right="'Confirm quit — stops napari, notebooks and the backend'"><i class="pi pi-check" /></button>
-            <button class="footer-btn" @click="cancel" v-tooltip.right="'Cancel'"><i class="pi pi-times" /></button>
+            <button class="footer-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg" @click="cancel" v-tooltip.right="'Cancel'"><i class="pi pi-times" /></button>
           </template>
         </ConfirmButton>
-        <button v-if="appCtl.dev" class="footer-btn" :disabled="appCtl.busy" @click="appCtl.restartBackend()"
+        <button v-if="appCtl.dev" class="footer-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg" :disabled="appCtl.busy" @click="appCtl.restartBackend()"
                 v-tooltip.right="'Restart the backend server (dev) — reconnects when it is back'">
           <i :class="['pi', appCtl.busy ? 'pi-spin pi-cog' : 'pi-refresh']" />
         </button>
@@ -308,16 +308,7 @@ function isNavDisabled(item: NavItem): boolean {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.proj-menu-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--cc-text-dim);
-  padding: 0.15rem 0.3rem;
-  border-radius: var(--cc-radius-xs);
-  font-size: var(--cc-fs-sm);
-  flex-shrink: 0;
-}
+/* .proj-menu-btn → cc-btn cc-btn-bare cc-btn-icon */
 .proj-menu-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 
 .open-project-btn {
@@ -450,20 +441,8 @@ function isNavDisabled(item: NavItem): boolean {
 .footer-ctl { display: flex; gap: 0.4rem; }   /* the right-hand quit + restart group */
 /* Settings link active state (RouterLink) — mark it when on /settings, like the nav items */
 .footer-btn.router-link-active { color: var(--cc-text); border-color: var(--cc-accent); }
-.footer-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--cc-surface-2);
-  border: 1px solid var(--cc-border);
-  color: var(--cc-text-dim);
-  border-radius: var(--cc-radius-sm);
-  padding: 0.35rem 0.55rem;
-  cursor: pointer;
-  font-size: var(--cc-fs-md);
-  text-decoration: none;            /* Settings is a RouterLink (<a>) — no underline */
-  transition: background 0.12s, color 0.12s;
-}
+.footer-btn { text-decoration: none; /* Settings is a RouterLink (<a>) — no underline */
+  transition: background 0.12s, color 0.12s; }   /* + cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg */
 .footer-btn:hover:not(:disabled) { color: var(--cc-text); background: var(--cc-surface-1); }
 .footer-btn.danger:hover:not(:disabled) { color: #fff; background: var(--cc-danger, #ef4444); border-color: var(--cc-danger, #ef4444); }
 .footer-btn:disabled { opacity: 0.45; cursor: not-allowed; }

--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -44,7 +44,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
         <span class="cc-modal-title">
           <slot name="title"><i v-if="icon" :class="['pi', icon]" /> {{ title }}</slot>
         </span>
-        <button class="cc-modal-close" @click="emit('close')" v-tooltip.left="'Close'">
+        <button class="cc-modal-close cc-btn cc-btn-bare cc-btn-icon cc-btn-lg" @click="emit('close')" v-tooltip.left="'Close'">
           <i class="pi pi-times" />
         </button>
       </div>
@@ -84,11 +84,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
   flex: 1; font-size: var(--cc-fs-lg); font-weight: 600; color: var(--cc-text);
   display: flex; gap: 0.45rem; align-items: center;
 }
-.cc-modal-close {
-  background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: var(--cc-fs-md);
-  padding: 0.2rem 0.4rem; border-radius: var(--cc-radius-xs);
-}
+/* .cc-modal-close → cc-btn cc-btn-bare cc-btn-icon cc-btn-lg */
 .cc-modal-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 
 /* BaseModal owns body padding — dialogs should NOT re-add their own (would double up). Use the #toolbar

--- a/frontend/src/components/ErrorConsole.vue
+++ b/frontend/src/components/ErrorConsole.vue
@@ -84,7 +84,7 @@ const filterOptions = computed<ChipOption[]>(() =>
     </span>
 
     <button
-      class="icon-btn bar-window-btn"
+      class="icon-btn cc-btn cc-btn-bare cc-btn-icon cc-btn-lg bar-window-btn"
       @click.stop="openConsoleWindow"
       v-tooltip.top="'Open the console in a separate window'"
     >
@@ -115,7 +115,7 @@ const filterOptions = computed<ChipOption[]>(() =>
       />
 
       <button
-        class="icon-btn"
+        class="icon-btn cc-btn cc-btn-bare cc-btn-icon cc-btn-lg"
         @click="log.clear()"
         v-tooltip.top="'Clear all console messages'"
         :disabled="log.entries.length === 0"
@@ -125,7 +125,7 @@ const filterOptions = computed<ChipOption[]>(() =>
 
       <button
         v-if="!fill"
-        class="icon-btn"
+        class="icon-btn cc-btn cc-btn-bare cc-btn-icon cc-btn-lg"
         @click="openConsoleWindow"
         v-tooltip.top="'Open the console in a separate window'"
       >
@@ -253,15 +253,7 @@ const filterOptions = computed<ChipOption[]>(() =>
 /* push the trailing icon buttons to the right edge (was .filter-tabs { flex: 1 }) */
 .filter-chips { margin-right: auto; }
 
-.icon-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--cc-text-dim);
-  padding: 0.2rem 0.4rem;
-  border-radius: var(--cc-radius-xs);
-  font-size: var(--cc-fs-md);
-}
+/* .icon-btn → cc-btn cc-btn-bare cc-btn-icon cc-btn-lg */
 .icon-btn:hover:not(:disabled) { background: var(--cc-surface-2); color: var(--cc-text); }
 .icon-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 

--- a/frontend/src/components/FloatingPanel.vue
+++ b/frontend/src/components/FloatingPanel.vue
@@ -83,11 +83,11 @@ function endGesture() {
     <div class="fp-header" @pointerdown="onHeaderDown">
       <i v-if="icon" :class="['pi', icon, 'fp-icon']" :style="accent ? { color: accent } : undefined" />
       <span class="fp-title">{{ title }}</span>
-      <button class="fp-btn" @click="st.collapsed = !st.collapsed"
+      <button class="fp-btn cc-btn cc-btn-bare cc-btn-icon" @click="st.collapsed = !st.collapsed"
               v-tooltip.bottom="st.collapsed ? 'Expand' : 'Collapse'">
         <i :class="['pi', st.collapsed ? 'pi-window-maximize' : 'pi-window-minimize']" />
       </button>
-      <button class="fp-btn" @click="emit('close')" v-tooltip.bottom="'Close'">
+      <button class="fp-btn cc-btn cc-btn-bare cc-btn-icon" @click="emit('close')" v-tooltip.bottom="'Close'">
         <i class="pi pi-times" />
       </button>
     </div>
@@ -133,20 +133,7 @@ function endGesture() {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.fp-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.4rem;
-  height: 1.4rem;
-  border: none;
-  background: none;
-  color: var(--cc-text-dim);
-  cursor: pointer;
-  border-radius: var(--cc-radius-xs);
-  font-size: var(--cc-fs-sm);
-  flex-shrink: 0;
-}
+/* .fp-btn → cc-btn cc-btn-bare cc-btn-icon */
 .fp-btn:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 .fp-body { flex: 1; overflow: auto; min-height: 0; }
 .fp-resize {

--- a/frontend/src/components/HintCallout.vue
+++ b/frontend/src/components/HintCallout.vue
@@ -19,7 +19,7 @@ function dismiss() {
   <div v-if="!dismissed" class="hint-callout" role="note">
     <i class="pi pi-info-circle hint-icon" />
     <span class="hint-text">{{ text }}</span>
-    <button class="hint-x" @click="dismiss" v-tooltip.left="'Dismiss'" aria-label="Dismiss hint">
+    <button class="hint-x cc-btn cc-btn-bare cc-btn-icon cc-btn-dense" @click="dismiss" v-tooltip.left="'Dismiss'" aria-label="Dismiss hint">
       <i class="pi pi-times" />
     </button>
   </div>
@@ -40,15 +40,6 @@ function dismiss() {
 }
 .hint-icon { color: var(--cc-accent); font-size: var(--cc-fs-md); flex-shrink: 0; }
 .hint-text { flex: 1; }
-.hint-x {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--cc-text-dim);
-  padding: 0.15rem 0.3rem;
-  border-radius: var(--cc-radius-xs);
-  flex-shrink: 0;
-}
+/* .hint-x → cc-btn cc-btn-bare cc-btn-icon */
 .hint-x:hover { background: var(--cc-surface-2); color: var(--cc-text); }
-.hint-x .pi { font-size: var(--cc-fs-xs); }
 </style>

--- a/frontend/src/components/ImageMetadataDialog.vue
+++ b/frontend/src/components/ImageMetadataDialog.vue
@@ -66,7 +66,7 @@ async function copy(key: string, value: string) {
         <h4 class="md-h">Original file</h4>
         <div v-if="img.oriPath" class="md-path">
           <code class="md-code">{{ img.oriPath }}</code>
-          <button class="md-copy" @click="copy('ori', img.oriPath!)"
+          <button class="md-copy cc-btn cc-btn-bare cc-btn-icon" @click="copy('ori', img.oriPath!)"
             v-tooltip.left="copied === 'ori' ? 'Copied!' : 'Copy path'">
             <i :class="copied === 'ori' ? 'pi pi-check' : 'pi pi-copy'" />
           </button>
@@ -171,10 +171,7 @@ async function copy(key: string, value: string) {
   color: var(--cc-text); background: var(--cc-surface-2); border: 1px solid var(--cc-border);
   border-radius: var(--cc-radius-sm); padding: 0.3rem 0.45rem; word-break: break-all;
 }
-.md-copy {
-  flex-shrink: 0; background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); padding: 0.25rem 0.35rem; border-radius: var(--cc-radius-xs); font-size: var(--cc-fs-sm);
-}
+/* .md-copy → cc-btn cc-btn-bare cc-btn-icon */
 .md-copy:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 .md-none { margin: 0; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); font-style: italic; }
 

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -666,13 +666,13 @@ onUnmounted(stopResize)
             v-tooltip.bottom="'Sort by name'">
             Name <i :class="['sort-ico', sortIcon('name')]" />
           </span>
-          <button v-if="!singleSelect && flaggedUids.length" class="select-flagged-btn"
+          <button v-if="!singleSelect && flaggedUids.length" class="select-flagged-btn cc-btn cc-btn-bare cc-btn-icon"
             :class="{ active: flaggedActive }" @click.stop="selectFlagged"
             v-tooltip.bottom="flaggedActive ? 'Deselect flagged images' : `Select all ${flaggedUids.length} flagged image(s)`">
             <i class="pi pi-exclamation-triangle" />
           </button>
           <button v-if="flaggedUids.length && (module === 'metadata' || module === 'import')"
-            class="select-flagged-btn" :disabled="resyncing"
+            class="select-flagged-btn cc-btn cc-btn-bare cc-btn-icon" :disabled="resyncing"
             @click.stop="resyncFlagged"
             v-tooltip.bottom="`Re-read physical size & timing from file for all ${flaggedUids.length} flagged image(s) — use if they were imported before this check existed and are actually fine.`">
             <i :class="['pi', resyncing ? 'pi-spin pi-spinner' : 'pi-sync']" />
@@ -767,7 +767,7 @@ onUnmounted(stopResize)
 
         <td class="col-resize td-name col-name">
           <span class="name-row">
-            <button v-if="warnIconFor(img)" class="warn-icon-btn" @click.stop="physSizeDialogUid = img.uid"
+            <button v-if="warnIconFor(img)" class="warn-icon-btn cc-btn cc-btn-bare cc-btn-icon" @click.stop="physSizeDialogUid = img.uid"
               v-tooltip.right="warnIconFor(img)!.tip">
               <i class="pi pi-exclamation-triangle" />
             </button>
@@ -782,7 +782,7 @@ onUnmounted(stopResize)
             <span class="cell-text" v-tooltip.right="img.filepath ?? img.name">{{ img.name }}</span>
             <!-- all per-row actions collapse into one ⋯ menu (keeps the name column narrow) -->
             <span class="runlog-cell" @click.stop>
-              <button class="row-icon-btn actions-btn" :class="{ on: actionsUid === img.uid }"
+              <button class="row-icon-btn cc-btn cc-btn-bare cc-btn-icon actions-btn" :class="{ on: actionsUid === img.uid }"
                 @click.stop="toggleActions(img.uid, $event)"
                 v-tooltip.right="'Actions'"><i class="pi pi-ellipsis-h" /></button>
             </span>
@@ -877,7 +877,7 @@ onUnmounted(stopResize)
 
         <td v-if="allowDelete" class="col-fixed col-actions" @click.stop>
           <button
-            class="action-btn del-btn"
+            class="action-btn cc-btn cc-btn-bare cc-btn-icon del-btn"
             @click="confirmDelete(img.uid)"
             v-tooltip.left="'Remove this image from the set.'"
             :disabled="img.status === 'converting'"
@@ -1002,11 +1002,7 @@ onUnmounted(stopResize)
 .th-sort:hover .sort-ico { opacity: 0.7; }
 .th-sort.active .sort-ico { opacity: 1; color: var(--cc-accent); }
 
-.select-flagged-btn {
-  background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: var(--cc-fs-sm); padding: 0.1rem 0.3rem;
-  margin-left: 0.3rem; border-radius: var(--cc-radius-xs); vertical-align: middle;
-}
+.select-flagged-btn { margin-left: 0.3rem; vertical-align: middle; }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .select-flagged-btn:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 .select-flagged-btn.active { color: #fbbf24; }
 .select-flagged-btn.active:hover { color: #fcd34d; }
@@ -1094,10 +1090,7 @@ th:hover .resize-handle::after { opacity: 1; }
 /* always visible when flagged — impossible-to-miss, sits in front of the name */
 /* Calibration warning icon (metadata.* findings) → click to fix. Warn severity token (colour-blind
    palette); the shape-distinct triangle icon carries the meaning, colour is secondary. */
-.warn-icon-btn {
-  flex-shrink: 0; background: none; border: none; cursor: pointer;
-  color: var(--cc-sev-warn); font-size: var(--cc-fs-sm); padding: 0.1rem; line-height: 1;
-}
+.warn-icon-btn { color: var(--cc-sev-warn); }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .warn-icon-btn:hover { filter: brightness(1.2); }
 
 /* QC badge — advisory "output looks off" flag (non-metadata findings; distinct from the calibration
@@ -1137,12 +1130,7 @@ th:hover .resize-handle::after { opacity: 1; }
 .note-text .pi { font-size: var(--cc-fs-2xs); }
 
 /* row-hover actions after the name: the "open editor" page icon + copy-UID — same look, one class */
-.row-icon-btn {
-  flex-shrink: 0; background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: var(--cc-fs-sm); padding: 0.1rem 0.2rem;
-  border-radius: var(--cc-radius-xs); line-height: 1;
-  opacity: 0; transition: opacity 0.1s, color 0.1s, background 0.1s;
-}
+.row-icon-btn { opacity: 0; transition: opacity 0.1s, color 0.1s, background 0.1s; }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .image-row:hover .row-icon-btn { opacity: 1; }
 .row-icon-btn:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 /* disabled (e.g. Crop on a not-yet-imported image): visibly greyed, no hover highlight, not-allowed */
@@ -1236,12 +1224,7 @@ th:hover .resize-handle::after { opacity: 1; }
 
 /* ── Delete button ───────────────────────────────────────────────────────────── */
 
-.action-btn {
-  background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: var(--cc-fs-sm);
-  padding: 0.2rem 0.4rem; border-radius: var(--cc-radius-xs);
-  opacity: 0; transition: opacity 0.1s, background 0.1s;
-}
+.action-btn { opacity: 0; transition: opacity 0.1s, background 0.1s; }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .image-row:hover .action-btn { opacity: 1; }
 .action-btn:disabled { opacity: 0.25 !important; cursor: not-allowed; }
 .del-btn:hover { background: #7f1d1d55; color: #fca5a5; }

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -282,7 +282,7 @@ async function dismissEntry(entry: LabLogEntry) {
 
       <!-- Claude: the AI assistant (in-app one-shot + external chat handoff) -->
       <div class="ll-tb-group">
-        <button class="ll-help" @click="showClaudeOverview = true"
+        <button class="ll-help cc-btn cc-btn-bare cc-btn-icon cc-btn-lg" @click="showClaudeOverview = true"
                 v-tooltip.top="'What can Claude do here? Ask vs Chat, what it sees / suggests / creates'">
           <i class="pi pi-question-circle" />
         </button>
@@ -429,10 +429,7 @@ async function dismissEntry(entry: LabLogEntry) {
 /* brief "copied" flash on the Chat-to-Claude button (replaces the toast) */
 .ll-capture.copied { color: var(--cc-sev-ok); border-color: var(--cc-sev-ok); background: rgba(12, 163, 12, 0.1); }
 .ll-capture:disabled { opacity: 0.5; cursor: default; }
-.ll-help {
-  display: inline-flex; align-items: center; border: none; background: none;
-  color: var(--cc-text-dim); cursor: pointer; padding: 0.2rem; font-size: var(--cc-fs-md);
-}
+/* .ll-help → cc-btn cc-btn-bare cc-btn-icon cc-btn-lg */
 .ll-help:hover { color: var(--cc-accent); }
 .ll-auto { display: inline-flex; align-items: center; gap: 0.25rem; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); cursor: pointer; }
 .ll-model {

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -471,7 +471,7 @@ const visibleUids = computed<string[]>(() =>
         <!-- drag the left edge to resize (persisted per module); shared by TaskRunner + every panel -->
         <div v-if="!settings.rightPanelCollapsed" class="right-resizer" @mousedown="startResize"
              v-tooltip.left="'Drag to resize'" />
-        <button class="right-handle"
+        <button class="right-handle cc-btn cc-btn-bare cc-btn-icon cc-btn-dense"
           @click="settings.rightPanelCollapsed = !settings.rightPanelCollapsed"
           v-tooltip.left="settings.rightPanelCollapsed ? 'Show functions panel' : 'Hide functions panel'"
           :aria-label="settings.rightPanelCollapsed ? 'Show functions panel' : 'Hide functions panel'">
@@ -529,21 +529,8 @@ const visibleUids = computed<string[]>(() =>
   flex-shrink: 0;
   overflow: hidden;
 }
-.right-handle {
-  flex-shrink: 0;
-  width: 1.1rem;
-  border: none;
-  border-left: 1px solid var(--cc-border);
-  background: var(--cc-surface-1);
-  color: var(--cc-text-dim);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.12s, color 0.12s;
-}
+.right-handle { border-left: 1px solid var(--cc-border); transition: background 0.12s, color 0.12s; }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .right-handle:hover { background: var(--cc-surface-2); color: var(--cc-text); }
-.right-handle .pi { font-size: var(--cc-fs-xs); }
 /* drag strip on the panel's left edge to resize (col-resize); thin, highlights on hover */
 .right-resizer { flex-shrink: 0; width: 5px; cursor: col-resize; background: transparent; transition: background 0.12s; }
 .right-resizer:hover { background: var(--cc-accent); }

--- a/frontend/src/components/ProjectPanel.vue
+++ b/frontend/src/components/ProjectPanel.vue
@@ -282,7 +282,7 @@ const typeColour: Record<ProjectType, string> = {
               <td class="col-date dim">{{ formatDate(p.lastOpenedAt) }}</td>
               <td class="col-actions">
                 <!-- export to a portable .ccbundle (allowed for any project, incl. the open one) -->
-                <button class="pp-row-btn" :disabled="ioBusy" @click.stop="exportProject(p)"
+                <button class="pp-row-btn cc-btn cc-btn-bare cc-btn-icon" :disabled="ioBusy" @click.stop="exportProject(p)"
                         v-tooltip.left="'Export this project to a portable .ccbundle'">
                   <i class="pi pi-download" />
                 </button>
@@ -390,7 +390,7 @@ const typeColour: Record<ProjectType, string> = {
             <div v-if="ioBusy" class="pp-io-bar">
               <div class="pp-io-fill" :style="{ width: Math.round((ioTask.progress ?? 0) * 100) + '%' }" />
             </div>
-            <button v-if="ioBusy" class="pp-row-btn" @click="cancelIo" v-tooltip.top="'Cancel'">
+            <button v-if="ioBusy" class="pp-row-btn cc-btn cc-btn-bare cc-btn-icon" @click="cancelIo" v-tooltip.top="'Cancel'">
               <i class="pi pi-times" />
             </button>
             <span v-if="ioTask.log.length" class="pp-io-log">{{ ioTask.log[ioTask.log.length - 1] }}</span>
@@ -540,11 +540,7 @@ const typeColour: Record<ProjectType, string> = {
 .col-actions { width: 72px; white-space: nowrap; text-align: right; }
 
 /* small square row-action button (export, cancel) — matches ConfirmDeleteButton's footprint */
-.pp-row-btn {
-  background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); padding: 0.2rem 0.3rem; border-radius: var(--cc-radius-xs);
-  transition: color 0.1s, background 0.1s;
-}
+.pp-row-btn { transition: color 0.1s, background 0.1s; }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .pp-row-btn:hover:not(:disabled) { color: var(--cc-accent); background: var(--cc-surface-2); }
 .pp-row-btn:disabled { opacity: 0.3; cursor: not-allowed; }
 

--- a/frontend/src/components/SetBar.vue
+++ b/frontend/src/components/SetBar.vue
@@ -108,7 +108,7 @@ async function deleteSet() {
       </select>
       <template v-if="activeSet">
         <span class="set-uid">{{ activeSet.uid }}</span>
-        <button class="set-uid-copy" @click="copySetUid(activeSet.uid)"
+        <button class="set-uid-copy cc-btn cc-btn-bare cc-btn-icon" @click="copySetUid(activeSet.uid)"
           v-tooltip.bottom="copiedSetUid ? 'Copied!' : 'Copy set UID to clipboard'">
           <i :class="copiedSetUid ? 'pi pi-check' : 'pi pi-copy'" />
         </button>
@@ -181,16 +181,7 @@ async function deleteSet() {
   color: var(--cc-text-dim);
   letter-spacing: 0.03em;
 }
-.set-uid-copy {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-sm);
-  padding: 0.2rem 0.35rem;
-  border-radius: var(--cc-radius-xs);
-  line-height: 1;
-}
+/* .set-uid-copy → cc-btn cc-btn-bare cc-btn-icon */
 .set-uid-copy:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 .set-label {
   font-size: var(--cc-fs-sm); font-weight: 600; color: var(--cc-text-dim);

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -596,31 +596,31 @@ onUnmounted(() => {
       <div class="viewer-section-title">View</div>
       <div class="viewer-opts">
         <button
-          class="opt-btn" :class="{ active: settings.napariUpdateImage }"
+          class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ active: settings.napariUpdateImage }"
           @click="settings.napariUpdateImage = !settings.napariUpdateImage"
           v-tooltip.bottom="'Auto-update: refresh Napari whenever a task finishes on that image'"
         ><i class="pi pi-refresh" /></button>
 
         <button
-          class="opt-btn" :class="{ active: settings.napariResetOnReload }"
+          class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ active: settings.napariResetOnReload }"
           @click="settings.napariResetOnReload = !settings.napariResetOnReload"
           v-tooltip.bottom="'Reset on reload: reopen the whole image (not just data) when reloading — needed when a task changed the image pixels (drift/denoise). Off = reload data only.'"
         ><i class="pi pi-image" /></button>
 
         <button
-          class="opt-btn" :class="{ active: settings.napariAutoSaveLayerProps }"
+          class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ active: settings.napariAutoSaveLayerProps }"
           @click="settings.napariAutoSaveLayerProps = !settings.napariAutoSaveLayerProps"
           v-tooltip.bottom="'Auto-save layer props: save brightness/contrast, colormap and the T/Z slider the moment you change them (survives navigation and crashes); reload on next open'"
         ><i class="pi pi-bookmark" /></button>
 
         <button
-          class="opt-btn" :class="{ active: show3D }" :disabled="!currentSetUid"
+          class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ active: show3D }" :disabled="!currentSetUid"
           @click="show3D = !show3D"
           v-tooltip.bottom="'3D view: open images in 3D where they have a z-axis (per experiment/set)'"
         ><span class="opt-text">3D</span></button>
 
         <button
-          class="opt-btn" :class="{ active: settings.napariAsDask }"
+          class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ active: settings.napariAsDask }"
           @click="settings.napariAsDask = !settings.napariAsDask"
           v-tooltip.bottom="'Lazy load (Dask): fast open, slices computed on demand. Untick to load full zarr into memory — slower to open but smoother viewing.'"
         ><i class="pi pi-database" /></button>
@@ -654,12 +654,12 @@ onUnmounted(() => {
             <!-- action icons are hidden until row hover (keeps the narrow sidebar tidy); an ACTIVE
                  toggle stays visible so you can see what's shown without hovering -->
             <button
-              class="opt-btn row-act" :class="{ active: visibleLabels[vn] }"
+              class="opt-btn cc-btn cc-btn-ghost cc-btn-icon row-act" :class="{ active: visibleLabels[vn] }"
               @click="toggleLabel(vn)"
               v-tooltip.right="visibleLabels[vn] ? 'Hide labels in Napari' : 'Show labels in Napari'"
             ><i class="pi pi-eye" /></button>
             <button
-              class="opt-btn row-act" :class="{ active: trackVns[vn] }"
+              class="opt-btn cc-btn cc-btn-ghost cc-btn-icon row-act" :class="{ active: trackVns[vn] }"
               @click="toggleTrack(vn)"
               v-tooltip.right="trackVns[vn] ? 'Hide this segmentation\'s tracks' : 'Show this segmentation\'s tracks'"
             ><i class="pi pi-share-alt" /></button>
@@ -679,19 +679,19 @@ onUnmounted(() => {
       <div class="viewer-opts">
         <button
           v-for="pt in POP_TYPES" :key="pt.key"
-          class="opt-btn" :class="{ active: popVisible(pt.key) }"
+          class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ active: popVisible(pt.key) }"
           @click="togglePopType(pt.key)"
           v-tooltip.bottom="`${popVisible(pt.key) ? 'Hide' : 'Show'} ${pt.label} (points)`"
         ><i :class="['pi', pt.icon]" /></button>
         <!-- Tracks as ribbons (TEST/SDGF gated track pops); per-segmentation _tracked toggles live
              in the Segmentations list above (directions icon per row) -->
         <button
-          class="opt-btn" :class="{ active: gatedTracksShown }"
+          class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ active: gatedTracksShown }"
           @click="toggleGatedTracks"
           v-tooltip.bottom="gatedTracksShown ? 'Hide track-pop ribbons' : 'Show track populations as ribbons (track-measure gates)'"
         ><i class="pi pi-share-alt" /></button>
         <button
-          class="opt-btn" :class="{ active: popVisible('trackclust') }"
+          class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ active: popVisible('trackclust') }"
           @click="toggleTrackclust"
           v-tooltip.bottom="popVisible('trackclust') ? 'Hide track-cluster ribbons' : 'Show track-cluster populations as ribbons'"
         ><i class="pi pi-sitemap" /></button>
@@ -736,7 +736,7 @@ onUnmounted(() => {
           <span class="movie-lbl" v-tooltip.bottom="'Resolution supersample (2× = double resolution)'">res</span>
           <input type="range" min="1" max="3" step="1" v-model.number="movieScale" class="movie-range" />
           <span class="movie-val">{{ movieScale }}×</span>
-          <button class="opt-btn movie-rec" :class="{ active: recording }" :disabled="recording"
+          <button class="opt-btn cc-btn cc-btn-ghost cc-btn-icon movie-rec" :class="{ active: recording }" :disabled="recording"
                   @click="recordTimelapse"
                   v-tooltip.bottom="'Record the current view over the time axis → mp4 in the project\'s movies/ folder'">
             <i :class="['pi', recording ? 'pi-spin pi-spinner' : 'pi-video']" />
@@ -906,22 +906,7 @@ onUnmounted(() => {
   gap: 0.25rem;
 }
 
-.opt-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.8rem;
-  height: 1.8rem;
-  border-radius: var(--cc-radius-sm);
-  border: 1px solid var(--cc-border);
-  background: var(--cc-surface-2);
-  color: var(--cc-text-dim);
-  cursor: pointer;
-  font-size: var(--cc-fs-sm);
-  line-height: 1;
-  transition: background 0.1s, color 0.1s, border-color 0.1s;
-  flex-shrink: 0;
-}
+.opt-btn { transition: background 0.1s, color 0.1s, border-color 0.1s; }   /* + cc-btn cc-btn-ghost cc-btn-icon */
 .opt-btn:hover        { color: var(--cc-text); border-color: #484f58; }
 .opt-btn.active       { background: #2d1b69; border-color: #7c3aed; color: #c4b5fd; }
 .opt-btn.active:hover { background: #3b2382; }

--- a/frontend/src/components/canvas/CanvasPanel.vue
+++ b/frontend/src/components/canvas/CanvasPanel.vue
@@ -100,18 +100,18 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
       <span class="panel-spacer" />
       <!-- pin the auto-hiding controls open (next to the drag icon). Only when there ARE controls
            to reveal and auto-hide is active. -->
-      <button v-if="autoHide && hasControls && !collapsed" class="panel-btn" :class="{ on: pinned }"
+      <button v-if="autoHide && hasControls && !collapsed" class="panel-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" :class="{ on: pinned }"
               v-tooltip.bottom="pinned ? 'Auto-hide controls (show on hover)' : 'Keep controls visible'"
               @mousedown.stop @click.stop="pinned = !pinned">
         <i class="pi pi-thumbtack" />
       </button>
-      <button v-if="!docked" class="panel-btn panel-collapse" v-tooltip.bottom="collapsed ? 'Expand' : 'Collapse'"
+      <button v-if="!docked" class="panel-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense panel-collapse" v-tooltip.bottom="collapsed ? 'Expand' : 'Collapse'"
               @mousedown.stop @click.stop="collapsed = !collapsed">
         <i :class="collapsed ? 'pi pi-chevron-down' : 'pi pi-chevron-up'" />
       </button>
       <template v-if="removable">
         <span class="ctrl-sep" />
-        <button class="panel-btn panel-remove" v-tooltip.bottom="'Remove this plot'"
+        <button class="panel-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense panel-remove" v-tooltip.bottom="'Remove this plot'"
                 @mousedown.stop @click.stop="emit('remove')">
           <i class="pi pi-minus" />
         </button>
@@ -169,9 +169,7 @@ onBeforeUnmount(() => { ro?.disconnect(); ro = null })
 .panel-controls.inflow { border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-1); }
 .panel-foot.inflow { border-top: 1px solid var(--cc-border); background: var(--cc-surface-2); flex-shrink: 0; }
 .ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
-.panel-btn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1); color: var(--cc-text-dim);
-  cursor: pointer; font-size: var(--cc-fs-xs); }
+/* .panel-btn → cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .panel-btn:hover { color: var(--cc-text); border-color: #484f58; }
 .panel-btn.on { color: var(--cc-text); border-color: var(--cc-accent); }
 .panel-remove:hover { color: #f87171; border-color: #f87171; }

--- a/frontend/src/components/canvas/CanvasZoomControl.vue
+++ b/frontend/src/components/canvas/CanvasZoomControl.vue
@@ -13,8 +13,8 @@ const pct = () => Math.round(props.zoom * 100)
 
 <template>
   <div class="cz" v-tooltip.bottom="'Zoom the view to fit your screen (does not change the exported page)'">
-    <button class="cz-btn" @click="emit('fitWidth')" v-tooltip.bottom="'Fit width'"><i class="pi pi-arrows-h" /></button>
-    <button class="cz-btn" @click="emit('fitHeight')" v-tooltip.bottom="'Fit height'"><i class="pi pi-arrows-v" /></button>
+    <button class="cz-btn cc-btn cc-btn-bare cc-btn-icon" @click="emit('fitWidth')" v-tooltip.bottom="'Fit width'"><i class="pi pi-arrows-h" /></button>
+    <button class="cz-btn cc-btn cc-btn-bare cc-btn-icon" @click="emit('fitHeight')" v-tooltip.bottom="'Fit height'"><i class="pi pi-arrows-v" /></button>
     <input class="cz-range" type="range" :min="ZOOM_MIN * 100" :max="ZOOM_MAX * 100" step="5"
            :value="pct()" @input="emit('update:zoom', +($event.target as HTMLInputElement).value / 100)" />
     <button class="cz-val" @click="emit('reset')" v-tooltip.bottom="'Reset to 100%'">{{ pct() }}%</button>
@@ -24,8 +24,7 @@ const pct = () => Math.round(props.zoom * 100)
 <style scoped>
 .cz { display: inline-flex; align-items: center; gap: 4px; border: 1px solid var(--cc-border);
   border-radius: var(--cc-radius-sm); padding: 1px 4px; background: var(--cc-surface-2); }
-.cz-btn { display: inline-flex; align-items: center; justify-content: center; width: 1.4rem; height: 1.4rem;
-  background: transparent; color: var(--cc-text-dim); border: none; cursor: pointer; font-size: var(--cc-fs-sm); }
+/* .cz-btn → cc-btn cc-btn-bare cc-btn-icon */
 .cz-btn:hover { color: var(--cc-text); }
 .cz-range { width: 6rem; }
 .cz-val { min-width: 2.6rem; text-align: center; background: transparent; border: none; cursor: pointer;

--- a/frontend/src/components/canvas/InteractivePanel.vue
+++ b/frontend/src/components/canvas/InteractivePanel.vue
@@ -45,7 +45,7 @@ defineExpose({ exportImage, exportSvg })
     <component v-if="entry" :is="entry.component" ref="viewRef" v-bind="context" :state="state" />
     <div v-else class="ip-missing">Unknown interactive plot “{{ view }}”.</div>
     <template v-if="duplicable || exportFormats.length" #footer>
-      <button v-if="duplicable" class="ip-iconbtn" type="button" @click="emit('duplicate')"
+      <button v-if="duplicable" class="ip-iconbtn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same settings) to tweak one thing'"><i class="pi pi-copy" /></button>
       <select v-if="exportFormats.length && !docked" class="ip-export" v-tooltip.top="'Export the shown plot'"
               @change="onExport(($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
@@ -58,9 +58,7 @@ defineExpose({ exportImage, exportSvg })
 
 <style scoped>
 .ip-missing { padding: 1rem; color: var(--cc-text-dim); font-size: var(--cc-fs-md); }
-.ip-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
+/* .ip-iconbtn → cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .ip-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
 .ip-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 </style>

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -393,7 +393,7 @@ defineExpose({ capturePage, collectCsvs })
                       @update:model-value="v => applyPreset(UNIFORM_PRESETS, v as string)" />
           <!-- custom grid size + slot height, tucked into a ⚙ popover to keep the bar tidy -->
           <div class="lc-opts">
-            <button ref="optsBtn" class="lc-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+            <button ref="optsBtn" class="lc-gear cc-btn cc-btn-ghost cc-btn-icon" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
                     v-tooltip.bottom="'Grid size & slot height'"><i class="pi pi-sliders-h" /></button>
             <TeleportPopover v-model="optsOpen" :anchor="optsBtn">
               <div class="lc-pop">
@@ -582,9 +582,7 @@ defineExpose({ capturePage, collectCsvs })
 .lc-clust select { font-size: var(--cc-fs-xs); }
 /* ⚙ grid-size / height popover */
 .lc-opts { position: relative; display: inline-flex; }
-.lc-gear { display: inline-flex; align-items: center; justify-content: center; width: 1.7rem; height: 1.6rem;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-2); color: var(--cc-text-dim);
-  cursor: pointer; font-size: var(--cc-fs-sm); }
+/* .lc-gear → cc-btn cc-btn-ghost cc-btn-icon */
 .lc-gear:hover, .lc-gear.on { color: var(--cc-text); border-color: #7c3aed; }
 .lc-custom { font-size: var(--cc-fs-xs); padding: 0.22rem 0.55rem; }
 .lc-custom.on { color: var(--cc-text); border-color: #7c3aed; }

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -260,7 +260,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
             <option v-for="f in FILTER_FUNS" :key="f" :value="f">{{ f }}</option>
           </select>
           <input v-model="c.values" class="pm-ff-vals" :placeholder="c.fun === 'in' ? 'a, b, c' : 'value'" />
-          <button v-if="fpConds.length > 1" class="pm-icon" @click="removeFpCond(i)" v-tooltip.left="'Remove condition'">
+          <button v-if="fpConds.length > 1" class="pm-icon cc-btn cc-btn-bare cc-btn-icon" @click="removeFpCond(i)" v-tooltip.left="'Remove condition'">
             <i class="pi pi-times" />
           </button>
         </div>
@@ -295,7 +295,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
           <!-- filter pops are badged (vs hand-drawn gates); the badge is the EDIT affordance (click →
                open the same form pre-filled). Read-only surfaces show a static badge. Tooltip = predicate. -->
           <button v-if="isFilterPop(p) && !readonly && !p.transient" type="button"
-                  class="pm-icon pm-filter-badge" v-tooltip.top="`Edit: ${popFilterSummary(p)}`"
+                  class="pm-icon cc-btn cc-btn-bare cc-btn-icon pm-filter-badge" v-tooltip.top="`Edit: ${popFilterSummary(p)}`"
                   @click.stop="beginEditFilter(p)"><i class="pi pi-filter" /></button>
           <i v-else-if="isFilterPop(p)" class="pi pi-filter pm-filter-badge"
              v-tooltip.top="popFilterSummary(p)" />
@@ -305,16 +305,16 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
             <small>{{ fmtPct(g.stats[p.path]?.pctParent) }}</small>
           </span>
 
-          <button v-if="p.gate" class="pm-icon" v-tooltip.left="'Show the plot where this gate was drawn'"
+          <button v-if="p.gate" class="pm-icon cc-btn cc-btn-bare cc-btn-icon" v-tooltip.left="'Show the plot where this gate was drawn'"
                   @click.stop="emit('showDefiningPlot', p)">
             <i class="pi pi-search" />
           </button>
-          <button class="pm-icon" :class="{ lit: isLit(p) }"
+          <button class="pm-icon cc-btn cc-btn-bare cc-btn-icon" :class="{ lit: isLit(p) }"
                   v-tooltip.left="isLit(p) ? 'Hide colour on plots' : 'Highlight colour on plots'"
                   @click.stop="emit('toggleHighlight', p.path)">
             <i :class="isLit(p) ? 'pi pi-eye' : 'pi pi-eye-slash'" />
           </button>
-          <button v-if="!p.transient" class="pm-icon" :class="{ lit: p.show }"
+          <button v-if="!p.transient" class="pm-icon cc-btn cc-btn-bare cc-btn-icon" :class="{ lit: p.show }"
                   v-tooltip.left="p.show ? 'Visible in napari (click to hide)' : 'Hidden in napari (click to show)'"
                   @click.stop="toggleNapari(p)">
             <i class="pi pi-images" />
@@ -324,7 +324,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
                   @confirm="g.deletePop(p.path)" />
           <!-- the napari selection is transient (never persisted) — this clears it so it doesn't
                linger forever; there's no persisted pop to delete. -->
-          <button v-else class="pm-icon danger" v-tooltip.left="'Clear napari selection'"
+          <button v-else class="pm-icon cc-btn cc-btn-bare cc-btn-icon danger" v-tooltip.left="'Clear napari selection'"
                   @click.stop="g.clearNapariSelection()">
             <i class="pi pi-trash" />
           </button>
@@ -372,7 +372,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
           <div class="pm-opt-head"><span>plot</span></div>
           <div class="pm-opt-row">
             <span class="pm-opt-label">Gate labels</span>
-            <button class="seg-btn" :class="{ active: gateLabels }"
+            <button class="seg-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg" :class="{ active: gateLabels }"
                     v-tooltip.top="'Show population names on gates'"
                     @click="emit('update:gateLabels', !gateLabels)"><i class="pi pi-tag" /></button>
           </div>
@@ -436,7 +436,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
 .pm-rename { flex: 1; background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); padding: 1px 4px; }
 .pm-stat { color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
 .pm-stat small { opacity: 0.7; margin-left: 3px; }
-.pm-icon { background: none; border: none; color: var(--cc-text-dim); cursor: pointer; padding: 2px; }
+/* .pm-icon → cc-btn cc-btn-bare cc-btn-icon */
 .pm-icon:hover { color: var(--cc-text); }
 .pm-icon.lit { color: var(--cc-accent); }
 .pm-icon.danger:hover { color: #f87171; }
@@ -486,12 +486,7 @@ button.pm-filter-badge:hover { opacity: 1; }
 
 /* segmented toggle (axis option in the #options slot; the shell owns the footer scope toggle) */
 .pm-seg { margin-left: auto; }
-.seg-btn {
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 1.8rem; height: 1.8rem; border-radius: var(--cc-radius-sm);
-  border: 1px solid var(--cc-border); background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-md); transition: background 0.1s, color 0.1s, border-color 0.1s;
-}
+.seg-btn { transition: background 0.1s, color 0.1s, border-color 0.1s; }   /* + cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg */
 .seg-btn:hover { color: var(--cc-text); border-color: #484f58; }
 .seg-btn.active { background: #2d1b69; border-color: #7c3aed; color: #c4b5fd; }
 

--- a/frontend/src/components/canvas/PopulationPanelShell.vue
+++ b/frontend/src/components/canvas/PopulationPanelShell.vue
@@ -56,7 +56,7 @@ function onHeaderDown(e: MouseEvent) { if (!props.docked) startDrag(e) }
       <i class="pi pi-sitemap" />
       <span class="pm-title">{{ title }}</span>
       <span v-if="count !== undefined" class="pm-count">{{ count }}</span>
-      <button v-if="!docked" class="pm-icon" v-tooltip.left="collapsed ? 'Expand' : 'Collapse'"
+      <button v-if="!docked" class="pm-icon cc-btn cc-btn-bare cc-btn-icon" v-tooltip.left="collapsed ? 'Expand' : 'Collapse'"
               @click.stop="collapsed = !collapsed">
         <i :class="collapsed ? 'pi pi-chevron-down' : 'pi pi-chevron-up'" />
       </button>
@@ -99,7 +99,7 @@ function onHeaderDown(e: MouseEvent) { if (!props.docked) startDrag(e) }
 .pm-title { font-weight: 600; }
 .pm-count { color: var(--cc-text-dim); margin-left: auto; }
 .pm-body { max-height: 60vh; overflow-y: auto; }
-.pm-icon { background: none; border: none; color: var(--cc-text-dim); cursor: pointer; padding: 2px; }
+/* .pm-icon → cc-btn cc-btn-bare cc-btn-icon */
 .pm-icon:hover { color: var(--cc-text); }
 .pm-opts { border-top: 1px solid var(--cc-border); }
 .pm-footer { display: flex; align-items: center; padding: 6px 8px; border-top: 1px solid var(--cc-border); background: var(--cc-surface-2); border-radius: 0 0 6px 6px; }

--- a/frontend/src/components/canvas/SeriesPicker.vue
+++ b/frontend/src/components/canvas/SeriesPicker.vue
@@ -48,7 +48,7 @@ const depthOf = (path: string) => Math.max(0, path.split('/').length - 2)
         <span class="pm-swatch" :style="{ background: p.colour }" />
         <span class="pm-name">{{ p.name }}</span>
         <span v-if="p.popType !== 'live'" class="pm-tag" v-tooltip.left="'Gated on per-track properties'">{{ p.popType }}</span>
-        <button class="pm-icon" :class="{ lit: isLit(grp.valueName, p.path, p.popType) }"
+        <button class="pm-icon cc-btn cc-btn-bare cc-btn-icon" :class="{ lit: isLit(grp.valueName, p.path, p.popType) }"
                 v-tooltip.left="isLit(grp.valueName, p.path, p.popType) ? 'Remove from plots' : 'Plot this population'"
                 @click.stop="emit('toggle', grp.valueName, p.path, p.popType)">
           <i :class="isLit(grp.valueName, p.path, p.popType) ? 'pi pi-eye' : 'pi pi-eye-slash'" />
@@ -74,7 +74,7 @@ const depthOf = (path: string) => Math.max(0, path.split('/').length - 2)
 .pm-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .pm-tag { font-size: var(--cc-fs-3xs); text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-text-dim);
   border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); padding: 0 3px; flex-shrink: 0; }
-.pm-icon { background: none; border: none; color: var(--cc-text-dim); cursor: pointer; padding: 2px; }
+/* .pm-icon → cc-btn cc-btn-bare cc-btn-icon */
 .pm-icon:hover { color: var(--cc-text); }
 .pm-icon.lit { color: var(--cc-accent); }
 </style>

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -509,7 +509,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
 
       <!-- secondary options (split-by + chart-specific) tucked into a popover to keep the bar tidy -->
       <div v-if="hasOpts" class="sp-pop-wrap">
-        <button ref="optsBtn" class="sp-iconbtn" type="button" :class="{ on: optsOpen }" @click.stop="optsOpen = !optsOpen"
+        <button ref="optsBtn" class="sp-iconbtn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" type="button" :class="{ on: optsOpen }" @click.stop="optsOpen = !optsOpen"
                 v-tooltip.bottom="'Plot options'">
           <i class="pi pi-sliders-h" />
         </button>
@@ -614,13 +614,13 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
 
     <!-- utility actions live in the footer so the header/controls never clip -->
     <template #footer>
-      <button class="sp-iconbtn" type="button" @click="emit('duplicate')"
+      <button class="sp-iconbtn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" type="button" @click="emit('duplicate')"
               v-tooltip.top="docked ? 'Duplicate this plot into the next empty slot' : 'Duplicate this plot (same series + settings) to tweak one thing'">
         <i class="pi pi-copy" />
       </button>
       <!-- Show series: pick measures → one copy of this plot per measure, to see them all at once -->
       <div v-if="canExplode" class="sp-explode-wrap">
-        <button class="sp-iconbtn" type="button" @click="openExplode"
+        <button class="sp-iconbtn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" type="button" @click="openExplode"
                 v-tooltip.top="'Show series: duplicate this plot for each selected measurement'">
           <i class="pi pi-chart-bar" />
         </button>
@@ -662,9 +662,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
 .sp-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 
 /* compact icon buttons (options / duplicate) */
-.sp-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
+/* .sp-iconbtn → cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .sp-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
 .sp-iconbtn.on { color: var(--cc-text); border-color: var(--cc-accent); }
 

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -204,23 +204,23 @@ function exportBoard(kind: string) {
         />
         <template v-else>
           <span class="tab-name">{{ t.name }}</span>
-          <button class="tab-close tab-dup" type="button" @click.stop="duplicateBoard(t.id)"
+          <button class="tab-close cc-btn cc-btn-bare cc-btn-icon cc-btn-micro tab-dup" type="button" @click.stop="duplicateBoard(t.id)"
                   v-tooltip.bottom="'Duplicate board (plots + layout)'" aria-label="Duplicate board"><i class="pi pi-copy" /></button>
           <ConfirmButton v-if="tabs.length > 1" :needs-confirm="plotCount(t.id) > 0" @confirm="closeTab(t.id)"
                          v-slot="{ armed, arm, confirm, cancel }">
             <span @click.stop>
-              <button v-if="!armed" class="tab-close" type="button" @click="arm"
+              <button v-if="!armed" class="tab-close cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" type="button" @click="arm"
                       v-tooltip.bottom="'Close board'" aria-label="Close board"><i class="pi pi-times" /></button>
               <template v-else>
-                <button class="tab-close" type="button" @click="confirm"
+                <button class="tab-close cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" type="button" @click="confirm"
                         v-tooltip.bottom="`Confirm — close board and its ${plotCount(t.id)} plot${plotCount(t.id) === 1 ? '' : 's'}`"><i class="pi pi-check" /></button>
-                <button class="tab-close" type="button" @click="cancel" v-tooltip.bottom="'Keep board'"><i class="pi pi-replay" /></button>
+                <button class="tab-close cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" type="button" @click="cancel" v-tooltip.bottom="'Keep board'"><i class="pi pi-replay" /></button>
               </template>
             </span>
           </ConfirmButton>
         </template>
       </div>
-      <button class="tab-add" type="button" @click="addTab" v-tooltip.bottom="'New board'" aria-label="New board">
+      <button class="tab-add cc-btn cc-btn-bare cc-btn-icon" type="button" @click="addTab" v-tooltip.bottom="'New board'" aria-label="New board">
         <i class="pi pi-plus" />
       </button>
       <!-- one export control: figure (PDF/SVG), data (CSV), or both in a single pass -->
@@ -261,17 +261,9 @@ function exportBoard(kind: string) {
 .tab-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tab-edit { font-size: var(--cc-fs-sm); width: 8rem; background: var(--cc-surface-2); color: var(--cc-text);
   border: 1px solid #7c3aed; border-radius: var(--cc-radius-xs); padding: 1px 4px; }
-.tab-close {
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 1rem; height: 1rem; border: none; border-radius: var(--cc-radius-xs);
-  background: transparent; color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-2xs);
-}
+/* .tab-close → cc-btn cc-btn-bare cc-btn-icon cc-btn-micro */
 .tab-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
-.tab-add {
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 1.8rem; border: none; background: transparent; color: var(--cc-text-dim);
-  cursor: pointer; font-size: var(--cc-fs-sm); margin-left: 2px;
-}
+.tab-add { margin-left: 2px; }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .tab-add:hover { color: var(--cc-text); }
 .tab-pdf { display: inline-flex; align-items: center; gap: 5px; margin-left: auto; margin-bottom: 2px;
   padding: 3px 10px; font-size: var(--cc-fs-xs); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm);

--- a/frontend/src/components/plots/GatingStrategyView.vue
+++ b/frontend/src/components/plots/GatingStrategyView.vue
@@ -203,7 +203,7 @@ defineExpose({ exportImage, exportSvg })
       </select>
       <RenderModeToggle v-model="renderMode" />
       <div class="gs-opts">
-        <button ref="gearBtn" class="gs-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+        <button ref="gearBtn" class="gs-gear cc-btn cc-btn-ghost cc-btn-icon" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
                 v-tooltip.bottom="'Plot size & hierarchy'"><i class="pi pi-cog" /></button>
         <TeleportPopover v-model="optsOpen" :anchor="gearBtn" placement="bottom-end">
           <div class="gs-pop">
@@ -235,8 +235,7 @@ defineExpose({ exportImage, exportSvg })
 /* ⚙ options popover (hierarchy toggle). margin-left:auto pins the gear to the far right so the popover —
    anchored right:0 — always opens LEFTWARD into the panel and is never clipped at the left edge. */
 .gs-opts { position: relative; display: inline-flex; margin-left: auto; }
-.gs-gear { background: var(--cc-surface-2); color: var(--cc-text-dim); border: 1px solid var(--cc-border);
-  border-radius: var(--cc-radius-sm); padding: 4px 8px; cursor: pointer; font-size: var(--cc-fs-sm); }
+/* .gs-gear → cc-btn cc-btn-ghost cc-btn-icon */
 .gs-gear.on { background: var(--cc-accent); color: #fff; border-color: var(--cc-accent); }
 /* inner layout only — TeleportPopover provides surface/border/shadow/position */
 .gs-pop { width: 13rem; display: flex; flex-direction: column; gap: 8px; padding: 10px; }

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -315,7 +315,7 @@ defineExpose({ exportImage })
                     :model-value="separator" @update:model-value="v => separator = v as 'straight' | 'angled'" />
       </div>
       <div class="is-opts">
-        <button ref="gearEl" class="is-gear" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
+        <button ref="gearEl" class="is-gear cc-btn cc-btn-ghost cc-btn-icon" :class="{ on: optsOpen }" @click="optsOpen = !optsOpen"
                 v-tooltip.bottom="'Caption size & separator'"><i class="pi pi-cog" /></button>
         <TeleportPopover v-model="optsOpen" :anchor="gearEl" placement="bottom-end">
           <div class="is-pop">
@@ -361,11 +361,11 @@ defineExpose({ exportImage })
         </button>
         <!-- per-frame actions (hidden while capturing) -->
         <div v-if="!capturingStrip" class="is-actions">
-          <button v-if="(c.assetId || c.src) && c.imageUid && c.snapshot" class="is-mini" @click="zoomToSource(i)"
+          <button v-if="(c.assetId || c.src) && c.imageUid && c.snapshot" class="is-mini cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" @click="zoomToSource(i)"
                   :disabled="zooming === i" v-tooltip.top="'Zoom to source: reopen this image in Napari and restore the exact view'">
             <i class="pi pi-directions" /></button>
-          <button v-if="c.assetId || c.src" class="is-mini" @click="capture(i)" v-tooltip.top="'Recapture'"><i class="pi pi-camera" /></button>
-          <button v-if="cells.length > 1" class="is-mini" @click="removeCell(i)" v-tooltip.top="'Remove frame'"><i class="pi pi-times" /></button>
+          <button v-if="c.assetId || c.src" class="is-mini cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" @click="capture(i)" v-tooltip.top="'Recapture'"><i class="pi pi-camera" /></button>
+          <button v-if="cells.length > 1" class="is-mini cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" @click="removeCell(i)" v-tooltip.top="'Remove frame'"><i class="pi pi-times" /></button>
         </div>
       </div>
     </div>
@@ -379,9 +379,7 @@ defineExpose({ exportImage })
 .is-bar { display: flex; align-items: center; gap: 8px; padding: 6px 8px; flex-wrap: wrap;
   font-size: var(--cc-fs-sm); }
 .is-opts { position: relative; display: inline-flex; }
-.is-gear { display: inline-flex; align-items: center; justify-content: center; width: 1.7rem; height: 1.6rem;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); color: var(--cc-text-dim);
-  cursor: pointer; font-size: var(--cc-fs-sm); }
+/* .is-gear → cc-btn cc-btn-ghost cc-btn-icon */
 .is-gear:hover, .is-gear.on { color: var(--cc-text); border-color: #7c3aed; }
 /* inner layout only — the teleported TeleportPopover shell provides surface/border/shadow/position */
 .is-pop { display: flex; flex-direction: column; gap: 6px; padding: 8px 10px; }
@@ -431,9 +429,7 @@ defineExpose({ exportImage })
 /* per-frame action buttons — match the app's icon buttons (like .is-gear / .opt-btn) rather than the
    old dark translucent pills: solid surface + border, purple accent on hover. Sit over the image, so a
    solid surface reads cleanly. */
-.is-mini { width: 1.5rem; height: 1.5rem; display: inline-flex; align-items: center; justify-content: center;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); color: var(--cc-text-dim);
-  cursor: pointer; font-size: var(--cc-fs-xs); transition: color 0.1s, border-color 0.1s, background 0.1s; }
+.is-mini { transition: color 0.1s, border-color 0.1s, background 0.1s; }   /* + cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .is-mini:hover { color: var(--cc-text); border-color: #7c3aed; background: var(--cc-surface-1); }
 .is-mini:disabled { opacity: 0.5; cursor: not-allowed; }
 /* while capturing for the PDF: hide the per-frame buttons (and empty-frame capture prompts) so the

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -315,10 +315,10 @@ async function render() {
                 </div>
                 <div v-if="keyframeTime(f)" class="tl-time">{{ keyframeTime(f) }}</div>
                 <div class="tl-colctl">
-                  <button class="tl-ico" :disabled="i === 0" @click="anim.move(f.id, -1)" v-tooltip.bottom="'Move earlier'"><i class="pi pi-chevron-left" /></button>
+                  <button class="tl-ico cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" :disabled="i === 0" @click="anim.move(f.id, -1)" v-tooltip.bottom="'Move earlier'"><i class="pi pi-chevron-left" /></button>
                   <span class="tl-kf">{{ i + 1 }}</span>
-                  <button class="tl-ico" :disabled="i === frames.length - 1" @click="anim.move(f.id, 1)" v-tooltip.bottom="'Move later'"><i class="pi pi-chevron-right" /></button>
-                  <button class="tl-ico" :disabled="!isEdited(f)" @click="resetKeyframe(f)" v-tooltip.bottom="'Reset to the captured view'"><i class="pi pi-refresh" /></button>
+                  <button class="tl-ico cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" :disabled="i === frames.length - 1" @click="anim.move(f.id, 1)" v-tooltip.bottom="'Move later'"><i class="pi pi-chevron-right" /></button>
+                  <button class="tl-ico cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" :disabled="!isEdited(f)" @click="resetKeyframe(f)" v-tooltip.bottom="'Reset to the captured view'"><i class="pi pi-refresh" /></button>
                   <ConfirmDeleteButton title="Delete keyframe" armed-title="Click again to delete" @confirm="deleteKeyframe(f)" />
                 </div>
                 <div class="tl-dur" v-tooltip.bottom="'Seconds this keyframe tweens from the previous'">
@@ -405,8 +405,7 @@ async function render() {
 .tl-time { font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); text-align: center; margin-top: 0.15rem; font-variant-numeric: tabular-nums; }
 .tl-colctl { display: flex; align-items: center; justify-content: center; gap: 0.1rem; margin-top: 0.3rem; }
 .tl-kf { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); min-width: 0.9rem; text-align: center; }
-.tl-ico { display: inline-flex; border: none; background: none; color: var(--cc-text-dim); cursor: pointer;
-  padding: 0.15rem; font-size: var(--cc-fs-2xs); border-radius: var(--cc-radius-xs); }
+/* .tl-ico → cc-btn cc-btn-bare cc-btn-icon cc-btn-micro */
 .tl-ico:hover:not(:disabled) { color: var(--cc-text); background: var(--cc-surface-2); }
 .tl-ico:disabled { opacity: 0.3; cursor: default; }
 .tl-dur { display: flex; align-items: center; justify-content: center; gap: 0.3rem; margin-top: 0.3rem; }

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -1082,7 +1082,7 @@ onActivated(async () => {
         </select>
         <button
           v-if="selectedRunId"
-          class="wb-btn live-resume-btn"
+          class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense live-resume-btn"
           :disabled="resumeBusy"
           @click="resumeRun"
           v-tooltip.bottom="resumeBusy
@@ -1095,7 +1095,7 @@ onActivated(async () => {
         </button>
         <button
           v-if="restartNodeId"
-          class="wb-btn live-copy-btn"
+          class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense live-copy-btn"
           @click="restartNodeId = null"
           v-tooltip.bottom="'Clear the resume-from node'"
         >
@@ -1103,21 +1103,21 @@ onActivated(async () => {
         </button>
         <button
           v-if="selectedRunId"
-          class="wb-btn live-copy-btn"
+          class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense live-copy-btn"
           @click="copyRunId"
           v-tooltip.bottom="`Copy run ID (${selectedRunId}) — e.g. for load_chain_run in the REPL`"
         >
           <i class="pi pi-copy" />
         </button>
         <button
-          class="wb-btn live-copy-btn"
+          class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense live-copy-btn"
           @click="loadRunList"
           v-tooltip.bottom="'Reload run history from disk'"
         >
           <i class="pi pi-refresh" />
         </button>
         <button
-          class="wb-btn qc-toggle"
+          class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense qc-toggle"
           :class="{ 'qc-on': showQc }"
           @click="showQc = !showQc"
           v-tooltip.bottom="'Show/hide the segmentation QC row'"
@@ -1126,7 +1126,7 @@ onActivated(async () => {
         </button>
         <button
           ref="throttleBtn"
-          class="wb-btn"
+          class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense"
           :class="{ 'qc-on': throttleOpen }"
           @click="throttleOpen = !throttleOpen"
           v-tooltip.bottom="'Throttle — how many tasks of each kind run at once'"
@@ -1163,7 +1163,7 @@ onActivated(async () => {
           <div class="qc-expand-card">
             <div class="qc-expand-head">
               <span>Segmentation QC · {{ qcExpand.valueName }}</span>
-              <button class="wb-btn" @click="qcExpand = null"><i class="pi pi-times" /></button>
+              <button class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" @click="qcExpand = null"><i class="pi pi-times" /></button>
             </div>
             <div class="qc-expand-body">
               <SummaryCanvas :image-uids="qcExpand.imageUids" module="segment" />
@@ -1197,7 +1197,7 @@ onActivated(async () => {
         </div>
         <div class="chain-bar-actions">
           <button
-            class="wb-btn"
+            class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense"
             @click="showNewInput = !showNewInput"
             v-tooltip.right="'Create a new chain template.'"
           >
@@ -1208,7 +1208,7 @@ onActivated(async () => {
             armed-title="Click again to permanently delete this chain"
             @confirm="removeChain" />
           <button
-            class="wb-btn"
+            class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense"
             :disabled="!activeChain || hasStartNode"
             @click="addStartNode"
             v-tooltip.right="'Add a start node — link it to the task(s) a run begins from. Only tasks reachable from it run; the rest stay as drafts.'"
@@ -1216,7 +1216,7 @@ onActivated(async () => {
             <i class="pi pi-circle-fill" />
           </button>
           <button
-            class="wb-btn"
+            class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense"
             :disabled="!activeChain"
             @click="loadChain(activeChain)"
             v-tooltip.right="'Reload chain from disk — discards unsaved edits.'"
@@ -1224,7 +1224,7 @@ onActivated(async () => {
             <i class="pi pi-refresh" />
           </button>
           <button
-            class="wb-btn wb-btn-save"
+            class="wb-btn wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense-save"
             :disabled="!activeChain || saving"
             @click="saveChain"
             v-tooltip.right="'Save the current chain to disk.'"
@@ -1244,7 +1244,7 @@ onActivated(async () => {
           @keydown.esc="showNewInput = false; newChainName = ''"
           autofocus
         />
-        <button class="wb-btn wb-btn-save" @click="createChain" :disabled="!newChainName.trim()">
+        <button class="wb-btn wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense-save" @click="createChain" :disabled="!newChainName.trim()">
           <i class="pi pi-check" />
         </button>
       </div>
@@ -1279,7 +1279,7 @@ onActivated(async () => {
 
             <div v-if="!paletteCategories.length" class="palette-hint palette-hint-retry">
               No task definitions found.
-              <button class="wb-btn palette-retry-btn" @click="loadAllTaskDefs"
+              <button class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense palette-retry-btn" @click="loadAllTaskDefs"
                 v-tooltip.right="'Retry loading task definitions from the server.'">
                 <i class="pi pi-refresh" />
               </button>
@@ -1662,20 +1662,7 @@ onActivated(async () => {
   font-style: italic;
 }
 
-.wb-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px; height: 26px;
-  border-radius: var(--cc-radius-sm);
-  border: 1px solid var(--cc-border);
-  background: var(--cc-surface-2);
-  color: var(--cc-text-dim);
-  cursor: pointer;
-  font-size: var(--cc-fs-xs);
-  flex-shrink: 0;
-  transition: background 0.1s, color 0.1s;
-}
+.wb-btn { transition: background 0.1s, color 0.1s; }   /* + cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .wb-btn:hover:not(:disabled) { background: var(--cc-surface-2); color: var(--cc-text); border-color: var(--cc-accent); }
 .wb-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 .wb-btn-save { color: var(--cc-accent); border-color: var(--cc-accent); }

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -334,7 +334,7 @@ async function switchWt(path: string) {
             <div class="field-row">
               <input class="field-input mono" :value="projectMeta.current.uid" readonly
                      v-tooltip.bottom="'Read-only unique identifier used internally.'" />
-              <button class="icon-btn" @click="copyUid" v-tooltip.left="'Copy project ID'">
+              <button class="icon-btn cc-btn cc-btn-bare cc-btn-icon cc-btn-lg" @click="copyUid" v-tooltip.left="'Copy project ID'">
                 <i class="pi pi-copy" />
               </button>
             </div>
@@ -862,16 +862,7 @@ async function switchWt(path: string) {
 .save-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 .save-btn:not(:disabled):hover { opacity: 0.85; }
 
-.icon-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-md);
-  padding: 0.3rem 0.4rem;
-  border-radius: var(--cc-radius-xs);
-  flex-shrink: 0;
-}
+/* .icon-btn → cc-btn cc-btn-bare cc-btn-icon cc-btn-lg */
 .icon-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 
 .toggle-row {

--- a/frontend/src/modules/TasksModule.vue
+++ b/frontend/src/modules/TasksModule.vue
@@ -125,7 +125,7 @@ const FILTERS: ChipOption[] = [
       <CcToggle class="follow-toggle" v-model="settings.taskListAutoFollow" label="Auto-follow"
         v-tooltip.left="'Automatically select the newest running task'" />
 
-      <button ref="throttleBtn" class="tm-throttle" :class="{ active: throttleOpen }"
+      <button ref="throttleBtn" class="tm-throttle cc-btn cc-btn-bare cc-btn-icon" :class="{ active: throttleOpen }"
         @click="throttleOpen = !throttleOpen"
         v-tooltip.left="'Throttle — how many tasks of each kind run at once'">
         <i class="pi pi-sliders-h" />
@@ -172,16 +172,16 @@ const FILTERS: ChipOption[] = [
 
           <div class="row-actions" @click.stop>
             <button v-if="t.status === 'running' || t.status === 'queued'"
-              class="ra-btn danger" @click="cancelTask(t)"
+              class="ra-btn cc-btn cc-btn-bare cc-btn-icon danger" @click="cancelTask(t)"
               v-tooltip.left="t.chainRunId ? 'Stop chain run' : 'Cancel task'">
               <i class="pi pi-times" />
             </button>
             <button v-if="canRerun(t)"
-              class="ra-btn" @click="rerun(t)" v-tooltip.left="'Rerun'">
+              class="ra-btn cc-btn cc-btn-bare cc-btn-icon" @click="rerun(t)" v-tooltip.left="'Rerun'">
               <i class="pi pi-replay" />
             </button>
             <button v-if="t.status === 'done' || t.status === 'failed' || t.status === 'cancelled'"
-              class="ra-btn" @click="tasks.remove(t.id)" v-tooltip.left="'Dismiss'">
+              class="ra-btn cc-btn cc-btn-bare cc-btn-icon" @click="tasks.remove(t.id)" v-tooltip.left="'Dismiss'">
               <i class="pi pi-trash" />
             </button>
           </div>
@@ -206,16 +206,16 @@ const FILTERS: ChipOption[] = [
             </div>
             <span v-if="elapsed(selected)" class="log-elapsed">{{ elapsed(selected) }}</span>
             <div class="log-actions">
-              <button class="ra-btn" @click="copyLog" v-tooltip.left="copied ? 'Copied!' : 'Copy log'">
+              <button class="ra-btn cc-btn cc-btn-bare cc-btn-icon" @click="copyLog" v-tooltip.left="copied ? 'Copied!' : 'Copy log'">
                 <i :class="['pi', copied ? 'pi-check' : 'pi-copy']" />
               </button>
               <button v-if="selected.status === 'running' || selected.status === 'queued'"
-                class="ra-btn danger" @click="cancelTask(selected)"
+                class="ra-btn cc-btn cc-btn-bare cc-btn-icon danger" @click="cancelTask(selected)"
                 v-tooltip.left="selected.chainRunId ? 'Stop chain run' : 'Cancel task'">
                 <i class="pi pi-times" />
               </button>
               <button v-if="canRerun(selected)"
-                class="ra-btn" @click="rerun(selected)" v-tooltip.left="'Rerun'">
+                class="ra-btn cc-btn cc-btn-bare cc-btn-icon" @click="rerun(selected)" v-tooltip.left="'Rerun'">
                 <i class="pi pi-replay" />
               </button>
             </div>
@@ -278,20 +278,7 @@ const FILTERS: ChipOption[] = [
 }
 .follow-toggle input { accent-color: var(--cc-accent); cursor: pointer; }
 
-.tm-throttle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.7rem;
-  height: 1.7rem;
-  border: 1px solid var(--cc-border);
-  border-radius: var(--cc-radius-sm);
-  background: none;
-  color: var(--cc-text-dim);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: background 0.1s, color 0.1s;
-}
+.tm-throttle { transition: background 0.1s, color 0.1s; }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .tm-throttle:hover  { background: var(--cc-surface-2); color: var(--cc-text); }
 .tm-throttle.active { background: var(--cc-accent); border-color: var(--cc-accent); color: #fff; }
 
@@ -464,15 +451,7 @@ const FILTERS: ChipOption[] = [
 }
 
 /* ── Shared button style ──────────────────────────────────────────────── */
-.ra-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-sm);
-  padding: 0.2rem 0.3rem;
-  border-radius: var(--cc-radius-xs);
-}
+/* .ra-btn → cc-btn cc-btn-bare cc-btn-icon */
 .ra-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 .ra-btn.danger:hover { background: #7f1d1d55; color: #fca5a5; }
 </style>

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -152,7 +152,7 @@ defineExpose({ exportImage, getCsv, exportSvg })
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel / the HMM panels -->
     <template #footer>
-      <button class="hm-iconbtn" type="button" @click="emit('duplicate')"
+      <button class="hm-iconbtn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same features) to tweak one thing'"><i class="pi pi-copy" /></button>
       <!-- per-plot export dropped in a docked slot (the board exports to PDF); kept when floating -->
       <select v-if="!docked" class="hm-export" v-tooltip.top="'Export the shown plot'" :disabled="!heatmap"
@@ -183,9 +183,7 @@ defineExpose({ exportImage, getCsv, exportSvg })
 .feat-empty { font-size: var(--cc-fs-xs); margin: 4px; }   /* + .cc-muted (colour) */
 .hm-sel { font-size: var(--cc-fs-sm); margin-left: 6px; }
 .hm-chk { display: inline-flex; align-items: center; gap: 3px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin-left: 6px; cursor: pointer; }
-.hm-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
+/* .hm-iconbtn → cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .hm-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
 .hm-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 .hm-body { display: flex; flex: 1; min-height: 0; padding: 6px; }

--- a/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
@@ -179,7 +179,7 @@ defineExpose({ exportImage, getCsv })
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel -->
     <template #footer>
-      <button class="hmm-iconbtn" type="button" @click="emit('duplicate')"
+      <button class="hmm-iconbtn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same settings) to tweak one thing'"><i class="pi pi-copy" /></button>
       <select v-if="!docked" class="hmm-export" v-tooltip.top="'Export the shown plot'" :disabled="!rows.length"
               @change="exportAs(($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
@@ -210,9 +210,7 @@ defineExpose({ exportImage, getCsv })
 .hmm-host :deep(.plot-title-overlay) { position: absolute; top: 4px; left: 8px; max-width: 70%; font-weight: 600;
   font-size: var(--cc-fs-sm); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cc-sel { font-size: var(--cc-fs-sm); }
-.hmm-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
+/* .hmm-iconbtn → cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .hmm-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
 .hmm-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 /* + .cc-empty .cc-empty-overlay (was a byte-identical copy of the same overlay empty in UmapView + ClusterHeatmapPanel) */

--- a/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
@@ -186,7 +186,7 @@ defineExpose({ exportImage, getCsv })
     </template>
     <!-- utility actions (duplicate / export) in the footer, like SummaryPanel -->
     <template #footer>
-      <button class="hmm-iconbtn" type="button" @click="emit('duplicate')"
+      <button class="hmm-iconbtn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same settings) to tweak one thing'"><i class="pi pi-copy" /></button>
       <select v-if="!docked" class="hmm-export" v-tooltip.top="'Export the shown plot'" :disabled="!rows.length"
               @change="exportAs(($event.target as HTMLSelectElement).value); ($event.target as HTMLSelectElement).value = ''">
@@ -219,9 +219,7 @@ defineExpose({ exportImage, getCsv })
 .hmm-host :deep(.plot-title-overlay) { position: absolute; top: 4px; left: 8px; max-width: 70%; font-weight: 600;
   font-size: var(--cc-fs-sm); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cc-sel { font-size: var(--cc-fs-sm); }
-.hmm-iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); background: var(--cc-surface-1);
-  color: var(--cc-text-dim); cursor: pointer; font-size: var(--cc-fs-xs); }
+/* .hmm-iconbtn → cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .hmm-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
 .hmm-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 /* + .cc-empty .cc-empty-overlay (was a byte-identical copy of the same overlay empty in UmapView + ClusterHeatmapPanel) */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -163,6 +163,36 @@ body {
 }
 .cc-btn-danger-ghost:hover:not(:disabled) { background: #7f1d1d88; }
 
+/* Bare — transparent, no border, dim until hovered. The most common button in the app by far (~50
+   icon-only sites had hand-rolled exactly this). `ghost` is its boxed counterpart: same colour
+   behaviour, but on a surface with a hairline border. */
+.cc-btn-bare {
+  background: none;
+  border-color: transparent;
+  color: var(--cc-text-dim);
+}
+.cc-btn-bare:hover:not(:disabled) { color: var(--cc-text); }
+
+/* Icon-only — a fixed SQUARE, so every icon button in a toolbar lines up regardless of glyph width.
+   That squareness is why this is a modifier rather than per-site padding: 48 sites had already
+   discovered they needed a fixed box, at nine different sizes. Compose with `-bare` or `-ghost`:
+     <button class="cc-btn cc-btn-bare  cc-btn-icon">   bare
+     <button class="cc-btn cc-btn-ghost cc-btn-icon">   boxed
+   The size steps are the same density axis as the text scale (measured: the sizes really do cluster
+   at four tiers). Tone comes from the existing variants — add `.cc-btn-danger-ghost`, or set `color`
+   in scoped CSS for the one-off tones (the napari viewer green). */
+.cc-btn-icon {
+  justify-content: center;
+  width: 1.5rem; height: 1.5rem;
+  padding: 0; gap: 0;
+  font-size: var(--cc-fs-sm);
+  border-radius: var(--cc-radius-sm);
+  flex-shrink: 0;
+}
+.cc-btn-icon.cc-btn-micro { width: 1rem;    height: 1rem;    font-size: var(--cc-fs-2xs); }
+.cc-btn-icon.cc-btn-dense { width: 1.25rem; height: 1.25rem; font-size: var(--cc-fs-xs); }
+.cc-btn-icon.cc-btn-lg    { width: 1.75rem; height: 1.75rem; font-size: var(--cc-fs-md); }
+
 /* ── Semantic role utilities ───────────────────────────────────────────────────
    Generalise the recurring UX *scenarios* (roles that repeat across many different elements) instead
    of styling each site ad-hoc. Compose them; add only layout (width/margin/flex) in scoped CSS.

--- a/frontend/src/tasks/ParamRenderer.vue
+++ b/frontend/src/tasks/ParamRenderer.vue
@@ -607,7 +607,7 @@ const pct = computed(() => {
   <div v-if="param.type === 'group'" class="param-group">
     <div class="group-header">
       <span class="group-title">{{ param.label }}</span>
-      <button v-if="param.repeatable" class="group-add-btn" type="button"
+      <button v-if="param.repeatable" class="group-add-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-micro" type="button"
         @click="addGroupEntry()"
         v-tooltip.right="'Add another entry'">
         <i class="pi pi-plus" />
@@ -809,19 +809,7 @@ const pct = computed(() => {
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
-.group-add-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px; height: 18px;
-  border-radius: var(--cc-radius-pill);
-  border: 1px solid var(--cc-border);
-  background: var(--cc-surface-2);
-  color: var(--cc-text-dim);
-  cursor: pointer;
-  font-size: var(--cc-fs-2xs);
-  transition: background 0.1s, border-color 0.1s;
-}
+.group-add-btn { transition: background 0.1s, border-color 0.1s; }   /* + cc-btn cc-btn-ghost cc-btn-icon cc-btn-micro */
 .group-add-btn:hover { background: var(--cc-accent); border-color: var(--cc-accent); color: #fff; }
 .group-empty {
   font-size: var(--cc-fs-sm);

--- a/frontend/src/tasks/TaskList.vue
+++ b/frontend/src/tasks/TaskList.vue
@@ -101,7 +101,7 @@ function elapsed(t: TaskEntry) {
 
         <div class="task-info">
           <span class="task-label" v-tooltip.right="t.label">
-            <button class="jump-btn" @click.stop="jumpToTask(t)" v-tooltip.right="'Open in task manager'">
+            <button class="jump-btn cc-btn cc-btn-bare cc-btn-icon cc-btn-lg" @click.stop="jumpToTask(t)" v-tooltip.right="'Open in task manager'">
               <i class="pi pi-arrow-left" />
             </button>
             <span class="task-seq">#{{ t.seq }}</span>
@@ -123,7 +123,7 @@ function elapsed(t: TaskEntry) {
         <div class="task-actions">
           <button
             v-if="t.log.length"
-            class="icon-btn"
+            class="icon-btn cc-btn cc-btn-bare cc-btn-icon"
             @click="toggleLog(t.id)"
             v-tooltip.left="expanded.has(t.id) ? 'Hide log' : 'Show task log'"
           >
@@ -132,7 +132,7 @@ function elapsed(t: TaskEntry) {
 
           <button
             v-if="t.status === 'running' || t.status === 'queued'"
-            class="icon-btn danger"
+            class="icon-btn cc-btn cc-btn-bare cc-btn-icon danger"
             @click="cancelTask(t)"
             v-tooltip.left="t.chainRunId ? 'Stop chain run' : 'Cancel this task'"
           >
@@ -141,7 +141,7 @@ function elapsed(t: TaskEntry) {
 
           <button
             v-if="!t.chainRunId && (t.status === 'done' || t.status === 'failed' || t.status === 'cancelled')"
-            class="icon-btn"
+            class="icon-btn cc-btn cc-btn-bare cc-btn-icon"
             @click="rerun(t)"
             v-tooltip.left="'Rerun this task with the same parameters.'"
           >
@@ -150,7 +150,7 @@ function elapsed(t: TaskEntry) {
 
           <button
             v-if="t.log.length"
-            class="icon-btn"
+            class="icon-btn cc-btn cc-btn-bare cc-btn-icon"
             @click="copyLog(t)"
             v-tooltip.left="copied.has(t.id) ? 'Copied!' : 'Copy log to clipboard'"
           >
@@ -159,7 +159,7 @@ function elapsed(t: TaskEntry) {
 
           <button
             v-if="t.status === 'done' || t.status === 'failed' || t.status === 'cancelled'"
-            class="icon-btn"
+            class="icon-btn cc-btn cc-btn-bare cc-btn-icon"
             @click="tasks.remove(t.id)"
             v-tooltip.left="'Dismiss this task from the list.'"
           >
@@ -269,26 +269,11 @@ function elapsed(t: TaskEntry) {
 
 .task-actions { display: flex; gap: 0.15rem; flex-shrink: 0; }
 
-.icon-btn {
-  background: none; border: none; cursor: pointer;
-  color: var(--cc-text-dim); font-size: var(--cc-fs-sm);
-  padding: 0.2rem 0.3rem; border-radius: var(--cc-radius-xs);
-}
+/* .icon-btn → cc-btn cc-btn-bare cc-btn-icon */
 .icon-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 .icon-btn.danger:hover { background: #7f1d1d55; color: #fca5a5; }
 
-.jump-btn {
-  display: none;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #4ade80;
-  font-size: var(--cc-fs-md);
-  padding: 0 0.15rem 0 0;
-  flex-shrink: 0;
-  line-height: 1;
-  -webkit-text-stroke: 0.4px #4ade80;
-}
+.jump-btn { color: #4ade80; -webkit-text-stroke: 0.4px #4ade80; }   /* + cc-btn cc-btn-bare cc-btn-icon cc-btn-lg */
 .task-item:hover .jump-btn { display: inline-flex; }
 
 .task-progress {

--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -367,7 +367,7 @@ const { width: sidebarWidth, onResizeStart } =
           Pool
         </span>
         <ChipSelect class="pool-chips" v-model="selectedPool" :options="poolOptions" aria-label="Resource pool" />
-        <button ref="throttleBtn" class="pool-throttle" :class="{ active: throttleOpen }"
+        <button ref="throttleBtn" class="pool-throttle cc-btn cc-btn-ghost cc-btn-icon" :class="{ active: throttleOpen }"
           @click="throttleOpen = !throttleOpen"
           v-tooltip.left="'Throttle — how many tasks of each kind run at once'">
           <i class="pi pi-sliders-h" />
@@ -385,14 +385,14 @@ const { width: sidebarWidth, onResizeStart } =
         <div class="tasks-heading-actions">
           <button
             v-if="activeTasks.length"
-            class="clear-btn danger"
+            class="clear-btn cc-btn cc-btn-bare cc-btn-icon danger"
             @click="cancelAll"
             v-tooltip.left="`Cancel all ${activeTasks.length} running/queued task(s) in this module.`"
           >
             <i class="pi pi-times-circle" />
           </button>
           <button
-            class="clear-btn"
+            class="clear-btn cc-btn cc-btn-bare cc-btn-icon"
             @click="taskStore.clearFinished(module, projectMeta.current?.uid)"
             v-tooltip.left="'Remove all completed and failed tasks from the list.'"
           >
@@ -453,15 +453,7 @@ const { width: sidebarWidth, onResizeStart } =
   gap: 0.15rem;
 }
 
-.clear-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-sm);
-  padding: 0.15rem 0.3rem;
-  border-radius: var(--cc-radius-xs);
-}
+/* .clear-btn → cc-btn cc-btn-bare cc-btn-icon */
 .clear-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 .clear-btn.danger:hover { background: #7f1d1d55; color: #fca5a5; }
 
@@ -497,20 +489,7 @@ const { width: sidebarWidth, onResizeStart } =
   flex-shrink: 0;
 }
 .pool-chips { flex: 1; min-width: 0; }
-.pool-throttle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.55rem;
-  height: 1.55rem;
-  flex-shrink: 0;
-  border: 1px solid var(--cc-border);
-  border-radius: var(--cc-radius-xs);
-  background: var(--cc-surface-2);
-  color: var(--cc-text-dim);
-  cursor: pointer;
-  transition: background 0.1s, color 0.1s;
-}
+.pool-throttle { transition: background 0.1s, color 0.1s; }   /* + cc-btn cc-btn-ghost cc-btn-icon */
 .pool-throttle:hover  { color: var(--cc-text); }
 .pool-throttle.active { background: var(--cc-accent); border-color: var(--cc-accent); color: #fff; }
 

--- a/frontend/src/utils/cssScenarios.test.ts
+++ b/frontend/src/utils/cssScenarios.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   styleBlocks, cssRules, scenarioFor, findReimplementedScenarios, findRawValues,
+  findHandRolledIconButtons,
 } from './cssScenarios'
 
 describe('styleBlocks', () => {
@@ -143,6 +144,33 @@ describe('hand-rolled UX scenarios', () => {
     expect(regressions).toEqual([])
     // Improvements fail too, on purpose: an un-updated baseline silently stops ratcheting.
     expect(improvements).toEqual([])
+  })
+})
+
+describe('icon-only buttons', () => {
+  // 116 sites carried 60 distinct class names — but only TWO shapes and four size steps, so they are
+  // all `.cc-btn` + `-bare`|`-ghost` + `-icon` now. What's left is a DIFFERENT primitive: three
+  // byte-identical hand-rolled `.seg` segmented controls, which owe themselves to `ChipSelect`
+  // (docs/UI.md) and need a component swap rather than a class swap. Tracked in the plan doc.
+  // Pinned explicitly, path and all: deriving the allow-list from the findings would make the check
+  // tautological, catching a new hand-rolled button only via the total count.
+  const SEG_BUTTONS = [
+    'components/canvas/SummaryCanvas.vue | (no class)',
+    'components/canvas/SummaryCanvas.vue | (no class)',
+    'components/canvas/SummaryCanvas.vue | { on: showManager }',
+    'modules/cluster/ClusterPlots.vue | (no class)',
+    'modules/cluster/ClusterPlots.vue | (no class)',
+    'modules/cluster/ClusterPlots.vue | { on: showManager }',
+    'modules/gate/GatingPlots.vue | (no class)',
+    'modules/gate/GatingPlots.vue | (no class)',
+    'modules/gate/GatingPlots.vue | (no class)',
+    'modules/gate/GatingPlots.vue | { on: showManager }',
+  ]
+
+  it('are built from .cc-btn', () => {
+    const sources = Object.entries(RAW).map(([path, text]) => ({ path: path.replace('/src/', ''), text }))
+    const found = findHandRolledIconButtons(sources).map(b => `${b.path} | ${b.classAttr}`)
+    expect(found.sort()).toEqual([...SEG_BUTTONS].sort())
   })
 })
 

--- a/frontend/src/utils/cssScenarios.ts
+++ b/frontend/src/utils/cssScenarios.ts
@@ -98,6 +98,40 @@ export function scenarioFor(rule: CssRule): Scenario | null {
   return null
 }
 
+// ── Icon-only buttons ─────────────────────────────────────────────────────────────────────────────
+
+/** A `<button>` whose entire content is one icon, and which isn't using the `.cc-btn` family. */
+export interface IconButton {
+  path:      string
+  classAttr: string
+}
+
+// A button whose whole content is a single <i>. Style blocks and HTML comments are removed first — a
+// usage example inside a doc comment is not a call site (ConfirmButton's docs read as one).
+const ICON_BUTTON = /<button\b([^>]*)>\s*<i\b[^>]*\/>\s*<\/button>/g
+
+/**
+ * Icon-only buttons not built from `.cc-btn`. Measured before unifying: 116 sites carried 60 distinct
+ * class names, but only TWO shapes (boxed / bare) and four size steps — so the canonical form is
+ * `.cc-btn` + `-bare`|`-ghost` + `-icon` (+ a size step), not a per-file class.
+ */
+export function findHandRolledIconButtons(
+  sources: Array<{ path: string, text: string }>,
+): IconButton[] {
+  const out: IconButton[] = []
+  for (const { path, text } of sources) {
+    const template = text
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/g, ' ')
+      .replace(/<!--[\s\S]*?-->/g, ' ')
+    for (const m of template.matchAll(ICON_BUTTON)) {
+      const cls = /\bclass="([^"]*)"/.exec(m[1])
+      // no class at all is also hand-rolled — it renders as a raw browser button
+      if (!cls || !/\bcc-btn\b/.test(cls[1])) out.push({ path, classAttr: cls?.[1] ?? '(no class)' })
+    }
+  }
+  return out
+}
+
 // ── Raw values ────────────────────────────────────────────────────────────────────────────────────
 
 /** A literal `font-size` / `border-radius` where a scale token exists. */


### PR DESCRIPTION
Follows #351 (now merged). The last open sweep item in `docs/todo/UX_PRIMITIVES_PLAN.md`.

## The plan's claim was half wrong

Icon-only buttons sat parked as *"~90, mostly intentional — different sizes / hover-reveal / viewer-green"*. Measured:

- **116 icon-only buttons carrying 60 distinct class names**
- but only **two shapes** — boxed (`surface + border`, 45) and bare (`transparent`, 50)
- and **four size tiers**
- **colour is not an axis at all**: 96 of 99 resolvable base rules are `--cc-text-dim`; the danger/viewer tones live in modifier classes

So it was 60 spellings of 2×4. The "intentional" part was real but small — hover-reveal and a couple of one-off tones — and both survive as scoped CSS.

## The primitive

Hangs off the existing button vocabulary rather than a new family: `.cc-btn-ghost` already had exactly the right colour behaviour, and 4 sites already spelled it that way.

```html
<button class="cc-btn cc-btn-bare  cc-btn-icon">              <!-- bare -->
<button class="cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense"> <!-- boxed, dense -->
```

- **`.cc-btn-bare`** — transparent, no border, dim until hover. The app's most common button by far.
- **`.cc-btn-icon`** — a fixed **square** (`1.5rem`), so a toolbar row lines up regardless of glyph width. This is why it's a modifier and not per-site padding: **48 sites had each independently discovered they needed a fixed box, at nine different sizes.**
- **`-micro` / `-dense` / `-lg`** — the same density axis as the text scale, on the measured tiers.

**103 sites across 35 files migrated, 45 bespoke classes collapsed.**

## Enforcement

`findHandRolledIconButtons` + test fail on any icon-only `<button>` not built from `.cc-btn` (confirmed by injecting one). Ten stragglers are pinned **by path**, not derived from the findings — deriving the allow-list would have made the check tautological.

Those ten are a *different* primitive: three **byte-identical** hand-rolled `.seg button {…}` segmented controls (`SummaryCanvas`, `ClusterPlots`, `GatingPlots`) that owe themselves to `ChipSelect`. That's a component swap (`v-model`), not a class swap, so it's left as a tracked item. They are the only remaining hand-rolled buttons in the app.

## Process note

Three defects in my migration script, all caught by **inspecting the output** rather than by the green tests:

1. An anchored selector regex silently skipped 11 classes whose rule was preceded by a comment (a 86-vs-103 site difference).
2. The splice consumed the leading whitespace *and any preceding comment*, gluing rules onto one line and deleting comments. Reverted and redone.
3. The button scan matched `<button class="footer-btn">` inside `ConfirmButton`'s usage-example doc comment.

Also resolved: three surviving `.foo .pi { font-size }` child rules that would have overridden the primitive's size — they rendered identically but weren't actually unified.

## Verification

`vue-tsc -b` clean · 359 tests pass (52 files) · `npm run build` clean. Net −130 lines.

## Reservations

- **Not run in a browser.** The size steps are new fixed squares, so buttons whose old box was 1.4 / 1.55 / 1.7 / 1.8rem change dimensions slightly. Toolbar rows should now align *better*, but this is the change most worth eyeballing.
- `.cc-btn-icon` sets `font-size` on the button and relies on `.pi` inheriting it — verified that primeicons' `.pi` rule does not set its own `font-size`.
- Hover-reveal buttons (`opacity: 0` until the row is hovered) keep their scoped rules; I checked those survive but didn't exercise them.
- The `.seg` allow-list is pinned by path, so renaming one of those files will fail the test until the list is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
