### PR TITLE
Give the batch-movies note field a size tier, and correct the .bm-busy reading

### DIFF
--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -145,11 +145,29 @@ Remaining — incremental adoption only (no forced sweeps). **No counts here on 
   list is the per-file `BASELINE` in `utils/cssScenarios.test.ts`; it may shrink and must never grow.
   Touch a file in it → migrate its rules and lower the number. This is deliberately decoupled from
   "finish the sweep": new divergence fails immediately, the backlog drains as files get touched.
-- [ ] **Per-row disclosure in a list** (`TaskList`, `ErrorConsole`) — a genuinely distinct, recurring
-  scenario that is *not* a section header. Worth naming if a third site appears; two is not yet a pattern.
-- [ ] **`BatchMoviesPanel`'s `.bm-busy`** paints an *in-progress* state amber, where `--cc-active` (the
-  blue "running" tone, per `lib/taskStatus.ts`) is arguably the right token. A hue change on a semantic
-  judgement, so it wants eyes rather than a sweep — the only one of these left that is a real question.
+- [ ] **Per-row disclosure in a list** (`TaskList`, `ErrorConsole`) — distinct from a section header, and
+  deliberately NOT extracted yet. Inspected, the two sites differ on **four** axes: `TaskList` uses a
+  focusable `<button>` (already `.cc-btn-bare .cc-btn-icon`) with a tooltip, the icon as click target and
+  multi-expand (a `Set`); `ErrorConsole` uses a non-focusable `<span>`, the whole row as click target and
+  single-expand. **Four differences from two samples** — you discover an axis by watching sites differ on
+  it, and at n=2 a real axis is indistinguishable from an accident of those two files. The cost is
+  asymmetric: extract now, both adopt, then site three differs on the un-modelled axis and hand-rolls,
+  leaving a primitive *and* divergence — strictly worse than divergence alone, and precisely the history
+  this doc records. Waiting costs two small scoped rules that no detector flags. There may also be
+  nothing to extract: one is already the canonical icon button, the other isn't a button at all, and the
+  only shared thing is "the chevron points up when open" — one line, needing no abstraction.
+- [ ] **Form controls have no density axis — the one primitive category this audit never listed.** The
+  global `input`/`select` base is a SINGLE size (`--cc-fs-md` + `0.32rem 0.6rem`), so every compact
+  control re-styles it: **52 rules across 28 files**, in which **24 of the 37 font-sizes are
+  `--cc-fs-sm`** against **18 distinct padding spellings**. That is the same signature as the icon
+  buttons ("60 spellings of 2×4") and the raw sizes ("33 spellings of 5 values") — the codebase has
+  already voted for a dense tier 24 times and has no name for it. A `.cc-input-dense`/`-micro` pair
+  (plus the `surface-1` + `--cc-radius-xs` that the three separate "note (optional)" fields each
+  arrived at independently) is the likely shape. **Get the number from a detector before sweeping** —
+  there is no input matcher in `cssScenarios.ts` yet, so this entry deliberately quotes a one-off
+  measurement rather than a maintained count, and it should be replaced by a detector, not trusted.
+  Surfaced by a real symptom: `BatchMoviesPanel`'s `.bm-note` never picked a tier at all and rendered
+  at the base 13.1px beside its `--cc-fs-sm` neighbours, hidden behind a redundant `font: inherit`.
 - [ ] **Not recommended as a sweep:** single-value range wrapper (base already accent-themed; readout now
   covered by `.cc-readout`; sliders are layout-entangled and some commit on release). Governed by the rule.
 - [ ] **Deliberately left bespoke, with reasons** (do not "fix" these without reading why):

--- a/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
+++ b/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
@@ -336,8 +336,11 @@ async function previewOpen() {
 <style scoped>
 .bm { display: flex; flex-direction: column; gap: 7px; flex: 1; min-width: 0; padding: 2px; }
 .bm-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); margin: 2px 0; }
+/* A resource-contention advisory — "the batch has taken over the single napari viewer" — NOT the job's
+   progress (the scheduler reports that in TasksModule). It states the condition of a resource, so it is
+   a severity and takes the CVD-safe amber, same as ViewerPanel's stale-bridge strip. */
 .bm-busy { display: flex; align-items: center; gap: 8px; padding: 6px 9px; border-radius: var(--cc-radius-md);
-  background: color-mix(in srgb, var(--cc-warn) 16%, transparent); border: 1px solid var(--cc-warn);
+  background: color-mix(in srgb, var(--cc-sev-warn) 16%, transparent); border: 1px solid var(--cc-sev-warn);
   color: var(--cc-text); font-size: var(--cc-fs-md); }
 .bm-sec { border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); padding: 6px 8px; background: var(--cc-surface-1); }
 .bm-sec h4 { display: flex; align-items: baseline; margin: 0 0 4px; font-size: var(--cc-fs-md); font-weight: 700; }
