### PR TITLE
Give form controls a density axis, and delete the 67 declarations that stood in for one

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -43,6 +43,7 @@ primitives still being extracted lives in `docs/todo/UX_PRIMITIVES_PLAN.md`.
 | Card / panel / surface container | `.cc-card` (+ `-2` when it sits *on* a surface-1 panel) | a scoped `surface + 1px border + radius` block |
 | Corner radius | `--cc-radius-xs/sm/md/lg/pill` | a raw `rem`/`px` radius |
 | Small text size | `--cc-fs-3xs/2xs/xs/sm/md/lg` | a raw `rem`/`px` font-size (incl. inline `style=`) |
+| Compact input / select / textarea | `.cc-input-dense` (12px) / `.cc-input-micro` (11px) — sets size AND padding | a scoped class re-typing the base's border/colour/background to change the size |
 | A colour a token already holds | that token — `var(--cc-accent)`, not `#a78bfa` | a hex literal, **or** a `var(--x, #hex)` fallback (add the token, never a fallback) |
 
 **Each utility varies on exactly one axis, and the modifier is that axis** — density (`-dense`/`-micro`),

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -156,28 +156,25 @@ Remaining — incremental adoption only (no forced sweeps). **No counts here on 
   this doc records. Waiting costs two small scoped rules that no detector flags. There may also be
   nothing to extract: one is already the canonical icon button, the other isn't a button at all, and the
   only shared thing is "the chevron points up when open" — one line, needing no abstraction.
-- [ ] **Form controls have no density axis — the one primitive category this audit never listed.** The
-  global `input`/`select` base is a SINGLE size (`--cc-fs-md` + `0.32rem 0.6rem`), so every compact
-  control re-styles it: **52 rules across 28 files**, in which **24 of the 37 font-sizes are
-  `--cc-fs-sm`** against **18 distinct padding spellings**. That is the same signature as the icon
-  buttons ("60 spellings of 2×4") and the raw sizes ("33 spellings of 5 values") — the codebase has
-  already voted for a dense tier 24 times and has no name for it. A `.cc-input-dense`/`-micro` pair
-  (plus the `surface-1` + `--cc-radius-xs` that the three separate "note (optional)" fields each
-  arrived at independently) is the likely shape. **Get the number from a detector before sweeping** —
-  there is no input matcher in `cssScenarios.ts` yet, so this entry deliberately quotes a one-off
-  measurement rather than a maintained count, and it should be replaced by a detector, not trusted.
-  Surfaced by a real symptom: `BatchMoviesPanel`'s `.bm-note` never picked a tier at all and rendered
-  at the base 13.1px beside its `--cc-fs-sm` neighbours, hidden behind a redundant `font: inherit`.
-- [ ] **Not recommended as a sweep:** single-value range wrapper (base already accent-themed; readout now
-  covered by `.cc-readout`; sliders are layout-entangled and some commit on release). Governed by the rule.
-- [ ] **Deliberately left bespoke, with reasons** (do not "fix" these without reading why):
-  `ImageTable`'s `.runlog-cog.on`/`.actions-btn.on` are the documented **hover-reveal** pattern
-  (`opacity: 0` + a parent `:hover`), not the accent-border scenario. `GatePairsPanel`'s `.chan-btn.on` is
-  a full-width select-*trigger* built from its own rules, not a `.cc-btn` — adopting the state axis there
-  means rebuilding the control first. `ModuleLayout`'s `.filter-toggle.active` sits between the outline
-  and tint intensities (accent-soft text, accent-strong border, no fill) and would change visually either
-  way; it is a popover trigger, not a toggle. `BatchMoviesPanel`'s `.bm-busy` uses amber for *in-progress*
-  where `--cc-active` is arguably the right token — a hue change, so it needs eyes, not a script.
+- [x] **Form-control density — done (2026-07-25).** The `input`/`select`/`textarea` base was a SINGLE
+  size, and that turned out to be the *mechanism* of the divergence, not a side effect: to make a
+  control smaller you had to write a class, and once writing a class sites re-typed everything they
+  could see. **67 declarations across 19 files restated the base's own `color`/`border`/`background`
+  verbatim** — no-ops by the cascade, so removing them is provably neutral.
+  Font-size was never the broken axis (50 uses, 5 values, all already tokens), and padding's 23
+  spellings were not 23 choices: sorted, they collapse to two tiers below the base, because padding
+  **tracks** the size rather than varying independently. So `.cc-input-dense` / `.cc-input-micro` set
+  both, exactly as `.cc-btn-icon` bundles box and glyph size. `BatchMoviesPanel`'s `.bm-note` — the
+  field that surfaced all this by rendering a tier too large — is the reference adoption.
+  Held by `findRestatedInputBase` as an exact list, one survivor: `.cby-swatch`, whose class is shared
+  with a `<span>` that gets nothing from the input base and so genuinely needs its own border.
+
+  Two detector-precision bugs found while building it, both now unit-tested, and both the *same shape*
+  as the blind spots above — a pattern matching more (or less) than the thing it names:
+  `\b(select)\b` matches inside `.chip-select` and `.select-flagged-btn`, because a hyphen is a word
+  boundary; and a rule must be judged by its **subject** compound, since
+  `.cc-toggle-input:checked ~ .cc-toggle-track` styles the track, not the input. The first run of the
+  check reported 77 hits across 22 files; after both fixes, 68 across 19. Nine were never real.
 
 Not swept, and NOT because they were forgotten: `ChainPicnicNode`'s amber and `AnimationModule`'s
 `.tl-badge` are **identity** hues (a node's colour, a keyframe badge), and the `.cc-del`/`.footer-btn

--- a/frontend/src/components/CohortCheckButton.vue
+++ b/frontend/src/components/CohortCheckButton.vue
@@ -98,8 +98,7 @@ async function check() {
   font-size: var(--cc-fs-sm); color: var(--cc-text-dim);
 }
 .cohort-run select {
-  font-size: var(--cc-fs-sm); padding: 0.15rem 0.3rem; border-radius: var(--cc-radius-sm);
-  color: var(--cc-text); background: var(--cc-surface-2); border: 1px solid var(--cc-border); cursor: pointer;
+  font-size: var(--cc-fs-sm); padding: 0.15rem 0.3rem; border-radius: var(--cc-radius-sm); cursor: pointer;
 }
 .cohort-run select:disabled { opacity: 0.6; cursor: default; }
 .cohort-check-btn {

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -1144,8 +1144,8 @@ th:hover .resize-handle::after { opacity: 1; }
 /* editable attribute cell: click to edit; subtle hover affordance */
 .attr-cell { cursor: text; border-radius: var(--cc-radius-xs); padding: 0 2px; }
 .attr-cell:hover { background: var(--cc-surface-2); outline: 1px dashed var(--cc-border); }
-.attr-edit { width: 100%; box-sizing: border-box; font: inherit; padding: 1px 3px;
-  border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); color: var(--cc-text); }
+.attr-edit { width: 100%; box-sizing: border-box; padding: 1px 3px;
+  border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); }
 
 .uid-row {
   display: flex;

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -397,12 +397,10 @@ async function dismissEntry(entry: LabLogEntry) {
   color: #d29922; margin-bottom: 0.3rem;
 }
 .ll-input {
-  width: 100%; resize: vertical; box-sizing: border-box;
-  background: var(--cc-surface-2); color: var(--cc-text);
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm);
-  padding: 0.4rem 0.5rem; font: inherit; line-height: 1.35;
+  width: 100%; resize: vertical; box-sizing: border-box; border-radius: var(--cc-radius-sm);
+  padding: 0.4rem 0.5rem; line-height: 1.35;
 }
