### PR TITLE
Drain the chain-node scenario backlog, and give eyebrows their missing density step

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -39,7 +39,7 @@ primitives still being extracted lives in `docs/todo/UX_PRIMITIVES_PLAN.md`.
 | Secondary / muted text (hint, subtitle, caption, meta) | `.cc-muted` (+ `-dense`/`-micro` in dense chrome) | a scoped `color: var(--cc-text-dim); font-size: …` |
 | Empty / "nothing here yet" state | `.cc-empty` (+ `-inline` one-liner / `-overlay` over a plot / `-lg` rich page empty) | a new `.*-empty` class |
 | Numeric value readout beside a control | `.cc-readout` (+ `-strong` prominent, `-dense` inline) | a bespoke `.*-val`/`.*-num` |
-| Eyebrow / section label (uppercase dim heading) | `.cc-eyebrow` (+ `-dense` for list/table headers) | a scoped uppercase-heading rule |
+| Eyebrow / section label (uppercase dim heading) | `.cc-eyebrow` (+ `-dense` list/table headers, `-micro` whiteboard-node labels) | a scoped uppercase-heading rule |
 | Card / panel / surface container | `.cc-card` (+ `-2` when it sits *on* a surface-1 panel) | a scoped `surface + 1px border + radius` block |
 | Corner radius | `--cc-radius-xs/sm/md/lg/pill` | a raw `rem`/`px` radius |
 | Small text size | `--cc-fs-3xs/2xs/xs/sm/md/lg` | a raw `rem`/`px` font-size (incl. inline `style=`) |

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -147,6 +147,9 @@ Remaining — incremental adoption only (no forced sweeps). **No counts here on 
   "finish the sweep": new divergence fails immediately, the backlog drains as files get touched.
 - [ ] **Per-row disclosure in a list** (`TaskList`, `ErrorConsole`) — a genuinely distinct, recurring
   scenario that is *not* a section header. Worth naming if a third site appears; two is not yet a pattern.
+- [ ] **`BatchMoviesPanel`'s `.bm-busy`** paints an *in-progress* state amber, where `--cc-active` (the
+  blue "running" tone, per `lib/taskStatus.ts`) is arguably the right token. A hue change on a semantic
+  judgement, so it wants eyes rather than a sweep — the only one of these left that is a real question.
 - [ ] **Not recommended as a sweep:** single-value range wrapper (base already accent-themed; readout now
   covered by `.cc-readout`; sliders are layout-entangled and some commit on release). Governed by the rule.
 - [ ] **Deliberately left bespoke, with reasons** (do not "fix" these without reading why):
@@ -341,12 +344,19 @@ should come from a committed detector, not a grep.
 **A detector can have blind spots too, and they share one shape.** Stripping the dead colour fallbacks
 made the ratchet jump by six rules in four chain-node files. Not new divergence — the `muted` matcher keys
 on `color: var(--cc-text-dim)` and never matched the `color: var(--cc-text-dim, #8b8ca7)` spelling, so it
-had been blind to them all along. They are in the `BASELINE` now at their true count. That is the **third**
-blind spot of exactly this shape (the others: the detector only reading `<style>` blocks, so inline
-`style="font-size:…"` was invisible; and the `muted` matcher keying on a *literal* size, so tokenising a
-rule would have silently un-flagged it). All three have one cause: **a matcher pinned to one spelling of a
-value the codebase writes more than one way.** When adding a matcher, ask which other spellings of the
-same declaration exist — token vs literal, with fallback vs without, scoped vs inline.
+had been blind to them all along. That is the **third** blind spot of exactly this shape (the others: the
+detector only reading `<style>` blocks, so inline `style="font-size:…"` was invisible; and the `muted`
+matcher keying on a *literal* size, so tokenising a rule would have silently un-flagged it). All three have
+one cause: **a matcher pinned to one spelling of a value the codebase writes more than one way.** When
+adding a matcher, ask which other spellings of the same declaration exist — token vs literal, with
+fallback vs without, scoped vs inline.
+
+Those six are **migrated** (all four files back to zero), and doing it surfaced one more missing step on
+the density axis: `.cc-muted` always had `-dense` *and* `-micro`, `.cc-eyebrow` only `-dense`. The 9px
+uppercase labels in the whiteboard nodes (start / scope / the QC footer) therefore had nowhere to land —
+the same "utility hard-codes a value on an axis where sites differ" trap, one step further down. Added
+`.cc-eyebrow-micro`, so the two text scenarios now carry the same three density steps. Also routed the
+five raw `font-family: monospace` stacks through `--cc-mono` while in those files.
 
 ### Raw sizes and radii — done, and it was never churn
 

