### PR TITLE
Fix the token scope that made the tooltip override dead, and drain the scenario tail

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -41,19 +41,25 @@ primitives still being extracted lives in `docs/todo/UX_PRIMITIVES_PLAN.md`.
 
 | Scenario | Use | Never |
 |------|-----|-------|
-| Secondary / muted text (hint, subtitle, caption, meta) | `.cc-muted` (+ `-dense`/`-micro` in dense chrome) | a scoped `color: var(--cc-text-dim); font-size: …` |
+| Secondary / muted text (hint, subtitle, caption, meta) | `.cc-muted` (+ `-lg`/`-md`/`-xs`/`-2xs`/`-3xs` — the modifier NAMES the scale step) | a scoped `color: var(--cc-text-dim); font-size: …` |
 | Small dim label beside a control | `.cc-muted` — same scenario, no separate utility | a per-file `.*-lbl`/`.*-label` |
 | Empty / "nothing here yet" state | `.cc-empty` (+ `-inline` one-liner / `-overlay` over a plot / `-lg` rich page empty) | a new `.*-empty` class |
-| Numeric value readout beside a control | `.cc-readout` (+ `-strong` prominent, `-dense` inline) | a bespoke `.*-val`/`.*-num` |
-| Eyebrow / section label (uppercase dim heading) | `.cc-eyebrow` (+ `-dense` list/table headers, `-micro` whiteboard-node labels) | a scoped uppercase-heading rule |
+| Numeric value readout beside a control | `.cc-readout` (+ `-strong` prominent; `-xs`/`-2xs` in dense chrome) | a bespoke `.*-val`/`.*-num` |
+| Eyebrow / section label (uppercase dim heading) | `.cc-eyebrow` (base is 11px; + `-2xs` list/table headers, `-3xs` whiteboard-node labels) | a scoped uppercase-heading rule |
 | Card / panel / surface container | `.cc-card` (+ `-2` when it sits *on* a surface-1 panel) | a scoped `surface + 1px border + radius` block |
 | Corner radius | `--cc-radius-xs/sm/md/lg/pill` | a raw `rem`/`px` radius |
 | Small text size | `--cc-fs-3xs/2xs/xs/sm/md/lg` | a raw `rem`/`px` font-size (incl. inline `style=`) |
-| Compact input / select / textarea | `.cc-input-dense` (11px) / `.cc-input-micro` (10px) — sets size AND padding. **The base is already 12px**, so most fields need neither | a scoped class re-typing the base's border/colour/background to change the size |
+| Compact input / select / textarea | `.cc-input-xs` (11px) / `.cc-input-2xs` (10px) — sets size AND padding. **The base is already 12px**, so most fields need neither | a scoped class re-typing the base's border/colour/background to change the size |
 | A colour a token already holds | that token — `var(--cc-accent)`, not `#a78bfa` | a hex literal, **or** a `var(--x, #hex)` fallback (add the token, never a fallback) |
 
-**Each utility varies on exactly one axis, and the modifier is that axis** — density (`-dense`/`-micro`),
-surface (`-2`), layout (`-inline`/`-overlay`/`-lg`). Reach for the modifier instead of re-declaring the
+**Each utility varies on exactly one axis, and the modifier is that axis** — density (a step on the
+`--cc-fs-*` scale), surface (`-2`), layout (`-inline`/`-overlay`/`-lg`).
+
+**Density modifiers name the scale step, not a relative amount** (`-xs`, not `-dense`). A relative name
+can only express the steps someone thought of: `.cc-muted` had no 11px step — the single largest cluster
+of hand-rolled muted text in the app — because "dense" was already spent on 10px, and there was no name
+at all for the step *above* the base. `-dense` was not even a consistent step: two tiers below
+`.cc-muted`'s base and one below `.cc-eyebrow`'s. Naming the step makes the axis complete by construction. Reach for the modifier instead of re-declaring the
 scenario locally: baking a value into the base is what stranded ~10 sites as "bespoke" before. Per-site
 *emphasis* (`font-style: italic`) and *geometry* (width/margin/flex/padding) still belong in scoped CSS.
 
@@ -89,7 +95,7 @@ the bug. Add layout in scoped CSS; never re-state a property the utility itself 
 **A tier that most sites override is the wrong default.** The form-control base was `--cc-fs-md` (= body)
 and read as "the fields are too big" in every dialog — twice reported from the running app. The fix was
 not another opt-in class: **33 form controls across 24 files had each hand-written