-.ll-input:focus { outline: none; border-color: var(--cc-accent); }
+.ll-input:focus { border-color: var(--cc-accent); }
 .ll-input:disabled { opacity: 0.6; }
 .ll-compose-row { display: flex; align-items: center; justify-content: space-between; margin-top: 0.35rem; }
 .ll-hint { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
@@ -436,7 +434,7 @@ async function dismissEntry(entry: LabLogEntry) {
   font-size: var(--cc-fs-xs); color: var(--cc-text-dim); cursor: pointer; padding: 0.05rem 0.2rem;
   /* background-COLOR, not the shorthand: the global `select` rule paints the custom caret via
      background-image, and a shorthand here would reset it to none (leaving an arrowless select). */
-  background-color: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs);
+  background-color: var(--cc-surface-2); border-radius: var(--cc-radius-xs);
 }
 /* capture status: floats to the far right of the whole bar (direct toolbar child) */
 .ll-note { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); margin-left: auto; }

--- a/frontend/src/components/LegacyMigrateDialog.vue
+++ b/frontend/src/components/LegacyMigrateDialog.vue
@@ -150,7 +150,7 @@ async function confirmImport() {
       </div>
       <input
         v-model="rscript"
-        class="lm-input lm-rscript"
+        class="lm-input"
         placeholder="Rscript path (optional — only if R isn't found, e.g. /usr/bin/Rscript or your renv Rscript)"
       />
 
@@ -242,11 +242,9 @@ async function confirmImport() {
 .lm-path { display: flex; gap: 0.5rem; }
 .lm-input {
   flex: 1; padding: 0.4rem 0.6rem; font-size: var(--cc-fs-lg);
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md);
-  background: var(--cc-surface-1); color: var(--cc-text);
+  background: var(--cc-surface-1);
 }
 .lm-input::placeholder { color: var(--cc-text-dim); }
-.lm-rscript { font-size: var(--cc-fs-md); }
 .lm-error { color: #f87171; margin: 0; font-size: var(--cc-fs-md); }
 .lm-summary { margin: 0; font-size: var(--cc-fs-lg); color: var(--cc-text); }
 .lm-tablewrap { max-height: 46vh; overflow: auto; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); }

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -666,8 +666,6 @@ const visibleUids = computed<string[]>(() =>
   padding: 0.15rem 0.4rem;
   border-radius: var(--cc-radius-sm);
   background: var(--cc-surface-1);
-  border: 1px solid var(--cc-border);
-  color: var(--cc-text);
   max-width: 240px;
 }
 .proc-mode { display: flex; align-items: center; gap: 0.55rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }

--- a/frontend/src/components/PackagesDialog.vue
+++ b/frontend/src/components/PackagesDialog.vue
@@ -114,7 +114,7 @@ function copyAll() {
 .pk-toolbar { display: flex; gap: 0.5rem; align-items: center; padding: 0.6rem 1rem; border-bottom: 1px solid var(--cc-border); flex-shrink: 0; }
 .search-wrap { flex: 1; display: flex; align-items: center; gap: 0.4rem; background: var(--cc-surface-2); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); padding: 0.25rem 0.5rem; }
 .search-wrap .pi-search { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
-.search-input { flex: 1; background: none; border: none; outline: none; color: var(--cc-text); font-size: var(--cc-fs-md); }
+.search-input { flex: 1; background: none; border: none; }
 .mini-btn { display: flex; align-items: center; gap: 0.3rem; font-size: var(--cc-fs-sm); padding: 0.3rem 0.6rem; border-radius: var(--cc-radius-sm); border: 1px solid var(--cc-border); background: var(--cc-surface-2); color: var(--cc-text-dim); cursor: pointer; white-space: nowrap; }
 .mini-btn:hover:not(:disabled) { color: var(--cc-text); }
 .mini-btn:disabled { opacity: 0.4; cursor: not-allowed; }

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -820,8 +820,7 @@ onUnmounted(() => {
 .movie-rec { margin-left: 0.1rem; }
 .movie-title-row { margin-top: 0.25rem; }
 .movie-title-toggle { display: inline-flex; align-items: center; gap: 0.25rem; cursor: pointer; text-transform: none; letter-spacing: 0; }
-.movie-note { flex: 2; min-width: 3rem; font-size: var(--cc-fs-2xs); padding: 1px 4px;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); color: var(--cc-text); }
+.movie-note { flex: 2; min-width: 3rem; font-size: var(--cc-fs-2xs); padding: 1px 4px; border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); }
 
 /* colour-by legend: value → swatch (a population's colour where one matches, else default) */
 .cby-legend { display: flex; flex-wrap: wrap; gap: 0.15rem 0.5rem; margin-top: 0.25rem; }

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -605,10 +605,8 @@ defineExpose({ capturePage, collectCsvs })
 .lc-slot { position: relative; border: 1px dashed var(--cc-border); border-radius: var(--cc-radius-md); overflow: hidden;
   display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--cc-bg); }
 /* per-slot title (figure caption): a plain-looking, centred, editable line above the plot */
-.lc-slot-cap { flex: 0 0 auto; width: 100%; box-sizing: border-box; border: none; background: transparent;
-  color: var(--cc-text); font-size: var(--cc-fs-sm); font-weight: 600; text-align: center; padding: 3px 6px 1px; }
+.lc-slot-cap { flex: 0 0 auto; width: 100%; box-sizing: border-box; border: none; background: transparent; font-size: var(--cc-fs-sm); font-weight: 600; text-align: center; padding: 3px 6px 1px; }
 .lc-slot-cap::placeholder { color: var(--cc-text-dim); font-weight: 400; opacity: 0.55; }
-.lc-slot-cap:focus { outline: none; background: var(--cc-surface-2); }
 /* the plot area fills the rest of the slot (was the slot itself before the caption was added) */
 .lc-slot-plot { flex: 1; min-width: 0; min-height: 0; display: flex; position: relative; }
 .lc-slot.filled { border-style: solid; }

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -434,7 +434,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
   font-size: var(--cc-fs-sm); color: var(--cc-text-dim); border-top: 1px solid var(--cc-border); padding-top: 6px; }
 .pm-colour-custom input { width: 28px; height: 20px; padding: 0; border: none; background: none; cursor: pointer; }
 .pm-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.pm-rename { flex: 1; background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); padding: 1px 4px; }