--- a/frontend/src/components/ChainLiveLabel.vue
+++ b/frontend/src/components/ChainLiveLabel.vue
@@ -15,16 +15,15 @@ defineProps<{
 </script>
 
 <template>
-  <div class="live-label" :class="data.kind">
+  <div class="live-label cc-muted cc-muted-dense" :class="data.kind">
     <span class="live-label-text">{{ data.text }}</span>
     <span v-if="data.sub" class="live-label-sub">{{ data.sub }}</span>
   </div>
 </template>
 
 <style scoped>
+/* + cc-muted cc-muted-dense (colour + the 10px tier); the rest is this label's geometry */
 .live-label {
-  font-size: var(--cc-fs-2xs);
-  color: var(--cc-text-dim);
   white-space: nowrap;
   pointer-events: none;
   display: flex;
@@ -58,7 +57,7 @@ defineProps<{
 }
 .live-label-sub {
   font-size: var(--cc-fs-3xs);
-  font-family: monospace;
+  font-family: var(--cc-mono);
   opacity: 0.7;
 }
 </style>

--- a/frontend/src/components/ChainLiveNode.vue
+++ b/frontend/src/components/ChainLiveNode.vue
@@ -136,7 +136,7 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
 .live-elapsed {
   margin-left: auto;
   font-size: var(--cc-fs-3xs);
-  font-family: monospace;
+  font-family: var(--cc-mono);
   opacity: 0.8;
 }
 

--- a/frontend/src/components/ChainPicnicNode.vue
+++ b/frontend/src/components/ChainPicnicNode.vue
@@ -87,7 +87,7 @@ defineProps<{
 .node-fn {
   font-size: var(--cc-fs-2xs);
   color: #d97706;
-  font-family: monospace;
+  font-family: var(--cc-mono);
   margin-top: 2px;
   white-space: nowrap;
   overflow: hidden;
@@ -108,7 +108,7 @@ defineProps<{
 .policy-val {
   font-size: var(--cc-fs-3xs);
   color: var(--cc-warn);
-  font-family: monospace;
+  font-family: var(--cc-mono);
 }
 .node-pool {
   display: flex;

--- a/frontend/src/components/ChainQcNode.vue
+++ b/frontend/src/components/ChainQcNode.vue
@@ -35,12 +35,12 @@ const fmt = (n?: number) => n == null ? '—' : n.toLocaleString()
       <span class="qc-name">{{ data.valueName }}</span>
       <span v-if="data.loading" class="qc-spin"><i class="pi pi-spin pi-spinner" /></span>
     </div>
-    <div class="qc-count">{{ fmt(data.total) }} <span class="qc-unit">cells</span></div>
+    <div class="qc-count">{{ fmt(data.total) }} <span class="qc-unit cc-muted cc-muted-micro">cells</span></div>
     <div class="qc-spark">
       <span v-for="(h, i) in bars" :key="i" class="qc-bar" :style="{ height: h + 'px' }" />
       <span v-if="!bars.length" class="qc-empty cc-empty-inline cc-muted-micro">no data</span>
     </div>
-    <div class="qc-foot">{{ data.imageCount ?? 0 }} img · expand</div>
+    <div class="qc-foot cc-eyebrow cc-eyebrow-micro">{{ data.imageCount ?? 0 }} img · expand</div>
   </div>
 </template>
 
@@ -59,10 +59,11 @@ const fmt = (n?: number) => n == null ? '—' : n.toLocaleString()
 .qc-name { font-size: var(--cc-fs-3xs); font-weight: 700; font-family: var(--cc-mono, monospace); letter-spacing: 0.04em; }
 .qc-spin { margin-left: auto; font-size: var(--cc-fs-2xs); opacity: 0.7; }
 .qc-count { font-size: var(--cc-fs-lg); font-weight: 700; color: var(--cc-text); margin: 2px 0; }
-.qc-unit { font-size: var(--cc-fs-3xs); font-weight: 400; color: var(--cc-text-dim); }
+/* + cc-muted cc-muted-micro — the weight reset is this site's (it sits inside a 700 count) */
+.qc-unit { font-weight: 400; }
 .qc-spark { display: flex; align-items: flex-end; gap: 2px; height: 24px; }
 /* 1px is deliberate and off-scale: --cc-radius-xs (3px) on a 4px-wide bar rounds it to a blob */
 .qc-bar { width: 4px; background: var(--cc-accent); opacity: 0.7; border-radius: 1px; }
 .qc-empty { font-style: italic; }   /* + .cc-empty-inline .cc-muted-micro (row/colour/9px tier) */
-.qc-foot { font-size: var(--cc-fs-3xs); color: var(--cc-text-dim); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2px; }
+.qc-foot { margin-top: 2px; }   /* + cc-eyebrow cc-eyebrow-micro */
 </style>

--- a/frontend/src/components/ChainStartNode.vue
+++ b/frontend/src/components/ChainStartNode.vue
@@ -14,7 +14,7 @@ defineProps<{ id: string; selected: boolean }>()
 <template>
   <div class="chain-start-node" :class="{ selected }" title="Start — link to the task(s) a run begins from">
     <span class="start-dot" />
-    <span class="start-label">start</span>
+    <span class="cc-eyebrow cc-eyebrow-micro">start</span>
     <!-- initial node: source only (no target handle) -->
     <Handle type="source" :position="Position.Right" class="node-handle" />
   </div>
@@ -40,13 +40,6 @@ defineProps<{ id: string; selected: boolean }>()
 }
 .chain-start-node.selected .start-dot {
   box-shadow: 0 0 0 3px var(--cc-accent);
-}
-.start-label {
-  font-size: var(--cc-fs-3xs);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--cc-text-dim);
 }
 .node-handle {
   width: 10px;

--- a/frontend/src/components/ChainTaskNode.vue
+++ b/frontend/src/components/ChainTaskNode.vue
@@ -21,10 +21,10 @@ defineProps<{
 
     <div class="node-scope" :title="`scope: ${data.scope}`">
       <span class="scope-dot" />
-      <span class="scope-label">{{ data.scope }}</span>
+      <span class="cc-eyebrow cc-eyebrow-micro">{{ data.scope }}</span>
     </div>
     <div class="node-label">{{ data.label || data.fn }}</div>
-    <div class="node-fn">{{ data.fn }}</div>
+    <div class="node-fn cc-muted cc-muted-dense">{{ data.fn }}</div>
     <div v-if="data.resource_pool" class="node-pool">
       <i class="pi pi-server" style="font-size:var(--cc-fs-2xs)" />
       {{ data.resource_pool }}
@@ -68,13 +68,6 @@ defineProps<{
   flex-shrink: 0;
 }
 .incremental .scope-dot { background: #60a5fa; }
-.scope-label {
-  font-size: var(--cc-fs-3xs);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--cc-text-dim);
-}
 
 .node-label {
   font-size: var(--cc-fs-sm);
@@ -85,10 +78,9 @@ defineProps<{
   text-overflow: ellipsis;
   max-width: 160px;
 }
+/* + cc-muted cc-muted-dense — the mono face and truncation are this site's */
 .node-fn {
-  font-size: var(--cc-fs-2xs);
-  color: var(--cc-text-dim);
-  font-family: monospace;
+  font-family: var(--cc-mono);
   margin-top: 2px;
   white-space: nowrap;
   overflow: hidden;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -353,6 +353,10 @@ body {
   text-transform: uppercase; color: var(--cc-text-dim);
 }
 .cc-eyebrow-dense { font-size: var(--cc-fs-2xs); }
+/* The density axis runs one step further for eyebrows than it did — `.cc-muted` always had both
+   -dense and -micro, `.cc-eyebrow` only -dense, and the missing bottom step is exactly why the
+   whiteboard nodes (start/scope labels, the QC footer) kept their own 9px uppercase rule. */
+.cc-eyebrow-micro { font-size: var(--cc-fs-3xs); }
 
 /* Surface / container chrome — a card/panel body (hairline border + md radius). Surface is the axis:
    the base is the recessed surface-1, `.cc-card-2` the raised surface-2 (a card sitting ON a

--- a/frontend/src/utils/cssScenarios.test.ts
+++ b/frontend/src/utils/cssScenarios.test.ts
@@ -94,19 +94,16 @@ describe('findRawColours', () => {
 // Touching a file in this list? Migrate its rules and lower the number. Adding a file? Use the utility
 // instead. The failure message tells you which.
 //
-// THE FALLBACKS WERE HIDING SIX OF THESE. The `muted` matcher keys on `color: var(--cc-text-dim)`,
-// which never matched the `color: var(--cc-text-dim, #8b8ca7)` spelling — so stripping the dead hex
-// fallbacks (see "raw colours" below) revealed six long-standing hand-rolled rules in four chain-node
-// files that this check had been blind to. They are backlog, not new divergence: entries added below
-// at their true count. That is the third blind spot of this exact shape (the others: the detector only
-// reading <style> blocks, and the muted matcher keying on a literal size), and they share a cause —
-// a matcher pinned to ONE spelling of a value that the codebase writes more than one way.
+// The four chain-node files that briefly appeared here are gone again, and how they showed up is worth
+// remembering: the `muted` matcher keys on `color: var(--cc-text-dim)` and never matched the
+// `color: var(--cc-text-dim, #8b8ca7)` spelling, so stripping the dead hex fallbacks revealed six
+// long-standing rules this check had been blind to. That was the third blind spot of one shape — a
+// matcher pinned to ONE spelling of a value the codebase writes more than one way (the others: only
+// reading <style> blocks, so inline `style="font-size:…"` was invisible; and keying on a *literal*
+// size, so tokenising a rule silently un-flagged it). When adding a matcher, ask which other spellings
+// of the same declaration exist: token vs literal, with fallback vs without, scoped vs inline.
 const BASELINE: Record<string, number> = {
   'components/AppSidebar.vue': 2,
-  'components/ChainLiveLabel.vue': 1,
-  'components/ChainQcNode.vue': 2,
-  'components/ChainStartNode.vue': 1,
-  'components/ChainTaskNode.vue': 2,
   'components/ClaudeOverviewDialog.vue': 2,
   'components/CohortCheckButton.vue': 1,
   'components/CopyDialog.vue': 1,


### PR DESCRIPTION
Closes out the scenario backlog that PR #358 exposed, and fixes the asymmetry it ran into.

## The six rules

Stripping the dead `var(--token, #hex)` fallbacks in #358 made the ratchet jump by six rules across four chain-node files. Those were never new divergence — the `muted` matcher keys on `color: var(--cc-text-dim)` and never matched the `color: var(--cc-text-dim, #8b8ca7)` spelling, so it had been blind to them the whole time. They went into the `BASELINE` at their true count; this migrates them, and all four files are back to **zero**.

## The missing density step

Doing it surfaced the same trap one tier further down. `.cc-muted` always had **both** `-dense` (10px) and `-micro` (9px); `.cc-eyebrow` only had `-dense`. So the 9px uppercase labels in the whiteboard nodes — `start`, `scope`, the QC footer — had nowhere to land and kept their own rule. That is precisely the documented failure mode: *a utility that hard-codes a value on an axis where sites legitimately differ*.

Adds `.cc-eyebrow-micro`, so the two text scenarios now carry the same three density steps.

Also routes the five remaining raw `font-family: monospace` stacks through `--cc-mono` while in these files — `ChainQcNode` next door already used the token, so these were the odd ones out.

## Verification

`pixi run test-frontend` **364 passed / 52 files** · `vue-tsc -b` clean · production build succeeds · re-ran the orphaned-state-class check (markup referencing a rule that was deleted): only the two pre-existing ones, unchanged from `main`. `.start-label`/`.scope-label` ended up with no rule at all once the eyebrow took over, so those now-styleless class names were dropped from the markup rather than left as decoration.

## Visible changes

Both confined to the chain whiteboard nodes, and both are the intended normalisation:

- the `start` / `scope` / QC-footer labels go from weight **700 + 0.07em** (0.05em for the footer) to the eyebrow's **600 + 0.06em** — the same normalisation already accepted twice in this plan;
- the five mono labels pick up the real `--cc-mono` stack (`ui-monospace, 'Cascadia Code', Consolas, …`) instead of bare `monospace`, so they render in a different face. That is the fix, but it is a genuine glyph change in dense 9–10px node text.

Not verified in a browser — the whiteboard is where these tiny labels sit inside fixed-width nodes, and the `--cc-fs-3xs` eyebrow path is new.

## What's deliberately still open

`BatchMoviesPanel`'s `.bm-busy` paints an *in-progress* state amber where `--cc-active` (the blue "running" tone from `lib/taskStatus.ts`) is arguably right — a hue change on a semantic judgement, so it wants eyes rather than a sweep. Now written into the plan as the one remaining real question. The per-row disclosure scenario stays parked by rule (two sites is not a pattern), and the four bespoke sites stay bespoke with their reasons recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