-`font-size: var(--cc-fs-sm)`**, while exactly *one* site had ever adopted `.cc-input-dense`. When two
+`font-size: var(--cc-fs-sm)`**, while exactly *one* site had ever adopted the density class. When two
 thirds of the population corrects the default by hand, the default is wrong. The base is `--cc-fs-sm`
 (12px) now, the density steps re-pitched below it, and those 33 declarations are gone as provable no-ops.
 The same rounding caused the tooltip regression (`0.72rem` → nearest step, which happened to be the larger
@@ -103,6 +109,16 @@ Touch a file, migrate its rules and lower its number; add a new one and the suit
 is deliberately *not* checked: `surface + border + radius` is the shape of a card, an input, a chip, a
 badge and an icon-button alike, and ~60% of matches wanted `.cc-btn`/`ChipSelect` instead, so it stays a
 review-time rule.
+
+**Tokens live on `:root`, and that is load-bearing.** `.cc-dark` is a `<div>` inside `<body>`
+(`App.vue`'s shell), so anything a library appends to `document.body` is a *sibling* of it and inherits
+nothing declared there. PrimeVue's tooltip does exactly that — so while the scale sat on `.cc-dark`,
+every `var(--cc-*)` in the tooltip override was invalid at computed-value time and the tooltip rendered
+at the browser default **16px**, with `<body>`'s own `font-size` dead the same way. Declared ≠ reachable,
+and the symptoms are identical, which is why the token guard stayed green throughout. If you style
+anything that mounts outside the app shell (a portal, teleport, or library overlay), check that the
+properties it references resolve *there*. `utils/cssTokens.test.ts` now fails if the global scale is
+declared anywhere but `:root`.
 
 **Every custom property you reference must be declared somewhere.** An undeclared one does not warn —
 it makes the whole declaration invalid at computed-value time, so `var(--cc-text-muted, #888)` silently

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -34,6 +34,7 @@ read these; do not re-derive one by grep.
 | `findRawColours` + `colourTokens` | `cssScenarios.ts` | a hex a token already holds exactly; any `var(--x, #hex)` fallback | must be empty |
 | `findRestatedInputBase` + `inputBase` | `cssScenarios.ts` | form-control rules re-stating the global input base | exact list (2 survivors, each a class shared with a non-input element) |
 | `findDeadTokenRefs` | `cssTokens.ts` | a reference to a `--*` property `style.css` never declares | must be empty |
+| `findNonRootTokenDecls` | `cssTokens.ts` | the global scale declared anywhere but `:root` (declared ≠ *reachable*) | must be empty |
 
 Shared plumbing at the top of `cssScenarios.ts`: `styleBlocks()` and `cssRules()` (which recurses into
 `@media`). `SCENARIO_HINT` supplies the "migrate it to this" text the ratchet prints. Three things that
@@ -53,8 +54,8 @@ are easy to break:
 - **The scenario backlog.** The live list is the per-file `BASELINE` in `cssScenarios.test.ts`; it may
   shrink and must never grow. Touch a file in it → migrate its rules and lower the number. Deliberately
   decoupled from "finish the sweep": new divergence fails immediately, the backlog drains as files get
-  touched. Roughly half the listed files hold one or two rules apiece, so those are one-line diffs;
-  the failure message now names the offending selector and the utility it wants.
+  touched. The ≤2-rule tail has been drained (45 files → 20), so what's left is the concentrated
+  remainder; the failure message names the offending selector and the utility it wants.
 - **Per-row disclosure in a list** (`TaskList`, `ErrorConsole`) — distinct from a section header, and
   deliberately NOT extracted. Inspected, the two sites differ on **four** axes: `TaskList` uses a
   focusable `<button>` (already `.cc-btn-bare .cc-btn-icon`) with a tooltip, the icon as click target and
@@ -99,7 +100,9 @@ The blow-by-blow is in git (`git log --oneline -- frontend/src/style.css`). What
 2. **A utility that hard-codes a value on an axis where sites legitimately differ will not be adopted.**
    Every site written off as "bespoke" had this one cause. There were only three such axes — density,
    surface, layout — and giving each scenario its missing modifier turned the whole stalled list into
-   mechanical migrations.
+   mechanical migrations. **Name the modifier after the scale step it selects, not a relative amount**
+   (`-xs`, not `-dense`) — a relative name can only express the steps you thought of, which is how
+   `.cc-muted` ended up with no 11px step under the largest remaining cluster of hand-rolled text.
 3. **A tier most sites override by hand is the wrong default.** Corollary of (2), and the more expensive
    half: the form-control base sat a step too large, so 33 controls across 24 files each hand-wrote the
    size they wanted while exactly one adopted the opt-in class. Count the overrides before adding
@@ -107,19 +110,27 @@ The blow-by-blow is in git (`git log --oneline -- frontend/src/style.css`). What
 4. **When tokenising a value between two steps, check which side the element belongs on.** Rounding to
    the nearest step took the input base and the tooltip *up* into body size; both surfaced later as
    visible regressions. Dense chrome rounds down.
-5. **A matcher pinned to one spelling has a blind spot, and they all look alike.** Four of them so far:
+5. **Declared is not reachable, and a green guard can mean neither.** The token scale sat on
+   `.cc-dark`, a `<div>` inside `<body>`, so PrimeVue's tooltip — which it appends to `document.body` —
+   resolved none of it and rendered at the browser default 16px for months. `findDeadTokenRefs` was
+   green and correct throughout: the tokens *were* declared. Two visible regressions were misdiagnosed
+   as rounding before anyone checked the DOM. When a value refuses to change, verify the rule is
+   *reaching* the element before tuning the value again — and note the sweep is what broke it, by
+   turning a working literal into a token reference in a scope that has no tokens.
+
+6. **A matcher pinned to one spelling has a blind spot, and they all look alike.** Four of them so far:
    reading only `<style>` blocks (inline `style="font-size:…"` invisible); keying on a *literal* size (so
    tokenising silently un-flagged a rule); keying on `var(--cc-text-dim)` and missing the
    `var(--cc-text-dim, #8b8ca7)` spelling; and `\b(select)\b` matching inside `.chip-select`, because a
    hyphen is a word boundary. When adding a matcher, ask which other spellings of the same declaration
    exist — token vs literal, with fallback vs without, scoped vs inline — and judge a rule by its
    **subject** compound, not any part of the selector.
-6. **CSS cannot express intent, so prefer precision over recall.** A button, a card, a chip, a badge and
+7. **CSS cannot express intent, so prefer precision over recall.** A button, a card, a chip, a badge and
    an input are all `surface + 1px border + radius` — which is why the `card` matcher was dropped, and
    why `.cc-btn-icon`'s fixed square collapsed two full-height strip controls that were markup-identical
    to an icon button. A noisy check grows an allow-list, and the allow-list is where this rots. Where a
    detector can't be precise, the category gets a review-time rule in `docs/UI.md` and no number at all.
-7. **A rule stated in one place while its neighbour keeps doing the old thing is the recurring tell.**
+8. **A rule stated in one place while its neighbour keeps doing the old thing is the recurring tell.**
    The ratchet was first built with the largest category carved out of it; the "no counts" rule was added
    to one section while the table above it kept its stale counts; the size audit counted `rem` and
    ignored `px`. When you add a rule here, grep the whole file for what it forbids before claiming it

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -144,7 +144,7 @@ function isNavDisabled(item: NavItem): boolean {
             <span class="proj-name" v-tooltip.right="`Project: ${projectMeta.current.name} (${projectMeta.current.type})`">
               {{ projectMeta.current.name }}
             </span>
-            <span class="proj-type">{{ projectMeta.current.type }}</span>
+            <span class="proj-type cc-eyebrow cc-eyebrow-2xs">{{ projectMeta.current.type }}</span>
           </div>
           <!-- no manual save: the /analysis boards autosave; everything else persists on edit -->
           <button class="proj-menu-btn cc-btn cc-btn-bare cc-btn-icon" @click="showPanel = true"
@@ -185,7 +185,7 @@ function isNavDisabled(item: NavItem): boolean {
             <i :class="['pi', item.icon, 'nav-icon']" />
             <span class="nav-label">{{ item.label }}</span>
             <span v-if="item.soon" class="soon-badge">soon</span>
-            <span v-else-if="item.requiresProject && !projectMeta.hasProject" class="lock-badge"
+            <span v-else-if="item.requiresProject && !projectMeta.hasProject" class="lock-badge cc-muted cc-muted-xs"
               v-tooltip.right="'Requires an open project.'">
               <i class="pi pi-lock" />
             </span>
@@ -302,12 +302,7 @@ function isNavDisabled(item: NavItem): boolean {
   text-overflow: ellipsis;
   cursor: default;
 }
-.proj-type {
-  font-size: var(--cc-fs-2xs);
-  color: var(--cc-text-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
+
 /* .proj-menu-btn → cc-btn cc-btn-bare cc-btn-icon */
 .proj-menu-btn:hover { background: var(--cc-surface-2); color: var(--cc-text); }
 
@@ -425,7 +420,7 @@ function isNavDisabled(item: NavItem): boolean {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.lock-badge { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); opacity: 0.7; }
+.lock-badge { opacity: 0.7; }
 
 /* ── Footer: quick app controls, pinned to the bottom ──────────────────────── */
 .sidebar-footer {

--- a/frontend/src/components/ChainLiveLabel.vue
+++ b/frontend/src/components/ChainLiveLabel.vue
@@ -15,14 +15,14 @@ defineProps<{
 </script>
 
 <template>
-  <div class="live-label cc-muted cc-muted-dense" :class="data.kind">
+  <div class="live-label cc-muted cc-muted-2xs" :class="data.kind">
     <span class="live-label-text">{{ data.text }}</span>
     <span v-if="data.sub" class="live-label-sub">{{ data.sub }}</span>
   </div>
 </template>
 
 <style scoped>
-/* + cc-muted cc-muted-dense (colour + the 10px tier); the rest is this label's geometry */
+/* + cc-muted cc-muted-2xs (colour + the 10px tier); the rest is this label's geometry */
 .live-label {
   white-space: nowrap;
   pointer-events: none;

--- a/frontend/src/components/ChainQcNode.vue
+++ b/frontend/src/components/ChainQcNode.vue
@@ -35,12 +35,12 @@ const fmt = (n?: number) => n == null ? '—' : n.toLocaleString()
       <span class="qc-name">{{ data.valueName }}</span>
       <span v-if="data.loading" class="qc-spin"><i class="pi pi-spin pi-spinner" /></span>
     </div>
-    <div class="qc-count">{{ fmt(data.total) }} <span class="qc-unit cc-muted cc-muted-micro">cells</span></div>
+    <div class="qc-count">{{ fmt(data.total) }} <span class="qc-unit cc-muted cc-muted-3xs">cells</span></div>
     <div class="qc-spark">
       <span v-for="(h, i) in bars" :key="i" class="qc-bar" :style="{ height: h + 'px' }" />
-      <span v-if="!bars.length" class="qc-empty cc-empty-inline cc-muted-micro">no data</span>
+      <span v-if="!bars.length" class="qc-empty cc-empty-inline cc-muted-3xs">no data</span>
     </div>
-    <div class="qc-foot cc-eyebrow cc-eyebrow-micro">{{ data.imageCount ?? 0 }} img · expand</div>
+    <div class="qc-foot cc-eyebrow cc-eyebrow-3xs">{{ data.imageCount ?? 0 }} img · expand</div>
   </div>
 </template>
 
@@ -59,11 +59,11 @@ const fmt = (n?: number) => n == null ? '—' : n.toLocaleString()
 .qc-name { font-size: var(--cc-fs-3xs); font-weight: 700; font-family: var(--cc-mono, monospace); letter-spacing: 0.04em; }
 .qc-spin { margin-left: auto; font-size: var(--cc-fs-2xs); opacity: 0.7; }
 .qc-count { font-size: var(--cc-fs-lg); font-weight: 700; color: var(--cc-text); margin: 2px 0; }
-/* + cc-muted cc-muted-micro — the weight reset is this site's (it sits inside a 700 count) */
+/* + cc-muted cc-muted-3xs — the weight reset is this site's (it sits inside a 700 count) */
 .qc-unit { font-weight: 400; }
 .qc-spark { display: flex; align-items: flex-end; gap: 2px; height: 24px; }
 /* 1px is deliberate and off-scale: --cc-radius-xs (3px) on a 4px-wide bar rounds it to a blob */
 .qc-bar { width: 4px; background: var(--cc-accent); opacity: 0.7; border-radius: 1px; }
-.qc-empty { font-style: italic; }   /* + .cc-empty-inline .cc-muted-micro (row/colour/9px tier) */
-.qc-foot { margin-top: 2px; }   /* + cc-eyebrow cc-eyebrow-micro */
+.qc-empty { font-style: italic; }   /* + .cc-empty-inline .cc-muted-3xs (row/colour/9px tier) */
+.qc-foot { margin-top: 2px; }   /* + cc-eyebrow cc-eyebrow-3xs */
 </style>

--- a/frontend/src/components/ChainStartNode.vue
+++ b/frontend/src/components/ChainStartNode.vue
@@ -14,7 +14,7 @@ defineProps<{ id: string; selected: boolean }>()
 <template>
   <div class="chain-start-node" :class="{ selected }" title="Start — link to the task(s) a run begins from">
     <span class="start-dot" />
-    <span class="cc-eyebrow cc-eyebrow-micro">start</span>
+    <span class="cc-eyebrow cc-eyebrow-3xs">start</span>
     <!-- initial node: source only (no target handle) -->
     <Handle type="source" :position="Position.Right" class="node-handle" />
   </div>

--- a/frontend/src/components/ChainTaskNode.vue
+++ b/frontend/src/components/ChainTaskNode.vue
@@ -21,10 +21,10 @@ defineProps<{
 
     <div class="node-scope" :title="`scope: ${data.scope}`">
       <span class="scope-dot" />
-      <span class="cc-eyebrow cc-eyebrow-micro">{{ data.scope }}</span>
+      <span class="cc-eyebrow cc-eyebrow-3xs">{{ data.scope }}</span>
     </div>
     <div class="node-label">{{ data.label || data.fn }}</div>
-    <div class="node-fn cc-muted cc-muted-dense">{{ data.fn }}</div>
+    <div class="node-fn cc-muted cc-muted-2xs">{{ data.fn }}</div>
     <div v-if="data.resource_pool" class="node-pool">
       <i class="pi pi-server" style="font-size:var(--cc-fs-2xs)" />
       {{ data.resource_pool }}
@@ -78,7 +78,7 @@ defineProps<{
   text-overflow: ellipsis;
   max-width: 160px;
 }
-/* + cc-muted cc-muted-dense — the mono face and truncation are this site's */
+/* + cc-muted cc-muted-2xs — the mono face and truncation are this site's */
 .node-fn {
   font-family: var(--cc-mono);
   margin-top: 2px;

--- a/frontend/src/components/ClaudeOverviewDialog.vue
+++ b/frontend/src/components/ClaudeOverviewDialog.vue
@@ -19,7 +19,7 @@ defineEmits<{ (e: 'close'): void }>()
     <div class="co-entries">
       <div v-for="e in CLAUDE_ENTRY_POINTS" :key="e.name" class="co-entry cc-card cc-card-2">
         <div class="co-entry-head"><i :class="['pi', e.icon]" /> {{ e.name }}</div>
-        <p class="co-entry-what">{{ e.what }}</p>
+        <p class="co-entry-what cc-muted cc-muted-md">{{ e.what }}</p>
         <ol class="co-steps">
           <li v-for="(s, i) in e.steps" :key="i">{{ s }}</li>
         </ol>
@@ -38,7 +38,7 @@ defineEmits<{ (e: 'close'): void }>()
 
     <!-- example prompts to try -->
     <div class="co-examples">
-      <span class="co-examples-label">Try asking</span>
+      <span class="co-examples-label cc-muted">Try asking</span>
       <div class="co-chips">
         <span v-for="(ex, i) in CLAUDE_EXAMPLES" :key="i" class="co-chip">{{ ex }}</span>
       </div>
@@ -52,7 +52,7 @@ defineEmits<{ (e: 'close'): void }>()
 .co-entry { padding: 14px 16px; }
 .co-entry-head { font-weight: 600; color: var(--cc-text); display: flex; align-items: center; gap: 6px; }
 .co-entry-head .pi { color: var(--cc-accent); }
-.co-entry-what { margin: 8px 0 10px; color: var(--cc-text-dim); font-size: var(--cc-fs-md); line-height: 1.4; }
+.co-entry-what { margin: 8px 0 10px; line-height: 1.4; }
 .co-steps { margin: 0; padding-left: 18px; color: var(--cc-text); font-size: var(--cc-fs-md); line-height: 1.55; }
 
 .co-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
@@ -66,7 +66,7 @@ defineEmits<{ (e: 'close'): void }>()
 .co-cell.tone-muted .co-cell-head { color: var(--cc-text-dim); }
 
 .co-examples { margin-top: 18px; }
-.co-examples-label { display: block; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin-bottom: 6px; }
+.co-examples-label { display: block; margin-bottom: 6px; }
 .co-chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .co-chip {
   font-size: var(--cc-fs-sm); color: var(--cc-text); background: var(--cc-surface-2);

--- a/frontend/src/components/CohortCheckButton.vue
+++ b/frontend/src/components/CohortCheckButton.vue
@@ -76,7 +76,7 @@ async function check() {
 
 <template>
   <span v-if="canCheck" class="cohort-check">
-    <label v-if="showSelector" class="cohort-run" v-tooltip.bottom="'Which clustering run to check'">
+    <label v-if="showSelector" class="cohort-run cc-muted" v-tooltip.bottom="'Which clustering run to check'">
       run:
       <select v-model="selectedRun" :disabled="busy">
         <option value="">All runs</option>
@@ -93,10 +93,7 @@ async function check() {
 
 <style scoped>
 .cohort-check { display: inline-flex; align-items: center; gap: 0.35rem; }
-.cohort-run {
-  display: inline-flex; align-items: center; gap: 0.25rem;
-  font-size: var(--cc-fs-sm); color: var(--cc-text-dim);
-}
+.cohort-run { display: inline-flex; align-items: center; gap: 0.25rem; }
 .cohort-run select { padding: 0.15rem 0.3rem; border-radius: var(--cc-radius-sm); cursor: pointer;
 }
 .cohort-run select:disabled { opacity: 0.6; cursor: default; }

--- a/frontend/src/components/CopyDialog.vue
+++ b/frontend/src/components/CopyDialog.vue
@@ -83,21 +83,21 @@ function copyImage() {
     </template>
 
     <div v-if="valueNames.length > 1" class="copy-row">
-      <span class="copy-lbl" v-tooltip.right="'Which image version to copy (becomes the copy\'s default)'">Version</span>
+      <span class="copy-lbl cc-muted" v-tooltip.right="'Which image version to copy (becomes the copy\'s default)'">Version</span>
       <select v-model="selectedValueName" class="copy-select">
         <option v-for="vn in valueNames" :key="vn" :value="vn">{{ vn }}</option>
       </select>
     </div>
 
     <div class="copy-row">
-      <span class="copy-lbl" v-tooltip.right="'Where to put the copy (data IS duplicated on disk).'">To set</span>
+      <span class="copy-lbl cc-muted" v-tooltip.right="'Where to put the copy (data IS duplicated on disk).'">To set</span>
       <select v-model="targetUid" class="copy-select">
         <option v-for="s in allSets" :key="s.uid" :value="s.uid">{{ s.name }}</option>
         <option value="">＋ New set…</option>
       </select>
     </div>
     <div v-if="!targetUid" class="copy-row">
-      <span class="copy-lbl" />
+      <span class="copy-lbl cc-muted" />
       <input class="copy-name-input" v-model="newName" placeholder="New set name…"
              @keydown.enter="copyImage" autofocus />
     </div>
@@ -118,7 +118,7 @@ function copyImage() {
 
 <style scoped>
 .copy-row { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.55rem; }
-.copy-lbl { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); width: 4rem; flex-shrink: 0; }
+.copy-lbl { width: 4rem; flex-shrink: 0; }
 .copy-select, .copy-name-input { flex: 1 1 auto; }
 .copy-hint { font-size: var(--cc-fs-xs); font-style: italic; margin: 0.3rem 0 0; }   /* + .cc-muted (colour) */
 .copy-version-tag {

--- a/frontend/src/components/CropDialog.vue
+++ b/frontend/src/components/CropDialog.vue
@@ -37,7 +37,7 @@ function defaultValueName(): string {
       <span v-if="selectedValueName" class="crop-version-tag">{{ selectedValueName }}</span>
     </template>
     <div v-if="valueNames.length > 1" class="crop-version-row">
-      <span class="crop-version-lbl" v-tooltip.right="'Which image version/iteration to crop'">Version</span>
+      <span class="crop-version-lbl cc-muted cc-muted-xs" v-tooltip.right="'Which image version/iteration to crop'">Version</span>
       <select v-model="selectedValueName" class="crop-version-select">
         <option v-for="vn in valueNames" :key="vn" :value="vn">{{ vn }}</option>
       </select>
@@ -53,7 +53,7 @@ function defaultValueName(): string {
 
 <style scoped>
 .crop-version-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem; }
-.crop-version-lbl { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
+
 .crop-version-select { flex: 0 1 auto; }
 .crop-version-tag {
   margin-left: 0.4rem; padding: 0.05rem 0.4rem; border-radius: var(--cc-radius-lg);

--- a/frontend/src/components/CropPanel.vue
+++ b/frontend/src/components/CropPanel.vue
@@ -136,17 +136,17 @@ function save() {
       </div>
 
       <div v-if="info.nT > 1" class="crop-row">
-        <span class="crop-lbl" v-tooltip.top="'Scrub timepoints to pick the clearest footprint'">frame</span>
+        <span class="crop-lbl cc-muted cc-muted-xs" v-tooltip.top="'Scrub timepoints to pick the clearest footprint'">frame</span>
         <input type="range" min="0" :max="info.nT - 1" v-model.number="t" />
         <span class="crop-tval">{{ t + 1 }}/{{ info.nT }}</span>
       </div>
       <div v-if="info.nZ > 1" class="crop-row">
-        <span class="crop-lbl" v-tooltip.top="'Keep this z-range — also re-projects the preview to just these slices'">z</span>
+        <span class="crop-lbl cc-muted cc-muted-xs" v-tooltip.top="'Keep this z-range — also re-projects the preview to just these slices'">z</span>
         <RangeSlider v-model:lo="zLo" v-model:hi="zHi" />
         <span class="crop-tval">{{ zLabel }}</span>
       </div>
       <div v-if="info.nT > 1" class="crop-row">
-        <span class="crop-lbl" v-tooltip.top="'Keep this time range'">t</span>
+        <span class="crop-lbl cc-muted cc-muted-xs" v-tooltip.top="'Keep this time range'">t</span>
         <RangeSlider v-model:lo="tLo" v-model:hi="tHi" />
         <span class="crop-tval">{{ tLabel }}</span>
       </div>
@@ -178,7 +178,7 @@ function save() {
 .crop-loading { position: absolute; top: 0.3rem; right: 0.3rem; color: var(--cc-accent); font-size: var(--cc-fs-md); }
 .crop-row { display: flex; align-items: center; gap: 0.4rem; }
 .crop-row input[type=range] { flex: 1 1 auto; }
-.crop-lbl { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); width: 2.6rem; }
+.crop-lbl { width: 2.6rem; }
 .crop-tval { font-size: var(--cc-fs-2xs); color: var(--cc-text); width: 4.2rem; text-align: right; font-variant-numeric: tabular-nums; }
 .crop-actions { display: flex; gap: 0.4rem; }
 .crop-hint { font-size: var(--cc-fs-xs); font-style: italic; }   /* + .cc-muted (colour) */

--- a/frontend/src/components/ErrorConsole.vue
+++ b/frontend/src/components/ErrorConsole.vue
@@ -73,7 +73,7 @@ const filterOptions = computed<ChipOption[]>(() =>
       Console
     </span>
 
-    <span v-if="log.lastEntry" class="bar-last" :class="log.lastEntry.level">
+    <span v-if="log.lastEntry" class="bar-last cc-muted" :class="log.lastEntry.level">
       <span class="lvl-dot" />
       {{ log.lastEntry.message }}
     </span>
@@ -153,7 +153,7 @@ const filterOptions = computed<ChipOption[]>(() =>
         <pre v-if="expandedId === entry.id && entry.detail" class="detail">{{ entry.detail }}</pre>
       </div>
 
-      <div v-if="visible.length === 0" class="empty">
+      <div v-if="visible.length === 0" class="empty cc-empty">
         No {{ filter === 'all' ? '' : filter + ' ' }}messages
       </div>
     </div>
@@ -191,17 +191,7 @@ const filterOptions = computed<ChipOption[]>(() =>
 }
 .console-bar:hover { background: var(--cc-surface-2); }
 
-.bar-last {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: var(--cc-fs-sm);
-  flex: 1;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  color: var(--cc-text-dim);
-}
+.bar-last { display: flex; align-items: center; gap: 0.4rem; flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .bar-last.error { color: #fca5a5; }
 .bar-last.warn  { color: #fcd34d; }
 .bar-last.info  { color: var(--cc-text-dim); }
@@ -315,10 +305,6 @@ const filterOptions = computed<ChipOption[]>(() =>
   overflow-x: auto;
 }
 
-.empty {
-  padding: 1.5rem;
-  text-align: center;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-md);
-}
+/* + cc-empty — padding is this console's own geometry, the rest is the scenario */
+.empty { padding: 1.5rem; }
 </style>

--- a/frontend/src/components/FileBrowser.vue
+++ b/frontend/src/components/FileBrowser.vue
@@ -160,11 +160,11 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 
       <!-- body -->
       <div class="fb-body">
-        <div v-if="loading" class="fb-state">
+        <div v-if="loading" class="fb-state cc-muted cc-muted-md">
           <i class="pi pi-spin pi-cog" /> Loading…
         </div>
 
-        <div v-else-if="error" class="fb-state error">
+        <div v-else-if="error" class="fb-state error cc-muted cc-muted-md">
           <i class="pi pi-exclamation-triangle" /> {{ error }}
           <button class="cc-btn cc-btn-ghost" @click="navigate('')">Back to home</button>
         </div>
@@ -196,7 +196,7 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
                 <i class="pi pi-arrow-up row-icon" />
                 <span class="row-name">..</span>
               </td>
-              <td class="col-type dim">parent</td>
+              <td class="col-type dim cc-muted">parent</td>
               <td class="col-size" />
             </tr>
 
@@ -232,8 +232,8 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
                 ]" />
                 <span class="row-name">{{ entry.name }}</span>
               </td>
-              <td class="col-type dim">{{ entry.isdir ? 'folder' : entry.ext }}</td>
-              <td class="col-size dim">{{ entry.isdir ? '' : formatSize(entry.size) }}</td>
+              <td class="col-type dim cc-muted">{{ entry.isdir ? 'folder' : entry.ext }}</td>
+              <td class="col-size dim cc-muted">{{ entry.isdir ? '' : formatSize(entry.size) }}</td>
             </tr>
 
             <tr v-if="listing && listing.entries.length === 0">
@@ -248,7 +248,7 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
       <span class="sel-count" v-else-if="selected.size > 0">
         {{ selected.size }} {{ mode === 'bundle' ? 'bundle' : 'file' }}{{ selected.size > 1 ? 's' : '' }} selected
       </span>
-      <span class="sel-count dim" v-else>{{ mode === 'bundle' ? 'No bundle selected' : 'No files selected' }}</span>
+      <span class="sel-count dim cc-muted" v-else>{{ mode === 'bundle' ? 'No bundle selected' : 'No files selected' }}</span>
 
       <div class="footer-actions">
         <button class="cc-btn cc-btn-ghost" @click="$emit('close')"
@@ -312,10 +312,7 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 
 /* body — BaseModal's cc-modal-body owns the scroll; .fb-body needs no shell styling. */
 
-.fb-state {
-  display: flex; align-items: center; gap: 0.5rem;
-  padding: 2rem; color: var(--cc-text-dim); font-size: var(--cc-fs-md);
-}
+.fb-state { display: flex; align-items: center; gap: 0.5rem; padding: 2rem; }
 .fb-state.error { color: #fca5a5; flex-direction: column; align-items: flex-start; }
 
 /* table */
@@ -352,7 +349,6 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 
 .col-name { display: table-cell; }
 .row-name { vertical-align: middle; }
-.dim { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
 
 .fb-empty { text-align: center; padding: 2rem; }   /* + .cc-muted */
 

--- a/frontend/src/components/LegacyMigrateDialog.vue
+++ b/frontend/src/components/LegacyMigrateDialog.vue
@@ -124,7 +124,7 @@ async function confirmImport() {
     <div v-if="done" class="lm lm-donebox">
       <p class="lm-doneline"><i class="pi pi-check-circle" /> Added <strong>{{ done }}</strong>
         image{{ done === 1 ? '' : 's' }} to the set.</p>
-      <p class="lm-lead">
+      <p class="lm-lead cc-muted cc-muted-lg">
         These are placeholders — no data has moved yet. To transfer the images, segmentation and
         tracking, select them and run the <strong>“Migrate legacy image”</strong> task from the task
         panel.
@@ -132,7 +132,7 @@ async function confirmImport() {
     </div>
 
     <div v-else class="lm">
-      <p class="lm-lead">
+      <p class="lm-lead cc-muted cc-muted-lg">
         Import images, segmentation &amp; tracking from an old (R/Shiny) cecelia project.
         <strong>Clustering, gating and HMM aren’t transferred.</strong> The source is never modified.
       </p>
@@ -235,7 +235,7 @@ async function confirmImport() {
 
 <style scoped>
 .lm { display: flex; flex-direction: column; gap: 0.75rem; color: var(--cc-text); }
-.lm-lead { margin: 0; font-size: var(--cc-fs-lg); color: var(--cc-text-dim); }
+.lm-lead { margin: 0; }
 .lm-donebox { padding: 0.5rem 0.25rem; }
 .lm-doneline { margin: 0 0 0.4rem; font-size: 1rem; color: var(--cc-text); }
 .lm-doneline .pi-check-circle { color: #4ade80; margin-right: 0.35rem; }

--- a/frontend/src/components/PhysicalSizeDialog.vue
+++ b/frontend/src/components/PhysicalSizeDialog.vue
@@ -272,15 +272,15 @@ async function fillFlagged() {
           v-tooltip.bottom="'Which fields Apply / Copy / Fill flagged write — untick what\'s already correct.'" />
 
         <div class="dims-row" :class="{ excluded: !includeX && !includeY && !includeZ }">
-          <label class="dim-label" v-tooltip.bottom="'Pixel size in X'">X</label>
+          <label class="dim-label cc-muted" v-tooltip.bottom="'Pixel size in X'">X</label>
           <input class="field-input" :class="{ warn: targetFlags.has('x'), mixed: isMixed('physicalSizeX') }"
             type="number" step="any" v-model.number="physX" :disabled="!includeX" placeholder="—"
             v-tooltip.bottom="isMixed('physicalSizeX') ? 'Other selected images have a different X — this is just ' + focusedImg?.name + '\'s.' : null" />
-          <label class="dim-label" v-tooltip.bottom="'Pixel size in Y'">Y</label>
+          <label class="dim-label cc-muted" v-tooltip.bottom="'Pixel size in Y'">Y</label>
           <input class="field-input" :class="{ warn: targetFlags.has('y'), mixed: isMixed('physicalSizeY') }"
             type="number" step="any" v-model.number="physY" :disabled="!includeY" placeholder="—"
             v-tooltip.bottom="isMixed('physicalSizeY') ? 'Other selected images have a different Y — this is just ' + focusedImg?.name + '\'s.' : null" />
-          <label class="dim-label" v-tooltip.bottom="'Voxel depth — the Z step'">Z</label>
+          <label class="dim-label cc-muted" v-tooltip.bottom="'Voxel depth — the Z step'">Z</label>
           <input class="field-input" :class="{ warn: targetFlags.has('z'), mixed: isMixed('physicalSizeZ') }"
             type="number" step="any" v-model.number="physZ" :disabled="!includeZ" placeholder="—"
             v-tooltip.bottom="isMixed('physicalSizeZ') ? 'Other selected images have a different Z — this is just ' + focusedImg?.name + '\'s.' : null" />
@@ -292,7 +292,7 @@ async function fillFlagged() {
         </div>
 
         <div class="dims-row" :class="{ excluded: !includeT }">
-          <label class="dim-label" v-tooltip.bottom="'Time between frames'">Δt</label>
+          <label class="dim-label cc-muted" v-tooltip.bottom="'Time between frames'">Δt</label>
           <input class="field-input" :class="{ warn: targetFlags.has('t'), mixed: isMixed('timeIncrement') }"
             type="number" step="any" v-model.number="timeInc" :disabled="!includeT" placeholder="—"
             v-tooltip.bottom="isMixed('timeIncrement') ? 'Other selected images have a different Δt — this is just ' + focusedImg?.name + '\'s.' : null" />
@@ -351,10 +351,7 @@ async function fillFlagged() {
 
 .dims-row { display: flex; align-items: center; gap: 0.4rem; transition: opacity 0.1s; }
 .dims-row.excluded { opacity: 0.4; }
-.dim-label {
-  flex-shrink: 0; width: 1.2rem; text-align: right;
-  font-size: var(--cc-fs-sm); font-weight: 600; color: var(--cc-text-dim);
-}
+.dim-label { flex-shrink: 0; width: 1.2rem; text-align: right; font-weight: 600; }
 .field-input { flex: 1; min-width: 0; }
 .field-input.warn { border-color: var(--cc-sev-warn) !important; background: #7c2d1222; }
 .field-input.mixed { border: 1px dashed #60a5fa !important; background: #1e3a5f55; cursor: help; }

--- a/frontend/src/components/PoolThrottle.vue
+++ b/frontend/src/components/PoolThrottle.vue
@@ -84,14 +84,14 @@ onUnmounted(() => { if (timer) clearInterval(timer) })
                @input="pools[name] = +($event.target as HTMLInputElement).value"
                @change="setPool(name, +($event.target as HTMLInputElement).value)" />
         <!-- live occupancy: how many tasks are running now vs the limit, + any queued for this pool -->
-        <div class="pt-occ" :class="{ busy: runningOf(name) > 0 || queuedOf(name) > 0 }">
+        <div class="pt-occ cc-readout cc-readout-2xs" :class="{ busy: runningOf(name) > 0 || queuedOf(name) > 0 }">
           <span><span class="pt-occ-n">{{ runningOf(name) }}</span><span class="pt-occ-sep">/</span>{{ pools[name] }} running</span>
           <span v-if="queuedOf(name) > 0" class="pt-occ-q">+{{ queuedOf(name) }} queued</span>
         </div>
         <div class="pt-bar"><div class="pt-bar-fill" :style="{ width: fillPct(name) }" /></div>
       </div>
     </div>
-    <p class="pt-hint">Lower to throttle, raise to run more at once. Saved automatically.</p>
+    <p class="pt-hint cc-muted cc-muted-xs">Lower to throttle, raise to run more at once. Saved automatically.</p>
   </div>
 </template>
 
@@ -107,10 +107,7 @@ onUnmounted(() => { if (timer) clearInterval(timer) })
 .pt-slider:disabled { opacity: 0.5; cursor: default; }
 
 /* live occupancy readout under each slider — dim when idle, brightens when the pool is busy */
-.pt-occ {
-  display: flex; justify-content: space-between; align-items: baseline; gap: 0.3rem;
-  font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); font-variant-numeric: tabular-nums;
-}
+.pt-occ { display: flex; justify-content: space-between; align-items: baseline; gap: 0.3rem; }
 .pt-occ.busy { color: var(--cc-text); }
 .pt-occ.busy .pt-occ-n { color: var(--cc-accent); font-weight: 600; }
 .pt-occ-sep { opacity: 0.5; margin: 0 1px; }
@@ -118,5 +115,5 @@ onUnmounted(() => { if (timer) clearInterval(timer) })
 .pt-bar { height: 3px; border-radius: var(--cc-radius-xs); background: var(--cc-surface-2); overflow: hidden; margin-top: 2px; }
 .pt-bar-fill { height: 100%; background: var(--cc-accent); transition: width 0.3s; }
 
-.pt-hint { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); margin: 0.55rem 0 0; }
+.pt-hint { margin: 0.55rem 0 0; }
 </style>

--- a/frontend/src/components/SetBar.vue
+++ b/frontend/src/components/SetBar.vue
@@ -107,7 +107,7 @@ async function deleteSet() {
         <option v-for="s in project.sets" :key="s.uid" :value="s.uid">{{ s.name }}</option>
       </select>
       <template v-if="activeSet">
-        <span class="set-uid">{{ activeSet.uid }}</span>
+        <span class="set-uid cc-muted cc-muted-xs">{{ activeSet.uid }}</span>
         <button class="set-uid-copy cc-btn cc-btn-bare cc-btn-icon" @click="copySetUid(activeSet.uid)"
           v-tooltip.bottom="copiedSetUid ? 'Copied!' : 'Copy set UID to clipboard'">
           <i :class="copiedSetUid ? 'pi pi-check' : 'pi pi-copy'" />
@@ -150,7 +150,7 @@ async function deleteSet() {
         </button>
       </template>
       <template v-if="confirmDelete">
-        <span class="confirm-text">Delete <strong>{{ activeSet?.name }}</strong>?</span>
+        <span class="confirm-text cc-muted cc-muted-md">Delete <strong>{{ activeSet?.name }}</strong>?</span>
         <button class="cc-btn cc-btn-danger-ghost" @click="deleteSet"
           v-tooltip.bottom="'Permanently delete this set and remove all its images from disk.'">
           Confirm
@@ -175,12 +175,7 @@ async function deleteSet() {
   flex-shrink: 0;
 }
 .set-selector { display: flex; align-items: center; gap: 0.5rem; }
-.set-uid {
-  font-family: var(--cc-mono);
-  font-size: var(--cc-fs-xs);
-  color: var(--cc-text-dim);
-  letter-spacing: 0.03em;
-}
+.set-uid { font-family: var(--cc-mono); letter-spacing: 0.03em; }
 /* .set-uid-copy → cc-btn cc-btn-bare cc-btn-icon */
 .set-uid-copy:hover { color: var(--cc-text); background: var(--cc-surface-2); }
 .set-label {
@@ -192,6 +187,6 @@ async function deleteSet() {
 .set-select:disabled { opacity: 0.4; cursor: not-allowed; }
 .set-name-input { width: 180px; border-color: var(--cc-accent); }
 .spacer { flex: 1; }
-.confirm-text { font-size: var(--cc-fs-md); color: var(--cc-text-dim); }
+
 /* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/components/canvas/InteractivePanel.vue
+++ b/frontend/src/components/canvas/InteractivePanel.vue
@@ -43,7 +43,7 @@ defineExpose({ exportImage, exportSvg })
                :title="entry?.label ?? view" :square="entry?.square ?? false"
                @activate="emit('activate', $event)" @remove="emit('remove')">
     <component v-if="entry" :is="entry.component" ref="viewRef" v-bind="context" :state="state" />
-    <div v-else class="ip-missing">Unknown interactive plot “{{ view }}”.</div>
+    <div v-else class="ip-missing cc-muted cc-muted-md">Unknown interactive plot “{{ view }}”.</div>
     <template v-if="duplicable || exportFormats.length" #footer>
       <button v-if="duplicable" class="ip-iconbtn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same settings) to tweak one thing'"><i class="pi pi-copy" /></button>
@@ -57,7 +57,7 @@ defineExpose({ exportImage, exportSvg })
 </template>
 
 <style scoped>
-.ip-missing { padding: 1rem; color: var(--cc-text-dim); font-size: var(--cc-fs-md); }
+.ip-missing { padding: 1rem; }
 /* .ip-iconbtn → cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .ip-iconbtn:hover { color: var(--cc-text); border-color: #484f58; }
 .ip-export { max-width: 7rem; }

--- a/frontend/src/components/canvas/PlotOptions.vue
+++ b/frontend/src/components/canvas/PlotOptions.vue
@@ -32,29 +32,29 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <i :class="open.layout ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" /><span class="cc-eyebrow">Layout</span>
       </button>
       <div v-show="open.layout" class="po-body">
-        <div class="po-row"><span>Legend</span>
+        <div class="po-row cc-muted cc-muted-xs"><span>Legend</span>
           <CcToggle :model-value="vis.legend" @update:model-value="set({ legend: $event })" /></div>
-        <div class="po-row" v-tooltip.left="'Log scale on the measure axis'"><span>Log scale</span>
+        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Log scale on the measure axis'"><span>Log scale</span>
           <CcToggle :model-value="vis.logScale" @update:model-value="set({ logScale: $event })" /></div>
-        <div class="po-row"><span>Gridlines</span>
+        <div class="po-row cc-muted cc-muted-xs"><span>Gridlines</span>
           <CcToggle :model-value="vis.grid" @update:model-value="set({ grid: $event })" /></div>
-        <div class="po-row" v-tooltip.left="'Rotate the x tick labels (angle below)'"><span>Rotate X labels</span>
+        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Rotate the x tick labels (angle below)'"><span>Rotate X labels</span>
           <CcToggle :model-value="vis.rotateXLabel" @update:model-value="set({ rotateXLabel: $event })" /></div>
-        <label v-if="vis.rotateXLabel" class="po-row" v-tooltip.left="'X tick-label angle (degrees)'"><span>X angle</span>
+        <label v-if="vis.rotateXLabel" class="po-row cc-muted cc-muted-xs" v-tooltip.left="'X tick-label angle (degrees)'"><span>X angle</span>
           <input type="range" min="0" max="90" step="5" :value="vis.rotateXAngle ?? 45"
                  @input="set({ rotateXAngle: parseInt(($event.target as HTMLInputElement).value) })" />
           <span class="po-val">{{ vis.rotateXAngle ?? 45 }}°</span></label>
-        <div class="po-row" v-tooltip.left="'Flip 90° — measure on X, series labels on Y (R coord_flip)'"><span>Rotate 90°</span>
+        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Flip 90° — measure on X, series labels on Y (R coord_flip)'"><span>Rotate 90°</span>
           <CcToggle :model-value="vis.rotate"
                  @update:model-value="set({ rotate: $event, ...($event ? { facet: false } : {}) })" /></div>
-        <div class="po-row" v-tooltip.left="'One small-multiple panel per series (mutually exclusive with rotate)'"><span>Facet</span>
+        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'One small-multiple panel per series (mutually exclusive with rotate)'"><span>Facet</span>
           <CcToggle :model-value="vis.facet"
                  @update:model-value="set({ facet: $event, ...($event ? { rotate: false } : {}) })" /></div>
-        <div class="po-row"><span>Dark theme</span>
+        <div class="po-row cc-muted cc-muted-xs"><span>Dark theme</span>
           <CcToggle :model-value="vis.darkTheme" @update:model-value="set({ darkTheme: $event })" /></div>
-        <label class="po-row" v-tooltip.left="'Measure-axis range (blank = auto)'"><span>Y min</span>
+        <label class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Measure-axis range (blank = auto)'"><span>Y min</span>
           <input class="po-txt" type="text" :value="vis.yMin" @change="set({ yMin: ($event.target as HTMLInputElement).value })" /></label>
-        <label class="po-row"><span>Y max</span>
+        <label class="po-row cc-muted cc-muted-xs"><span>Y max</span>
           <input class="po-txt" type="text" :value="vis.yMax" @change="set({ yMax: ($event.target as HTMLInputElement).value })" /></label>
       </div>
     </template>
@@ -65,17 +65,17 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <i :class="open.points ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" /><span class="cc-eyebrow">Points</span>
       </button>
       <div v-show="open.points" class="po-body">
-        <label class="po-row" v-tooltip.left="'Data offset (beeswarm / random / none)'"><span>Offset</span>
+        <label class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Data offset (beeswarm / random / none)'"><span>Offset</span>
           <select class="po-sel" :value="vis.jitter" @change="set({ jitter: ($event.target as HTMLSelectElement).value as VisProps['jitter'] })">
             <option value="beeswarm">beeswarm</option><option value="random">random</option><option value="none">none</option>
           </select></label>
-        <div class="po-row" v-tooltip.left="'Colour points by series (else grey)'"><span>Colour data</span>
+        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Colour points by series (else grey)'"><span>Colour data</span>
           <CcToggle :model-value="vis.colorData" @update:model-value="set({ colorData: $event })" /></div>
-        <label class="po-row"><span>Point size</span>
+        <label class="po-row cc-muted cc-muted-xs"><span>Point size</span>
           <input type="range" min="0.5" max="8" step="0.5" :value="vis.pointSize"
                  @input="set({ pointSize: Number(($event.target as HTMLInputElement).value) })" />
           <span class="po-val">{{ vis.pointSize }}</span></label>
-        <label class="po-row"><span>Point opacity</span>
+        <label class="po-row cc-muted cc-muted-xs"><span>Point opacity</span>
           <input type="range" min="0.05" max="1" step="0.05" :value="vis.pointOpacity"
                  @input="set({ pointOpacity: Number(($event.target as HTMLInputElement).value) })" />
           <span class="po-val">{{ vis.pointOpacity.toFixed(2) }}</span></label>
@@ -88,7 +88,7 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <i :class="open.colours ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" /><span class="cc-eyebrow">Colours</span>
       </button>
       <div v-show="open.colours" class="po-body">
-        <label class="po-row"><span>Palette</span>
+        <label class="po-row cc-muted cc-muted-xs"><span>Palette</span>
           <select class="po-sel" :value="vis.palette" @change="set({ palette: ($event.target as HTMLSelectElement).value as VisProps['palette'] })">
             <option value="standard">standard (population)</option><option value="distinct">distinct</option>
             <option value="cecelia">Cecelia</option>
@@ -96,7 +96,7 @@ const has = (s: string) => props.sections.includes(s as 'layout')
             <option value="tol-bright">Tol bright</option><option value="tol-muted">Tol muted</option>
             <option value="tol-light">Tol light</option><option value="user">user</option>
           </select></label>
-        <label v-if="vis.palette === 'user'" class="po-row po-col" v-tooltip.left="'Comma-separated colours/hex, in series order'">
+        <label v-if="vis.palette === 'user'" class="po-row po-col cc-muted cc-muted-xs" v-tooltip.left="'Comma-separated colours/hex, in series order'">
           <span>Colours</span>
           <input class="po-txt wide" type="text" :value="vis.userColors" placeholder="#4477AA,#EE6677,…"
                  @change="set({ userColors: ($event.target as HTMLInputElement).value })" /></label>
@@ -109,13 +109,13 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <i :class="open.labels ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" /><span class="cc-eyebrow">Labels</span>
       </button>
       <div v-show="open.labels" class="po-body">
-        <label class="po-row po-col"><span>Title</span>
+        <label class="po-row po-col cc-muted cc-muted-xs"><span>Title</span>
           <input class="po-txt wide" type="text" :value="vis.title" @change="set({ title: ($event.target as HTMLInputElement).value })" /></label>
-        <label class="po-row po-col"><span>X label</span>
+        <label class="po-row po-col cc-muted cc-muted-xs"><span>X label</span>
           <input class="po-txt wide" type="text" :value="vis.labX" @change="set({ labX: ($event.target as HTMLInputElement).value })" /></label>
-        <label class="po-row po-col"><span>Y label</span>
+        <label class="po-row po-col cc-muted cc-muted-xs"><span>Y label</span>
           <input class="po-txt wide" type="text" :value="vis.labY" @change="set({ labY: ($event.target as HTMLInputElement).value })" /></label>
-        <label class="po-row"><span>Font size</span>
+        <label class="po-row cc-muted cc-muted-xs"><span>Font size</span>
           <input type="range" min="8" max="20" step="1" :value="vis.fontSize"
                  @input="set({ fontSize: Number(($event.target as HTMLInputElement).value) })" />
           <span class="po-val">{{ vis.fontSize }}</span></label>
@@ -129,7 +129,7 @@ const has = (s: string) => props.sections.includes(s as 'layout')
 /* + cc-section-toggle (row) — this keeps only the padding and the uppercase section-label tier */
 .po-toggle { padding: 6px 8px; }
 .po-body { padding: 4px 10px 10px; display: flex; flex-direction: column; gap: 8px; }
-.po-row { display: flex; align-items: center; gap: 8px; color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
+.po-row { display: flex; align-items: center; gap: 8px; }
 .po-row > span:first-child { flex: 1; }
 .po-row input[type="range"] { flex: 1; max-width: 110px; }
 .po-val { width: 2.2rem; text-align: right; font-variant-numeric: tabular-nums; }

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -339,7 +339,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
                   :style="popClusterIds(p).includes(id) ? { background: p.colour, borderColor: p.colour, color: '#111' } : {}"
                   v-tooltip.bottom="clusterOwner(id) && clusterOwner(id)?.path !== p.path ? `In “${clusterOwner(id)?.name}”` : ''"
                   @click.stop="!readonly && toggleCluster(p, id)">{{ id }}</button>
-          <span v-if="!props.clusterIds.length" class="pm-chip-empty cc-empty-inline cc-muted-dense">no clusters at this suffix</span>
+          <span v-if="!props.clusterIds.length" class="pm-chip-empty cc-empty-inline cc-muted-2xs">no clusters at this suffix</span>
         </div>
       </template>
 
@@ -482,7 +482,7 @@ button.pm-filter-badge:hover { opacity: 1; }
 .pm-chip.ro { cursor: default; }
 .pm-chip.ro:hover { border-color: var(--cc-border); color: var(--cc-text-dim); }
 .pm-chip.ro.on:hover { color: #111; }
-.pm-chip-empty { font-style: italic; }   /* + .cc-empty-inline .cc-muted-dense (row/colour/10px tier) */
+.pm-chip-empty { font-style: italic; }   /* + .cc-empty-inline .cc-muted-2xs (row/colour/10px tier) */
 
 /* segmented toggle (axis option in the #options slot; the shell owns the footer scope toggle) */
 .pm-seg { margin-left: auto; }

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -174,8 +174,8 @@ watch(segPops, () => {
           </button>
         </div>
         <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
-        <span v-if="!specs.length" class="sc-hint">No plot types available for this module yet.</span>
-        <span v-else class="sc-hint">eye-select populations to plot · drag plots by their title</span>
+        <span v-if="!specs.length" class="sc-hint cc-muted cc-muted-xs">No plot types available for this module yet.</span>
+        <span v-else class="sc-hint cc-muted cc-muted-xs">eye-select populations to plot · drag plots by their title</span>
       </div>
       <div ref="canvasRef" class="sc-canvas">
         <!-- scaled workspace: the panels zoom together; the population picker stays full-size (below) -->
@@ -213,7 +213,7 @@ watch(segPops, () => {
 .sc-cmp { min-width: 8rem; }
 .sc-attr { min-width: 5.5rem; max-width: 8rem; }   /* short attribute names — no need for 9rem */
 .sc-x { opacity: 0.6; }
-.sc-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); opacity: 0.7; margin-left: auto; }
+.sc-hint { opacity: 0.7; margin-left: auto; }
 .sc-canvas { position: relative; flex: 1; min-height: 70vh; }
 /* the scaled workspace (offsetParent for the floating panels); size + transform set inline by
    useCanvasWorkspace — grows to viewport/zoom when zoomed out so the whole page stays usable */

--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -267,15 +267,15 @@ const corrFont = (r: number | null | undefined) => `${Math.round(13 + Math.abs(r
 
 <template>
   <div ref="gridRef" class="gm-grid" :class="{ single, matrix: cols != null }" :style="gridStyle">
-    <div v-if="err" class="gm-msg">{{ err }}</div>
-    <div v-else-if="!defs.length" class="gm-msg"><slot name="empty">Nothing to show.</slot></div>
+    <div v-if="err" class="gm-msg cc-muted cc-muted-md">{{ err }}</div>
+    <div v-else-if="!defs.length" class="gm-msg cc-muted cc-muted-md"><slot name="empty">Nothing to show.</slot></div>
     <template v-for="d in defs" :key="d.key">
       <!-- DIAGONAL (ggpairs): the channel name — labels its whole row and column -->
       <div v-if="d.role === 'diagonal'" class="gm-cell gm-diag"><span>{{ colLabel(d.xChan) }}</span></div>
       <!-- UPPER triangle (ggpairs): the pair's correlation, reused from its mirror scatter -->
       <div v-else-if="d.role === 'corr'" class="gm-cell gm-corr"
            v-tooltip.top="`corr(${colLabel(d.xChan)}, ${colLabel(d.yChan)})`">
-        <span class="gm-corr-k">Corr</span>
+        <span class="gm-corr-k cc-eyebrow cc-eyebrow-2xs">Corr</span>
         <span class="gm-corr-v" :style="{ fontSize: corrFont(corrFor(d)) }">{{ fmtCorr(corrFor(d)) }}</span>
       </div>
       <div v-else class="gm-cell">
@@ -333,10 +333,10 @@ const corrFont = (r: number | null | undefined) => `${Math.round(13 + Math.abs(r
   color: var(--cc-text); font-weight: 700; font-size: var(--cc-fs-sm); padding: 4px; text-align: center; word-break: break-word; }
 /* upper-triangle correlation cell (ggpairs): "Corr" label + the value, text scaled by |r| */
 .gm-corr { align-items: center; justify-content: center; aspect-ratio: 1; gap: 2px; border-color: var(--cc-border); }
-.gm-corr-k { font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.05em; color: var(--cc-text-dim); }
+
 .gm-corr-v { font-weight: 700; color: var(--cc-text); font-variant-numeric: tabular-nums; line-height: 1; }
 .gm-title { flex-shrink: 0; font-size: var(--cc-fs-xs); font-weight: 700; padding: 3px 6px; color: var(--cc-text-dim);
   border-bottom: 1px solid var(--cc-border); background: var(--cc-surface-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .gm-loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--cc-text-dim); aspect-ratio: 1; }
-.gm-msg { grid-column: 1 / -1; padding: 16px; color: var(--cc-text-dim); font-size: var(--cc-fs-md); }
+.gm-msg { grid-column: 1 / -1; padding: 16px; }
 </style>

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -319,22 +319,22 @@ defineExpose({ exportImage })
                 v-tooltip.bottom="'Caption size & separator'"><i class="pi pi-cog" /></button>
         <TeleportPopover v-model="optsOpen" :anchor="gearEl" placement="bottom-end">
           <div class="is-pop">
-            <CcToggle class="is-check" label="legend (channels · pops · colour-by)"
+            <CcToggle class="is-check cc-muted cc-muted-xs" label="legend (channels · pops · colour-by)"
               :model-value="showLegend" @update:model-value="showLegend = $event" />
-            <CcToggle class="is-check" label="clean capture"
+            <CcToggle class="is-check cc-muted cc-muted-xs" label="clean capture"
               v-tooltip.bottom="'Hide napari\'s scale bar + timestamp when capturing, for a clean publication still (add your own externally)'"
               :model-value="settings.cleanCapture" @update:model-value="settings.cleanCapture = $event" />
-            <CcToggle class="is-check" label="scale bar"
+            <CcToggle class="is-check cc-muted cc-muted-xs" label="scale bar"
               v-tooltip.bottom="'Draw a vector scale bar on each frame (from the image\'s physical pixel size)'"
               :model-value="showScaleBar" @update:model-value="showScaleBar = $event" />
-            <CcToggle class="is-check" label="timestamp"
+            <CcToggle class="is-check cc-muted cc-muted-xs" label="timestamp"
               v-tooltip.bottom="'Draw the elapsed-time timestamp on each frame'"
               :model-value="showTimestamp" @update:model-value="showTimestamp = $event" />
             <template v-if="separator === 'angled' && orientation === 'h'">
-              <label class="is-slider">angle
+              <label class="is-slider cc-muted cc-muted-xs">angle
                 <input type="range" min="0" max="80" :value="skew" @input="skew = +($event.target as HTMLInputElement).value" />
                 <span class="is-val">{{ skew }}</span></label>
-              <label class="is-slider">width
+              <label class="is-slider cc-muted cc-muted-xs">width
                 <input type="range" min="1" max="12" :value="thick" @input="thick = +($event.target as HTMLInputElement).value" />
                 <span class="is-val">{{ thick }}</span></label>
             </template>
@@ -385,9 +385,9 @@ defineExpose({ exportImage })
 .is-pop { display: flex; flex-direction: column; gap: 6px; padding: 8px 10px; }
 .is-val { min-width: 1.2rem; text-align: right; font-weight: 700; color: var(--cc-text); }
 .is-err { color: #fca5a5; font-size: var(--cc-fs-xs); }
-.is-slider { display: inline-flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
+.is-slider { display: inline-flex; align-items: center; gap: 4px; }
 .is-slider input[type="range"] { width: 4.5rem; }
-.is-check { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
+.is-check { display: inline-flex; align-items: center; gap: 6px; }
 /* view legend (shared <ViewLegend>): overlaid bottom-left of the frame (z above the auto-hide toolbar
    like the caption/actions); included in the PDF export (not hidden while capturing). The container
    sets the on-image styling (white text, shadow, dark chip); ViewLegend inherits color + font-size. */

--- a/frontend/src/components/plots/PlotSpinner.vue
+++ b/frontend/src/components/plots/PlotSpinner.vue
@@ -15,7 +15,7 @@ defineProps<{ label?: string }>()
 <template>
   <div class="plot-spinner" role="status" aria-live="polite">
     <div class="plot-spinner__wheel" aria-hidden="true" />
-    <span v-if="label" class="plot-spinner__label">{{ label }}</span>
+    <span v-if="label" class="plot-spinner__label cc-muted cc-muted-xs">{{ label }}</span>
   </div>
 </template>
 
@@ -41,10 +41,7 @@ defineProps<{ label?: string }>()
   border-top-color: var(--cc-accent);
   animation: plot-spinner-rot 0.7s linear infinite;
 }
-.plot-spinner__label {
-  font-size: var(--cc-fs-xs);
-  color: var(--cc-text-dim);
-}
+
 @keyframes plot-spinner-rot { to { transform: rotate(360deg); } }
 @media (prefers-reduced-motion: reduce) {
   .plot-spinner__wheel { animation-duration: 2.4s; }

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -584,7 +584,7 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
 
 <template>
   <div class="uv">
-    <div class="uv-ctrl cc-panel-controls">
+    <div class="uv-ctrl cc-panel-controls cc-muted">
       <button class="cc-btn cc-btn-ghost" :class="{ 'cc-btn-on cc-btn-on-solid':labels }" @click="labels = !labels"
               v-tooltip.bottom="'Toggle centroid labels'"><i class="pi pi-tag" /> #</button>
       <!-- legend visibility follows the picker's Legend option (vis.legend) — no separate toggle here -->
@@ -593,27 +593,27 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
               v-tooltip.bottom="'Colour & facet options'"><i class="pi pi-palette" /> options</button>
       <TeleportPopover v-model="optsOpen" :anchor="optsBtn" placement="bottom-start">
         <div class="uv-opts">
-          <label class="uv-opt"><span>Colour by</span>
+          <label class="uv-opt cc-muted"><span>Colour by</span>
             <select v-model="colourBy">
               <option value="cluster">cluster</option>
               <option value="population">population</option>
               <option value="attribute">attribute</option>
             </select>
           </label>
-          <label v-if="colourBy === 'attribute'" class="uv-opt"><span>Colour attribute</span>
+          <label v-if="colourBy === 'attribute'" class="uv-opt cc-muted"><span>Colour attribute</span>
             <select v-model="colourAttr">
               <option value="" disabled>attribute…</option>
               <option v-for="a in attrs" :key="a.name" :value="a.name">{{ a.name }}</option>
             </select>
           </label>
-          <label class="uv-opt"><span>Facet by</span>
+          <label class="uv-opt cc-muted"><span>Facet by</span>
             <select v-model="facetBy">
               <option value="none">no facet</option>
               <option value="attribute">attribute</option>
               <option value="population">population</option>
             </select>
           </label>
-          <label v-if="facetBy === 'attribute'" class="uv-opt"><span>Facet attribute</span>
+          <label v-if="facetBy === 'attribute'" class="uv-opt cc-muted"><span>Facet attribute</span>
             <select v-model="facetAttr">
               <option value="" disabled>attribute…</option>
               <option v-for="a in attrs" :key="a.name" :value="a.name">{{ a.name }}</option>
@@ -625,7 +625,7 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
             <div class="uv-pop">
               <div v-if="!popGroups.length" class="uv-pop-empty cc-muted">No populations in the clustered segmentations.</div>
               <template v-for="grp in popGroups" :key="grp.valueName">
-                <div v-if="grp.populations.length" class="uv-pop-head cc-eyebrow cc-eyebrow-dense">{{ grp.valueName }}</div>
+                <div v-if="grp.populations.length" class="uv-pop-head cc-eyebrow cc-eyebrow-2xs">{{ grp.valueName }}</div>
                 <div v-for="p in grp.populations" :key="p.popType + grp.valueName + p.path"
                      class="uv-pop-row" :class="{ on: isPopOn(grp.valueName, p.path, p.popType) }"
                      @click="togglePop(grp.valueName, p.path, p.popType)">
@@ -680,20 +680,20 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
 <style scoped>
 /* position: relative so the overlaid .uv-ctrl (.cc-panel-controls) anchors to the plot box */
 .uv { position: relative; display: flex; flex-direction: column; flex: 1; min-height: 0; }
-.uv-ctrl { display: flex; align-items: center; gap: 8px; padding: 4px 6px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.uv-ctrl { display: flex; align-items: center; gap: 8px; padding: 4px 6px; }
 /* active (ticked) label toggle: filled accent so it's clearly on/off */
 .uv-spacer { flex: 1; }
 .uv-count { font-variant-numeric: tabular-nums; }
 /* colour & facet options popover (inner layout only — TeleportPopover gives surface/border/shadow) */
 .uv-opts { width: 15rem; display: flex; flex-direction: column; gap: 8px; padding: 10px; }
-.uv-opt { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.uv-opt { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .uv-opt select { padding: 2px 4px; max-width: 8.5rem; }
 .uv-opt-sep { font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.06em; color: var(--cc-text-dim);
   border-top: 1px solid var(--cc-border); padding-top: 6px; margin-top: 2px; }
 /* population checklist (inside the options popover) */
 .uv-pop { max-height: 14rem; overflow-y: auto; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); }
 .uv-pop-empty { padding: 10px; }   /* + .cc-muted */
-/* + .cc-eyebrow .cc-eyebrow-dense (case/tracking/weight/colour at the 10px tier) */
+/* + .cc-eyebrow .cc-eyebrow-2xs (case/tracking/weight/colour at the 10px tier) */
 .uv-pop-head { padding: 4px 8px; background: var(--cc-surface-2); position: sticky; top: 0; }
 .uv-pop-row { display: flex; align-items: center; gap: 6px; padding: 4px 8px; cursor: pointer; font-size: var(--cc-fs-sm); color: var(--cc-text); }
 .uv-pop-row:hover { background: var(--cc-surface-2); }

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -1263,7 +1263,7 @@ onActivated(async () => {
               :key="cat.name"
               class="palette-category"
             >
-              <div class="palette-cat-heading cc-eyebrow cc-eyebrow-dense">{{ cat.name }}</div>
+              <div class="palette-cat-heading cc-eyebrow cc-eyebrow-2xs">{{ cat.name }}</div>
               <div
                 v-for="def in cat.defs"
                 :key="def.fun_name"
@@ -1296,7 +1296,7 @@ onActivated(async () => {
 
         <!-- ── Run table ──────────────────────────────────────────────────── -->
         <div class="run-table-section">
-          <div class="run-section-heading cc-eyebrow cc-eyebrow-dense">Run</div>
+          <div class="run-section-heading cc-eyebrow cc-eyebrow-2xs">Run</div>
 
           <select
             v-if="project.sets.length"
@@ -1689,7 +1689,7 @@ onActivated(async () => {
 
 .palette-category { margin-bottom: 0.25rem; }
 
-.palette-cat-heading { padding: 0.5rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-eyebrow-dense */
+.palette-cat-heading { padding: 0.5rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-eyebrow-2xs */
 
 .palette-item {
   display: flex;
@@ -1857,7 +1857,7 @@ onActivated(async () => {
   background: var(--cc-bg);
 }
 
-.run-section-heading { padding: 0.45rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-eyebrow-dense */
+.run-section-heading { padding: 0.45rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-eyebrow-2xs */
 
 .run-set-select {
   margin: 0 0.45rem 0.3rem;

--- a/frontend/src/modules/MoviesModule.vue
+++ b/frontend/src/modules/MoviesModule.vue
@@ -170,21 +170,21 @@ function movieTime(mtime: number): string {
           Native player with adjustable speed and zoom.</p>
       </div>
       <div class="mov-head-ctl">
-        <label class="mov-ctl" v-tooltip.bottom="'Playback speed'">
+        <label class="mov-ctl cc-muted" v-tooltip.bottom="'Playback speed'">
           <i class="pi pi-forward" />
           <select v-model.number="settings.moviesPlaybackRate" class="mov-select">
             <option v-for="s in SPEEDS" :key="s" :value="s">{{ s }}×</option>
           </select>
         </label>
-        <label class="mov-ctl" v-tooltip.bottom="'Zoom the video. Shift + mouse wheel zooms to the cursor; Shift +/− and Shift + 0 (reset) also work. Scroll/pan when zoomed in.'">
+        <label class="mov-ctl cc-muted" v-tooltip.bottom="'Zoom the video. Shift + mouse wheel zooms to the cursor; Shift +/− and Shift + 0 (reset) also work. Scroll/pan when zoomed in.'">
           <i class="pi pi-search-plus" />
           <input type="range" :min="MOVIES_ZOOM_MIN" :max="MOVIES_ZOOM_MAX" step="0.25" :value="settings.moviesZoom"
                  @input="onZoomSlider(($event.target as HTMLInputElement).valueAsNumber)" class="mov-range" />
           <span class="mov-num cc-readout">{{ zoomLabel }}</span>
         </label>
-        <CcToggle class="mov-ctl" v-model="settings.moviesAutoplay" label="Autoplay"
+        <CcToggle class="mov-ctl cc-muted" v-model="settings.moviesAutoplay" label="Autoplay"
                   v-tooltip.bottom="'Play a movie automatically when you select it'" />
-        <CcToggle class="mov-ctl" v-model="settings.moviesLoop" label="Loop"
+        <CcToggle class="mov-ctl cc-muted" v-model="settings.moviesLoop" label="Loop"
                   v-tooltip.bottom="'Repeat the movie when it reaches the end'" />
         <button class="cc-btn cc-btn-ghost" :disabled="loading || !hasProject" @click="refresh"
                 v-tooltip.bottom="'Re-scan the project movies folder'">
@@ -217,7 +217,7 @@ function movieTime(mtime: number): string {
           <i class="pi pi-video mov-item-ico" />
           <span class="mov-item-body">
             <span class="mov-item-name">{{ movieDisplayName(m.name) }}</span>
-            <span class="mov-item-meta">{{ formatBytes(m.size) }} · {{ movieTime(m.mtime) }}</span>
+            <span class="mov-item-meta cc-muted cc-muted-xs">{{ formatBytes(m.size) }} · {{ movieTime(m.mtime) }}</span>
           </span>
         </button>
       </aside>
@@ -231,7 +231,7 @@ function movieTime(mtime: number): string {
 .mov-head h1 { margin: 0; font-size: 1.15rem; }
 .mov-sub { margin: 0.2rem 0 0; max-width: 46rem; }   /* + .cc-muted (colour/size) */
 .mov-head-ctl { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
-.mov-ctl { display: flex; align-items: center; gap: 0.35rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.mov-ctl { display: flex; align-items: center; gap: 0.35rem; }
 .mov-select {
   border-radius: var(--cc-radius-sm); padding: 0.15rem 0.35rem;
 }
@@ -265,5 +265,5 @@ function movieTime(mtime: number): string {
 .mov-item-ico { font-size: var(--cc-fs-md); flex-shrink: 0; color: var(--cc-accent); }
 .mov-item-body { display: flex; flex-direction: column; min-width: 0; }
 .mov-item-name { font-size: var(--cc-fs-md); font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.mov-item-meta { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+
 </style>

--- a/frontend/src/modules/SetupModule.vue
+++ b/frontend/src/modules/SetupModule.vue
@@ -86,13 +86,13 @@ async function waitForBackend(timeoutMs = 60000) {
       <h1 class="setup-title">Welcome to Cecelia</h1>
       <p class="setup-sub cc-muted">Where would you like to store your projects?</p>
 
-      <label class="setup-label" for="setup-path">Projects folder</label>
+      <label class="setup-label cc-muted cc-muted-md" for="setup-path">Projects folder</label>
       <input id="setup-path" v-model="path" class="setup-input" type="text" spellcheck="false"
              autocomplete="off" placeholder="~/cecelia-projects"
              @keyup.enter="submit" />
 
       <!-- validation hint: neutral until checked, green when usable, danger when not -->
-      <p class="setup-hint" :class="check ? (check.ok ? 'ok' : 'bad') : ''">
+      <p class="setup-hint cc-muted cc-muted-md" :class="check ? (check.ok ? 'ok' : 'bad') : ''">
         <template v-if="check">
           <i :class="check.ok ? 'pi pi-check-circle' : 'pi pi-exclamation-circle'" />
           {{ check.message }}
@@ -134,17 +134,9 @@ async function waitForBackend(timeoutMs = 60000) {
 .setup-logo { font-size: 2.5rem; line-height: 1; }
 .setup-title { margin: 0.5rem 0 0; font-size: 1.4rem; font-weight: 600; }
 .setup-sub { margin: 0 0 1rem; }   /* + .cc-muted */
-.setup-label { font-size: var(--cc-fs-md); color: var(--cc-text-dim); margin-bottom: 0.15rem; }
+.setup-label { margin-bottom: 0.15rem; }
 .setup-input { width: 100%; font-family: var(--cc-mono, monospace); }
-.setup-hint {
-  min-height: 1.2rem;
-  margin: 0.15rem 0 0.5rem;
-  font-size: var(--cc-fs-md);
-  color: var(--cc-text-dim);
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-}
+.setup-hint { min-height: 1.2rem; margin: 0.15rem 0 0.5rem; display: flex; align-items: center; gap: 0.35rem; }
 .setup-hint.ok  { color: var(--cc-viewer); }
 .setup-hint.bad { color: var(--cc-sev-fail); }
 .setup-go { margin-top: 0.5rem; align-self: flex-end; }

--- a/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
+++ b/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
@@ -369,7 +369,7 @@ async function previewOpen() {
 .bm-title-toggle { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; flex-shrink: 0; font-weight: 600; }
 .bm-title-range { flex: 1; min-width: 3rem; accent-color: var(--cc-accent); }
 /* This field is the reason the input base got re-pitched: it rendered a tier larger than its
-   neighbours, was patched with `cc-input-dense`, and then the SAME complaint arrived for the legacy-
+   neighbours, was patched with a density class, and then the SAME complaint arrived for the legacy-
    migrate dialog's fields. One field wanting the class is a site fix; two is the default being wrong.
    The base is --cc-fs-sm now, so the class is gone from here — a plain input already renders at the
    size this one was asking for. What stays is the surface and this panel's layout.

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -215,7 +215,7 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
           </button>
         </div>
         <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
-        <span class="cp-hint">drag plots by their title · resize from the corner</span>
+        <span class="cp-hint cc-muted cc-muted-xs">drag plots by their title · resize from the corner</span>
       </div>
 
       <!-- membership: cluster pops only apply to images that were in the run (carry clusters.{suffix}).
@@ -275,7 +275,7 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
 .cp-bar { display: flex; align-items: center; gap: 14px; padding: 8px 4px; font-size: var(--cc-fs-sm); flex-shrink: 0; }
 .cp-bar label { display: flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .cp-bar select { min-width: 7rem; }
-.cp-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); opacity: 0.7; }
+.cp-hint { opacity: 0.7; }
 .cp-members { display: flex; align-items: flex-start; gap: 6px; margin: 0 4px 6px; padding: 6px 9px;
   font-size: var(--cc-fs-xs); color: #fcd34d; background: #78350f22; border: 1px solid #b4530933; border-radius: var(--cc-radius-sm); }
 .cp-members .pi { margin-top: 1px; }

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -346,7 +346,7 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
                   @update:model-value="v => mode = (v || 'off') as typeof mode" />
       <!-- axis (X, Y) + displayed population — one row each, stacked so they don't wrap awkwardly -->
       <div class="panel-ctrl">
-        <label class="ax-row"><span class="ax-lbl">X</span>
+        <label class="ax-row cc-muted"><span class="ax-lbl">X</span>
           <select class="ax-chan" v-model="xChan">
             <option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option>
             <optgroup v-if="g.spatialAxes.length" label="Spatial / Time">
@@ -357,7 +357,7 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
             <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
           <i v-if="xCoerced" class="pi pi-exclamation-triangle ax-warn"
              v-tooltip.bottom="`${g.colLabel(xChan)}’s range is too small for ${xt} — shown linear`" /></label>
-        <label class="ax-row"><span class="ax-lbl">Y</span>
+        <label class="ax-row cc-muted"><span class="ax-lbl">Y</span>
           <select class="ax-chan" v-model="yChan">
             <option v-for="c in g.columns" :key="c" :value="c">{{ g.colLabel(c) }}</option>
             <optgroup v-if="g.spatialAxes.length" label="Spatial / Time">
@@ -368,10 +368,10 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
             <option v-for="t in TRANSFORMS" :key="t" :value="t">{{ t }}</option></select>
           <i v-if="yCoerced" class="pi pi-exclamation-triangle ax-warn"
              v-tooltip.bottom="`${g.colLabel(yChan)}’s range is too small for ${yt} — shown linear`" /></label>
-        <label class="ax-row"><span class="ax-lbl">pop</span>
+        <label class="ax-row cc-muted"><span class="ax-lbl">pop</span>
           <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to display; new gates are its children'">
           <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select>
-          <span v-if="mode !== 'off' && !pending" class="gate-hint">hold <kbd>Shift</kbd> to adjust gates</span></label>
+          <span v-if="mode !== 'off' && !pending" class="gate-hint cc-muted cc-muted-2xs">hold <kbd>Shift</kbd> to adjust gates</span></label>
       </div>
     </template>
     <!-- utility actions (export) in the footer, like the summary / cluster panels -->
@@ -422,7 +422,8 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
 /* fixed widths so the controls don't stretch when the plot is resized */
 .ax-chan { width: 9rem; flex: none; }
 .ax-row .tsel { flex-shrink: 0; }
-.panel-ctrl label { display: flex; align-items: center; gap: 4px; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
+/* + cc-muted on each label — only the row layout is this panel's business */
+.panel-ctrl label { display: flex; align-items: center; gap: 4px; }
 /* fixed widths so the bar doesn't reflow when the selected option text changes; the rest
    (background, border, chevron, focus) comes from the global form base in style.css */
 .panel-ctrl select { width: 8rem; padding-top: 2px; padding-bottom: 2px; }
@@ -441,8 +442,7 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
 .name-hint { color: var(--cc-sev-fail); font-size: var(--cc-fs-2xs); max-width: 150px; line-height: 1.2; }
 /* subtle draw-mode affordance (top-right of the plot); mirrors .panel-name but muted and non-interactive */
 /* inline affordance beside the pop selector (was overlaid on the plot, which obscured gating) */
-.gate-hint { margin-left: 2px; pointer-events: none; display: inline-flex; align-items: center; gap: 4px;
-  font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); white-space: nowrap; }
+.gate-hint { margin-left: 2px; pointer-events: none; display: inline-flex; align-items: center; gap: 4px; white-space: nowrap; }
 
 /* centred empty-state over the plot: track-grained pop type on an untracked segmentation.
    + .cc-empty-inline .cc-card — an inline empty wearing card chrome; only the centring is local */

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -267,7 +267,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
         <button class="cc-btn" v-tooltip.bottom="'Copy this gating to other images in the set'"
                 @click="showCopy = true"><i class="pi pi-copy" /> Copy</button>
         <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
-        <span class="gp-hint">drag plots by their title · resize from the corner</span>
+        <span class="gp-hint cc-muted cc-muted-xs">drag plots by their title · resize from the corner</span>
       </div>
       <div ref="canvasRef" class="gp-canvas">
         <!-- scaled workspace: the plots zoom together; the population manager stays full-size (below) -->
@@ -304,7 +304,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
 .gp-bar { display: flex; align-items: center; gap: 14px; padding: 8px 4px; font-size: var(--cc-fs-sm); flex-shrink: 0; }
 .gp-bar label { display: flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .gp-bar select { min-width: 9rem; }   /* visual styling from the global form base */
-.gp-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); opacity: 0.7; }
+.gp-hint { opacity: 0.7; }
 /* z-slice window stepper (shown only in slice mode) */
 .zwin { display: flex; align-items: center; gap: 2px; color: var(--cc-text-dim); }
 .zwin input { width: 3.2rem; padding: 3px 4px; }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,7 +1,18 @@
 /* ── Cecelia design tokens ──────────────────────────────────────────────────── */
 /* Dark-first. The .cc-dark class is always applied at shell level.             */
 
-.cc-dark {
+/* Declared on :root, NOT on .cc-dark — and that is load-bearing, not tidiness.
+   `.cc-dark` is a <div> inside <body> (App.vue's shell), so anything a library appends to
+   document.body is a SIBLING of it and inherits none of these. PrimeVue's tooltip does exactly that
+   (`document.body.appendChild(container)`), so every `var(--cc-*)` in the tooltip override was invalid
+   at computed-value time — the declaration dropped, and the tooltip fell back to inheriting from
+   <body>, whose own `font-size: var(--cc-fs-md)` was dead for the same reason. It had been rendering
+   at the browser default 16px. Same for `body`'s size and the tooltip's radius.
+   `TeleportPopover` had already hit this and worked around it by re-adding `.cc-dark` to its
+   teleported node; that is a patch on one caller, this is the fix.
+   Note this is NOT what `cssTokens.test.ts` checks — the tokens were all correctly *declared*. The
+   blind spot is reachability: declared in a scope the element never sees. */
+:root {
   /* backgrounds */
   --cc-bg:         #0f1117;
   --cc-surface-1:  #161b22;
@@ -108,8 +119,12 @@ body {
 /* ── PrimeVue tooltip overrides ────────────────────────────────────────────── */
 
 .p-tooltip .p-tooltip-text {
-  /* Same rounding-up as the input base: this was 0.72rem and the sweep took it to the nearer step,
-     which happened to be the larger one. A tooltip is dense chrome, so it belongs on --cc-fs-xs. */
+  /* --cc-fs-xs (≈10.9px) is the step nearest the 0.72rem this rule carried before the tokenisation
+     sweep. The sweep's own choice (--cc-fs-sm) was defensible on rounding, but it silently turned a
+     working literal into an unreachable token — see the :root note above — so the tooltip stopped
+     being 11.5px and started inheriting the browser default 16px. That, not the rounding, is why
+     tooltips looked oversized. This is the first version of this rule whose font-size actually
+     applies. */
   font-size: var(--cc-fs-xs);
   padding: 0.3rem 0.6rem;
   background: #21262d;
@@ -313,15 +328,26 @@ body {
 /* Each scenario below is `base class + optional modifier`, and the modifiers exist for one reason:
    the axis a site legitimately varies on. Bake that axis into the base and adoption forces a visual
    change, so the site stays hand-rolled — which is how the "kept bespoke" list in
-   UX_PRIMITIVES_PLAN.md accumulated. The axes are DENSITY (-dense/-micro, for dense chrome),
+   UX_PRIMITIVES_PLAN.md accumulated. The axes are DENSITY (a step on the --cc-fs-* scale),
    SURFACE (-2) and LAYOUT (-inline/-overlay/-lg). Per-site emphasis (italic) and geometry
-   (width/margin/flex) still belong in scoped CSS. */
+   (width/margin/flex) still belong in scoped CSS.
 
-/* Secondary / de-emphasised text — hints, subtitles, captions, meta lines. -dense/-micro drop to the
-   two smallest tiers for dense contexts (chip rows, whiteboard nodes) without changing the role. */
+   DENSITY MODIFIERS NAME THE SCALE STEP (-md/-xs/-2xs/-3xs), not a relative amount. They were
+   -dense/-micro, and that broke twice for the same reason: a relative name can only ever express the
+   steps you thought of. `.cc-muted` had no 11px step — the single largest cluster of hand-rolled muted
+   text in the app, 14 rules — because "dense" was already spent on 10px, and there was no name at all
+   for the step ABOVE the base. Worse, -dense was not even a consistent step: two tiers down from
+   `.cc-muted`'s 12px base and one from `.cc-eyebrow`'s 11px. Naming the step makes the axis complete by
+   construction and the next one obvious to add. */
+
+/* Secondary / de-emphasised text — hints, subtitles, captions, meta lines. The modifier picks the tier;
+   the role (dim, secondary) is what the base class means and does not change with size. */
 .cc-muted { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
-.cc-muted-dense { font-size: var(--cc-fs-2xs); }
-.cc-muted-micro { font-size: var(--cc-fs-3xs); }
+.cc-muted-lg  { font-size: var(--cc-fs-lg); }
+.cc-muted-md  { font-size: var(--cc-fs-md); }
+.cc-muted-xs  { font-size: var(--cc-fs-xs); }
+.cc-muted-2xs { font-size: var(--cc-fs-2xs); }
+.cc-muted-3xs { font-size: var(--cc-fs-3xs); }
 
 /* Empty / placeholder state — "nothing here yet" message. Centred, muted, padded; drop an icon /
    title / CTA inside for the rich variant (it's a flex column).
@@ -342,23 +368,23 @@ body {
 .cc-empty-lg { padding: 4rem 2rem; gap: 0.5rem; }
 
 /* Numeric value readout shown beside a control/metric (slider values, counts, occupancy). Default is
-   muted; add .cc-readout-strong for a prominent count (same scenario, higher prominence), or
-   .cc-readout-dense for an inline readout in dense chrome. */
+   muted; add .cc-readout-strong for a prominent count (same scenario, higher prominence), or a density
+   step for an inline readout in dense chrome. */
 .cc-readout { font-variant-numeric: tabular-nums; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
 .cc-readout-strong { color: var(--cc-text); font-weight: 600; }
-.cc-readout-dense { font-size: var(--cc-fs-2xs); }
+.cc-readout-xs  { font-size: var(--cc-fs-xs); }
+.cc-readout-2xs { font-size: var(--cc-fs-2xs); }
 
-/* Eyebrow / section label — small uppercase dim heading above a group of controls. -dense for the
-   sticky list/table headers, which sit a tier smaller. */
+/* Eyebrow / section label — small uppercase dim heading above a group of controls. Note the base is a
+   tier smaller than `.cc-muted`'s: an eyebrow is chrome, not prose. */
 .cc-eyebrow {
   font-size: var(--cc-fs-xs); font-weight: 600; letter-spacing: 0.06em;
   text-transform: uppercase; color: var(--cc-text-dim);
 }
-.cc-eyebrow-dense { font-size: var(--cc-fs-2xs); }
-/* The density axis runs one step further for eyebrows than it did — `.cc-muted` always had both
-   -dense and -micro, `.cc-eyebrow` only -dense, and the missing bottom step is exactly why the
-   whiteboard nodes (start/scope labels, the QC footer) kept their own 9px uppercase rule. */
-.cc-eyebrow-micro { font-size: var(--cc-fs-3xs); }
+.cc-eyebrow-2xs { font-size: var(--cc-fs-2xs); }
+/* The bottom step is why the whiteboard nodes (start/scope labels, the QC footer) kept their own 9px
+   uppercase rule for so long — the axis simply stopped above them. */
+.cc-eyebrow-3xs { font-size: var(--cc-fs-3xs); }
 
 /* Surface / container chrome — a card/panel body (hairline border + md radius). Surface is the axis:
    the base is the recessed surface-1, `.cc-card-2` the raised surface-2 (a card sitting ON a
@@ -378,7 +404,7 @@ input[type="password"], input[type="email"], textarea {
   /* One step BELOW body, which is what this base has always meant to be: it started life at 0.8rem
      and the tokenisation sweep rounded it UP to the nearest step (--cc-fs-md, = body). That read as
      "the fields got bigger" in every dialog, and the density axis was not the answer — measured, only
-     ONE of ~25 text fields had ever opted into `.cc-input-dense`, so the tier sites actually wanted
+     ONE of ~25 text fields had ever opted into the density class, so the tier sites actually wanted
      was the DEFAULT, not an opt-in. The steps below are re-pitched accordingly. */
   font-size: var(--cc-fs-sm);
   color: var(--cc-text);
@@ -405,15 +431,15 @@ input[type="password"]:focus, input[type="email"]:focus, textarea:focus {
    background verbatim. Padding's 23 spellings were not 23 choices — sorted, they collapse to two tiers
    below the base, because padding TRACKS the size rather than varying independently. So each step sets
    both, exactly as `.cc-btn-icon` bundles box and glyph size. Compose:
-   `class="my-field cc-input-dense"`, and keep only real layout (width / flex / margin) in scoped CSS.
+   `class="my-field cc-input-xs"`, and keep only real layout (width / flex / margin) in scoped CSS.
    Guarded by `findRestatedInputBase` in cssScenarios.test.ts.
 
    Re-pitched one step down when the base was: adding the axis was right, but it was hung off a base
    that had itself drifted a tier too large, so the steps started at the size the base should have
    been. Adoption proved it — one call site in the whole app, and it existed to get a field back to
    the size a plain input should already have rendered at. */
-.cc-input-dense { font-size: var(--cc-fs-xs); padding: 0.15rem 0.4rem; }
-.cc-input-micro { font-size: var(--cc-fs-2xs); padding: 0.05rem 0.25rem; }
+.cc-input-xs  { font-size: var(--cc-fs-xs);  padding: 0.15rem 0.4rem; }
+.cc-input-2xs { font-size: var(--cc-fs-2xs); padding: 0.05rem 0.25rem; }
 
 /* native select chevron → custom caret so dropdowns match across browsers */
 select {

--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -311,7 +311,7 @@ const { width: sidebarWidth, onResizeStart } =
 
     <!-- ── Function selector ── -->
     <section v-if="defs.length" class="runner-section">
-      <h3 class="section-heading">Function</h3>
+      <h3 class="section-heading cc-eyebrow cc-eyebrow-2xs">Function</h3>
       <select
         class="fn-select"
         v-model="selectedTask"
@@ -334,7 +334,7 @@ const { width: sidebarWidth, onResizeStart } =
 
     <!-- ── Parameters ── -->
     <section class="runner-section params-section" v-if="taskDef">
-      <h3 class="section-heading">Parameters</h3>
+      <h3 class="section-heading cc-eyebrow cc-eyebrow-2xs">Parameters</h3>
       <div class="params-list">
         <ParamRenderer
           v-for="p in taskDef.params"
@@ -362,7 +362,7 @@ const { width: sidebarWidth, onResizeStart } =
       </button>
 
       <div class="pool-row" v-if="pools.length > 0">
-        <span class="pool-label"
+        <span class="pool-label cc-muted cc-muted-xs"
           v-tooltip.right="'Resource pool controls how many tasks share a concurrency slot. GPU tasks should use the gpu pool to avoid running multiple models at once.'">
           Pool
         </span>
@@ -382,7 +382,7 @@ const { width: sidebarWidth, onResizeStart } =
     <!-- ── Task list ── -->
     <section class="runner-section tasks-section">
       <div class="tasks-heading">
-        <h3 class="section-heading">Tasks</h3>
+        <h3 class="section-heading cc-eyebrow cc-eyebrow-2xs">Tasks</h3>
         <div class="tasks-heading-actions">
           <button
             v-if="activeTasks.length"
@@ -483,24 +483,12 @@ const { width: sidebarWidth, onResizeStart } =
   gap: 0.5rem;
   margin-top: 0.5rem;
 }
-.pool-label {
-  font-size: var(--cc-fs-xs);
-  color: var(--cc-text-dim);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
+.pool-label { white-space: nowrap; flex-shrink: 0; }
 .pool-chips { flex: 1; min-width: 0; }
 .pool-throttle { transition: background 0.1s, color 0.1s; }   /* + cc-btn cc-btn-ghost cc-btn-icon */
 .pool-throttle:hover  { color: var(--cc-text); }
 
-.section-heading {
-  font-size: var(--cc-fs-2xs);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--cc-text-dim);
-  margin: 0 0 0.5rem;
-}
+.section-heading { margin: 0 0 0.5rem; }
 
 /* function selector */
 .fn-select {

--- a/frontend/src/utils/cssScenarios.test.ts
+++ b/frontend/src/utils/cssScenarios.test.ts
@@ -188,51 +188,26 @@ describe('inputBase', () => {
 // size, so tokenising a rule silently un-flagged it). When adding a matcher, ask which other spellings
 // of the same declaration exist: token vs literal, with fallback vs without, scoped vs inline.
 const BASELINE: Record<string, number> = {
-  'components/AppSidebar.vue': 2,
-  'components/ClaudeOverviewDialog.vue': 2,
-  'components/CohortCheckButton.vue': 1,
-  'components/CopyDialog.vue': 1,
-  'components/CropDialog.vue': 1,
-  'components/CropPanel.vue': 1,
-  'components/ErrorConsole.vue': 2,
-  'components/FileBrowser.vue': 2,
   'components/ImageMetadataDialog.vue': 3,
   'components/ImageTable.vue': 3,
   'components/LabLogPanel.vue': 5,
-  'components/LegacyMigrateDialog.vue': 1,
   'components/ModuleLayout.vue': 5,
   'components/PackagesDialog.vue': 4,
-  'components/PhysicalSizeDialog.vue': 1,
-  'components/PoolThrottle.vue': 2,
   'components/ProjectPanel.vue': 5,
-  'components/SetBar.vue': 2,
   'components/ViewerPanel.vue': 5,
-  'components/canvas/InteractivePanel.vue': 1,
   'components/canvas/LayoutCanvas.vue': 3,
   'components/canvas/PlateBuilder.vue': 3,
-  'components/canvas/PlotOptions.vue': 1,
   'components/canvas/PopulationManager.vue': 4,
-  'components/canvas/SummaryCanvas.vue': 1,
   'components/canvas/SummaryPanel.vue': 3,
-  'components/plots/GateMontage.vue': 2,
   'components/plots/GateScatterCell.vue': 3,
-  'components/plots/ImageStripView.vue': 2,
-  'components/plots/PlotSpinner.vue': 1,
-  'components/plots/UmapView.vue': 2,
   'modules/AnimationModule.vue': 6,
   'modules/ChainModule.vue': 11,
-  'modules/MoviesModule.vue': 2,
   'modules/SettingsModule.vue': 3,
-  'modules/SetupModule.vue': 2,
   'modules/TasksModule.vue': 6,
   'modules/batchmovies/BatchMoviesPanel.vue': 4,
-  'modules/cluster/ClusterPlots.vue': 1,
-  'modules/gate/GatePlotPanel.vue': 2,
-  'modules/gate/GatingPlots.vue': 1,
   'modules/metadata/MetadataPanel.vue': 4,
   'tasks/ParamRenderer.vue': 5,
   'tasks/TaskList.vue': 5,
-  'tasks/TaskRunner.vue': 2,
 }
 
 const RAW = import.meta.glob('/src/**/*.{vue,css}', {
@@ -347,7 +322,7 @@ describe('raw colours', () => {
 })
 
 describe('form controls', () => {
-  // The input/select/textarea base is one size, and until `.cc-input-dense`/`-micro` existed there was
+  // The input/select/textarea base is one size, and until the density steps existed there was
   // no way to make a control smaller except to write a class — at which point sites re-typed the base's
   // border/colour/background too. 67 such declarations across 19 files were removed; they were no-ops
   // by the cascade, so the removal is provably neutral.

--- a/frontend/src/utils/cssScenarios.ts
+++ b/frontend/src/utils/cssScenarios.ts
@@ -115,9 +115,9 @@ export function scenarioFor(rule: CssRule): Scenario | null {
  * picks. Asserting `.cc-muted` there would silently talk people out of the tabular figures.
  */
 export const SCENARIO_HINT: Record<Scenario, string> = {
-  muted:   '.cc-muted (or .cc-readout if it is a numeric value beside a control)',
+  muted:   '.cc-muted + the step (-lg/-md/-xs/-2xs/-3xs), or .cc-readout for a numeric value',
   empty:   '.cc-empty (+ -inline / -overlay / -lg)',
-  eyebrow: '.cc-eyebrow (+ -dense / -micro)',
+  eyebrow: '.cc-eyebrow (+ -2xs / -3xs)',
 }
 
 // ── Scoped overrides of a global utility ──────────────────────────────────────────────────────────
@@ -281,7 +281,7 @@ export function inputBase(styleCss: string): Record<string, string> {
  * density steps — of ~112 rules touching a form control, 67 declarations across 19 files were pure
  * re-statement (`color`, `border`, `background` dominating), while font-size used only 5 values (all
  * already tokens) and padding's 23 spellings collapsed to two tiers once sorted, because padding
- * TRACKS the size rather than varying independently. Hence `.cc-input-dense`/`-micro` set both.
+ * TRACKS the size rather than varying independently. Hence `.cc-input-xs`/`-2xs` set both.
  *
  * A rule counts as targeting a form control when its SUBJECT names one, or names a class this file's
  * template puts on one — the same markup-informed test the icon-button check uses.

--- a/frontend/src/utils/cssTokens.test.ts
+++ b/frontend/src/utils/cssTokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { definedTokens, referencedTokens, findDeadTokenRefs } from './cssTokens'
+import { definedTokens, referencedTokens, findDeadTokenRefs, findNonRootTokenDecls } from './cssTokens'
 
 describe('definedTokens', () => {
   it('collects declarations and ignores references', () => {
@@ -53,6 +53,20 @@ describe('findDeadTokenRefs', () => {
   })
 })
 
+describe('findNonRootTokenDecls', () => {
+  it('accepts :root and flags a scale hidden behind a class', () => {
+    expect(findNonRootTokenDecls(':root { --cc-fs-sm: 0.75rem; }')).toEqual([])
+    expect(findNonRootTokenDecls(':root, .cc-dark { --cc-fs-sm: 0.75rem; }')).toEqual([])
+    expect(findNonRootTokenDecls('.cc-dark { --cc-fs-sm: 0.75rem; }'))
+      .toEqual([{ selector: '.cc-dark', token: '--cc-fs-sm' }])
+  })
+
+  // A component-local token set on its own class is fine — this check is only about style.css.
+  it('ignores non-token declarations', () => {
+    expect(findNonRootTokenDecls('.foo { color: red; }')).toEqual([])
+  })
+})
+
 // ── The real check: no component may reference a token style.css doesn't declare ──────────────────
 
 // Sources are pulled in with Vite's raw glob rather than node's fs, so this test needs no
@@ -72,5 +86,14 @@ describe('the app stylesheet', () => {
     const dead = findDeadTokenRefs(RAW['/src/style.css'], sources)
     // Reported as readable lines so a failure names the file and token directly.
     expect(dead.map(d => `${d.path}: ${d.token}`)).toEqual([])
+  })
+
+  // Declared is not the same as reachable, and the symptoms are identical. The scale lived on
+  // `.cc-dark` — a <div> inside <body> — so PrimeVue's tooltip, which it appends to document.body,
+  // was a sibling of that div and resolved none of these: its font-size and radius dropped and it
+  // rendered at the browser default 16px, with the token guard green the whole time.
+  it('declares the global scale on :root, so body-appended overlays can reach it', () => {
+    const stray = findNonRootTokenDecls(RAW['/src/style.css'])
+    expect(stray.map(s => `${s.selector} declares ${s.token}`)).toEqual([])
   })
 })

--- a/frontend/src/utils/cssTokens.ts
+++ b/frontend/src/utils/cssTokens.ts
@@ -54,6 +54,33 @@ export function referencedTokens(text: string): TokenRef[] {
   return out
 }
 
+/**
+ * Custom properties the global stylesheet declares somewhere OTHER than `:root`.
+ *
+ * `findDeadTokenRefs` proves a token is *declared*; it cannot prove the element referencing it can
+ * *reach* the declaration, and those are different bugs with identical symptoms. The global tokens
+ * used to live on `.cc-dark`, which is a `<div>` inside `<body>` (App.vue's shell) — so anything a
+ * library appends to `document.body` is a SIBLING of that div and inherits none of them. PrimeVue's
+ * tooltip does exactly that, so every `var(--cc-*)` in the tooltip override was invalid at
+ * computed-value time and the tooltip silently rendered at the browser default 16px. `<body>`'s own
+ * `font-size: var(--cc-fs-md)` was dead the same way.
+ *
+ * Nothing failed, nothing warned, and the token guard was green throughout — the tokens were all
+ * correctly declared. Only reachability was wrong. `:root` is the one selector every node in the
+ * document can see, portal/teleport targets included, so that is where the scale belongs.
+ */
+export function findNonRootTokenDecls(styleCss: string): Array<{ selector: string, token: string }> {
+  const out: Array<{ selector: string, token: string }> = []
+  const css = stripComments(styleCss)
+  // top-level `selector { … }` blocks; nested at-rules are not where the scale is declared
+  for (const m of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const selector = m[1].trim().replace(/\s+/g, ' ')
+    if (!selector || selector.startsWith('@') || /(^|,)\s*:root\b/.test(selector)) continue
+    for (const d of m[2].matchAll(/(--cc-[A-Za-z0-9_-]+)\s*:/g)) out.push({ selector, token: d[1] })
+  }
+  return out
+}
+
 export interface DeadTokenRef extends TokenRef {
   path: string
 }


### PR DESCRIPTION
Two visible regressions this session were both misdiagnosed as rounding. The real cause is that a token
can be correctly **declared** and still be **unreachable**.

## The tooltip was never the size any of us thought

`.cc-dark` is a `<div>` inside `<body>` (`App.vue`'s shell), and the whole token scale was declared on
it. PrimeVue's tooltip does `document.body.appendChild(...)`, so it is a **sibling** of that div and
inherits none of them. Every `var(--cc-*)` in the tooltip override was invalid at computed-value time,
the declarations dropped, and the tooltip fell back to inheriting from `<body>` — whose own
`font-size: var(--cc-fs-md)` was dead the same way. **It had been rendering at the browser default
16px**, with its border-radius dead too.

The tokenisation sweep is what broke it: pre-sweep the rule said `0.72rem`, a literal, which worked
regardless of scope. The sweep turned a working literal into a token reference in a scope that has no
tokens. `cssTokens.test.ts` was green throughout, and correctly so — the tokens were all declared.

- tokens moved to `:root`, the one selector every node in the document can see
- tooltip → `--cc-fs-xs`, the step nearest the original `0.72rem`. **The first version of this rule
  whose font-size actually applies**
- new `findNonRootTokenDecls` + test: the global scale may only be declared on `:root`.
  Declared-vs-missing and declared-vs-unreachable are different bugs with identical symptoms, so the
  second one needs its own check

`TeleportPopover` had already hit this and worked around it by re-adding `.cc-dark` to its teleported
node — a patch on one caller. This is the fix.

## Density modifiers name the scale step

`-xs`, not `-dense`. Not cosmetic: **14 of the 38 remaining tail rules sat at 11px and `.cc-muted` had
no step there**, because "dense" was already spent on 10px and nothing named the step *above* the base.
`-dense` wasn't even a consistent step — two tiers below `.cc-muted`'s base, one below `.cc-eyebrow`'s.
The tail could not be migrated until the axis was complete. `.cc-input-dense/-micro` →
`.cc-input-xs/-2xs` for the same reason (zero call sites, so free).

## The tail is drained

38 rules across 25 files onto the utilities.

| | before | after |
|---|---|---|
| baseline rules | 128 | **90** |
| baseline files | 45 | **20** |

Halving the *file* surface is the point — it's what makes the remainder legible. Two needed hand-work:
`ErrorConsole`'s `.empty` → `.cc-empty`, and `GatePlotPanel`'s `.panel-ctrl label` descendant rule →
`.cc-muted` on the three labels.

**Intended visual changes:** `.section-heading` weight 700 → 600 (the eyebrow's), two letter-spacing
0.05em → 0.06em, and `ErrorConsole`'s empty state becomes a centred flex column. Everything else is
byte-equivalent — the utility supplies exactly the declarations that were stripped.

## Verification

`pixi run test-frontend` 379 passed (52 files) · `npm run typecheck` clean · 39 files, +18 net.

## Reservations

1. **The `:root` move is the highest-risk item** — it widens every token's scope from the shell div to
   the document. Nothing should notice (the shell is inside `:root`), but it's a one-line change with
   app-wide reach and hasn't been seen in a browser.
2. **The tooltip drops 16px → ~10.9px** — a far bigger visible jump than the "one step" discussed,
   because it was never at the size we thought. `--cc-fs-sm` (12px) is the step back if it reads small.
3. **The `-dense`/`-micro` → step-name rename breaks any in-flight branch** using the old modifiers.
4. Migration was scripted; empty rules, stray semicolons and sample diffs were checked, but 25 files of
   template edits are only spot-checked.
5. The remaining 90 rules are the concentrated files (`ChainModule` 11, `AnimationModule`/`TasksModule`
   6 each) — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
