### PR TITLE
Fix icon-button regression on full-height strip controls

### DIFF
--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -116,8 +116,17 @@ already had exactly the right colour behaviour and 4 sites already spelled it th
 genuinely intentional part. `findHandRolledIconButtons` + its test now fail on any icon-only `<button>`
 not built from `.cc-btn`, with the ten `.seg` buttons pinned by path.
 
-Three defects in my own migration script, all caught by inspecting output rather than by the green
-tests: an anchored selector regex silently skipped 11 classes whose rule was preceded by a comment; the
+**Regression, found in the GUI (not by any check): full-height strip controls.** `ModuleLayout`
+`.right-handle` (the right-panel collapse strip) and `TabbedCanvas` `.tab-add` (the "+" cell in the tab
+strip) are markup-identical to an icon-only button — one `<i>`, nothing else — but their rules set a
+**width and no height**, so they stretch as a flex child to fill the panel edge. `.cc-btn-icon`'s fixed
+square collapsed both to a chip at the top. Both restored to their own rules and exempted by name in
+the test. **Markup cannot distinguish these**, so the rule to carry forward is: if a `<button>` has no
+height of its own and relies on stretching, it is not a square icon button — check the geometry, not
+just the contents. The class name said so (`-handle`) and I noted it and moved on anyway.
+
+Three further defects in my own migration script, all caught by inspecting output rather than by the
+green tests: an anchored selector regex silently skipped 11 classes whose rule was preceded by a comment; the
 splice consumed the leading whitespace **and any preceding comment**, gluing rules onto one line; and
 the button scan matched `<button class="footer-btn">` inside `ConfirmButton`'s usage-example doc
 comment. Also resolved: three surviving `.foo .pi { font-size }` child rules that would have overridden

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -204,7 +204,13 @@ function setAttrFilter(key: string, next: string[]) {
 }
 // chips for one attribute key (value = label, tooltip = the value)
 function attrChipOpts(key: string): ChipOption[] {
-  return (attrValueMap.value[key] ?? []).map(v => ({ value: v, label: v, tip: v }))
+  // A blank attribute value is a legitimate filter ("which images did I not annotate?"), but its chip
+  // rendered as an unlabelled pill: ChipSelect hides the label span when label === '' (that's how
+  // icon-only chips work), so an empty label with no icon leaves an empty chip. Keep the value — the
+  // filter matches on it — and give it something to show.
+  return (attrValueMap.value[key] ?? []).map(v => v.trim() === ''
+    ? { value: v, label: '—', tip: `No ${key} set` }
+    : { value: v, label: v, tip: v })
 }
 function applyFilters() {
   appliedFilters.value = Object.fromEntries(
@@ -471,7 +477,7 @@ const visibleUids = computed<string[]>(() =>
         <!-- drag the left edge to resize (persisted per module); shared by TaskRunner + every panel -->
         <div v-if="!settings.rightPanelCollapsed" class="right-resizer" @mousedown="startResize"
              v-tooltip.left="'Drag to resize'" />
-        <button class="right-handle cc-btn cc-btn-bare cc-btn-icon cc-btn-dense"
+        <button class="right-handle"
           @click="settings.rightPanelCollapsed = !settings.rightPanelCollapsed"
           v-tooltip.left="settings.rightPanelCollapsed ? 'Show functions panel' : 'Hide functions panel'"
           :aria-label="settings.rightPanelCollapsed ? 'Show functions panel' : 'Hide functions panel'">
@@ -529,7 +535,22 @@ const visibleUids = computed<string[]>(() =>
   flex-shrink: 0;
   overflow: hidden;
 }
-.right-handle { border-left: 1px solid var(--cc-border); transition: background 0.12s, color 0.12s; }   /* + cc-btn cc-btn-bare cc-btn-icon */
+/* Full-height strip down the panel's edge, NOT an icon button: it has no height of its own and
+   stretches as a flex child. .cc-btn-icon's fixed square collapsed it to a chip at the top. */
+.right-handle {
+  flex-shrink: 0;
+  width: 1.1rem;
+  border: none;
+  border-left: 1px solid var(--cc-border);
+  background: var(--cc-surface-1);
+  color: var(--cc-text-dim);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.12s, color 0.12s;
+}
+.right-handle .pi { font-size: var(--cc-fs-xs); }
 .right-handle:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 /* drag strip on the panel's left edge to resize (col-resize); thin, highlights on hover */
 .right-resizer { flex-shrink: 0; width: 5px; cursor: col-resize; background: transparent; transition: background 0.12s; }

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -220,7 +220,7 @@ function exportBoard(kind: string) {
           </ConfirmButton>
         </template>
       </div>
-      <button class="tab-add cc-btn cc-btn-bare cc-btn-icon" type="button" @click="addTab" v-tooltip.bottom="'New board'" aria-label="New board">
+      <button class="tab-add" type="button" @click="addTab" v-tooltip.bottom="'New board'" aria-label="New board">
         <i class="pi pi-plus" />
       </button>
       <!-- one export control: figure (PDF/SVG), data (CSV), or both in a single pass -->
@@ -263,7 +263,12 @@ function exportBoard(kind: string) {
   border: 1px solid #7c3aed; border-radius: var(--cc-radius-xs); padding: 1px 4px; }
 /* .tab-close → cc-btn cc-btn-bare cc-btn-icon cc-btn-micro */
 .tab-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
-.tab-add { margin-left: 2px; }   /* + cc-btn cc-btn-bare cc-btn-icon */
+/* full-height cell in the tab strip (stretches as a flex child) — not a fixed square */
+.tab-add {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 1.8rem; border: none; background: transparent; color: var(--cc-text-dim);
+  cursor: pointer; font-size: var(--cc-fs-sm); margin-left: 2px;
+}
 .tab-add:hover { color: var(--cc-text); }
 .tab-pdf { display: inline-flex; align-items: center; gap: 5px; margin-left: auto; margin-bottom: 2px;
   padding: 3px 10px; font-size: var(--cc-fs-xs); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm);

--- a/frontend/src/utils/cssScenarios.test.ts
+++ b/frontend/src/utils/cssScenarios.test.ts
@@ -152,9 +152,18 @@ describe('icon-only buttons', () => {
   // all `.cc-btn` + `-bare`|`-ghost` + `-icon` now. What's left is a DIFFERENT primitive: three
   // byte-identical hand-rolled `.seg` segmented controls, which owe themselves to `ChipSelect`
   // (docs/UI.md) and need a component swap rather than a class swap. Tracked in the plan doc.
+  //
+  // …plus two FULL-HEIGHT STRIP controls. In markup these look exactly like icon-only buttons — one
+  // <i> and nothing else — but their rule sets a width and NO height, so they stretch as a flex child
+  // to fill the panel edge / tab strip. `.cc-btn-icon`'s fixed square collapsed both to a chip at the
+  // top. Markup alone cannot distinguish them, so they are exempt by name: a <button> that stretches
+  // is not a square icon button.
+  //
   // Pinned explicitly, path and all: deriving the allow-list from the findings would make the check
   // tautological, catching a new hand-rolled button only via the total count.
   const SEG_BUTTONS = [
+    'components/ModuleLayout.vue | right-handle',       // full-height right-panel collapse strip
+    'components/canvas/TabbedCanvas.vue | tab-add',     // full-height "+" cell in the tab strip
     'components/canvas/SummaryCanvas.vue | (no class)',
     'components/canvas/SummaryCanvas.vue | (no class)',
     'components/canvas/SummaryCanvas.vue | { on: showManager }',


### PR DESCRIPTION
Follow-up to #353. One reported regression, one more found by audit, plus a pre-existing filter oddity noticed alongside it.

## The regression

Two controls look exactly like icon-only buttons in markup — a single `<i>` and nothing else — but their rules set a **width and no height**, so they stretch as a flex child to fill the panel edge. `.cc-btn-icon`'s fixed square collapsed both to a chip at the top:

| Control | What it is | How it surfaced |
|---|---|---|
| `ModuleLayout` `.right-handle` | full-height right-panel collapse strip | reported from the GUI |
| `TabbedCanvas` `.tab-add` | full-height "+" cell in the tab strip | found by auditing the other 63 migrated buttons; not yet noticed in use |

Both restored to their own rules, and exempted **by name** in the icon-button guard rather than by a smarter pattern: markup cannot distinguish a stretching button from a square one, so the check is inherently geometry-blind here.

The rule is recorded in `UX_PRIMITIVES_PLAN.md` — *a button with no height of its own, relying on stretching, is not a square icon button.* Worth noting how this got through: the class name said so (`-handle`), I wrote "that name suggests it's a resize handle" while classifying, and moved on without checking the geometry. The tests were green throughout, because nothing here is testable without a browser.

**Audit caveat:** it reads each button's *own* rule (`width` / `height` / `align-self`), so a button that stretches because of a **parent** rule would not have been caught. These two are all it found.

## Also: label blank attribute-filter chips

A blank attribute value is a legitimate filter — *"which images did I not annotate?"* — but its chip rendered as an unlabelled pill:

- `ModuleLayout:192` guards `null`/`undefined` but not `''`, so a blank value becomes a chip option
- it sorts first, because `''` precedes letters and digits
- `ChipSelect:129` hides the label span when `label === ''` — that's the mechanism icon-only chips rely on, so an empty label with no icon leaves an empty chip

It was clickable and filtered correctly, just unidentifiable. Now shows an explicit `—` with a "No &lt;key&gt; set" tooltip; the value is unchanged so filtering still matches. **Pre-existing since the initial commit**, not from the button work.

## Verification

`vue-tsc -b` clean · 359 tests pass (52 files) · `npm run build` clean.

## Reservations

- **Not run in a browser.** Both strip controls were restored to their original CSS verbatim, so they should render exactly as before the regression — but I haven't seen them.
- `.lc-gear` / `.is-gear` still changed size in #353 (~12%, 1.7×1.6rem → 1.5rem square). Those are genuine icon buttons so they stay unified; flagging because they're the other visible size change from that PR.
- An attribute holding both `''` and `'  '` would render two `—` chips. Real but implausible, not engineered around.
- The guard allow-list is pinned by path, so renaming either file fails the test until the list is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