@@ -365,6 +368,10 @@ async function previewOpen() {
 .bm-title-row { display: flex; align-items: center; gap: 0.5rem; }
 .bm-title-toggle { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; flex-shrink: 0; font-weight: 600; }
 .bm-title-range { flex: 1; min-width: 3rem; accent-color: var(--cc-accent); }
-.bm-note { width: 100%; box-sizing: border-box; font: inherit; padding: 3px 6px; margin-top: 5px;
+/* --cc-fs-sm to match .bm-mini and the rest of this panel's controls. It had `font: inherit`, which is
+   redundant (the global input base already declares it) and left the field at the base 13.1px next to
+   its --cc-fs-sm neighbours — the shorthand reads like a deliberate sizing choice while actually
+   meaning "no tier was picked". Beware `font:` on an input generally: it resets line-height/weight too. */
+.bm-note { width: 100%; box-sizing: border-box; font-size: var(--cc-fs-sm); padding: 3px 6px; margin-top: 5px;
   border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); color: var(--cc-text); }
 </style>


### PR DESCRIPTION
Two small fixes from reviewing the batch-movies panel in the running app, plus the finding that came out of measuring the first one.

## The note field was a tier too large

`.bm-note` renders at the input base's 13.1px while every other control in that panel (`.bm-mini` and friends) is `--cc-fs-sm`, because it never picked a tier at all. That was masked by a `font: inherit` declaration which is **redundant** — the global input base on `style.css:375` already declares exactly that — but reads like a deliberate sizing decision.

Worth knowing generally: `font:` is a *shorthand*, so putting it on an input also resets `line-height`, `font-weight` and `font-style`. It's a poor way to say "inherit the size", and here it said nothing at all while hiding the omission.

## `.bm-busy` — a misreading, corrected

The previous plan entry called this an in-progress indicator that might want `--cc-active` (the blue "running" tone). That was wrong. It is a **resource-contention advisory** — *"the batch has taken over the single napari viewer"* — not the job's progress, which the scheduler reports in `TasksModule`. It states the condition of a resource, so under the status-vs-not rule it is a severity, same as `ViewerPanel`'s stale-bridge strip: `--cc-sev-warn`. Amber to amber, so the only change is picking up the CVD-safe value.

## The category the audit never listed: form controls have no density axis

Measuring why the note field was wrong turned up the real thing. The global `input`/`select` base is a **single size** (`--cc-fs-md` + `0.32rem 0.6rem`), so every compact control re-styles it:

- **52 rules across 28 files**
- **24 of the 37 font-sizes are `--cc-fs-sm`** — one dominant tier
- against **18 distinct padding spellings**

That is the same signature as the icon buttons (*"60 spellings of 2 shapes × 4 sizes"*) and the raw sizes (*"33 spellings of 5 values"*). The codebase has already voted for a dense input tier 24 times; it just has no name for it. A `.cc-input-dense`/`-micro` pair — plus the `surface-1` + `--cc-radius-xs` that the three separate "note (optional)" fields each arrived at independently — is the likely shape.

Recorded as an open item, and **explicitly flagged in the doc as a one-off measurement to be replaced by a detector rather than trusted**, per the rule this saga established. No sweep here.

## Per-row disclosure — why it is still not extracted

Also recorded, now with the concrete evidence rather than "two is not a pattern":

| | `TaskList` | `ErrorConsole` |
|---|---|---|
| element | focusable `<button>` (already `.cc-btn-bare .cc-btn-icon`) | non-focusable `<span>` |
| tooltip | yes | no |
| click target | the icon | the whole row |
| expansion | multi (a `Set`) | single (`expandedId`) |

Four axes of difference from two samples. You discover an axis by watching sites differ on it, and at n=2 a real axis is indistinguishable from an accident of those two files. The cost is asymmetric: extract now, both adopt, then site three differs on the un-modelled axis and hand-rolls — leaving a primitive *and* divergence, which is strictly worse than divergence alone and is exactly the history this plan records. There may also be nothing to extract: one is already the canonical icon button, the other isn't a button, and the only shared thing is "the chevron points up when open".

## Verification

`pixi run test-frontend` **364 passed / 52 files** · `vue-tsc -b` clean. The `.bm-note` change is a visible size reduction in that panel (that's the point); `.bm-busy` shifts `#f59e0b` → `#fab219`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