+.pm-rename { flex: 1; background: var(--cc-bg); border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); padding: 1px 4px; }
 .pm-stat { color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
 .pm-stat small { opacity: 0.7; margin-left: 3px; }
 /* .pm-icon → cc-btn cc-btn-bare cc-btn-icon */
@@ -453,13 +453,12 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
 .pm-ff { display: flex; flex-direction: column; gap: 5px; padding: 6px 8px; border-bottom: 1px solid var(--cc-border);
   background: var(--cc-surface-1); }
 .pm-ff-head { display: flex; gap: 5px; align-items: center; }
-.pm-ff-name { flex: 1; font-size: var(--cc-fs-xs); padding: 3px 6px; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs);
-  background: var(--cc-surface-2); color: var(--cc-text); }
-.pm-ff-colour { width: 24px; height: 24px; padding: 0; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs);
+.pm-ff-name { flex: 1; font-size: var(--cc-fs-xs); padding: 3px 6px; border-radius: var(--cc-radius-xs); }
+.pm-ff-colour { width: 24px; height: 24px; padding: 0; border-radius: var(--cc-radius-xs);
   background: none; cursor: pointer; }
 .pm-ff-row, .pm-ff-cond { display: flex; gap: 4px; align-items: center; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
-.pm-ff-cond select, .pm-ff-row select, .pm-ff-vals { font-size: var(--cc-fs-xs); padding: 2px 4px; border: 1px solid var(--cc-border);
-  border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); color: var(--cc-text); }
+.pm-ff-cond select, .pm-ff-row select, .pm-ff-vals { font-size: var(--cc-fs-xs); padding: 2px 4px;
+  border-radius: var(--cc-radius-xs); }
 .pm-ff-measure { flex: 1; min-width: 0; }
 .pm-ff-fun { width: 48px; }
 .pm-ff-vals { width: 64px; }

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -259,7 +259,7 @@ function exportBoard(kind: string) {
 .tab:hover { color: var(--cc-text); }
 .tab.active { color: var(--cc-text); background: var(--cc-bg); border-color: var(--cc-accent-strong); }
 .tab-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.tab-edit { font-size: var(--cc-fs-sm); width: 8rem; background: var(--cc-surface-2); color: var(--cc-text);
+.tab-edit { font-size: var(--cc-fs-sm); width: 8rem;
   border: 1px solid var(--cc-accent-strong); border-radius: var(--cc-radius-xs); padding: 1px 4px; }
 /* .tab-close → cc-btn cc-btn-bare cc-btn-icon cc-btn-micro */
 .tab-close:hover { background: var(--cc-surface-2); color: var(--cc-text); }
@@ -271,9 +271,9 @@ function exportBoard(kind: string) {
 }
 .tab-add:hover { color: var(--cc-text); }
 .tab-pdf { display: inline-flex; align-items: center; gap: 5px; margin-left: auto; margin-bottom: 2px;
-  padding: 3px 10px; font-size: var(--cc-fs-xs); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm);
+  padding: 3px 10px; font-size: var(--cc-fs-xs); border-radius: var(--cc-radius-sm);
   background: var(--cc-surface-1); color: var(--cc-text-dim); cursor: pointer; }
-.tab-pdf:hover:not(:disabled) { color: var(--cc-text); border-color: var(--cc-accent-strong); }
+.tab-pdf:hover:not(:disabled) { border-color: var(--cc-accent-strong); }
 .tab-pdf:disabled { opacity: 0.5; cursor: default; }
 /* info hint for the figure-export format choice */
 .tab-info { align-self: center; margin-left: 4px; margin-bottom: 2px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); cursor: help; }

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -376,8 +376,8 @@ async function render() {
 .anim-range { width: 5rem; accent-color: var(--cc-accent); }
 .anim-num { font-size: var(--cc-fs-sm); color: var(--cc-text); font-variant-numeric: tabular-nums; min-width: 1.2rem; }
 .anim-title-toggle { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.35rem; cursor: pointer; }
-.anim-note { font-size: var(--cc-fs-sm); width: 9rem; padding: 2px 6px; border: 1px solid var(--cc-border);
-  border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); color: var(--cc-text); }
+.anim-note { font-size: var(--cc-fs-sm); width: 9rem; padding: 2px 6px;
+  border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); }
 .anim-toolbar { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.9rem; }
 .anim-img { font-size: var(--cc-fs-sm); font-weight: 600; color: var(--cc-text); margin-right: 0.2rem; }
 .anim-sync { display: inline-flex; align-items: center; gap: 0.3rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); cursor: pointer; }

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -1646,10 +1646,7 @@ onActivated(async () => {
   flex: 1;
   min-width: 0;
   font-size: var(--cc-fs-sm);
-  background: var(--cc-surface-2);
-  border: 1px solid var(--cc-border);
   border-radius: var(--cc-radius-sm);
-  color: var(--cc-text);
   padding: 0.25rem 0.4rem;
   cursor: pointer;
 }
@@ -1681,12 +1678,9 @@ onActivated(async () => {
   flex: 1;
   min-width: 0;
   font-size: var(--cc-fs-sm);
-  background: var(--cc-surface-2);
   border: 1px solid var(--cc-accent);
   border-radius: var(--cc-radius-sm);
-  color: var(--cc-text);
   padding: 0.2rem 0.4rem;
-  outline: none;
 }
 
 .palette-scroll {
@@ -1842,10 +1836,7 @@ onActivated(async () => {
 .config-select, .config-input {
   width: 100%;
   font-size: var(--cc-fs-sm);
-  background: var(--cc-surface-2);
-  border: 1px solid var(--cc-border);
   border-radius: var(--cc-radius-sm);
-  color: var(--cc-text);
   padding: 0.28rem 0.5rem;
 }
 .config-select:focus, .config-input:focus { outline: 1px solid var(--cc-accent); border-color: var(--cc-accent); }

--- a/frontend/src/modules/MoviesModule.vue
+++ b/frontend/src/modules/MoviesModule.vue
@@ -233,7 +233,6 @@ function movieTime(mtime: number): string {
 .mov-head-ctl { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
 .mov-ctl { display: flex; align-items: center; gap: 0.35rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
 .mov-select {
-  background: var(--cc-surface-2); color: var(--cc-text); border: 1px solid var(--cc-border);
   border-radius: var(--cc-radius-sm); padding: 0.15rem 0.35rem; font-size: var(--cc-fs-sm);
 }
 .mov-range { width: 6rem; }

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -887,7 +887,7 @@ async function switchWt(path: string) {
 .svc-row { display: grid; grid-template-columns: 8rem 7rem 3.5rem 1fr; align-items: center;
   column-gap: 0.6rem; margin-bottom: 0.55rem; }
 .svc-name { font-size: var(--cc-fs-md); color: var(--cc-text); }
-.wt-select { font-size: var(--cc-fs-md); padding: 2px 6px; max-width: 18rem; }
+.wt-select { padding: 2px 6px; max-width: 18rem; }
 .svc-pill { justify-self: start; display: inline-flex; align-items: center; gap: 0.35rem; font-size: var(--cc-fs-sm);
   color: var(--cc-text-dim); padding: 0.1rem 0.55rem; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-pill);
   white-space: nowrap; }

--- a/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
+++ b/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
@@ -313,7 +313,7 @@ async function previewOpen() {
             <span class="bm-val">{{ titleDur }}s</span>
           </template>
         </div>
-        <input v-if="titleCardOn" type="text" class="bm-note" v-model="titleNote"
+        <input v-if="titleCardOn" type="text" class="bm-note cc-input-dense" v-model="titleNote"
                placeholder="note (optional)" />
       </section>
 
@@ -368,10 +368,10 @@ async function previewOpen() {
 .bm-title-row { display: flex; align-items: center; gap: 0.5rem; }
 .bm-title-toggle { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; flex-shrink: 0; font-weight: 600; }
 .bm-title-range { flex: 1; min-width: 3rem; accent-color: var(--cc-accent); }
-/* --cc-fs-sm to match .bm-mini and the rest of this panel's controls. It had `font: inherit`, which is
-   redundant (the global input base already declares it) and left the field at the base 13.1px next to
-   its --cc-fs-sm neighbours — the shorthand reads like a deliberate sizing choice while actually
-   meaning "no tier was picked". Beware `font:` on an input generally: it resets line-height/weight too. */
-.bm-note { width: 100%; box-sizing: border-box; font-size: var(--cc-fs-sm); padding: 3px 6px; margin-top: 5px;
-  border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); color: var(--cc-text); }
+/* + cc-input-dense — the tier this field never picked, which is what made it render at the base
+   13.1px beside its --cc-fs-sm neighbours. It previously said `font: inherit`, redundant with the
+   global base and reading like a deliberate choice. (Beware `font:` on an input: it is a shorthand
+   and resets line-height/weight too.) What stays here is the surface and this panel's layout. */
+.bm-note { width: 100%; box-sizing: border-box; margin-top: 5px;
+  border-radius: var(--cc-radius-xs); background: var(--cc-surface-1); }
 </style>

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -430,13 +430,13 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
 /* amber: this axis' preferred transform was auto-linearised because the measure's range can't use it */
 .panel-ctrl select.tsel.tsel-amber { border-color: var(--cc-sev-warn); color: var(--cc-sev-warn); }
 .ax-warn { color: var(--cc-sev-warn); font-size: var(--cc-fs-xs); flex-shrink: 0; cursor: help; }
-.panel-ctrl select:focus { outline: none; border-color: var(--cc-accent); }
+.panel-ctrl select:focus { border-color: var(--cc-accent); }
 .ctrl-sep { width: 1px; align-self: stretch; background: var(--cc-border); margin: 2px 2px; }
 .gp-export { font-size: var(--cc-fs-sm); max-width: 7rem; }
 /* the plot body (scatter/layers/gate + ticks/axes + PNG export) lives in GateScatterCell now. */
 .panel-name { position: absolute; top: 4px; left: 4px; display: flex; align-items: center; gap: 5px;
   background: var(--cc-surface-1); border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); padding: 4px 6px; font-size: var(--cc-fs-xs); }
-.panel-name input { background: var(--cc-bg); color: var(--cc-text); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-xs); padding: 1px 5px; width: 90px; }
+.panel-name input { background: var(--cc-bg); border-radius: var(--cc-radius-xs); padding: 1px 5px; width: 90px; }
 .panel-name input.name-invalid { border-color: var(--cc-sev-fail); }
 .name-hint { color: var(--cc-sev-fail); font-size: var(--cc-fs-2xs); max-width: 150px; line-height: 1.2; }
 /* subtle draw-mode affordance (top-right of the plot); mirrors .panel-name but muted and non-interactive */

--- a/frontend/src/modules/metadata/MetadataPanel.vue
+++ b/frontend/src/modules/metadata/MetadataPanel.vue
@@ -561,11 +561,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 .field-input:disabled { opacity: 0.4; cursor: not-allowed; }
 
 .field-textarea {
-  background: var(--cc-surface-2);
-  border: 1px solid var(--cc-border);
   border-radius: var(--cc-radius-sm);
-  color: var(--cc-text);
-  font-size: var(--cc-fs-md);
   padding: 0.35rem 0.5rem;
   resize: vertical;
   font-family: var(--cc-mono);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -392,6 +392,17 @@ input[type="password"]:focus, input[type="email"]:focus, textarea:focus {
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--cc-accent) 22%, transparent);
 }
 
+/* Density steps for form controls — the axis the base was missing, and the reason ~112 rules re-styled
+   it. To make an input smaller you had to write a class, and once you were writing a class you re-typed
+   everything you could see: 67 declarations across 19 files restated the base's own border/colour/
+   background verbatim. Font-size was never the problem (50 uses, 5 values, all tokens) and padding's 23
+   spellings were not 23 choices — sorted, they collapse to two tiers below the base, because padding
+   TRACKS the size rather than varying independently. So each step sets both, exactly as `.cc-btn-icon`
+   bundles box and glyph size. Compose: `class="my-field cc-input-dense"`, and keep only real layout
+   (width / flex / margin) in scoped CSS. Guarded by `findRestatedInputBase` in cssScenarios.test.ts. */
+.cc-input-dense { font-size: var(--cc-fs-sm); padding: 0.15rem 0.4rem; }
+.cc-input-micro { font-size: var(--cc-fs-xs); padding: 0.05rem 0.25rem; }
+
 /* native select chevron → custom caret so dropdowns match across browsers */
 select {
   appearance: none;

--- a/frontend/src/tasks/ParamRenderer.vue
+++ b/frontend/src/tasks/ParamRenderer.vue
@@ -707,7 +707,6 @@ const pct = computed(() => {
     var(--cc-accent) 0%, var(--cc-accent) var(--pct, 0%),
     var(--cc-surface-2) var(--pct, 0%), var(--cc-surface-2) 100%);
   cursor: pointer;
-  outline: none;
 }
 .slider::-webkit-slider-thumb {
   appearance: none;

--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -505,11 +505,7 @@ const { width: sidebarWidth, onResizeStart } =
 /* function selector */
 .fn-select {
   width: 100%;
-  background: var(--cc-surface-2);
-  border: 1px solid var(--cc-border);
   border-radius: var(--cc-radius-sm);
-  color: var(--cc-text);
-  font-size: var(--cc-fs-md);
   padding: 0.35rem 0.5rem;
   cursor: pointer;
 }

--- a/frontend/src/utils/cssScenarios.test.ts
+++ b/frontend/src/utils/cssScenarios.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   styleBlocks, cssRules, scenarioFor, findReimplementedScenarios, findRawValues,
-  findHandRolledIconButtons, findRawColours, colourTokens,
+  findHandRolledIconButtons, findRawColours, colourTokens, findRestatedInputBase, inputBase,
 } from './cssScenarios'
 
 describe('styleBlocks', () => {
@@ -81,6 +81,44 @@ describe('findRawColours', () => {
 
   it('exempts plain white/black — not a scale, and what .cc-btn-primary itself uses', () => {
     expect(find('.a { color: #fff } .b { color: #000000 }')).toEqual([])
+  })
+})
+
+describe('findRestatedInputBase', () => {
+  const base = { color: 'var(--cc-text)', border: '1px solid var(--cc-border)' }
+  const find = (text: string) =>
+    findRestatedInputBase([{ path: 'x.vue', text }], base).map(r => `${r.selector} | ${r.decl}`)
+
+  it('flags a declaration equal to the base, and leaves a different value alone', () => {
+    expect(find('<template><input class="a"></template><style>.a { color: var(--cc-text) }</style>'))
+      .toEqual(['.a | color: var(--cc-text)'])
+    expect(find('<template><input class="a"></template><style>.a { color: var(--cc-accent) }</style>'))
+      .toEqual([])
+  })
+
+  // `\b(select)\b` matches inside `.chip-select` — a hyphen is a word boundary. That swept a chip
+  // wrapper and a plain button into the first run of this check.
+  it('does not mistake an element name inside a class name for the element', () => {
+    expect(find('<style>.chip-select { color: var(--cc-text) }</style>')).toEqual([])
+    expect(find('<style>.select-flagged-btn { color: var(--cc-text) }</style>')).toEqual([])
+    expect(find('<style>select { color: var(--cc-text) }</style>')).toEqual(['select | color: var(--cc-text)'])
+  })
+
+  // The rule's SUBJECT is its last compound. A sibling/descendant of an input is not the input.
+  it('judges the subject, not any part of the selector', () => {
+    const t = '<template><input class="ci"></template><style>.ci:checked ~ .track { color: var(--cc-text) }</style>'
+    expect(find(t)).toEqual([])
+  })
+})
+
+describe('inputBase', () => {
+  it('takes the resting rule only — folding in :focus would flag every focus rule in the app', () => {
+    const css = `
+      select, input[type="text"], textarea { color: var(--cc-text); background: var(--cc-surface-2); }
+      select:focus, input[type="text"]:focus, textarea:focus { border-color: var(--cc-accent); }`
+    const b = inputBase(css)
+    expect(b['color']).toBe('var(--cc-text)')
+    expect(b['border-color']).toBeUndefined()
   })
 })
 
@@ -230,6 +268,36 @@ describe('raw colours', () => {
 
     const found = findRawColours(sources, tokens).map(r => `${r.path} | ${r.selector} | ${r.hex} → ${r.token}`)
     expect(found.sort()).toEqual([])
+  })
+})
+
+describe('form controls', () => {
+  // The input/select/textarea base is one size, and until `.cc-input-dense`/`-micro` existed there was
+  // no way to make a control smaller except to write a class — at which point sites re-typed the base's
+  // border/colour/background too. 67 such declarations across 19 files were removed; they were no-ops
+  // by the cascade, so the removal is provably neutral.
+  //
+  // An exact list, not a ratchet: a value match makes a declaration redundant with ONE real exception —
+  // re-stating the base defensively to beat a more specific rule, or because the class is shared with a
+  // non-input element. Each survivor says which.
+  const ALLOWED = [
+    // .cby-swatch is on BOTH a <span> (static swatch) and an <input type="color"> (editable one).
+    // A <span> gets nothing from the input base, so this border is load-bearing for that half.
+    'components/ViewerPanel.vue | .cby-swatch | border: 1px solid var(--cc-border)',
+  ]
+
+  it('never re-state what the global input base already gives', () => {
+    const base = inputBase(RAW['/src/style.css'] ?? '')
+    expect(base['background']).toBeTruthy()          // the base rule was found and parsed
+    expect(base['border-color']).toBeUndefined()     // ...and the :focus rule was NOT folded into it
+
+    const sources = Object.entries(RAW)
+      .filter(([path]) => path !== '/src/style.css')
+      .map(([path, text]) => ({ path: path.replace('/src/', ''), text }))
+
+    const found = findRestatedInputBase(sources, base)
+      .map(r => `${r.path} | ${r.selector} | ${r.decl}`)
+    expect(found.sort()).toEqual([...ALLOWED].sort())
   })
 })
 

--- a/frontend/src/utils/cssScenarios.ts
+++ b/frontend/src/utils/cssScenarios.ts
@@ -132,6 +132,97 @@ export function findHandRolledIconButtons(
   return out
 }
 
+// ── Form controls ─────────────────────────────────────────────────────────────────────────────────
+
+/** A scoped declaration on an input/select/textarea that re-states what the global base already gives. */
+export interface RestatedBase {
+  path:     string
+  selector: string
+  decl:     string
+}
+
+// The element name as a SELECTOR, not as a fragment of a class name. `\b(select)\b` alone matches
+// inside `.chip-select` and `.select-flagged-btn`, because a hyphen is a word boundary — which
+// silently swept a chip wrapper and a plain button into the first run of this check.
+const FORM_EL = /(?<![\w.#-])(input|select|textarea)\b/
+
+// The SUBJECT of a selector is its last compound — what the rule actually styles. Without this,
+// `.cc-toggle-input:checked ~ .cc-toggle-track` counts as targeting an input when it styles the track.
+const subjects = (selector: string) =>
+  selector.split(',').map(part => part.trim().split(/[\s>+~]+/).filter(Boolean).pop() ?? '')
+
+/**
+ * The global `input`/`select`/`textarea` base rule in `style.css`, as property → value.
+ * Parsed rather than hard-coded, so the check can't drift from the thing it checks against.
+ *
+ * Resting state only: the `:focus`/`:hover` rules share the same selector list, and folding them in
+ * would put `border-color: var(--cc-accent)` in the "base", flagging every legitimate focus rule in
+ * the app as redundant.
+ */
+export function inputBase(styleCss: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const rule of cssRules(styleCss)) {
+    // the base is the one rule that covers BOTH a typed text input and textarea
+    if (!/input\[type="text"\]/.test(rule.selector) || !/\btextarea\b/.test(rule.selector)) continue
+    if (/:(focus|hover|active|disabled)/.test(rule.selector)) continue
+    for (const d of rule.body.split(';')) {
+      const i = d.indexOf(':')
+      if (i < 0) continue
+      out[d.slice(0, i).trim()] = d.slice(i + 1).trim()
+    }
+  }
+  return out
+}
+
+/**
+ * Declarations on a form control that the global base already provides, identically.
+ *
+ * These are provable no-ops, and they are the *mechanism* behind the form-control divergence rather
+ * than a side effect of it: the base is one size, so making an input smaller means writing a class,
+ * and once you are writing a class you re-type everything you can see. Measured before adding the
+ * density steps — of ~112 rules touching a form control, 67 declarations across 19 files were pure
+ * re-statement (`color`, `border`, `background` dominating), while font-size used only 5 values (all
+ * already tokens) and padding's 23 spellings collapsed to two tiers once sorted, because padding
+ * TRACKS the size rather than varying independently. Hence `.cc-input-dense`/`-micro` set both.
+ *
+ * A rule counts as targeting a form control when its SUBJECT names one, or names a class this file's
+ * template puts on one — the same markup-informed test the icon-button check uses.
+ *
+ * Precision: an exact value match makes the declaration redundant by the cascade, with one real
+ * exception — re-stating the base defensively, or on a class shared with a non-input element. So this
+ * pins an exact list rather than ratcheting a count, and each survivor carries its reason.
+ */
+export function findRestatedInputBase(
+  sources: Array<{ path: string, text: string }>,
+  base: Record<string, string>,
+): RestatedBase[] {
+  const out: RestatedBase[] = []
+  for (const { path, text } of sources) {
+    const template = text.replace(/<style[^>]*>[\s\S]*?<\/style>/g, ' ')
+    const onFormEl = new Set<string>()
+    for (const m of template.matchAll(/<(input|select|textarea)\b[^>]*?\bclass="([^"]*)"/g)) {
+      for (const c of m[2].split(/\s+/)) if (c) onFormEl.add(c)
+    }
+    for (const block of styleBlocks(text)) {
+      for (const rule of cssRules(block)) {
+        const hits = subjects(rule.selector).some(s =>
+          FORM_EL.test(s) || [...s.matchAll(/\.([\w-]+)/g)].some(m => onFormEl.has(m[1])))
+        if (!hits) continue
+        for (const d of rule.body.split(';')) {
+          const i = d.indexOf(':')
+          if (i < 0) continue
+          const prop = d.slice(0, i).trim()
+          const val  = d.slice(i + 1).trim()
+          if (base[prop] && base[prop] === val) {
+            out.push({ path, selector: rule.selector.replace(/\s+/g, ' '), decl: `${prop}: ${val}` })
+          }
+        }
+      }
+    }
+  }
+  return out
+}
+
 // ── Raw values ────────────────────────────────────────────────────────────────────────────────────
 
 /** A literal `font-size` / `border-radius` where a scale token exists. */


### PR DESCRIPTION
Closes the last open item from the UX-primitive saga: form controls, the one category the audit never listed.

## The base being one size *was* the mechanism

Not a side effect of the divergence — the cause of it. The `input`/`select`/`textarea` base declares a single size, so making a control smaller means writing a class, and once you are writing a class you re-type everything you can see:

**67 declarations across 19 files restated the base's own `color` / `border` / `background` verbatim.** They are no-ops by the cascade, so deleting them is provably neutral.

Font-size was never the broken axis — 50 uses, 5 values, **all already tokens**. Padding *looked* broken (23 spellings) but is not an independent choice: it **tracks** the size, and sorted it collapses to two tiers below the base. So the steps set both, exactly as `.cc-btn-icon` bundles box and glyph size:

```css
.cc-input-dense { font-size: var(--cc-fs-sm); padding: 0.15rem 0.4rem; }
.cc-input-micro { font-size: var(--cc-fs-xs); padding: 0.05rem 0.25rem; }
```

`BatchMoviesPanel`'s `.bm-note` — the field that surfaced this by rendering a tier too large — is the reference adoption.

## Detector first, and it changed the answer twice

Per the rule this saga produced. `findRestatedInputBase` parses the base rule *out of* `style.css` rather than hard-coding it, so the check cannot drift from the thing it checks.

| run | hits | files |
|---|---|---|
| first | 77 | 22 |
| after two precision fixes | **68** | **19** |

Nine were never real. Both bugs are the same shape as the blind spots this plan already records — *a pattern matching more than the thing it names* — and both are now unit-tested:

- **`\b(select)\b` matches inside `.chip-select`** and `.select-flagged-btn`, because a hyphen is a word boundary. That swept a chip wrapper and a plain button into the first run.
- **A rule must be judged by its SUBJECT compound.** `.cc-toggle-input:checked ~ .cc-toggle-track` styles the track, not the input.

Also: `inputBase` deliberately reads the resting rule only. The `:focus` rule shares the same selector list, and folding it in would put `border-color: var(--cc-accent)` in the "base" and flag every legitimate focus rule in the app.

Pinned as an exact list, with one survivor: `.cby-swatch`, whose class sits on **both** a `<span>` and an `<input type="color">`. A `<span>` gets nothing from the input base, so that border is load-bearing for half its uses.

## Verification

`pixi run test-frontend` **369 passed / 52 files** (364 + 5 new) · `vue-tsc -b` clean · production build succeeds.

## Reservations

- **The 67 removals are provably neutral; the two classes are barely adopted yet.** Only `.bm-note` uses them. That is deliberate — I did **not** force ~30 sites onto the tiers, because unlike the deletions that would be a genuine 1–2px shift each. The primitive exists and the detector prevents new restatement; adoption stays opportunistic, per this plan's standing rule against forced sweeps.
- **An earlier attempt at this corrupted code and I nearly shipped it.** The tidy regexes ran over whole files instead of `<style>` blocks, mangling `${…}` template literals and **deleting a live line** in `LabLogPanel.vue`. Caught by reading the diff, reverted, redone with every transformation confined to style blocks — and then verified mechanically: all 19 files changed *only* inside `<style>`. Stating it plainly because green tests would not have caught that deletion.
- **Not verified in a browser.** The removals should be invisible by construction; `.bm-note`'s padding shifts ~0.6px adopting `-dense`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
