### PR TITLE
Migrate the last 90 hand-rolled scenarios, and collapse the density ladder to one shared scale

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -41,25 +41,27 @@ primitives still being extracted lives in `docs/todo/UX_PRIMITIVES_PLAN.md`.
 
 | Scenario | Use | Never |
 |------|-----|-------|
-| Secondary / muted text (hint, subtitle, caption, meta) | `.cc-muted` (+ `-lg`/`-md`/`-xs`/`-2xs`/`-3xs` — the modifier NAMES the scale step) | a scoped `color: var(--cc-text-dim); font-size: …` |
+| Secondary / muted text (hint, subtitle, caption, meta) | `.cc-muted` (+ a `.cc-fs-*` step) | a scoped `color: var(--cc-text-dim); font-size: …` |
 | Small dim label beside a control | `.cc-muted` — same scenario, no separate utility | a per-file `.*-lbl`/`.*-label` |
 | Empty / "nothing here yet" state | `.cc-empty` (+ `-inline` one-liner / `-overlay` over a plot / `-lg` rich page empty) | a new `.*-empty` class |
-| Numeric value readout beside a control | `.cc-readout` (+ `-strong` prominent; `-xs`/`-2xs` in dense chrome) | a bespoke `.*-val`/`.*-num` |
-| Eyebrow / section label (uppercase dim heading) | `.cc-eyebrow` (base is 11px; + `-2xs` list/table headers, `-3xs` whiteboard-node labels) | a scoped uppercase-heading rule |
+| Numeric value readout beside a control | `.cc-readout` (+ `-strong` prominent; + a `.cc-fs-*` step) | a bespoke `.*-val`/`.*-num` |
+| Eyebrow / section label (uppercase dim heading) | `.cc-eyebrow` (base is 11px; + a `.cc-fs-*` step) | a scoped uppercase-heading rule |
 | Card / panel / surface container | `.cc-card` (+ `-2` when it sits *on* a surface-1 panel) | a scoped `surface + 1px border + radius` block |
 | Corner radius | `--cc-radius-xs/sm/md/lg/pill` | a raw `rem`/`px` radius |
-| Small text size | `--cc-fs-3xs/2xs/xs/sm/md/lg` | a raw `rem`/`px` font-size (incl. inline `style=`) |
+| Small text size | the `--cc-fs-*` token in CSS, or the `.cc-fs-*` class in markup | a raw `rem`/`px` font-size (incl. inline `style=`) |
 | Compact input / select / textarea | `.cc-input-xs` (11px) / `.cc-input-2xs` (10px) — sets size AND padding. **The base is already 12px**, so most fields need neither | a scoped class re-typing the base's border/colour/background to change the size |
 | A colour a token already holds | that token — `var(--cc-accent)`, not `#a78bfa` | a hex literal, **or** a `var(--x, #hex)` fallback (add the token, never a fallback) |
 
-**Each utility varies on exactly one axis, and the modifier is that axis** — density (a step on the
-`--cc-fs-*` scale), surface (`-2`), layout (`-inline`/`-overlay`/`-lg`).
+**Pick a scenario, then a size.** `.cc-muted .cc-fs-xs` · `.cc-eyebrow .cc-fs-2xs` ·
+`.cc-readout .cc-fs-2xs` · `.cc-empty-inline .cc-fs-3xs`. The size ladder is ONE shared set of classes
+(`.cc-fs-lg/-md/-sm/-xs/-2xs/-3xs`, the same steps as the `--cc-fs-*` tokens), not a per-scenario one:
+`.cc-muted-2xs`, `.cc-eyebrow-2xs` and `.cc-readout-2xs` were three names for one declaration, and
+naming them per scenario only made you guess which to reach for. Modifiers that carry real semantics
+DO stay on their scenario — `.cc-readout-strong` is prominence, `.cc-empty-inline` is layout.
 
-**Density modifiers name the scale step, not a relative amount** (`-xs`, not `-dense`). A relative name
-can only express the steps someone thought of: `.cc-muted` had no 11px step — the single largest cluster
-of hand-rolled muted text in the app — because "dense" was already spent on 10px, and there was no name
-at all for the step *above* the base. `-dense` was not even a consistent step: two tiers below
-`.cc-muted`'s base and one below `.cc-eyebrow`'s. Naming the step makes the axis complete by construction. Reach for the modifier instead of re-declaring the
+**The step is named, not relative** (`-xs`, not `-dense`). A relative name can only express the steps
+someone thought of: `.cc-muted` had no 11px step — the single largest cluster of hand-rolled muted text
+in the app — because "dense" was already spent on 10px, and nothing named the step *above* the base. Reach for the modifier instead of re-declaring the
 scenario locally: baking a value into the base is what stranded ~10 sites as "bespoke" before. Per-site
 *emphasis* (`font-style: italic`) and *geometry* (width/margin/flex/padding) still belong in scoped CSS.
 

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -36,6 +36,7 @@ read these; do not re-derive one by grep.
 | `findRestatedInputBase` + `inputBase` | `cssScenarios.ts` | form-control rules re-stating the global input base | exact list (2 survivors, each a class shared with a non-input element) |
 | `findDeadTokenRefs` | `cssTokens.ts` | a reference to a `--*` property `style.css` never declares | must be empty |
 | `findNonRootTokenDecls` | `cssTokens.ts` | the global scale declared anywhere but `:root` (declared ≠ *reachable*) | must be empty |
+| the ladder-order assertion | `cssScenarios.test.ts` | `.cc-fs-*` must be declared AFTER every scenario base that sets a font-size — equal specificity, so source order decides | must hold |
 
 Shared plumbing at the top of `cssScenarios.ts`: `styleBlocks()` and `cssRules()` (which recurses into
 `@media`). `SCENARIO_HINT` supplies the "migrate it to this" text the ratchet prints. Three things that
@@ -50,11 +51,14 @@ are easy to break:
   labelled `muted`. Nothing in the CSS separates them, so `SCENARIO_HINT` names both candidates rather
   than talking the next migrator out of the tabular figures.
 
-## Open
+## Status: the sweep is finished
 
-- **Nothing.** The scenario backlog is done: ~310 → 132 → 90 → **0**, and the ratchet is an exact
-  empty list rather than a shrinking per-file count. New divergence fails immediately and there is no
-  longer a backlog to hide in.
+**The scenario backlog is zero** — ~310 → 132 → 90 → **0** — and the ratchet is an exact empty list
+rather than a shrinking per-file count. New divergence fails immediately, and there is no longer a
+backlog for it to hide in. What follows is the standing not-doing list, not open work.
+
+## Deliberately not extracted
+
 - **Per-row disclosure in a list** (`TaskList`, `ErrorConsole`) — distinct from a section header, and
   deliberately NOT extracted. Inspected, the two sites differ on **four** axes: `TaskList` uses a
   focusable `<button>` (already `.cc-btn-bare .cc-btn-icon`) with a tooltip, the icon as click target and

--- a/docs/todo/UX_PRIMITIVES_PLAN.md
+++ b/docs/todo/UX_PRIMITIVES_PLAN.md
@@ -27,8 +27,9 @@ read these; do not re-derive one by grep.
 
 | Detector | In | Owns | Bar |
 |---|---|---|---|
-| `findReimplementedScenarios` | `cssScenarios.ts` | scoped rules re-declaring `.cc-muted`/`.cc-empty`/`.cc-eyebrow` | per-file `BASELINE` — **may shrink, must never grow** |
+| `findReimplementedScenarios` | `cssScenarios.ts` | scoped rules re-declaring `.cc-muted`/`.cc-empty`/`.cc-eyebrow` | exact list — currently **empty** |
 | `findScopedUtilityOverride` + `utilityRules` | `cssScenarios.ts` | a scoped rule whose selector *is* a global `.cc-*` utility, re-stating a property it declares | must be empty (no allow-list — composition is legal by construction) |
+| `findShadowedUtilities` | `cssScenarios.ts` | a text utility that another class on the SAME element beats on the utility's own role properties, so it does nothing | exact list (9 deliberate overrides, each with its reason) |
 | `findHandRolledIconButtons` | `cssScenarios.ts` | an icon-only `<button>` not built from `.cc-btn` | exact list (2 full-height strip exemptions) |
 | `findRawValues` | `cssScenarios.ts` | literal `font-size` / `border-radius`, incl. inline `style=` | exact list (1 documented exception) |
 | `findRawColours` + `colourTokens` | `cssScenarios.ts` | a hex a token already holds exactly; any `var(--x, #hex)` fallback | must be empty |
@@ -51,11 +52,9 @@ are easy to break:
 
 ## Open
 
-- **The scenario backlog.** The live list is the per-file `BASELINE` in `cssScenarios.test.ts`; it may
-  shrink and must never grow. Touch a file in it → migrate its rules and lower the number. Deliberately
-  decoupled from "finish the sweep": new divergence fails immediately, the backlog drains as files get
-  touched. The ≤2-rule tail has been drained (45 files → 20), so what's left is the concentrated
-  remainder; the failure message names the offending selector and the utility it wants.
+- **Nothing.** The scenario backlog is done: ~310 → 132 → 90 → **0**, and the ratchet is an exact
+  empty list rather than a shrinking per-file count. New divergence fails immediately and there is no
+  longer a backlog to hide in.
 - **Per-row disclosure in a list** (`TaskList`, `ErrorConsole`) — distinct from a section header, and
   deliberately NOT extracted. Inspected, the two sites differ on **four** axes: `TaskList` uses a
   focusable `<button>` (already `.cc-btn-bare .cc-btn-icon`) with a tooltip, the icon as click target and
@@ -130,7 +129,35 @@ The blow-by-blow is in git (`git log --oneline -- frontend/src/style.css`). What
    why `.cc-btn-icon`'s fixed square collapsed two full-height strip controls that were markup-identical
    to an icon button. A noisy check grows an allow-list, and the allow-list is where this rots. Where a
    detector can't be precise, the category gets a review-time rule in `docs/UI.md` and no number at all.
-8. **A rule stated in one place while its neighbour keeps doing the old thing is the recurring tell.**
+8. **Adopting a utility can silently cancel it.** Scoped CSS weighs (0,2,0) with `[data-v-…]`; a global
+   utility weighs (0,1,0). So a scoped class that used to win a same-specificity tie on SOURCE ORDER
+   starts winning outright the moment its neighbour becomes a utility — and the utility you just added
+   does nothing. This bit `TaskList`'s log placeholder and, one PR earlier and unnoticed,
+   `FileBrowser`'s "No files selected", which stopped being dim. `findShadowedUtilities` exists for
+   exactly this and found both. Migrating a class to a utility is a specificity *downgrade*; check what
+   else is on the element.
+
+9. **Three names for one declaration is a guess waiting to happen.** `.cc-muted-2xs`,
+   `.cc-eyebrow-2xs` and `.cc-readout-2xs` were all `font-size: var(--cc-fs-2xs)` — ten classes holding
+   six declarations. Naming them per scenario never made them scenario-specific; two sites had already
+   reached for `.cc-muted-3xs` on elements that were not muted. Collapsed to one shared `.cc-fs-*`
+   ladder. Keep a modifier on its scenario only when it carries semantics the scenario owns
+   (`-strong` = prominence, `-inline` = layout).
+
+10. **"The utility cannot apply" is usually a fact about the base rule, and the base rule is yours to
+    change.** The last un-migrated site was exempted because `.tl-rowhead` set `color` and `font-size`,
+    so no global utility could outrank it — true, and the wrong conclusion. The base had no business
+    owning either: the colour was redundant (nothing above the timeline dims) and the size belonged on
+    the cells. It took one question — "why is this one different?" — to dissolve a documented
+    exemption. Ask it before writing the exemption.
+
+11. **Source order decides between equal-specificity classes, and no test of *presence* can see it.**
+    Collapsing the density ladder put `.cc-fs-*` above the scenario bases, which each set their own
+    font-size at the same (0,1,0). Markup right, class names right, all tests green, and every
+    `.cc-eyebrow .cc-fs-2xs` silently rendering at the eyebrow's 11px. When two global classes are
+    designed to compose, their ORDER in the stylesheet is part of the contract — assert it.
+
+12. **A rule stated in one place while its neighbour keeps doing the old thing is the recurring tell.**
    The ratchet was first built with the largest category carved out of it; the "no counts" rule was added
    to one section while the table above it kept its stale counts; the size audit counted `rem` and
    ignored `px`. When you add a rule here, grep the whole file for what it forbids before claiming it

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -144,7 +144,7 @@ function isNavDisabled(item: NavItem): boolean {
             <span class="proj-name" v-tooltip.right="`Project: ${projectMeta.current.name} (${projectMeta.current.type})`">
               {{ projectMeta.current.name }}
             </span>
-            <span class="proj-type cc-eyebrow cc-eyebrow-2xs">{{ projectMeta.current.type }}</span>
+            <span class="proj-type cc-eyebrow cc-fs-2xs">{{ projectMeta.current.type }}</span>
           </div>
           <!-- no manual save: the /analysis boards autosave; everything else persists on edit -->
           <button class="proj-menu-btn cc-btn cc-btn-bare cc-btn-icon" @click="showPanel = true"
@@ -185,7 +185,7 @@ function isNavDisabled(item: NavItem): boolean {
             <i :class="['pi', item.icon, 'nav-icon']" />
             <span class="nav-label">{{ item.label }}</span>
             <span v-if="item.soon" class="soon-badge">soon</span>
-            <span v-else-if="item.requiresProject && !projectMeta.hasProject" class="lock-badge cc-muted cc-muted-xs"
+            <span v-else-if="item.requiresProject && !projectMeta.hasProject" class="lock-badge cc-muted cc-fs-xs"
               v-tooltip.right="'Requires an open project.'">
               <i class="pi pi-lock" />
             </span>

--- a/frontend/src/components/ChainLiveLabel.vue
+++ b/frontend/src/components/ChainLiveLabel.vue
@@ -15,14 +15,14 @@ defineProps<{
 </script>
 
 <template>
-  <div class="live-label cc-muted cc-muted-2xs" :class="data.kind">
+  <div class="live-label cc-muted cc-fs-2xs" :class="data.kind">
     <span class="live-label-text">{{ data.text }}</span>
     <span v-if="data.sub" class="live-label-sub">{{ data.sub }}</span>
   </div>
 </template>
 
 <style scoped>
-/* + cc-muted cc-muted-2xs (colour + the 10px tier); the rest is this label's geometry */
+/* + cc-muted cc-fs-2xs (colour + the 10px tier); the rest is this label's geometry */
 .live-label {
   white-space: nowrap;
   pointer-events: none;

--- a/frontend/src/components/ChainQcNode.vue
+++ b/frontend/src/components/ChainQcNode.vue
@@ -35,12 +35,12 @@ const fmt = (n?: number) => n == null ? '—' : n.toLocaleString()
       <span class="qc-name">{{ data.valueName }}</span>
       <span v-if="data.loading" class="qc-spin"><i class="pi pi-spin pi-spinner" /></span>
     </div>
-    <div class="qc-count">{{ fmt(data.total) }} <span class="qc-unit cc-muted cc-muted-3xs">cells</span></div>
+    <div class="qc-count">{{ fmt(data.total) }} <span class="qc-unit cc-muted cc-fs-3xs">cells</span></div>
     <div class="qc-spark">
       <span v-for="(h, i) in bars" :key="i" class="qc-bar" :style="{ height: h + 'px' }" />
-      <span v-if="!bars.length" class="qc-empty cc-empty-inline cc-muted-3xs">no data</span>
+      <span v-if="!bars.length" class="qc-empty cc-empty-inline cc-fs-3xs">no data</span>
     </div>
-    <div class="qc-foot cc-eyebrow cc-eyebrow-3xs">{{ data.imageCount ?? 0 }} img · expand</div>
+    <div class="qc-foot cc-eyebrow cc-fs-3xs">{{ data.imageCount ?? 0 }} img · expand</div>
   </div>
 </template>
 
@@ -59,11 +59,11 @@ const fmt = (n?: number) => n == null ? '—' : n.toLocaleString()
 .qc-name { font-size: var(--cc-fs-3xs); font-weight: 700; font-family: var(--cc-mono, monospace); letter-spacing: 0.04em; }
 .qc-spin { margin-left: auto; font-size: var(--cc-fs-2xs); opacity: 0.7; }
 .qc-count { font-size: var(--cc-fs-lg); font-weight: 700; color: var(--cc-text); margin: 2px 0; }
-/* + cc-muted cc-muted-3xs — the weight reset is this site's (it sits inside a 700 count) */
+/* + cc-muted cc-fs-3xs — the weight reset is this site's (it sits inside a 700 count) */
 .qc-unit { font-weight: 400; }
 .qc-spark { display: flex; align-items: flex-end; gap: 2px; height: 24px; }
 /* 1px is deliberate and off-scale: --cc-radius-xs (3px) on a 4px-wide bar rounds it to a blob */
 .qc-bar { width: 4px; background: var(--cc-accent); opacity: 0.7; border-radius: 1px; }
-.qc-empty { font-style: italic; }   /* + .cc-empty-inline .cc-muted-3xs (row/colour/9px tier) */
-.qc-foot { margin-top: 2px; }   /* + cc-eyebrow cc-eyebrow-3xs */
+.qc-empty { font-style: italic; }   /* + .cc-empty-inline .cc-fs-3xs (row/colour/9px tier) */
+.qc-foot { margin-top: 2px; }   /* + cc-eyebrow cc-fs-3xs */
 </style>

--- a/frontend/src/components/ChainStartNode.vue
+++ b/frontend/src/components/ChainStartNode.vue
@@ -14,7 +14,7 @@ defineProps<{ id: string; selected: boolean }>()
 <template>
   <div class="chain-start-node" :class="{ selected }" title="Start — link to the task(s) a run begins from">
     <span class="start-dot" />
-    <span class="cc-eyebrow cc-eyebrow-3xs">start</span>
+    <span class="cc-eyebrow cc-fs-3xs">start</span>
     <!-- initial node: source only (no target handle) -->
     <Handle type="source" :position="Position.Right" class="node-handle" />
   </div>

--- a/frontend/src/components/ChainTaskNode.vue
+++ b/frontend/src/components/ChainTaskNode.vue
@@ -21,10 +21,10 @@ defineProps<{
 
     <div class="node-scope" :title="`scope: ${data.scope}`">
       <span class="scope-dot" />
-      <span class="cc-eyebrow cc-eyebrow-3xs">{{ data.scope }}</span>
+      <span class="cc-eyebrow cc-fs-3xs">{{ data.scope }}</span>
     </div>
     <div class="node-label">{{ data.label || data.fn }}</div>
-    <div class="node-fn cc-muted cc-muted-2xs">{{ data.fn }}</div>
+    <div class="node-fn cc-muted cc-fs-2xs">{{ data.fn }}</div>
     <div v-if="data.resource_pool" class="node-pool">
       <i class="pi pi-server" style="font-size:var(--cc-fs-2xs)" />
       {{ data.resource_pool }}
@@ -78,7 +78,7 @@ defineProps<{
   text-overflow: ellipsis;
   max-width: 160px;
 }
-/* + cc-muted cc-muted-2xs — the mono face and truncation are this site's */
+/* + cc-muted cc-fs-2xs — the mono face and truncation are this site's */
 .node-fn {
   font-family: var(--cc-mono);
   margin-top: 2px;

--- a/frontend/src/components/ClaudeOverviewDialog.vue
+++ b/frontend/src/components/ClaudeOverviewDialog.vue
@@ -19,7 +19,7 @@ defineEmits<{ (e: 'close'): void }>()
     <div class="co-entries">
       <div v-for="e in CLAUDE_ENTRY_POINTS" :key="e.name" class="co-entry cc-card cc-card-2">
         <div class="co-entry-head"><i :class="['pi', e.icon]" /> {{ e.name }}</div>
-        <p class="co-entry-what cc-muted cc-muted-md">{{ e.what }}</p>
+        <p class="co-entry-what cc-muted cc-fs-md">{{ e.what }}</p>
         <ol class="co-steps">
           <li v-for="(s, i) in e.steps" :key="i">{{ s }}</li>
         </ol>

--- a/frontend/src/components/CropDialog.vue
+++ b/frontend/src/components/CropDialog.vue
@@ -37,7 +37,7 @@ function defaultValueName(): string {
       <span v-if="selectedValueName" class="crop-version-tag">{{ selectedValueName }}</span>
     </template>
     <div v-if="valueNames.length > 1" class="crop-version-row">
-      <span class="crop-version-lbl cc-muted cc-muted-xs" v-tooltip.right="'Which image version/iteration to crop'">Version</span>
+      <span class="crop-version-lbl cc-muted cc-fs-xs" v-tooltip.right="'Which image version/iteration to crop'">Version</span>
       <select v-model="selectedValueName" class="crop-version-select">
         <option v-for="vn in valueNames" :key="vn" :value="vn">{{ vn }}</option>
       </select>

--- a/frontend/src/components/CropPanel.vue
+++ b/frontend/src/components/CropPanel.vue
@@ -136,17 +136,17 @@ function save() {
       </div>
 
       <div v-if="info.nT > 1" class="crop-row">
-        <span class="crop-lbl cc-muted cc-muted-xs" v-tooltip.top="'Scrub timepoints to pick the clearest footprint'">frame</span>
+        <span class="crop-lbl cc-muted cc-fs-xs" v-tooltip.top="'Scrub timepoints to pick the clearest footprint'">frame</span>
         <input type="range" min="0" :max="info.nT - 1" v-model.number="t" />
         <span class="crop-tval">{{ t + 1 }}/{{ info.nT }}</span>
       </div>
       <div v-if="info.nZ > 1" class="crop-row">
-        <span class="crop-lbl cc-muted cc-muted-xs" v-tooltip.top="'Keep this z-range — also re-projects the preview to just these slices'">z</span>
+        <span class="crop-lbl cc-muted cc-fs-xs" v-tooltip.top="'Keep this z-range — also re-projects the preview to just these slices'">z</span>
         <RangeSlider v-model:lo="zLo" v-model:hi="zHi" />
         <span class="crop-tval">{{ zLabel }}</span>
       </div>
       <div v-if="info.nT > 1" class="crop-row">
-        <span class="crop-lbl cc-muted cc-muted-xs" v-tooltip.top="'Keep this time range'">t</span>
+        <span class="crop-lbl cc-muted cc-fs-xs" v-tooltip.top="'Keep this time range'">t</span>
         <RangeSlider v-model:lo="tLo" v-model:hi="tHi" />
         <span class="crop-tval">{{ tLabel }}</span>
       </div>

--- a/frontend/src/components/FileBrowser.vue
+++ b/frontend/src/components/FileBrowser.vue
@@ -160,11 +160,11 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 
       <!-- body -->
       <div class="fb-body">
-        <div v-if="loading" class="fb-state cc-muted cc-muted-md">
+        <div v-if="loading" class="fb-state cc-muted cc-fs-md">
           <i class="pi pi-spin pi-cog" /> Loading…
         </div>
 
-        <div v-else-if="error" class="fb-state error cc-muted cc-muted-md">
+        <div v-else-if="error" class="fb-state error cc-muted cc-fs-md">
           <i class="pi pi-exclamation-triangle" /> {{ error }}
           <button class="cc-btn cc-btn-ghost" @click="navigate('')">Back to home</button>
         </div>
@@ -248,7 +248,7 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
       <span class="sel-count" v-else-if="selected.size > 0">
         {{ selected.size }} {{ mode === 'bundle' ? 'bundle' : 'file' }}{{ selected.size > 1 ? 's' : '' }} selected
       </span>
-      <span class="sel-count dim cc-muted" v-else>{{ mode === 'bundle' ? 'No bundle selected' : 'No files selected' }}</span>
+      <span class="sel-count cc-muted" v-else>{{ mode === 'bundle' ? 'No bundle selected' : 'No files selected' }}</span>
 
       <div class="footer-actions">
         <button class="cc-btn cc-btn-ghost" @click="$emit('close')"
@@ -353,7 +353,9 @@ const shortcuts   = computed(() => listing.value?.shortcuts ?? [])
 .fb-empty { text-align: center; padding: 2rem; }   /* + .cc-muted */
 
 /* footer */
-.sel-count { font-size: var(--cc-fs-sm); color: var(--cc-text); flex: 1; }
+/* no colour here: the placeholder variant composes .cc-muted, and a scoped colour would
+   outrank it. The other two spans inherit --cc-text from the shell regardless. */
+.sel-count { font-size: var(--cc-fs-sm); flex: 1; }
 .footer-actions { display: flex; gap: 0.4rem; }
 /* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/components/ImageMetadataDialog.vue
+++ b/frontend/src/components/ImageMetadataDialog.vue
@@ -63,7 +63,7 @@ async function copy(key: string, value: string) {
 
       <!-- headline: the original source file this image was converted from -->
       <section class="md-section">
-        <h4 class="md-h">Original file</h4>
+        <h4 class="md-h cc-eyebrow">Original file</h4>
         <div v-if="img.oriPath" class="md-path">
           <code class="md-code">{{ img.oriPath }}</code>
           <button class="md-copy cc-btn cc-btn-bare cc-btn-icon" @click="copy('ori', img.oriPath!)"
@@ -71,11 +71,11 @@ async function copy(key: string, value: string) {
             <i :class="copied === 'ori' ? 'pi pi-check' : 'pi pi-copy'" />
           </button>
         </div>
-        <p v-else class="md-none">Not recorded — imported before source paths were tracked, or created in-app.</p>
+        <p v-else class="md-none cc-muted">Not recorded — imported before source paths were tracked, or created in-app.</p>
       </section>
 
       <section class="md-section">
-        <h4 class="md-h">Identity</h4>
+        <h4 class="md-h cc-eyebrow">Identity</h4>
         <div class="md-grid">
           <span class="md-k">UID</span><span class="md-v md-mono">{{ img.uid }}</span>
           <span class="md-k">Kind</span><span class="md-v">{{ img.kind || '—' }}</span>
@@ -84,7 +84,7 @@ async function copy(key: string, value: string) {
       </section>
 
       <section class="md-section">
-        <h4 class="md-h">Dimensions &amp; calibration</h4>
+        <h4 class="md-h cc-eyebrow">Dimensions &amp; calibration</h4>
         <div class="md-grid">
           <span class="md-k">Channels (C)</span><span class="md-v">{{ num(img.sizeC) }}</span>
           <span class="md-k">Z-slices (Z)</span><span class="md-v">{{ num(img.sizeZ) }}</span>
@@ -97,31 +97,31 @@ async function copy(key: string, value: string) {
       </section>
 
       <section v-if="channels.length" class="md-section">
-        <h4 class="md-h">Channels</h4>
+        <h4 class="md-h cc-eyebrow">Channels</h4>
         <ol class="md-chips">
           <li v-for="(c, i) in channels" :key="i" class="md-chip">{{ c }}</li>
         </ol>
       </section>
 
       <section class="md-section">
-        <h4 class="md-h">Stored files</h4>
+        <h4 class="md-h cc-eyebrow">Stored files</h4>
         <div class="md-grid">
           <span class="md-k">Active version</span><span class="md-v">{{ img.activeValueName || '—' }}</span>
         </div>
         <div v-for="[vn, fn] in versions" :key="'v-' + vn" class="md-file">
-          <span class="md-file-vn">{{ vn }}</span>
+          <span class="md-file-vn cc-muted">{{ vn }}</span>
           <code class="md-code">{{ fn }}</code>
         </div>
         <template v-if="labels.length">
           <div v-for="[vn, fns] in labels" :key="'l-' + vn" class="md-file">
-            <span class="md-file-vn">labels · {{ vn }}</span>
+            <span class="md-file-vn cc-muted">labels · {{ vn }}</span>
             <code class="md-code">{{ fns.join(', ') }}</code>
           </div>
         </template>
       </section>
 
       <section v-if="attrs.length" class="md-section">
-        <h4 class="md-h">Attributes</h4>
+        <h4 class="md-h cc-eyebrow">Attributes</h4>
         <div class="md-grid">
           <template v-for="[k, v] in attrs" :key="'a-' + k">
             <span class="md-k">{{ k }}</span><span class="md-v">{{ v }}</span>
@@ -130,7 +130,7 @@ async function copy(key: string, value: string) {
       </section>
 
       <section v-if="extra.length" class="md-section">
-        <h4 class="md-h">Other metadata</h4>
+        <h4 class="md-h cc-eyebrow">Other metadata</h4>
         <div class="md-grid">
           <template v-for="[k, v] in extra" :key="'e-' + k">
             <span class="md-k">{{ k }}</span><span class="md-v">{{ v }}</span>
@@ -139,7 +139,7 @@ async function copy(key: string, value: string) {
       </section>
 
       <section v-if="img.note" class="md-section">
-        <h4 class="md-h">Note</h4>
+        <h4 class="md-h cc-eyebrow">Note</h4>
         <p class="md-note-text">{{ img.note }}</p>
       </section>
     </div>
@@ -152,10 +152,7 @@ async function copy(key: string, value: string) {
 .md-name { margin: 0; font-size: var(--cc-fs-md); font-weight: 600; color: var(--cc-text); }
 
 .md-section { display: flex; flex-direction: column; gap: 0.4rem; }
-.md-h {
-  margin: 0; font-size: var(--cc-fs-xs); font-weight: 600; text-transform: uppercase;
-  letter-spacing: 0.04em; color: var(--cc-text-dim);
-}
+.md-h { margin: 0; }
 
 .md-grid {
   display: grid; grid-template-columns: max-content 1fr;
@@ -173,7 +170,7 @@ async function copy(key: string, value: string) {
 }
 /* .md-copy → cc-btn cc-btn-bare cc-btn-icon */
 .md-copy:hover { color: var(--cc-text); background: var(--cc-surface-2); }
-.md-none { margin: 0; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); font-style: italic; }
+.md-none { margin: 0; font-style: italic; }
 
 .md-chips { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 0.3rem; counter-reset: ch; }
 .md-chip {
@@ -184,7 +181,7 @@ async function copy(key: string, value: string) {
 .md-chip::before { counter-increment: ch; content: counter(ch) '· '; color: var(--cc-text-dim); }
 
 .md-file { display: flex; align-items: baseline; gap: 0.5rem; }
-.md-file-vn { flex-shrink: 0; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); min-width: 6rem; }
+.md-file-vn { flex-shrink: 0; min-width: 6rem; }
 
 .md-note-text { margin: 0; font-size: var(--cc-fs-md); color: var(--cc-text); white-space: pre-wrap; }
 </style>

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -791,7 +791,7 @@ onUnmounted(stopResize)
             </span>
           </span>
           <span class="uid-row">
-            <span class="img-uid">{{ img.uid }}</span>
+            <span class="img-uid cc-muted cc-fs-xs">{{ img.uid }}</span>
             <!-- last successful run — task-manager-style module tag (see run log / taskModule palette) -->
             <span v-if="lastRunTag(img)" class="run-tag" :style="lastRunTag(img)!.style"
               v-tooltip.right="lastRunTag(img)!.tip">
@@ -945,8 +945,8 @@ onUnmounted(stopResize)
        positions from the cog rect (was clipped by the following row) -->
   <TeleportPopover v-model="runLogOpen" :anchor="runLogAnchor">
     <div v-if="runLogImg" class="runlog-pop">
-      <div class="runlog-hd">Run history</div>
-      <div v-if="!runLogImg.runLog || !runLogImg.runLog.length" class="runlog-empty">No functions recorded yet.</div>
+      <div class="runlog-hd cc-eyebrow cc-fs-2xs">Run history</div>
+      <div v-if="!runLogImg.runLog || !runLogImg.runLog.length" class="runlog-empty cc-muted cc-fs-xs">No functions recorded yet.</div>
       <div v-for="(e, i) in [...(runLogImg.runLog ?? [])].reverse()" :key="i" class="runlog-row">
         <span class="runlog-fun">{{ e.fun }}</span>
         <span v-if="e.valueName" class="runlog-vn">{{ e.valueName }}</span>
@@ -1159,23 +1159,13 @@ th:hover .resize-handle::after { opacity: 1; }
 .runlog-cog.on { color: var(--cc-text); background: var(--cc-surface-2); opacity: 1; }
 /* inner layout only — TeleportPopover provides surface/border/shadow/position */
 .runlog-pop { min-width: 15rem; max-height: 16rem; overflow-y: auto; padding: 6px 8px; }
-.runlog-hd { font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.05em; color: var(--cc-text-dim); margin-bottom: 4px; }
-.runlog-empty { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.runlog-hd { margin-bottom: 4px; }
+
 .runlog-row { display: flex; align-items: baseline; gap: 6px; padding: 2px 0; font-size: var(--cc-fs-xs); }
 .runlog-fun { font-weight: 600; color: var(--cc-text); font-family: var(--cc-mono); }
 .runlog-vn { color: var(--cc-accent); font-size: var(--cc-fs-2xs); }
 .runlog-at { margin-left: auto; color: var(--cc-text-dim); font-variant-numeric: tabular-nums; white-space: nowrap; }
-.img-uid {
-  font-family: var(--cc-mono);
-  font-size: var(--cc-fs-xs);
-  color: var(--cc-text-dim);
-  letter-spacing: 0.03em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-  min-width: 0;
-}
+.img-uid { font-family: var(--cc-mono); letter-spacing: 0.03em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
 
 /* last-successful-run tag — mirrors the task-manager module pill (colour from taskModule palette),
    pushed to the right of the UID. Module id bold/uppercase, function label alongside. */

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -256,7 +256,7 @@ async function dismissEntry(entry: LabLogEntry) {
         @keydown="onKeydown"
       />
       <div class="ll-compose-row">
-        <span class="ll-hint">Enter to save · Shift+Enter for a new line</span>
+        <span class="ll-hint cc-muted cc-fs-xs">Enter to save · Shift+Enter for a new line</span>
         <button class="ll-save" :disabled="!draft.trim() || !projectUid || busy" @click="submit">
           {{ busy ? 'Saving…' : (correcting ? 'Save correction' : 'Save') }}
         </button>
@@ -304,13 +304,13 @@ async function dismissEntry(entry: LabLogEntry) {
                   : 'Copy a starter prompt to your clipboard — paste it into Claude Code (or any MCP assistant) for a full chat about this project'">
           <i :class="['pi', chatCopied ? 'pi-check' : 'pi-comments']" /> {{ chatCopied ? 'Copied' : 'Chat to Claude' }}
         </button>
-        <span v-if="observerTokens" class="ll-tokens"
+        <span v-if="observerTokens" class="ll-tokens cc-muted cc-fs-xs"
               v-tooltip.top="'Assistant token use for this observer session (real usage)'">{{ observerTokens }}</span>
         <button v-if="observerTokens" class="ll-clearctx" @click="clearContext"
                 v-tooltip.top="'Clear the assistant session and reset the token count'">clear</button>
       </div>
 
-      <span v-if="captureNote" class="ll-note">{{ captureNote }}</span>
+      <span v-if="captureNote" class="ll-note cc-muted cc-fs-xs">{{ captureNote }}</span>
     </div>
 
     <!-- Set-up guidance: the integration needs NO config — just Claude Code installed + logged in.
@@ -348,16 +348,16 @@ async function dismissEntry(entry: LabLogEntry) {
 
     <!-- entries, newest-first -->
     <div class="ll-list">
-      <div v-if="loading" class="ll-empty">Loading…</div>
-      <div v-else-if="!projectUid" class="ll-empty">No project open.</div>
-      <div v-else-if="!visibleEntries.length" class="ll-empty">
+      <div v-if="loading" class="ll-empty cc-muted">Loading…</div>
+      <div v-else-if="!projectUid" class="ll-empty cc-muted">No project open.</div>
+      <div v-else-if="!visibleEntries.length" class="ll-empty cc-muted">
         No entries yet. The first note you save appears here.
       </div>
       <template v-else>
         <div v-for="(e, i) in visibleEntries" :key="e.raw + i" class="ll-entry" :class="'k-' + authorKind(e.author)">
           <div class="ll-entry-head">
             <span class="ll-author">{{ e.author }}</span>
-            <span class="ll-date">{{ e.date }}</span>
+            <span class="ll-date cc-muted cc-fs-xs">{{ e.date }}</span>
             <span class="ll-actions">
               <template v-if="isRatable(e.author)">
                 <button class="ll-thumb" v-tooltip.top="'Good decision — add a note'"
@@ -403,7 +403,7 @@ async function dismissEntry(entry: LabLogEntry) {
 .ll-input:focus { border-color: var(--cc-accent); }
 .ll-input:disabled { opacity: 0.6; }
 .ll-compose-row { display: flex; align-items: center; justify-content: space-between; margin-top: 0.35rem; }
-.ll-hint { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+
 .ll-save {
   border: 1px solid var(--cc-accent); background: var(--cc-accent); color: #fff;
   border-radius: var(--cc-radius-sm); padding: 0.22rem 0.6rem; font-size: var(--cc-fs-sm); cursor: pointer;
@@ -437,9 +437,9 @@ async function dismissEntry(entry: LabLogEntry) {
   background-color: var(--cc-surface-2); border-radius: var(--cc-radius-xs);
 }
 /* capture status: floats to the far right of the whole bar (direct toolbar child) */
-.ll-note { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); margin-left: auto; }
+.ll-note { margin-left: auto; }
 /* token readout sits inline within the Claude group (no auto-margin — it's not a toolbar child) */
-.ll-tokens { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+
 .ll-clearctx {
   border: none; background: transparent; color: var(--cc-text-dim);
   font-size: var(--cc-fs-xs); cursor: pointer; text-decoration: underline; padding: 0;
@@ -478,7 +478,7 @@ async function dismissEntry(entry: LabLogEntry) {
 .ll-error { padding: 0.4rem 0.6rem; color: #f85149; font-size: var(--cc-fs-sm); }
 
 .ll-list { flex: 1; overflow-y: auto; padding: 0.4rem 0.5rem 0.6rem; }
-.ll-empty { color: var(--cc-text-dim); text-align: center; padding: 1.2rem 0.5rem; font-size: var(--cc-fs-sm); }
+.ll-empty { padding: 1.2rem 0.5rem; }
 
 .ll-entry {
   border-left: 3px solid var(--cc-border);
@@ -499,7 +499,7 @@ async function dismissEntry(entry: LabLogEntry) {
 
 .ll-entry-head { display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.2rem; }
 .ll-author { font-weight: 700; font-size: var(--cc-fs-sm); }
-.ll-date { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); }
+
 /* per-entry actions: hidden until hover (thumbs prefill a note — they carry no persisted state) */
 .ll-actions { margin-left: auto; display: inline-flex; align-items: center; gap: 0.15rem; visibility: hidden; }
 .ll-entry:hover .ll-actions { visibility: visible; }

--- a/frontend/src/components/LegacyMigrateDialog.vue
+++ b/frontend/src/components/LegacyMigrateDialog.vue
@@ -124,7 +124,7 @@ async function confirmImport() {
     <div v-if="done" class="lm lm-donebox">
       <p class="lm-doneline"><i class="pi pi-check-circle" /> Added <strong>{{ done }}</strong>
         image{{ done === 1 ? '' : 's' }} to the set.</p>
-      <p class="lm-lead cc-muted cc-muted-lg">
+      <p class="lm-lead cc-muted cc-fs-lg">
         These are placeholders — no data has moved yet. To transfer the images, segmentation and
         tracking, select them and run the <strong>“Migrate legacy image”</strong> task from the task
         panel.
@@ -132,7 +132,7 @@ async function confirmImport() {
     </div>
 
     <div v-else class="lm">
-      <p class="lm-lead cc-muted cc-muted-lg">
+      <p class="lm-lead cc-muted cc-fs-lg">
         Import images, segmentation &amp; tracking from an old (R/Shiny) cecelia project.
         <strong>Clustering, gating and HMM aren’t transferred.</strong> The source is never modified.
       </p>

--- a/frontend/src/components/ModuleLayout.vue
+++ b/frontend/src/components/ModuleLayout.vue
@@ -313,7 +313,7 @@ const visibleUids = computed<string[]>(() =>
         <div class="action-bar">
           <slot name="actions" :has-set="!!activeSet" />
 
-          <span class="image-count" v-if="activeSet">
+          <span class="image-count cc-muted" v-if="activeSet">
             <template v-if="showFilter && filteredUids">
               {{ filteredUids.length }} / {{ activeSet.images.length }}
             </template>
@@ -331,7 +331,7 @@ const visibleUids = computed<string[]>(() =>
               &nbsp;·&nbsp;{{ selectedUids.length }} selected
             </template>
           </span>
-          <span class="no-set-hint" v-else>{{ noSetHint }}</span>
+          <span class="no-set-hint cc-muted" v-else>{{ noSetHint }}</span>
 
           <div class="table-tools" v-if="activeSet && activeSet.images.length > 0">
             <!-- Cohort consistency: self-hides unless this module banks cohort metrics (cohortStages) -->
@@ -387,14 +387,14 @@ const visibleUids = computed<string[]>(() =>
         <!-- Task dropdown: filter to images a given function has been run on (ever / on last run) -->
         <div v-if="showFilter && activeSet && runFuns.length > 0 && taskOpen" class="attr-filter">
           <div class="filter-row proc-row">
-            <span class="filter-key" v-tooltip.right="'Filter to images processed with a function'">Processed with</span>
+            <span class="filter-key cc-eyebrow cc-fs-sm" v-tooltip.right="'Filter to images processed with a function'">Processed with</span>
             <div class="proc-controls">
               <select v-model="procFun" class="proc-select"
                 v-tooltip.bottom="'Only show images this function has been run on'">
                 <option value="">any function…</option>
                 <option v-for="fun in runFuns" :key="fun" :value="fun">{{ procFunLabel(fun) }}</option>
               </select>
-              <div class="proc-mode" :class="{ disabled: !procFun }">
+              <div class="proc-mode cc-muted" :class="{ disabled: !procFun }">
                 <label v-tooltip.bottom="'Match images the function has EVER been run on'">
                   <input type="radio" value="ever" v-model="procMode" :disabled="!procFun" /> ever
                 </label>
@@ -410,7 +410,7 @@ const visibleUids = computed<string[]>(() =>
         <div v-if="showFilter && activeSet && attrKeys.length > 0 && filtersOpen" class="attr-filter">
           <div class="filter-rows">
             <div v-for="key in attrKeys" :key="key" class="filter-row">
-              <span class="filter-key" v-tooltip.right="`Filter by ${key}`">{{ key }}</span>
+              <span class="filter-key cc-eyebrow cc-fs-sm" v-tooltip.right="`Filter by ${key}`">{{ key }}</span>
               <ChipSelect class="filter-chips" multiple :options="attrChipOpts(key)"
                 :model-value="attrFilters[key] ?? []"
                 @update:model-value="v => setAttrFilter(key, v as string[])" />
@@ -430,7 +430,7 @@ const visibleUids = computed<string[]>(() =>
         <div class="panel-scroll">
           <CollapsibleSection label="Images" max-height="none"
             :storage-key="`cc-images-open:${module ?? 'default'}`">
-            <div v-if="!activeSet" class="no-set">
+            <div v-if="!activeSet" class="no-set cc-empty">
               <i class="pi pi-folder-open" style="font-size:2rem; opacity:0.2" />
               <p>No set selected.</p>
             </div>
@@ -567,13 +567,7 @@ const visibleUids = computed<string[]>(() =>
   flex-shrink: 0;
 }
 
-.image-count {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
+.image-count { display: flex; align-items: center; gap: 0.4rem; }
 .excluded-note { color: var(--cc-sev-warn); }
 
 .filter-badge {
@@ -587,11 +581,7 @@ const visibleUids = computed<string[]>(() =>
   color: var(--cc-accent-soft);
 }
 
-.no-set-hint {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  font-style: italic;
-}
+.no-set-hint { font-style: italic; }
 
 /* ── Attr filter ──────────────────────────────────────────────────────────── */
 
@@ -667,7 +657,7 @@ const visibleUids = computed<string[]>(() =>
   background: var(--cc-surface-1);
   max-width: 240px;
 }
-.proc-mode { display: flex; align-items: center; gap: 0.55rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.proc-mode { display: flex; align-items: center; gap: 0.55rem; }
 .proc-mode label { display: inline-flex; align-items: center; gap: 0.25rem; cursor: pointer; }
 .proc-mode.disabled { opacity: 0.4; }
 .proc-mode input { cursor: pointer; }
@@ -681,18 +671,7 @@ const visibleUids = computed<string[]>(() =>
   min-height: 1.6rem;
 }
 
-.filter-key {
-  font-size: var(--cc-fs-sm);
-  font-weight: 600;
-  color: var(--cc-text-dim);
-  min-width: 80px;
-  flex-shrink: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
+.filter-key { min-width: 80px; flex-shrink: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 .filter-chips  { flex: 1; min-width: 0; }
 
@@ -706,15 +685,5 @@ const visibleUids = computed<string[]>(() =>
   min-height: 0;
 }
 
-.no-set {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem 1rem;
-  gap: 0.4rem;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-md);
-}
 .no-set p { margin: 0; }
 </style>

--- a/frontend/src/components/PackagesDialog.vue
+++ b/frontend/src/components/PackagesDialog.vue
@@ -71,39 +71,39 @@ function copyAll() {
     </template>
 
     <div class="pk-body">
-      <p v-if="loading" class="state-line"><i class="pi pi-spin pi-cog" /> Reading packages…</p>
-      <p v-else-if="error" class="state-line err"><i class="pi pi-times-circle" /> {{ error }}</p>
+      <p v-if="loading" class="state-line cc-muted"><i class="pi pi-spin pi-cog" /> Reading packages…</p>
+      <p v-else-if="error" class="state-line err cc-muted"><i class="pi pi-times-circle" /> {{ error }}</p>
 
       <template v-else-if="data">
         <!-- Python env (pixi: conda + pypi) -->
         <div class="grp-head">
-          Python env <span class="grp-sub">pixi · conda + pypi</span>
+          Python env <span class="grp-sub cc-muted cc-fs-xs">pixi · conda + pypi</span>
           <span class="grp-count">{{ py.length }}</span>
         </div>
-        <p v-if="data.pythonError" class="state-line warn">
+        <p v-if="data.pythonError" class="state-line warn cc-muted">
           <i class="pi pi-exclamation-triangle" /> {{ data.pythonError }}
         </p>
         <div v-else class="pkg-grid">
           <template v-for="p in py" :key="'py-' + p.name">
             <span class="pk-name">{{ p.name }}</span>
-            <span class="pk-ver mono">{{ p.version }}</span>
-            <span class="pk-kind" :class="p.kind">{{ p.kind }}</span>
+            <span class="pk-ver mono cc-muted">{{ p.version }}</span>
+            <span class="pk-kind cc-eyebrow cc-fs-2xs" :class="p.kind">{{ p.kind }}</span>
           </template>
-          <p v-if="!py.length" class="state-line dim">No matches.</p>
+          <p v-if="!py.length" class="state-line dim cc-muted">No matches.</p>
         </div>
 
         <!-- Julia (juliaup + Manifest — outside pixi) -->
         <div class="grp-head">
-          Julia <span class="grp-sub">juliaup · Manifest</span>
+          Julia <span class="grp-sub cc-muted cc-fs-xs">juliaup · Manifest</span>
           <span class="grp-count">{{ jl.length }}</span>
         </div>
         <div class="pkg-grid">
           <template v-for="p in jl" :key="'jl-' + p.name">
             <span class="pk-name">{{ p.name }}</span>
-            <span class="pk-ver mono">{{ p.version }}</span>
-            <span class="pk-kind" />
+            <span class="pk-ver mono cc-muted">{{ p.version }}</span>
+            <span class="pk-kind cc-eyebrow cc-fs-2xs" />
           </template>
-          <p v-if="!jl.length" class="state-line dim">No matches.</p>
+          <p v-if="!jl.length" class="state-line dim cc-muted">No matches.</p>
         </div>
       </template>
     </div>
@@ -121,18 +121,18 @@ function copyAll() {
 
 .grp-head { display: flex; align-items: baseline; gap: 0.5rem; font-size: var(--cc-fs-md); font-weight: 600; color: var(--cc-text); margin: 0.85rem 0 0.4rem; position: sticky; top: 0; background: var(--cc-surface-1); padding: 0.2rem 0; }
 .grp-head:first-child { margin-top: 0.2rem; }
-.grp-sub { font-size: var(--cc-fs-xs); font-weight: 400; color: var(--cc-text-dim); }
+
 .grp-count { margin-left: auto; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); background: var(--cc-surface-2); border-radius: var(--cc-radius-pill); padding: 0.05rem 0.5rem; }
 
 .pkg-grid { display: grid; grid-template-columns: 1fr auto auto; gap: 0.1rem 0.75rem; align-items: baseline; }
 .pk-name { font-size: var(--cc-fs-sm); color: var(--cc-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.pk-ver { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
-.pk-kind { font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.03em; color: var(--cc-text-dim); min-width: 3.2rem; }
+
+.pk-kind { min-width: 3.2rem; }
 .pk-kind.conda { color: #34d399; }
 .pk-kind.pypi  { color: #60a5fa; }
 
 .mono { font-variant-numeric: tabular-nums; }
-.state-line { display: flex; align-items: center; gap: 0.4rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin: 0.4rem 0; }
+.state-line { display: flex; align-items: center; gap: 0.4rem; margin: 0.4rem 0; }
 .state-line.err  { color: #f87171; }
 .state-line.warn { color: #fbbf24; }
 .state-line.dim  { grid-column: 1 / -1; }

--- a/frontend/src/components/PoolThrottle.vue
+++ b/frontend/src/components/PoolThrottle.vue
@@ -84,14 +84,14 @@ onUnmounted(() => { if (timer) clearInterval(timer) })
                @input="pools[name] = +($event.target as HTMLInputElement).value"
                @change="setPool(name, +($event.target as HTMLInputElement).value)" />
         <!-- live occupancy: how many tasks are running now vs the limit, + any queued for this pool -->
-        <div class="pt-occ cc-readout cc-readout-2xs" :class="{ busy: runningOf(name) > 0 || queuedOf(name) > 0 }">
+        <div class="pt-occ cc-readout cc-fs-2xs" :class="{ busy: runningOf(name) > 0 || queuedOf(name) > 0 }">
           <span><span class="pt-occ-n">{{ runningOf(name) }}</span><span class="pt-occ-sep">/</span>{{ pools[name] }} running</span>
           <span v-if="queuedOf(name) > 0" class="pt-occ-q">+{{ queuedOf(name) }} queued</span>
         </div>
         <div class="pt-bar"><div class="pt-bar-fill" :style="{ width: fillPct(name) }" /></div>
       </div>
     </div>
-    <p class="pt-hint cc-muted cc-muted-xs">Lower to throttle, raise to run more at once. Saved automatically.</p>
+    <p class="pt-hint cc-muted cc-fs-xs">Lower to throttle, raise to run more at once. Saved automatically.</p>
   </div>
 </template>
 

--- a/frontend/src/components/ProjectPanel.vue
+++ b/frontend/src/components/ProjectPanel.vue
@@ -229,7 +229,7 @@ const typeColour: Record<ProjectType, string> = {
       <!-- ── RECENT tab ─────────────────────────────────────────────────── -->
       <div v-if="tab === 'recent'" class="pp-body">
 
-        <div v-if="projectMeta.recent.length === 0" class="pp-empty">
+        <div v-if="projectMeta.recent.length === 0" class="pp-empty cc-empty">
           <i class="pi pi-folder" style="font-size:2rem; opacity:0.2" />
           <p>No projects yet.<br>A project holds all your images and analysis for one experiment.</p>
           <button class="cc-btn cc-btn-ghost" @click="tab = 'new'">
@@ -276,10 +276,10 @@ const typeColour: Record<ProjectType, string> = {
                   {{ p.type }}
                 </span>
               </td>
-              <td class="col-path dim" v-tooltip.bottom="p.path">
+              <td class="col-path dim cc-muted" v-tooltip.bottom="p.path">
                 {{ p.path.length > 40 ? '…' + p.path.slice(-38) : p.path }}
               </td>
-              <td class="col-date dim">{{ formatDate(p.lastOpenedAt) }}</td>
+              <td class="col-date dim cc-muted">{{ formatDate(p.lastOpenedAt) }}</td>
               <td class="col-actions">
                 <!-- export to a portable .ccbundle (allowed for any project, incl. the open one) -->
                 <button class="pp-row-btn cc-btn cc-btn-bare cc-btn-icon" :disabled="ioBusy" @click.stop="exportProject(p)"
@@ -330,7 +330,7 @@ const typeColour: Record<ProjectType, string> = {
         </div>
 
         <div class="form-row">
-          <span class="field-hint"
+          <span class="field-hint cc-muted"
             v-tooltip.right="'Override with the CECELIA_PROJECTS_DIR environment variable when starting the Julia server.'">
             <i class="pi pi-folder" />
             <template v-if="projectMeta.projectsDir">
@@ -384,7 +384,7 @@ const typeColour: Record<ProjectType, string> = {
            or import stays visible even when the controls are collapsed. -->
       <template v-if="tab === 'recent'">
         <div v-if="ioTask" class="pp-io pp-io-live">
-          <div class="pp-io-status" :class="ioTask.status">
+          <div class="pp-io-status cc-muted" :class="ioTask.status">
             <span class="pp-io-label">{{ ioTask.label }}</span>
             <span class="pp-io-state">{{ ioTask.status }}</span>
             <div v-if="ioBusy" class="pp-io-bar">
@@ -401,14 +401,14 @@ const typeColour: Record<ProjectType, string> = {
                             storage-key="cc-pm-io-open" max-height="none">
           <div class="pp-io">
             <div class="pp-io-dest">
-              <span class="dim">Exports to</span>
+              <span class="dim cc-muted">Exports to</span>
               <code class="pp-io-destpath" v-tooltip.top="exportDir">{{ exportDir || 'cecelia_exports (default)' }}</code>
               <button class="cc-btn cc-btn-ghost" :disabled="ioBusy" @click="browserMode = 'export'"
                       v-tooltip.top="'Choose where exported bundles are written (any folder, incl. mounted servers/drives).'">
                 <i class="pi pi-folder-open" /> Change
               </button>
             </div>
-            <p class="pp-io-hint dim">Export a project to a portable <code>.ccbundle</code> with the
+            <p class="pp-io-hint dim cc-muted">Export a project to a portable <code>.ccbundle</code> with the
               <i class="pi pi-download" /> button on any row above. Import one below.</p>
             <div class="pp-io-import">
               <select v-if="bundles.length" class="form-input pp-io-select" :disabled="ioBusy"
@@ -449,7 +449,7 @@ const typeColour: Record<ProjectType, string> = {
     <div class="pp-conflict">
       <p>A project <strong>{{ conflict.name }}</strong> (<code>{{ conflict.uid }}</code>) already
         exists on disk. What would you like to do?</p>
-      <ul class="pp-conflict-opts">
+      <ul class="pp-conflict-opts cc-muted cc-fs-md">
         <li><strong>Import as copy</strong> — keep both; the import gets a new id and its name is suffixed.</li>
         <li><strong>Replace</strong> — overwrite the existing project with the bundle. <em>Destructive.</em></li>
       </ul>
@@ -514,12 +514,7 @@ const typeColour: Record<ProjectType, string> = {
 /* body — BaseModal's cc-modal-body owns the scroll; the tab panes are plain flow. */
 .pp-body { display: flex; flex-direction: column; }
 
-.pp-empty {
-  display: flex; flex-direction: column; align-items: center;
-  justify-content: center; gap: 0.75rem;
-  padding: 3rem 1rem;
-  color: var(--cc-text-dim); font-size: var(--cc-fs-md);
-}
+.pp-empty { gap: 0.75rem; padding: 3rem 1rem; }
 .pp-empty p { margin: 0; }
 
 /* project table */
@@ -556,7 +551,7 @@ const typeColour: Record<ProjectType, string> = {
 .pp-conflict { padding: 1rem 1.25rem; font-size: var(--cc-fs-md); color: var(--cc-text); }
 .pp-conflict p { margin: 0 0 0.6rem; }
 .pp-conflict code { font-family: var(--cc-mono); font-size: var(--cc-fs-sm); background: var(--cc-surface-2); padding: 0.05rem 0.3rem; border-radius: var(--cc-radius-xs); }
-.pp-conflict-opts { margin: 0; padding-left: 1.1rem; color: var(--cc-text-dim); font-size: var(--cc-fs-md); }
+.pp-conflict-opts { margin: 0; padding-left: 1.1rem; }
 .pp-conflict-opts li { margin: 0.2rem 0; }
 
 .pp-io-dest { display: flex; gap: 0.4rem; align-items: center; font-size: var(--cc-fs-sm); flex-wrap: wrap; }
@@ -569,10 +564,7 @@ const typeColour: Record<ProjectType, string> = {
 .pp-io-import { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }
 .pp-io-select { flex: 1 1 180px; }
 .pp-io-path { flex: 2 1 180px; }
-.pp-io-status {
-  display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
-  font-size: var(--cc-fs-sm); color: var(--cc-text-dim);
-}
+.pp-io-status { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
 .pp-io-label { color: var(--cc-text); font-weight: 500; }
 .pp-io-state { text-transform: uppercase; font-size: var(--cc-fs-2xs); font-weight: 700; letter-spacing: 0.05em; }
 .pp-io-status.done  .pp-io-state { color: #34d399; }
@@ -603,7 +595,6 @@ const typeColour: Record<ProjectType, string> = {
   border: 1px solid #a78bfa44;
 }
 .type-badge { font-size: var(--cc-fs-sm); font-weight: 600; text-transform: uppercase; }
-.dim { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
 
 /* form */
 .pp-form { padding: 1.25rem 1.5rem; display: flex; flex-direction: column; gap: 1.25rem; }
@@ -618,10 +609,7 @@ const typeColour: Record<ProjectType, string> = {
 .form-input::placeholder { color: var(--cc-text-dim); }
 
 .field-error { font-size: var(--cc-fs-sm); color: #fca5a5; }
-.field-hint {
-  font-size: var(--cc-fs-sm); color: var(--cc-text-dim);
-  display: flex; align-items: center; gap: 0.3rem;
-}
+.field-hint { display: flex; align-items: center; gap: 0.3rem; }
 .dir-hint {
   font-family: var(--cc-mono);
   font-size: var(--cc-fs-xs);

--- a/frontend/src/components/SetBar.vue
+++ b/frontend/src/components/SetBar.vue
@@ -107,7 +107,7 @@ async function deleteSet() {
         <option v-for="s in project.sets" :key="s.uid" :value="s.uid">{{ s.name }}</option>
       </select>
       <template v-if="activeSet">
-        <span class="set-uid cc-muted cc-muted-xs">{{ activeSet.uid }}</span>
+        <span class="set-uid cc-muted cc-fs-xs">{{ activeSet.uid }}</span>
         <button class="set-uid-copy cc-btn cc-btn-bare cc-btn-icon" @click="copySetUid(activeSet.uid)"
           v-tooltip.bottom="copiedSetUid ? 'Copied!' : 'Copy set UID to clipboard'">
           <i :class="copiedSetUid ? 'pi pi-check' : 'pi pi-copy'" />
@@ -150,7 +150,7 @@ async function deleteSet() {
         </button>
       </template>
       <template v-if="confirmDelete">
-        <span class="confirm-text cc-muted cc-muted-md">Delete <strong>{{ activeSet?.name }}</strong>?</span>
+        <span class="confirm-text cc-muted cc-fs-md">Delete <strong>{{ activeSet?.name }}</strong>?</span>
         <button class="cc-btn cc-btn-danger-ghost" @click="deleteSet"
           v-tooltip.bottom="'Permanently delete this set and remove all its images from disk.'">
           Confirm

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -593,7 +593,7 @@ onUnmounted(() => {
          Top of the panel — these are always available, even before an image is open. -->
     <!-- Convention: append new toggles at the END of the row. -->
     <div class="viewer-section first">
-      <div class="viewer-section-title">View</div>
+      <div class="viewer-section-title cc-eyebrow cc-fs-2xs">View</div>
       <div class="viewer-opts">
         <button
           class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ 'cc-btn-on cc-btn-on-tint': settings.napariUpdateImage }"
@@ -630,7 +630,7 @@ onUnmounted(() => {
     <template v-if="napariImage">
       <!-- ── Current image: what's open + its versions + segmentation label sets ── -->
       <div class="viewer-section">
-        <div class="viewer-section-title">Current image</div>
+        <div class="viewer-section-title cc-eyebrow cc-fs-2xs">Current image</div>
         <div class="viewer-image">
           <i class="pi pi-eye viewer-eye" />
           <span class="viewer-name" :title="napariImage.name">{{ napariImage.name }}</span>
@@ -644,13 +644,13 @@ onUnmounted(() => {
         >
           <option v-for="vn in valueNames" :key="vn" :value="vn">{{ vn }}</option>
         </select>
-        <span v-else class="viewer-hint">No versions registered.</span>
+        <span v-else class="viewer-hint cc-muted">No versions registered.</span>
 
         <!-- segmentation label sets: show labels / tracks, delete -->
         <div v-if="hasLabels" class="viewer-labels-list">
           <div v-for="vn in labelNames" :key="vn" class="viewer-label-row">
             <i class="pi pi-th-large viewer-label-icon" />
-            <span class="viewer-label-name" :title="vn">{{ vn }}</span>
+            <span class="viewer-label-name cc-muted" :title="vn">{{ vn }}</span>
             <!-- action icons are hidden until row hover (keeps the narrow sidebar tidy); an ACTIVE
                  toggle stays visible so you can see what's shown without hovering -->
             <button
@@ -675,7 +675,7 @@ onUnmounted(() => {
     <!-- pop toggles show coloured centroid POINTS (layers namespaced by pop type, so they coexist);
          the ribbon toggles show gated / cluster track populations as napari Tracks layers. -->
     <div class="viewer-section">
-      <div class="viewer-section-title">Populations &amp; tracks</div>
+      <div class="viewer-section-title cc-eyebrow cc-fs-2xs">Populations &amp; tracks</div>
       <div class="viewer-opts">
         <button
           v-for="pt in POP_TYPES" :key="pt.key"
@@ -700,7 +700,7 @@ onUnmounted(() => {
 
       <!-- ── Colour by: shade tracks + labels by an obs column (e.g. HMM state); '' = default ── -->
       <div v-if="obsCols.length" class="viewer-section">
-        <div class="viewer-section-title">Colour by</div>
+        <div class="viewer-section-title cc-eyebrow cc-fs-2xs">Colour by</div>
         <select class="opt-colourby" :value="colourByCol" @change="onColourBy"
                 v-tooltip.right="'Colour tracks + labels by a cell property (e.g. HMM state). Values matching a population use its colour.'">
           <option value="">default</option>
@@ -708,7 +708,7 @@ onUnmounted(() => {
         </select>
         <!-- legend for a categorical colour-by: value → colour (a population's colour where one matches) -->
         <div v-if="legendItems.length" class="cby-legend">
-          <span v-for="item in legendItems" :key="item.key" class="cby-item"
+          <span v-for="item in legendItems" :key="item.key" class="cby-item cc-muted cc-fs-xs"
                 v-tooltip.right="item.editable
                   ? `${item.label} — click the swatch to recolour`
                   : `population: ${item.label} — colour set in the population manager`">
@@ -728,12 +728,12 @@ onUnmounted(() => {
            Records exactly what's shown (channels, populations, tracks, colour-by). fps + resolution
            are per-set; the fuller config (which channels/pops, T-range, batch) is F1.2/F1.3. -->
       <div class="viewer-section">
-        <div class="viewer-section-title">Movie</div>
+        <div class="viewer-section-title cc-eyebrow cc-fs-2xs">Movie</div>
         <div class="movie-row">
-          <span class="movie-lbl" v-tooltip.bottom="'Frames per second'">fps</span>
+          <span class="movie-lbl cc-eyebrow cc-fs-2xs" v-tooltip.bottom="'Frames per second'">fps</span>
           <input type="range" min="1" max="60" step="1" v-model.number="movieFps" class="movie-range" />
           <span class="movie-val">{{ movieFps }}</span>
-          <span class="movie-lbl" v-tooltip.bottom="'Resolution supersample (2× = double resolution)'">res</span>
+          <span class="movie-lbl cc-eyebrow cc-fs-2xs" v-tooltip.bottom="'Resolution supersample (2× = double resolution)'">res</span>
           <input type="range" min="1" max="3" step="1" v-model.number="movieScale" class="movie-range" />
           <span class="movie-val">{{ movieScale }}×</span>
           <button class="opt-btn cc-btn cc-btn-ghost cc-btn-icon movie-rec" :class="{ 'cc-btn-on cc-btn-on-tint': recording }" :disabled="recording"
@@ -744,7 +744,7 @@ onUnmounted(() => {
         </div>
         <!-- Title card (Phase H): prepend a description slide (name, attributes, channels & colours) -->
         <div class="movie-row movie-title-row">
-          <CcToggle class="movie-lbl movie-title-toggle" v-model="titleCardOn" label="title"
+          <CcToggle class="movie-lbl movie-title-toggle cc-eyebrow cc-fs-2xs" v-model="titleCardOn" label="title"
                  v-tooltip.bottom="'Prepend a title slide: image name, attributes, channels & their colours'" />
           <template v-if="titleCardOn">
             <input type="range" min="1" max="10" step="1" v-model.number="titleDur" class="movie-range"
@@ -755,7 +755,7 @@ onUnmounted(() => {
         </div>
       </div>
     </template>
-    <div v-else class="viewer-section"><span class="viewer-hint">No image open in Napari.</span></div>
+    <div v-else class="viewer-section"><span class="viewer-hint cc-muted">No image open in Napari.</span></div>
   </div>
 </template>
 
@@ -814,7 +814,7 @@ onUnmounted(() => {
 .opt-colourby { font-size: var(--cc-fs-xs); width: 100%; min-width: 0; }
 /* movie recording params — one compact row: fps slider · res slider · record button */
 .movie-row { display: flex; align-items: center; gap: 0.3rem; }
-.movie-lbl { font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); flex-shrink: 0; text-transform: uppercase; letter-spacing: 0.04em; }
+.movie-lbl { flex-shrink: 0; }
 .movie-range { flex: 1; min-width: 2.5rem; accent-color: var(--cc-accent-strong); }
 .movie-val { font-size: var(--cc-fs-2xs); color: var(--cc-text); width: 1.4rem; text-align: right; flex-shrink: 0; font-variant-numeric: tabular-nums; }
 .movie-rec { margin-left: 0.1rem; }
@@ -824,7 +824,7 @@ onUnmounted(() => {
 
 /* colour-by legend: value → swatch (a population's colour where one matches, else default) */
 .cby-legend { display: flex; flex-wrap: wrap; gap: 0.15rem 0.5rem; margin-top: 0.25rem; }
-.cby-item { display: inline-flex; align-items: center; gap: 0.25rem; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.cby-item { display: inline-flex; align-items: center; gap: 0.25rem; }
 .cby-swatch { width: 0.7rem; height: 0.7rem; border-radius: var(--cc-radius-xs); flex-shrink: 0; border: 1px solid var(--cc-border); }
 /* editable swatch: a native colour input squeezed to swatch size (categories with no population) */
 .cby-swatch-edit { padding: 0; cursor: pointer; background: none; -webkit-appearance: none; appearance: none; }
@@ -850,18 +850,6 @@ onUnmounted(() => {
 }
 /* the top section (View) sits flush against the panel top — no leading divider */
 .viewer-section.first { padding-top: 0; border-top: none; }
-.viewer-section-title {
-  font-size: var(--cc-fs-2xs);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--cc-text-dim);
-}
-
-.viewer-hint {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-}
 
 .viewer-labels-list {
   display: flex;
@@ -879,14 +867,7 @@ onUnmounted(() => {
   color: var(--cc-accent);
   flex-shrink: 0;
 }
-.viewer-label-name {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+.viewer-label-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .opt-btn.danger:hover { border-color: var(--cc-danger); color: var(--cc-danger); }
 /* row action icons (eye / directions / trash): hidden until the row is hovered to keep the narrow
    sidebar uncluttered; an ACTIVE toggle (shown layer/tracks) stays visible so state is readable */

--- a/frontend/src/components/canvas/InteractivePanel.vue
+++ b/frontend/src/components/canvas/InteractivePanel.vue
@@ -43,7 +43,7 @@ defineExpose({ exportImage, exportSvg })
                :title="entry?.label ?? view" :square="entry?.square ?? false"
                @activate="emit('activate', $event)" @remove="emit('remove')">
     <component v-if="entry" :is="entry.component" ref="viewRef" v-bind="context" :state="state" />
-    <div v-else class="ip-missing cc-muted cc-muted-md">Unknown interactive plot “{{ view }}”.</div>
+    <div v-else class="ip-missing cc-muted cc-fs-md">Unknown interactive plot “{{ view }}”.</div>
     <template v-if="duplicable || exportFormats.length" #footer>
       <button v-if="duplicable" class="ip-iconbtn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense" type="button" @click="emit('duplicate')"
               v-tooltip.top="'Duplicate this plot (same settings) to tweak one thing'"><i class="pi pi-copy" /></button>

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -387,7 +387,7 @@ defineExpose({ capturePage, collectCsvs })
            (varied presets, wraps to two lines), then the data/compare row. -->
       <div class="lc-bar">
         <div class="lc-row">
-          <span class="lc-lbl">Layout</span>
+          <span class="lc-lbl cc-eyebrow">Layout</span>
           <ChipSelect variant="segmented" :options="uniformOptions" :model-value="uniformMatchId"
                       v-tooltip.bottom="'Uniform grids'" aria-label="Uniform grid layout"
                       @update:model-value="v => applyPreset(UNIFORM_PRESETS, v as string)" />
@@ -397,15 +397,15 @@ defineExpose({ capturePage, collectCsvs })
                     v-tooltip.bottom="'Grid size & slot height'"><i class="pi pi-sliders-h" /></button>
             <TeleportPopover v-model="optsOpen" :anchor="optsBtn">
               <div class="lc-pop">
-                <label class="lc-pop-row"><span>cols</span>
+                <label class="lc-pop-row cc-muted"><span>cols</span>
                   <input type="range" min="1" max="6" :value="entry.cols"
                          @input="layout.applyTemplate(canvasKey, uniform(+($event.target as HTMLInputElement).value, entry.rows))" />
                   <span class="lc-val">{{ entry.cols }}</span></label>
-                <label class="lc-pop-row"><span>rows</span>
+                <label class="lc-pop-row cc-muted"><span>rows</span>
                   <input type="range" min="1" max="6" :value="entry.rows"
                          @input="layout.applyTemplate(canvasKey, uniform(entry.cols, +($event.target as HTMLInputElement).value))" />
                   <span class="lc-val">{{ entry.rows }}</span></label>
-                <label class="lc-pop-row"><span>height</span>
+                <label class="lc-pop-row cc-muted"><span>height</span>
                   <input type="range" min="160" max="720" step="10" :value="rowHeight"
                          @input="rowHeight = +($event.target as HTMLInputElement).value" />
                   <span class="lc-val">{{ rowHeight }}</span></label>
@@ -421,7 +421,7 @@ defineExpose({ capturePage, collectCsvs })
                              @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
           <!-- clustering run: ONE per board (drives all cluster slots + the cluster pop manager) -->
           <div v-if="hasClusterSlot" class="lc-clust" v-tooltip.bottom="'Clustering run shown by this board’s cluster plots'">
-            <span class="lc-lbl">cluster</span>
+            <span class="lc-lbl cc-eyebrow">cluster</span>
             <select v-model="clustPopType">
               <option value="clust">cells</option>
               <option value="trackclust">tracks</option>
@@ -435,7 +435,7 @@ defineExpose({ capturePage, collectCsvs })
           <div class="lc-right">
             <div v-if="canCompare" class="lc-compare"
                  v-tooltip.bottom="'Compare across the selected images'">
-              <span class="lc-lbl">compare</span>
+              <span class="lc-lbl cc-eyebrow">compare</span>
               <select v-model="compareMode">
                 <option value="image">this image</option>
                 <option value="per_image">per image</option>
@@ -458,7 +458,7 @@ defineExpose({ capturePage, collectCsvs })
           </div>
         </div>
         <div class="lc-row">
-          <span class="lc-lbl">Plates</span>
+          <span class="lc-lbl cc-eyebrow">Plates</span>
           <ChipSelect variant="pill" :options="plateOptions" :model-value="plateMatchId"
                       v-tooltip.bottom="'Comic plates — varied-size panels, matched to the sheet orientation'"
                       aria-label="Comic plate layout"
@@ -540,7 +540,7 @@ defineExpose({ capturePage, collectCsvs })
                   <option v-for="v in imageOptions" :key="v.key" :value="`interactive:${v.key}`">{{ v.label }}</option>
                 </optgroup>
               </select>
-              <span class="lc-add-hint">empty slot</span>
+              <span class="lc-add-hint cc-muted cc-fs-xs">empty slot</span>
             </div>
             </div>
           </div>
@@ -573,7 +573,7 @@ defineExpose({ capturePage, collectCsvs })
 /* sits right after the sliders (NOT pushed to the far right) so it doesn't shift when the compare
    dropdown changes width (e.g. "by attribute" adds selects) */
 .lc-right { display: flex; align-items: center; gap: 10px; }
-.lc-lbl { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); text-transform: uppercase; letter-spacing: 0.04em; }
+
 .lc-sep { width: 1px; height: 1.4rem; background: var(--cc-border); }
 .lc-nm { display: inline-flex; align-items: center; gap: 6px; color: var(--cc-text-dim); }
 .lc-nm input[type="range"] { width: 5rem; }
@@ -587,7 +587,7 @@ defineExpose({ capturePage, collectCsvs })
 .lc-custom { font-size: var(--cc-fs-xs); padding: 0.22rem 0.55rem; }
 /* inner layout only — TeleportPopover provides surface/border/shadow/position */
 .lc-pop { min-width: 13rem; display: flex; flex-direction: column; gap: 8px; padding: 10px; }
-.lc-pop-row { display: flex; align-items: center; gap: 8px; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.lc-pop-row { display: flex; align-items: center; gap: 8px; }
 .lc-pop-row span:first-child { width: 3rem; }
 .lc-pop-row input[type="range"] { flex: 1; }
 .lc-val { min-width: 0.9rem; text-align: center; font-weight: 700; color: var(--cc-text); }
@@ -618,7 +618,7 @@ defineExpose({ capturePage, collectCsvs })
 /* reorder drag handle now lives IN the panel header (CanvasPanel docked drag icon); its native
    dragstart bubbles to .lc-slot (@dragstart above). No absolute overlay grip here anymore. */
 .lc-add { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; }
-.lc-add-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); opacity: 0.6; }
+.lc-add-hint { opacity: 0.6; }
 /* stick to the top of the scroll viewport so the pop manager stays reachable as the (tall) board
    scrolls past — otherwise you must scroll back up to change the selection. align-self so the sticky
    box hugs the top of the flex row; its own overflow-y scrolls a manager taller than the viewport. */

--- a/frontend/src/components/canvas/PlateBuilder.vue
+++ b/frontend/src/components/canvas/PlateBuilder.vue
@@ -67,11 +67,11 @@ function apply() { emit('apply', buildPlate(cols.value, rows.value, spans.value)
 <template>
   <div class="pb">
     <div class="pb-head">
-      <label class="pb-num"><span>cols</span>
+      <label class="pb-num cc-muted cc-fs-xs"><span>cols</span>
         <input type="number" :min="MIN" :max="MAX" v-model.number="cols" @change="cols = clamp(cols)" /></label>
-      <label class="pb-num"><span>rows</span>
+      <label class="pb-num cc-muted cc-fs-xs"><span>rows</span>
         <input type="number" :min="MIN" :max="MAX" v-model.number="rows" @change="rows = clamp(rows)" /></label>
-      <span class="pb-hint">drag to merge · click a merge to split</span>
+      <span class="pb-hint cc-muted cc-fs-2xs">drag to merge · click a merge to split</span>
     </div>
 
     <div ref="gridRef" class="pb-grid" :style="gridTmpl" @pointerdown.prevent="onDown">
@@ -81,7 +81,7 @@ function apply() { emit('apply', buildPlate(cols.value, rows.value, spans.value)
     </div>
 
     <div class="pb-foot">
-      <span class="pb-count">{{ slotCount }} panel{{ slotCount === 1 ? '' : 's' }}</span>
+      <span class="pb-count cc-muted cc-fs-xs">{{ slotCount }} panel{{ slotCount === 1 ? '' : 's' }}</span>
       <span class="pb-spacer" />
       <button class="cc-btn cc-btn-ghost" type="button" @click="emit('cancel')">Cancel</button>
       <button class="cc-btn cc-btn-primary" type="button" @click="apply">Apply</button>
@@ -92,9 +92,9 @@ function apply() { emit('apply', buildPlate(cols.value, rows.value, spans.value)
 <style scoped>
 .pb { display: flex; flex-direction: column; gap: 8px; width: 15rem; }
 .pb-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.pb-num { display: inline-flex; align-items: center; gap: 4px; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.pb-num { display: inline-flex; align-items: center; gap: 4px; }
 .pb-num input { width: 3rem; padding: 2px 4px; }
-.pb-hint { flex-basis: 100%; font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); opacity: 0.75; }
+.pb-hint { flex-basis: 100%; opacity: 0.75; }
 /* the plate canvas: an A4-portrait-ish aspect so the preview reads like a page */
 .pb-grid { position: relative; display: grid; gap: 3px; aspect-ratio: 0.78; width: 100%;
   padding: 3px; background: var(--cc-border); border-radius: var(--cc-radius-sm); user-select: none; touch-action: none; }
@@ -109,6 +109,6 @@ function apply() { emit('apply', buildPlate(cols.value, rows.value, spans.value)
 .pb-drag { pointer-events: none; z-index: 3; border-radius: var(--cc-radius-xs);
   background: color-mix(in srgb, var(--cc-accent) 22%, transparent); border: 1px dashed var(--cc-accent); }
 .pb-foot { display: flex; align-items: center; gap: 6px; }
-.pb-count { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+
 .pb-spacer { flex: 1; }
 </style>

--- a/frontend/src/components/canvas/PlotOptions.vue
+++ b/frontend/src/components/canvas/PlotOptions.vue
@@ -32,29 +32,29 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <i :class="open.layout ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" /><span class="cc-eyebrow">Layout</span>
       </button>
       <div v-show="open.layout" class="po-body">
-        <div class="po-row cc-muted cc-muted-xs"><span>Legend</span>
+        <div class="po-row cc-muted cc-fs-xs"><span>Legend</span>
           <CcToggle :model-value="vis.legend" @update:model-value="set({ legend: $event })" /></div>
-        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Log scale on the measure axis'"><span>Log scale</span>
+        <div class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Log scale on the measure axis'"><span>Log scale</span>
           <CcToggle :model-value="vis.logScale" @update:model-value="set({ logScale: $event })" /></div>
-        <div class="po-row cc-muted cc-muted-xs"><span>Gridlines</span>
+        <div class="po-row cc-muted cc-fs-xs"><span>Gridlines</span>
           <CcToggle :model-value="vis.grid" @update:model-value="set({ grid: $event })" /></div>
-        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Rotate the x tick labels (angle below)'"><span>Rotate X labels</span>
+        <div class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Rotate the x tick labels (angle below)'"><span>Rotate X labels</span>
           <CcToggle :model-value="vis.rotateXLabel" @update:model-value="set({ rotateXLabel: $event })" /></div>
-        <label v-if="vis.rotateXLabel" class="po-row cc-muted cc-muted-xs" v-tooltip.left="'X tick-label angle (degrees)'"><span>X angle</span>
+        <label v-if="vis.rotateXLabel" class="po-row cc-muted cc-fs-xs" v-tooltip.left="'X tick-label angle (degrees)'"><span>X angle</span>
           <input type="range" min="0" max="90" step="5" :value="vis.rotateXAngle ?? 45"
                  @input="set({ rotateXAngle: parseInt(($event.target as HTMLInputElement).value) })" />
           <span class="po-val">{{ vis.rotateXAngle ?? 45 }}°</span></label>
-        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Flip 90° — measure on X, series labels on Y (R coord_flip)'"><span>Rotate 90°</span>
+        <div class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Flip 90° — measure on X, series labels on Y (R coord_flip)'"><span>Rotate 90°</span>
           <CcToggle :model-value="vis.rotate"
                  @update:model-value="set({ rotate: $event, ...($event ? { facet: false } : {}) })" /></div>
-        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'One small-multiple panel per series (mutually exclusive with rotate)'"><span>Facet</span>
+        <div class="po-row cc-muted cc-fs-xs" v-tooltip.left="'One small-multiple panel per series (mutually exclusive with rotate)'"><span>Facet</span>
           <CcToggle :model-value="vis.facet"
                  @update:model-value="set({ facet: $event, ...($event ? { rotate: false } : {}) })" /></div>
-        <div class="po-row cc-muted cc-muted-xs"><span>Dark theme</span>
+        <div class="po-row cc-muted cc-fs-xs"><span>Dark theme</span>
           <CcToggle :model-value="vis.darkTheme" @update:model-value="set({ darkTheme: $event })" /></div>
-        <label class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Measure-axis range (blank = auto)'"><span>Y min</span>
+        <label class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Measure-axis range (blank = auto)'"><span>Y min</span>
           <input class="po-txt" type="text" :value="vis.yMin" @change="set({ yMin: ($event.target as HTMLInputElement).value })" /></label>
-        <label class="po-row cc-muted cc-muted-xs"><span>Y max</span>
+        <label class="po-row cc-muted cc-fs-xs"><span>Y max</span>
           <input class="po-txt" type="text" :value="vis.yMax" @change="set({ yMax: ($event.target as HTMLInputElement).value })" /></label>
       </div>
     </template>
@@ -65,17 +65,17 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <i :class="open.points ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" /><span class="cc-eyebrow">Points</span>
       </button>
       <div v-show="open.points" class="po-body">
-        <label class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Data offset (beeswarm / random / none)'"><span>Offset</span>
+        <label class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Data offset (beeswarm / random / none)'"><span>Offset</span>
           <select class="po-sel" :value="vis.jitter" @change="set({ jitter: ($event.target as HTMLSelectElement).value as VisProps['jitter'] })">
             <option value="beeswarm">beeswarm</option><option value="random">random</option><option value="none">none</option>
           </select></label>
-        <div class="po-row cc-muted cc-muted-xs" v-tooltip.left="'Colour points by series (else grey)'"><span>Colour data</span>
+        <div class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Colour points by series (else grey)'"><span>Colour data</span>
           <CcToggle :model-value="vis.colorData" @update:model-value="set({ colorData: $event })" /></div>
-        <label class="po-row cc-muted cc-muted-xs"><span>Point size</span>
+        <label class="po-row cc-muted cc-fs-xs"><span>Point size</span>
           <input type="range" min="0.5" max="8" step="0.5" :value="vis.pointSize"
                  @input="set({ pointSize: Number(($event.target as HTMLInputElement).value) })" />
           <span class="po-val">{{ vis.pointSize }}</span></label>
-        <label class="po-row cc-muted cc-muted-xs"><span>Point opacity</span>
+        <label class="po-row cc-muted cc-fs-xs"><span>Point opacity</span>
           <input type="range" min="0.05" max="1" step="0.05" :value="vis.pointOpacity"
                  @input="set({ pointOpacity: Number(($event.target as HTMLInputElement).value) })" />
           <span class="po-val">{{ vis.pointOpacity.toFixed(2) }}</span></label>
@@ -88,7 +88,7 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <i :class="open.colours ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" /><span class="cc-eyebrow">Colours</span>
       </button>
       <div v-show="open.colours" class="po-body">
-        <label class="po-row cc-muted cc-muted-xs"><span>Palette</span>
+        <label class="po-row cc-muted cc-fs-xs"><span>Palette</span>
           <select class="po-sel" :value="vis.palette" @change="set({ palette: ($event.target as HTMLSelectElement).value as VisProps['palette'] })">
             <option value="standard">standard (population)</option><option value="distinct">distinct</option>
             <option value="cecelia">Cecelia</option>
@@ -96,7 +96,7 @@ const has = (s: string) => props.sections.includes(s as 'layout')
             <option value="tol-bright">Tol bright</option><option value="tol-muted">Tol muted</option>
             <option value="tol-light">Tol light</option><option value="user">user</option>
           </select></label>
-        <label v-if="vis.palette === 'user'" class="po-row po-col cc-muted cc-muted-xs" v-tooltip.left="'Comma-separated colours/hex, in series order'">
+        <label v-if="vis.palette === 'user'" class="po-row po-col cc-muted cc-fs-xs" v-tooltip.left="'Comma-separated colours/hex, in series order'">
           <span>Colours</span>
           <input class="po-txt wide" type="text" :value="vis.userColors" placeholder="#4477AA,#EE6677,…"
                  @change="set({ userColors: ($event.target as HTMLInputElement).value })" /></label>
@@ -109,13 +109,13 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <i :class="open.labels ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" /><span class="cc-eyebrow">Labels</span>
       </button>
       <div v-show="open.labels" class="po-body">
-        <label class="po-row po-col cc-muted cc-muted-xs"><span>Title</span>
+        <label class="po-row po-col cc-muted cc-fs-xs"><span>Title</span>
           <input class="po-txt wide" type="text" :value="vis.title" @change="set({ title: ($event.target as HTMLInputElement).value })" /></label>
-        <label class="po-row po-col cc-muted cc-muted-xs"><span>X label</span>
+        <label class="po-row po-col cc-muted cc-fs-xs"><span>X label</span>
           <input class="po-txt wide" type="text" :value="vis.labX" @change="set({ labX: ($event.target as HTMLInputElement).value })" /></label>
-        <label class="po-row po-col cc-muted cc-muted-xs"><span>Y label</span>
+        <label class="po-row po-col cc-muted cc-fs-xs"><span>Y label</span>
           <input class="po-txt wide" type="text" :value="vis.labY" @change="set({ labY: ($event.target as HTMLInputElement).value })" /></label>
-        <label class="po-row cc-muted cc-muted-xs"><span>Font size</span>
+        <label class="po-row cc-muted cc-fs-xs"><span>Font size</span>
           <input type="range" min="8" max="20" step="1" :value="vis.fontSize"
                  @input="set({ fontSize: Number(($event.target as HTMLInputElement).value) })" />
           <span class="po-val">{{ vis.fontSize }}</span></label>

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -246,12 +246,12 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
           <input v-model="fpName" class="pm-ff-name" placeholder="Population name" />
           <input v-model="fpColour" type="color" class="pm-ff-colour" v-tooltip.top="'Colour'" />
         </div>
-        <label class="pm-ff-row">Under
+        <label class="pm-ff-row cc-muted cc-fs-xs">Under
           <select v-model="fpParent" :disabled="!!fpEditPath" v-tooltip.top="fpEditPath ? 'Parent is fixed when editing — delete & recreate to move' : ''">
             <option v-for="o in parentOptions" :key="o" :value="o">{{ o === 'root' ? '(all cells)' : o }}</option>
           </select>
         </label>
-        <div v-for="(c, i) in fpConds" :key="i" class="pm-ff-cond">
+        <div v-for="(c, i) in fpConds" :key="i" class="pm-ff-cond cc-muted cc-fs-xs">
           <select v-model="c.measure" class="pm-ff-measure">
             <option value="" disabled>measure…</option>
             <option v-for="m in filterMeasures" :key="m" :value="m">{{ g.colLabel(m) }}</option>
@@ -339,7 +339,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
                   :style="popClusterIds(p).includes(id) ? { background: p.colour, borderColor: p.colour, color: '#111' } : {}"
                   v-tooltip.bottom="clusterOwner(id) && clusterOwner(id)?.path !== p.path ? `In “${clusterOwner(id)?.name}”` : ''"
                   @click.stop="!readonly && toggleCluster(p, id)">{{ id }}</button>
-          <span v-if="!props.clusterIds.length" class="pm-chip-empty cc-empty-inline cc-muted-2xs">no clusters at this suffix</span>
+          <span v-if="!props.clusterIds.length" class="pm-chip-empty cc-empty-inline cc-fs-2xs">no clusters at this suffix</span>
         </div>
       </template>
 
@@ -369,23 +369,23 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
         </button>
         <div v-show="optionsOpen" class="pm-opts-body">
           <template v-if="!clusterMode">
-          <div class="pm-opt-head"><span>plot</span></div>
+          <div class="pm-opt-head cc-eyebrow cc-fs-2xs"><span>plot</span></div>
           <div class="pm-opt-row">
-            <span class="pm-opt-label">Gate labels</span>
+            <span class="pm-opt-label cc-muted cc-fs-xs">Gate labels</span>
             <button class="seg-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg"
                     :class="{ 'cc-btn-on cc-btn-on-tint': gateLabels }"
                     v-tooltip.top="'Show population names on gates'"
                     @click="emit('update:gateLabels', !gateLabels)"><i class="pi pi-tag" /></button>
           </div>
           <div class="pm-opt-row">
-            <span class="pm-opt-label">Line width</span>
+            <span class="pm-opt-label cc-muted cc-fs-xs">Line width</span>
             <input type="range" min="0.5" max="4" step="0.5" :value="lineWidth"
                    v-tooltip.top="'Gate line thickness'"
                    @input="emit('update:lineWidth', parseFloat(($event.target as HTMLInputElement).value))" />
-            <span class="pm-opt-val">{{ lineWidth.toFixed(1) }}</span>
+            <span class="pm-opt-val cc-readout cc-fs-xs">{{ lineWidth.toFixed(1) }}</span>
           </div>
           <div class="pm-opt-row">
-            <span class="pm-opt-label">Axis</span>
+            <span class="pm-opt-label cc-muted cc-fs-xs">Axis</span>
             <ChipSelect class="pm-seg" variant="segmented" :options="AXIS_OPTIONS"
                         :model-value="axisFromZero ? 'zero' : 'auto'" aria-label="Axis scale"
                         @update:model-value="v => emit('update:axisFromZero', v === 'zero')" />
@@ -396,15 +396,15 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
                Points (size slider); track/trackclust render as Tracks ribbons (no point size — tail
                width is a plot-panel concern), so the group is hidden for those. -->
           <template v-if="props.popType !== 'track' && props.popType !== 'trackclust'">
-            <div class="pm-opt-head"><span>viewer</span></div>
+            <div class="pm-opt-head cc-eyebrow cc-fs-2xs"><span>viewer</span></div>
             <!-- napari point size (re-renders the napari overlay on release) -->
             <div class="pm-opt-row">
-              <span class="pm-opt-label">Napari dots</span>
+              <span class="pm-opt-label cc-muted cc-fs-xs">Napari dots</span>
               <input type="range" min="1" max="20" step="1" :value="napariPointSize"
                      v-tooltip.top="'Population point size in napari (per experiment/set)'"
                      @input="napariPointSize = parseInt(($event.target as HTMLInputElement).value)"
                      @change="g.refreshNapariPops()" />
-              <span class="pm-opt-val">{{ napariPointSize }}</span>
+              <span class="pm-opt-val cc-readout cc-fs-xs">{{ napariPointSize }}</span>
             </div>
           </template>
         </div>
@@ -456,7 +456,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
 .pm-ff-name { flex: 1; font-size: var(--cc-fs-xs); padding: 3px 6px; border-radius: var(--cc-radius-xs); }
 .pm-ff-colour { width: 24px; height: 24px; padding: 0; border-radius: var(--cc-radius-xs);
   background: none; cursor: pointer; }
-.pm-ff-row, .pm-ff-cond { display: flex; gap: 4px; align-items: center; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.pm-ff-row, .pm-ff-cond { display: flex; gap: 4px; align-items: center; }
 .pm-ff-cond select, .pm-ff-row select, .pm-ff-vals { font-size: var(--cc-fs-xs); padding: 2px 4px;
   border-radius: var(--cc-radius-xs); }
 .pm-ff-measure { flex: 1; min-width: 0; }
@@ -482,7 +482,7 @@ button.pm-filter-badge:hover { opacity: 1; }
 .pm-chip.ro { cursor: default; }
 .pm-chip.ro:hover { border-color: var(--cc-border); color: var(--cc-text-dim); }
 .pm-chip.ro.on:hover { color: #111; }
-.pm-chip-empty { font-style: italic; }   /* + .cc-empty-inline .cc-muted-2xs (row/colour/10px tier) */
+.pm-chip-empty { font-style: italic; }   /* + .cc-empty-inline .cc-fs-2xs (row/colour/10px tier) */
 
 /* segmented toggle (axis option in the #options slot; the shell owns the footer scope toggle) */
 .pm-seg { margin-left: auto; }
@@ -495,12 +495,11 @@ button.pm-filter-badge:hover { opacity: 1; }
 .pm-opts-toggle { padding: 6px 8px; }
 .pm-opts-body { padding: 4px 10px 10px; display: flex; flex-direction: column; gap: 8px; }
 /* small section heading: ──── plot ──── */
-.pm-opt-head { display: flex; align-items: center; gap: 6px; margin-top: 2px;
-  color: var(--cc-text-dim); font-size: var(--cc-fs-2xs); text-transform: uppercase; letter-spacing: 0.08em; }
+.pm-opt-head { display: flex; align-items: center; gap: 6px; margin-top: 2px; }
 .pm-opt-head::before, .pm-opt-head::after { content: ""; flex: 1; height: 1px; background: var(--cc-border); }
 .pm-opt-head:first-child { margin-top: 0; }
 .pm-opt-row { display: flex; align-items: center; gap: 8px; }
-.pm-opt-label { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); flex: 1; }
+.pm-opt-label { flex: 1; }
 .pm-opt-row input[type="range"] { flex: 1; max-width: 110px; }
-.pm-opt-val { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); width: 1.8rem; text-align: right; font-variant-numeric: tabular-nums; }
+.pm-opt-val { width: 1.8rem; text-align: right; }
 </style>

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -174,8 +174,8 @@ watch(segPops, () => {
           </button>
         </div>
         <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
-        <span v-if="!specs.length" class="sc-hint cc-muted cc-muted-xs">No plot types available for this module yet.</span>
-        <span v-else class="sc-hint cc-muted cc-muted-xs">eye-select populations to plot · drag plots by their title</span>
+        <span v-if="!specs.length" class="sc-hint cc-muted cc-fs-xs">No plot types available for this module yet.</span>
+        <span v-else class="sc-hint cc-muted cc-fs-xs">eye-select populations to plot · drag plots by their title</span>
       </div>
       <div ref="canvasRef" class="sc-canvas">
         <!-- scaled workspace: the panels zoom together; the population picker stays full-size (below) -->

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -516,7 +516,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
         <TeleportPopover v-model="optsOpen" :anchor="optsBtn" placement="bottom-end">
         <div class="sp-pop" @click.stop>
           <!-- generic split-by (sub-axis) for the per-series charts; the heatmap uses Category below -->
-          <label v-if="chartType !== 'heatmap' && groupByOpts.length" class="sp-pop-row"
+          <label v-if="chartType !== 'heatmap' && groupByOpts.length" class="sp-pop-row cc-muted"
                  v-tooltip.left="'Split the measure by a categorical column (e.g. HMM state)'">
             <span>Split by</span>
             <select v-model="groupBy">
@@ -525,7 +525,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
             </select>
           </label>
           <!-- statistical unit: each cell/track, or one point per image (its mean) — "each dot an image" -->
-          <label v-if="canStatUnit" class="sp-pop-row"
+          <label v-if="canStatUnit" class="sp-pop-row cc-muted"
                  v-tooltip.left="'Individual: every cell/track is a datapoint. Image mean: each image contributes one point (its mean) — one dot per image (n = images, pseudoreplication-safe).'">
             <span>Datapoint</span>
             <select v-model="statUnit">
@@ -533,7 +533,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
               <option value="image">image</option>
             </select>
           </label>
-          <label v-if="canStatUnit && statUnit === 'image'" class="sp-pop-row"
+          <label v-if="canStatUnit && statUnit === 'image'" class="sp-pop-row cc-muted"
                  v-tooltip.left="'How to collapse each image to its one point: mean (average) or median (robust to outliers).'">
             <span>Per image</span>
             <select v-model="imageAgg">
@@ -546,26 +546,26 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
                (state signature = profile, transition matrix = crosstab) pin their mode, so the two
                plots stay distinct rather than each being able to become the other. -->
           <template v-if="chartType === 'heatmap'">
-            <label v-if="!specPinnedMode" class="sp-pop-row" v-tooltip.left="'profile = measures × category (signature); crosstab = a from_to column → transition matrix'">
+            <label v-if="!specPinnedMode" class="sp-pop-row cc-muted" v-tooltip.left="'profile = measures × category (signature); crosstab = a from_to column → transition matrix'">
               <span>Mode</span>
               <select v-model="matrixMode">
                 <option value="profile">profile</option>
                 <option value="crosstab">crosstab</option>
               </select>
             </label>
-            <label v-if="groupByOpts.length" class="sp-pop-row"
+            <label v-if="groupByOpts.length" class="sp-pop-row cc-muted"
                    v-tooltip.left="'Categorical column: profile columns / crosstab from_to pairs'">
               <span>Category</span>
               <select v-model="categorySel">
                 <option v-for="g in groupByOpts" :key="g" :value="g">{{ g }}</option>
               </select>
             </label>
-            <div v-if="matrixMode === 'profile'" class="sp-pop-row"
+            <div v-if="matrixMode === 'profile'" class="sp-pop-row cc-muted"
                    v-tooltip.left="'Off: rescale each feature to 0–1 (viridis). On: z-score rows → diverging above/below-mean (RdBu).'">
               <span>Z-score rows</span>
               <CcToggle v-model="zscore" />
             </div>
-            <label v-else class="sp-pop-row" v-tooltip.left="'Normalise the transition matrix'">
+            <label v-else class="sp-pop-row cc-muted" v-tooltip.left="'Normalise the transition matrix'">
               <span>Normalize</span>
               <select v-model="matrixNormalize">
                 <option value="row">row · P(to|from)</option>
@@ -574,16 +574,16 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
                 <option value="none">counts</option>
               </select>
             </label>
-            <div class="sp-pop-row" v-tooltip.left="'Print the value in each cell'">
+            <div class="sp-pop-row cc-muted" v-tooltip.left="'Print the value in each cell'">
               <span>Cell values</span>
               <CcToggle v-model="heatmapValues" />
             </div>
           </template>
-          <label v-if="chartType === 'histogram'" class="sp-pop-row">
+          <label v-if="chartType === 'histogram'" class="sp-pop-row cc-muted">
             <span>Bins</span>
             <input type="number" min="5" max="100" step="5" v-model.number="bins" />
           </label>
-          <label v-else-if="chartType === 'bar'" class="sp-pop-row">
+          <label v-else-if="chartType === 'bar'" class="sp-pop-row cc-muted">
             <span>Error</span>
             <select v-model="errorMetric">
               <option value="ci95">95% CI</option>
@@ -591,17 +591,17 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
               <option value="sd">SD</option>
             </select>
           </label>
-          <div v-else-if="chartType === 'frequency' || chartType === 'count' || !hasMeasure" class="sp-pop-row"
+          <div v-else-if="chartType === 'frequency' || chartType === 'count' || !hasMeasure" class="sp-pop-row cc-muted"
                  v-tooltip.left="hasMeasure && chartType === 'frequency' ? '' : 'Plot each population’s FRACTION of its image’s (plotted) total instead of the raw count'">
             <span>Proportion</span>
             <CcToggle v-model="normalize" />
           </div>
           <template v-if="timeSeries">
-            <label class="sp-pop-row" v-tooltip.left="'LOESS span — % of points in each local fit (geom_smooth span)'">
+            <label class="sp-pop-row cc-muted" v-tooltip.left="'LOESS span — % of points in each local fit (geom_smooth span)'">
               <span>Smooth span</span>
               <input type="number" min="5" max="100" step="5" v-model.number="smooth" />
             </label>
-            <div class="sp-pop-row" v-tooltip.left="'Show the ±95% confidence ribbon of the fit'">
+            <div class="sp-pop-row cc-muted" v-tooltip.left="'Show the ±95% confidence ribbon of the fit'">
               <span>Interval</span>
               <CcToggle v-model="interval" />
             </div>
@@ -625,7 +625,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
           <i class="pi pi-chart-bar" />
         </button>
         <div v-if="showExplode" class="sp-explode-pop" @click.stop>
-          <div class="sp-explode-hd">Measurements to plot</div>
+          <div class="sp-explode-hd cc-muted cc-fs-xs">Measurements to plot</div>
           <label v-for="m in measureOpts" :key="m" class="sp-explode-row">
             <input type="checkbox" :checked="explodeSel.includes(m)" @change="toggleExplode(m)" /> {{ m }}
           </label>
@@ -647,9 +647,9 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
     </template>
 
     <div class="sp-body">
-      <div v-if="!series.length" class="sp-msg">Select one or more populations (eye icon) to plot.</div>
-      <div v-else-if="error" class="sp-msg sp-err">{{ error }}</div>
-      <div v-else-if="!hasData && !loading" class="sp-msg">No data for the selected populations.</div>
+      <div v-if="!series.length" class="sp-msg cc-muted">Select one or more populations (eye icon) to plot.</div>
+      <div v-else-if="error" class="sp-msg sp-err cc-muted">{{ error }}</div>
+      <div v-else-if="!hasData && !loading" class="sp-msg cc-muted">No data for the selected populations.</div>
       <PlotChart v-else-if="hasData" ref="plotRef" :data="result" :opts="buildOpts" />
       <PlotSpinner v-if="showSpinner" label="Loading…" />
     </div>
@@ -671,7 +671,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
   min-width: 13rem; max-height: 60vh; overflow-y: auto; padding: 8px;
   background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md);
   box-shadow: 0 6px 18px rgba(0,0,0,0.35); font-size: var(--cc-fs-sm); }
-.sp-explode-hd { color: var(--cc-text-dim); font-size: var(--cc-fs-xs); margin-bottom: 6px; }
+.sp-explode-hd { margin-bottom: 6px; }
 .sp-explode-row { display: flex; align-items: center; gap: 6px; padding: 2px 0; color: var(--cc-text); cursor: pointer; }
 .sp-explode-ft { display: flex; justify-content: flex-end; gap: 6px; margin-top: 8px; }
 
@@ -683,11 +683,10 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
    positioning mode live here. New plot popovers should reuse this pattern (docs/PLOTS.md §0). */
 /* inner layout only — TeleportPopover provides surface/border/shadow/position */
 .sp-pop { min-width: 11rem; display: flex; flex-direction: column; gap: 6px; padding: 8px; }
-.sp-pop-row { display: flex; align-items: center; justify-content: space-between; gap: 8px;
-  font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.sp-pop-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .sp-pop-row select { max-width: 7rem; }
 .sp-pop-row input[type="number"] { width: 3.6rem; padding: 2px 4px; }
 .sp-body { position: relative; flex: 1; min-height: 200px; padding: 8px; overflow: hidden; }
-.sp-msg { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); text-align: center; padding: 12px; }
+.sp-msg { display: flex; align-items: center; justify-content: center; height: 100%; padding: 12px; }
 .sp-err { color: var(--cc-danger); }
 </style>

--- a/frontend/src/components/plots/GateMontage.vue
+++ b/frontend/src/components/plots/GateMontage.vue
@@ -267,15 +267,15 @@ const corrFont = (r: number | null | undefined) => `${Math.round(13 + Math.abs(r
 
 <template>
   <div ref="gridRef" class="gm-grid" :class="{ single, matrix: cols != null }" :style="gridStyle">
-    <div v-if="err" class="gm-msg cc-muted cc-muted-md">{{ err }}</div>
-    <div v-else-if="!defs.length" class="gm-msg cc-muted cc-muted-md"><slot name="empty">Nothing to show.</slot></div>
+    <div v-if="err" class="gm-msg cc-muted cc-fs-md">{{ err }}</div>
+    <div v-else-if="!defs.length" class="gm-msg cc-muted cc-fs-md"><slot name="empty">Nothing to show.</slot></div>
     <template v-for="d in defs" :key="d.key">
       <!-- DIAGONAL (ggpairs): the channel name — labels its whole row and column -->
       <div v-if="d.role === 'diagonal'" class="gm-cell gm-diag"><span>{{ colLabel(d.xChan) }}</span></div>
       <!-- UPPER triangle (ggpairs): the pair's correlation, reused from its mirror scatter -->
       <div v-else-if="d.role === 'corr'" class="gm-cell gm-corr"
            v-tooltip.top="`corr(${colLabel(d.xChan)}, ${colLabel(d.yChan)})`">
-        <span class="gm-corr-k cc-eyebrow cc-eyebrow-2xs">Corr</span>
+        <span class="gm-corr-k cc-eyebrow cc-fs-2xs">Corr</span>
         <span class="gm-corr-v" :style="{ fontSize: corrFont(corrFor(d)) }">{{ fmtCorr(corrFor(d)) }}</span>
       </div>
       <div v-else class="gm-cell">

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -246,15 +246,15 @@ defineExpose({ exportImage, exportSvg, hiRes, getHost: () => hostEl.value,
       <span class="axisline axisline-x" />
       <span class="axisline axisline-y" />
       <span v-for="t in xTicks" :key="'x'+t.pos" class="xtick" :style="{ left: tickX(t.pos, viewExtents) }">
-        <span class="xtick-mark" /><span class="xtick-lbl">{{ fmtTick(t.label) }}</span>
+        <span class="xtick-mark" /><span class="xtick-lbl cc-muted">{{ fmtTick(t.label) }}</span>
       </span>
       <span v-for="t in yTicks" :key="'y'+t.pos" class="ytick" :style="{ top: tickY(t.pos, viewExtents) }">
-        <span class="ytick-lbl">{{ fmtTick(t.label) }}</span><span class="ytick-mark" />
+        <span class="ytick-lbl cc-muted">{{ fmtTick(t.label) }}</span><span class="ytick-mark" />
       </span>
       <span v-if="!hideAxisLabels" class="axis-x">{{ xLabel }}</span>
       <span v-if="!hideAxisLabels" class="axis-y">{{ yLabel }}</span>
       <PlotSpinner v-if="showSpinner && !compact" label="Loading…" />
-      <div v-else-if="loading && compact" class="panel-loading">…</div>
+      <div v-else-if="loading && compact" class="panel-loading cc-muted cc-fs-xs">…</div>
       <slot />
     </div>
   </div>
@@ -307,15 +307,15 @@ defineExpose({ exportImage, exportSvg, hiRes, getHost: () => hostEl.value,
 .axisline-y { left: 0; top: 0; bottom: 0; width: 1px; }
 .xtick { position: absolute; bottom: 0; transform: translate(-50%, 100%); display: flex; flex-direction: column; align-items: center; pointer-events: none; }
 .xtick-mark { width: 1px; height: 5px; background: var(--cc-text-dim); }
-.xtick-lbl { margin-top: 3px; font-size: calc(var(--gate-font, 11px) - 1px); color: var(--cc-text-dim); white-space: nowrap; }
+.xtick-lbl { margin-top: 3px; font-size: calc(var(--gate-font, 11px) - 1px); white-space: nowrap; }
 .ytick { position: absolute; left: 0; transform: translate(-100%, -50%); display: flex; align-items: center; pointer-events: none; }
 .ytick-mark { width: 5px; height: 1px; background: var(--cc-text-dim); }
-.ytick-lbl { margin-right: 3px; font-size: calc(var(--gate-font, 11px) - 1px); color: var(--cc-text-dim); white-space: nowrap; }
+.ytick-lbl { margin-right: 3px; font-size: calc(var(--gate-font, 11px) - 1px); white-space: nowrap; }
 /* nowrap so a long channel name (e.g. "Bcells-ubiTom") stays on ONE line in the axis gutter instead of
    wrapping into the plot; it sits in the .plot-capture padding, which overflows visibly if needed */
 .axis-x { position: absolute; bottom: -40px; left: 50%; transform: translateX(-50%); white-space: nowrap; font-size: calc(var(--gate-font, 11px) + 2px); font-weight: 600; color: var(--cc-text); }
 /* vertical text via writing-mode (rotate's origin offsets by half the text width → overlap) */
 .axis-y { position: absolute; left: -66px; top: 50%; transform: translateY(-50%) rotate(180deg);
   writing-mode: vertical-rl; white-space: nowrap; font-size: calc(var(--gate-font, 11px) + 2px); font-weight: 600; color: var(--cc-text); }
-.panel-loading { position: absolute; top: 4px; right: 6px; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.panel-loading { position: absolute; top: 4px; right: 6px; }
 </style>

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -319,22 +319,22 @@ defineExpose({ exportImage })
                 v-tooltip.bottom="'Caption size & separator'"><i class="pi pi-cog" /></button>
         <TeleportPopover v-model="optsOpen" :anchor="gearEl" placement="bottom-end">
           <div class="is-pop">
-            <CcToggle class="is-check cc-muted cc-muted-xs" label="legend (channels · pops · colour-by)"
+            <CcToggle class="is-check cc-muted cc-fs-xs" label="legend (channels · pops · colour-by)"
               :model-value="showLegend" @update:model-value="showLegend = $event" />
-            <CcToggle class="is-check cc-muted cc-muted-xs" label="clean capture"
+            <CcToggle class="is-check cc-muted cc-fs-xs" label="clean capture"
               v-tooltip.bottom="'Hide napari\'s scale bar + timestamp when capturing, for a clean publication still (add your own externally)'"
               :model-value="settings.cleanCapture" @update:model-value="settings.cleanCapture = $event" />
-            <CcToggle class="is-check cc-muted cc-muted-xs" label="scale bar"
+            <CcToggle class="is-check cc-muted cc-fs-xs" label="scale bar"
               v-tooltip.bottom="'Draw a vector scale bar on each frame (from the image\'s physical pixel size)'"
               :model-value="showScaleBar" @update:model-value="showScaleBar = $event" />
-            <CcToggle class="is-check cc-muted cc-muted-xs" label="timestamp"
+            <CcToggle class="is-check cc-muted cc-fs-xs" label="timestamp"
               v-tooltip.bottom="'Draw the elapsed-time timestamp on each frame'"
               :model-value="showTimestamp" @update:model-value="showTimestamp = $event" />
             <template v-if="separator === 'angled' && orientation === 'h'">
-              <label class="is-slider cc-muted cc-muted-xs">angle
+              <label class="is-slider cc-muted cc-fs-xs">angle
                 <input type="range" min="0" max="80" :value="skew" @input="skew = +($event.target as HTMLInputElement).value" />
                 <span class="is-val">{{ skew }}</span></label>
-              <label class="is-slider cc-muted cc-muted-xs">width
+              <label class="is-slider cc-muted cc-fs-xs">width
                 <input type="range" min="1" max="12" :value="thick" @input="thick = +($event.target as HTMLInputElement).value" />
                 <span class="is-val">{{ thick }}</span></label>
             </template>

--- a/frontend/src/components/plots/PlotSpinner.vue
+++ b/frontend/src/components/plots/PlotSpinner.vue
@@ -15,7 +15,7 @@ defineProps<{ label?: string }>()
 <template>
   <div class="plot-spinner" role="status" aria-live="polite">
     <div class="plot-spinner__wheel" aria-hidden="true" />
-    <span v-if="label" class="plot-spinner__label cc-muted cc-muted-xs">{{ label }}</span>
+    <span v-if="label" class="plot-spinner__label cc-muted cc-fs-xs">{{ label }}</span>
   </div>
 </template>
 

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -625,7 +625,7 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
             <div class="uv-pop">
               <div v-if="!popGroups.length" class="uv-pop-empty cc-muted">No populations in the clustered segmentations.</div>
               <template v-for="grp in popGroups" :key="grp.valueName">
-                <div v-if="grp.populations.length" class="uv-pop-head cc-eyebrow cc-eyebrow-2xs">{{ grp.valueName }}</div>
+                <div v-if="grp.populations.length" class="uv-pop-head cc-eyebrow cc-fs-2xs">{{ grp.valueName }}</div>
                 <div v-for="p in grp.populations" :key="p.popType + grp.valueName + p.path"
                      class="uv-pop-row" :class="{ on: isPopOn(grp.valueName, p.path, p.popType) }"
                      @click="togglePop(grp.valueName, p.path, p.popType)">
@@ -693,7 +693,7 @@ defineExpose({ exportFormats: ['png', 'svg', 'csv'], exportAs, exportImage })
 /* population checklist (inside the options popover) */
 .uv-pop { max-height: 14rem; overflow-y: auto; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm); }
 .uv-pop-empty { padding: 10px; }   /* + .cc-muted */
-/* + .cc-eyebrow .cc-eyebrow-2xs (case/tracking/weight/colour at the 10px tier) */
+/* + .cc-eyebrow .cc-fs-2xs (case/tracking/weight/colour at the 10px tier) */
 .uv-pop-head { padding: 4px 8px; background: var(--cc-surface-2); position: sticky; top: 0; }
 .uv-pop-row { display: flex; align-items: center; gap: 6px; padding: 4px 8px; cursor: pointer; font-size: var(--cc-fs-sm); color: var(--cc-text); }
 .uv-pop-row:hover { background: var(--cc-surface-2); }

--- a/frontend/src/modules/AnimationModule.vue
+++ b/frontend/src/modules/AnimationModule.vue
@@ -252,7 +252,7 @@ async function render() {
           channels/populations per keyframe, then render — the movie interpolates between keyframes.</p>
       </div>
       <div class="anim-head-ctl">
-        <label class="anim-fps" v-tooltip.bottom="'Output frames per second'">
+        <label class="anim-fps cc-muted" v-tooltip.bottom="'Output frames per second'">
           fps <input type="range" min="1" max="40" step="1" v-model.number="anim.fps" class="anim-range" />
           <span class="anim-num">{{ anim.fps }}</span>
         </label>
@@ -260,7 +260,7 @@ async function render() {
         <CcToggle class="anim-title-toggle" v-model="anim.titleCard.enabled" label="Title card"
                v-tooltip.bottom="'Prepend a title slide — name, attributes, and every channel / population / colour-by shown at some point across the animation'" />
         <template v-if="anim.titleCard.enabled">
-          <label class="anim-fps" v-tooltip.bottom="'Title-card duration (seconds)'">
+          <label class="anim-fps cc-muted" v-tooltip.bottom="'Title-card duration (seconds)'">
             <input type="range" min="1" max="10" step="1" v-model.number="anim.titleCard.durationSec" class="anim-range" />
             <span class="anim-num">{{ anim.titleCard.durationSec }}s</span>
           </label>
@@ -313,10 +313,10 @@ async function render() {
                   <img v-if="f.assetId" :src="assetUrl(f)" :alt="`keyframe ${i+1}`" />
                   <span v-if="isEdited(f)" class="tl-badge" v-tooltip.bottom="'Edited from the captured view — use ↺ to reset'">edited</span>
                 </div>
-                <div v-if="keyframeTime(f)" class="tl-time">{{ keyframeTime(f) }}</div>
+                <div v-if="keyframeTime(f)" class="tl-time cc-readout cc-fs-2xs">{{ keyframeTime(f) }}</div>
                 <div class="tl-colctl">
                   <button class="tl-ico cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" :disabled="i === 0" @click="anim.move(f.id, -1)" v-tooltip.bottom="'Move earlier'"><i class="pi pi-chevron-left" /></button>
-                  <span class="tl-kf">{{ i + 1 }}</span>
+                  <span class="tl-kf cc-muted cc-fs-xs">{{ i + 1 }}</span>
                   <button class="tl-ico cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" :disabled="i === frames.length - 1" @click="anim.move(f.id, 1)" v-tooltip.bottom="'Move later'"><i class="pi pi-chevron-right" /></button>
                   <button class="tl-ico cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" :disabled="!isEdited(f)" @click="resetKeyframe(f)" v-tooltip.bottom="'Reset to the captured view'"><i class="pi pi-refresh" /></button>
                   <ConfirmDeleteButton title="Delete keyframe" armed-title="Click again to delete" @confirm="deleteKeyframe(f)" />
@@ -324,15 +324,15 @@ async function render() {
                 <div class="tl-dur" v-tooltip.bottom="'Seconds this keyframe tweens from the previous'">
                   <input type="range" min="0.1" max="10" step="0.1" :value="f.duration ?? 1" class="tl-durrange"
                          @input="f.duration = Number(($event.target as HTMLInputElement).value)" />
-                  <span class="tl-durval">{{ (f.duration ?? 1).toFixed(1) }}s</span>
+                  <span class="tl-durval cc-readout cc-fs-2xs">{{ (f.duration ?? 1).toFixed(1) }}s</span>
                 </div>
               </th>
             </tr>
           </thead>
           <tbody>
-            <tr class="tl-group"><td class="tl-rowhead">Channels</td><td v-for="f in frames" :key="f.id" /></tr>
+            <tr class="tl-group"><td class="tl-rowhead cc-eyebrow cc-fs-3xs">Channels</td><td v-for="f in frames" :key="f.id" /></tr>
             <tr v-for="name in channelRows" :key="'c'+name" class="tl-row">
-              <td class="tl-rowhead" :title="name">{{ name }}</td>
+              <td class="tl-rowhead cc-fs-sm" :title="name">{{ name }}</td>
               <td v-for="f in frames" :key="f.id" class="tl-cell">
                 <button v-if="cellState(f, name) !== null" class="tl-dot" :class="{ on: cellState(f, name) }"
                         :style="cellState(f, name) ? { background: layerColour(f, name), borderColor: layerColour(f, name) } : undefined"
@@ -342,9 +342,9 @@ async function render() {
             </tr>
 
             <template v-if="popRows.length">
-              <tr class="tl-group"><td class="tl-rowhead">Populations &amp; overlays</td><td v-for="f in frames" :key="f.id" /></tr>
+              <tr class="tl-group"><td class="tl-rowhead cc-eyebrow cc-fs-3xs">Populations &amp; overlays</td><td v-for="f in frames" :key="f.id" /></tr>
               <tr v-for="name in popRows" :key="'p'+name" class="tl-row">
-                <td class="tl-rowhead" :title="name">{{ name }}</td>
+                <td class="tl-rowhead cc-fs-sm" :title="name">{{ name }}</td>
                 <td v-for="f in frames" :key="f.id" class="tl-cell">
                   <button v-if="cellState(f, name) !== null" class="tl-dot" :class="{ on: cellState(f, name) }"
                           :style="cellState(f, name) ? { background: layerColour(f, name), borderColor: layerColour(f, name) } : undefined"
@@ -354,10 +354,10 @@ async function render() {
               </tr>
             </template>
 
-            <tr class="tl-group"><td class="tl-rowhead">Camera</td><td v-for="f in frames" :key="f.id" /></tr>
+            <tr class="tl-group"><td class="tl-rowhead cc-eyebrow cc-fs-3xs">Camera</td><td v-for="f in frames" :key="f.id" /></tr>
             <tr class="tl-row">
-              <td class="tl-rowhead">zoom</td>
-              <td v-for="f in frames" :key="f.id" class="tl-cell tl-cam">{{ cameraZoom(f) }}</td>
+              <td class="tl-rowhead cc-fs-sm">zoom</td>
+              <td v-for="f in frames" :key="f.id" class="tl-cell tl-cam cc-readout cc-fs-xs">{{ cameraZoom(f) }}</td>
             </tr>
           </tbody>
         </table>
@@ -372,7 +372,7 @@ async function render() {
 .anim-head h1 { font-size: 1.1rem; margin: 0 0 0.2rem; }
 .anim-sub { max-width: 46rem; margin: 0; }   /* + .cc-muted */
 .anim-head-ctl { display: flex; align-items: center; gap: 0.9rem; flex-shrink: 0; }
-.anim-fps { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.4rem; }
+.anim-fps { display: inline-flex; align-items: center; gap: 0.4rem; }
 .anim-range { width: 5rem; accent-color: var(--cc-accent); }
 .anim-num { font-size: var(--cc-fs-sm); color: var(--cc-text); font-variant-numeric: tabular-nums; min-width: 1.2rem; }
 .anim-title-toggle { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); display: inline-flex; align-items: center; gap: 0.35rem; cursor: pointer; }
@@ -386,8 +386,11 @@ async function render() {
 .anim-timeline { overflow-x: auto; border: 1px solid var(--cc-border); border-radius: var(--cc-radius-lg);
   background: var(--cc-surface-1); padding: 0.6rem 0.7rem 0.8rem; }
 .tl { border-collapse: separate; border-spacing: 0; }
-.tl-rowhead { position: sticky; left: 0; background: var(--cc-surface-1); text-align: left; font-size: var(--cc-fs-sm);
-  color: var(--cc-text); padding: 0.25rem 0.9rem 0.25rem 0.1rem; max-width: 11rem; overflow: hidden;
+/* No colour or size here: the group-header cells compose .cc-eyebrow, and a scoped class outranks a
+   global utility (0,2,0 vs 0,1,0), so owning either property here made the utility a no-op. The
+   colour was redundant regardless — nothing above the timeline dims, so these inherit --cc-text. */
+.tl-rowhead { position: sticky; left: 0; background: var(--cc-surface-1); text-align: left;
+  padding: 0.25rem 0.9rem 0.25rem 0.1rem; max-width: 11rem; overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap; z-index: 1; }
 .tl-corner { min-width: 7rem; }
 .tl-col { padding: 0 0.35rem 0.4rem; vertical-align: top; text-align: center; }
@@ -402,17 +405,17 @@ async function render() {
 .tl-thumb.selected { border-color: var(--cc-selected); box-shadow: 0 0 0 2px color-mix(in srgb, var(--cc-selected) 55%, transparent); }
 .tl-badge { position: absolute; top: 4px; right: 4px; font-size: var(--cc-fs-3xs); font-weight: 700; text-transform: uppercase;
   letter-spacing: 0.04em; color: #1f1400; background: var(--cc-warn); padding: 1px 5px; border-radius: var(--cc-radius-pill); }
-.tl-time { font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); text-align: center; margin-top: 0.15rem; font-variant-numeric: tabular-nums; }
+.tl-time { margin-top: 0.15rem; }
 .tl-colctl { display: flex; align-items: center; justify-content: center; gap: 0.1rem; margin-top: 0.3rem; }
-.tl-kf { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); min-width: 0.9rem; text-align: center; }
+.tl-kf { min-width: 0.9rem; text-align: center; }
 /* .tl-ico → cc-btn cc-btn-bare cc-btn-icon cc-btn-micro */
 .tl-ico:hover:not(:disabled) { color: var(--cc-text); background: var(--cc-surface-2); }
 .tl-ico:disabled { opacity: 0.3; cursor: default; }
 .tl-dur { display: flex; align-items: center; justify-content: center; gap: 0.3rem; margin-top: 0.3rem; }
 .tl-durrange { width: 68px; accent-color: var(--cc-accent); }
-.tl-durval { font-size: var(--cc-fs-2xs); color: var(--cc-text-dim); font-variant-numeric: tabular-nums; min-width: 1.8rem; text-align: left; }
-.tl-group .tl-rowhead { font-size: var(--cc-fs-3xs); font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--cc-text-dim); padding-top: 0.7rem; padding-bottom: 0.2rem; }
+.tl-durval { min-width: 1.8rem; text-align: left; }
+/* + .cc-eyebrow .cc-fs-3xs on the cell — only the spacing is the timeline's business */
+.tl-group .tl-rowhead { padding-top: 0.7rem; padding-bottom: 0.2rem; }
 .tl-row:hover .tl-cell, .tl-row:hover .tl-rowhead { background: rgba(255, 255, 255, 0.03); }
 .tl-cell { text-align: center; padding: 0.22rem 0.35rem; }
 .tl-dot { width: 15px; height: 15px; border-radius: var(--cc-radius-pill); border: 1.5px solid var(--cc-border);
@@ -420,7 +423,6 @@ async function render() {
 .tl-dot:hover { transform: scale(1.18); }
 .tl-dot.on { border-style: solid; }         /* on: filled with the layer colour (set inline) */
 .tl-absent { color: var(--cc-text-dim); opacity: 0.35; }
-.tl-cam { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); font-variant-numeric: tabular-nums; }
 
 /* buttons use the global .cc-btn utilities (style.css) */
 </style>

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -1136,7 +1136,7 @@ onActivated(async () => {
         <TeleportPopover v-model="throttleOpen" :anchor="throttleBtn" placement="bottom-end">
           <PoolThrottle />
         </TeleportPopover>
-        <span v-if="!runOptions.length" class="live-hint">No runs yet — start a chain run to see progress.</span>
+        <span v-if="!runOptions.length" class="live-hint cc-muted">No runs yet — start a chain run to see progress.</span>
       </div>
 
       <div v-if="liveNodes.length" class="live-canvas-wrap">
@@ -1171,7 +1171,7 @@ onActivated(async () => {
           </div>
         </div>
       </div>
-      <div v-else class="live-empty">
+      <div v-else class="live-empty cc-empty">
         <i class="pi pi-hourglass" style="font-size:2rem; opacity:0.2" />
         <p>No nodes for this run yet.</p>
       </div>
@@ -1193,7 +1193,7 @@ onActivated(async () => {
           >
             <option v-for="name in chainNames" :key="name" :value="name">{{ name }}</option>
           </select>
-          <span v-else class="no-chains-hint">No chains yet</span>
+          <span v-else class="no-chains-hint cc-muted">No chains yet</span>
         </div>
         <div class="chain-bar-actions">
           <button
@@ -1249,7 +1249,7 @@ onActivated(async () => {
         </button>
       </div>
 
-      <div v-if="!projectMeta.hasProject" class="palette-hint">
+      <div v-if="!projectMeta.hasProject" class="palette-hint cc-muted">
         Open a project first.
       </div>
 
@@ -1263,7 +1263,7 @@ onActivated(async () => {
               :key="cat.name"
               class="palette-category"
             >
-              <div class="palette-cat-heading cc-eyebrow cc-eyebrow-2xs">{{ cat.name }}</div>
+              <div class="palette-cat-heading cc-eyebrow cc-fs-2xs">{{ cat.name }}</div>
               <div
                 v-for="def in cat.defs"
                 :key="def.fun_name"
@@ -1277,7 +1277,7 @@ onActivated(async () => {
               </div>
             </div>
 
-            <div v-if="!paletteCategories.length" class="palette-hint palette-hint-retry">
+            <div v-if="!paletteCategories.length" class="palette-hint palette-hint-retry cc-muted">
               No task definitions found.
               <button class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense palette-retry-btn" @click="loadAllTaskDefs"
                 v-tooltip.right="'Retry loading task definitions from the server.'">
@@ -1289,14 +1289,14 @@ onActivated(async () => {
 
         <!-- Plots (collapsible) — drag plot nodes onto the canvas; not built yet -->
         <CollapsibleSection label="Plots" :default-open="false" max-height="50vh">
-          <div class="palette-soon">
+          <div class="palette-soon cc-muted">
             Plot nodes — drop summary plots into the chain — coming soon.
           </div>
         </CollapsibleSection>
 
         <!-- ── Run table ──────────────────────────────────────────────────── -->
         <div class="run-table-section">
-          <div class="run-section-heading cc-eyebrow cc-eyebrow-2xs">Run</div>
+          <div class="run-section-heading cc-eyebrow cc-fs-2xs">Run</div>
 
           <select
             v-if="project.sets.length"
@@ -1306,7 +1306,7 @@ onActivated(async () => {
           >
             <option v-for="s in project.sets" :key="s.uid" :value="s.uid">{{ s.name }}</option>
           </select>
-          <span v-else class="palette-hint">No sets in project.</span>
+          <span v-else class="palette-hint cc-muted">No sets in project.</span>
 
           <!-- Image list -->
           <div v-if="runImages.length" class="run-image-list">
@@ -1323,7 +1323,7 @@ onActivated(async () => {
                   runSomeSelected  ? 'pi-minus-circle' : 'pi-stop'
                 ]" />
               </span>
-              <span class="run-all-label">All ({{ includedRunUids.length }})</span>
+              <span class="run-all-label cc-muted">All ({{ includedRunUids.length }})</span>
               <span class="run-sel-count" v-if="runSomeSelected">{{ runSelectedUids.length }}</span>
             </div>
 
@@ -1339,7 +1339,7 @@ onActivated(async () => {
               <span class="run-check-icon">
                 <i :class="['pi', isExcluded(img) ? 'pi-ban' : runSelectedUids.includes(img.uid) ? 'pi-check-square' : 'pi-stop']" />
               </span>
-              <span class="run-img-name">{{ img.name }}</span>
+              <span class="run-img-name cc-muted">{{ img.name }}</span>
             </div>
           </div>
 
@@ -1379,14 +1379,14 @@ onActivated(async () => {
 
         <!-- Empty state -->
         <template v-if="!activeChain && projectMeta.hasProject" #empty>
-          <div class="canvas-empty">
+          <div class="canvas-empty cc-empty">
             <i class="pi pi-sitemap" />
             <p>Select a chain or create one to start editing.</p>
           </div>
         </template>
       </VueFlow>
 
-      <div class="canvas-hints">
+      <div class="canvas-hints cc-muted cc-fs-2xs">
         Drag to pan · Scroll to zoom · Double-click edge to remove
       </div>
     </div>
@@ -1404,7 +1404,7 @@ onActivated(async () => {
         </div>
 
         <div v-if="selectedNode.type === 'start'" class="config-section">
-          <p class="no-params-hint">Link this to the task(s) a run should begin from. Only tasks
+          <p class="no-params-hint cc-muted">Link this to the task(s) a run should begin from. Only tasks
           reachable from it will run — the rest stay in the editor as drafts.</p>
         </div>
 
@@ -1475,17 +1475,17 @@ onActivated(async () => {
         </div>
 
         <div class="config-section" v-else-if="selectedTaskDef && !selectedTaskDef.params.length">
-          <span class="no-params-hint">No parameters for this function.</span>
+          <span class="no-params-hint cc-muted">No parameters for this function.</span>
         </div>
 
         <div class="config-section" v-else>
-          <span class="no-params-hint">Function not found in task definitions.</span>
+          <span class="no-params-hint cc-muted">Function not found in task definitions.</span>
         </div>
         </template>
 
       </template>
 
-      <div v-else class="config-placeholder">
+      <div v-else class="config-placeholder cc-empty">
         <i class="pi pi-mouse-pointer" style="font-size:1.4rem; opacity:0.3" />
         <p>Click a node to configure it.</p>
       </div>
@@ -1574,11 +1574,7 @@ onActivated(async () => {
 }
 .qc-expand-body { flex: 1; min-height: 0; overflow: auto; }
 
-.live-hint {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  font-style: italic;
-}
+.live-hint { font-style: italic; }
 
 .live-canvas-wrap {
   flex: 1;
@@ -1586,17 +1582,7 @@ onActivated(async () => {
   position: relative;
 }
 
-.live-empty {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-md);
-  font-style: italic;
-}
+.live-empty { flex: 1; font-style: italic; }
 
 /* Edit tab: flex row layout ─────────────────────────────────────────────── */
 .edit-content {
@@ -1604,7 +1590,6 @@ onActivated(async () => {
   display: flex;
   overflow: hidden;
 }
-
 
 /* ── Palette ──────────────────────────────────────────────────────────────── */
 .wb-palette {
@@ -1651,12 +1636,7 @@ onActivated(async () => {
 }
 .chain-select:focus { outline: 1px solid var(--cc-accent); }
 
-.no-chains-hint {
-  flex: 1;
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  font-style: italic;
-}
+.no-chains-hint { flex: 1; font-style: italic; }
 
 .wb-btn { transition: background 0.1s, color 0.1s; }   /* + cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense */
 .wb-btn:hover:not(:disabled) { background: var(--cc-surface-2); color: var(--cc-text); border-color: var(--cc-accent); }
@@ -1689,7 +1669,7 @@ onActivated(async () => {
 
 .palette-category { margin-bottom: 0.25rem; }
 
-.palette-cat-heading { padding: 0.5rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-eyebrow-2xs */
+.palette-cat-heading { padding: 0.5rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-fs-2xs */
 
 .palette-item {
   display: flex;
@@ -1721,19 +1701,8 @@ onActivated(async () => {
   text-overflow: ellipsis;
 }
 
-.palette-hint {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  font-style: italic;
-  padding: 0.75rem 0.65rem;
-}
-.palette-soon {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  font-style: italic;
-  padding: 0.75rem 0.65rem;
-  opacity: 0.7;
-}
+.palette-hint { font-style: italic; padding: 0.75rem 0.65rem; }
+.palette-soon { font-style: italic; padding: 0.75rem 0.65rem; opacity: 0.7; }
 .palette-hint-retry {
   display: flex;
   align-items: center;
@@ -1758,28 +1727,10 @@ onActivated(async () => {
   height: 100%;
 }
 
-.canvas-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-md);
-  font-style: italic;
-}
+.canvas-empty { font-style: italic; }
 .canvas-empty i { font-size: 2rem; opacity: 0.25; }
 
-.canvas-hints {
-  position: absolute;
-  bottom: 0.5rem;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: var(--cc-fs-2xs);
-  color: var(--cc-text-dim);
-  opacity: 0.5;
-  pointer-events: none;
-  white-space: nowrap;
-}
+.canvas-hints { position: absolute; bottom: 0.5rem; left: 50%; transform: translateX(-50%); opacity: 0.5; pointer-events: none; white-space: nowrap; }
 
 /* ── Config panel ─────────────────────────────────────────────────────────── */
 .wb-config {
@@ -1797,17 +1748,7 @@ onActivated(async () => {
   overflow-y: auto;
 }
 
-.config-placeholder {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 2rem 1rem;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-sm);
-  font-style: italic;
-  text-align: center;
-}
+.config-placeholder { padding: 2rem 1rem; font-style: italic; }
 
 .config-header {
   display: flex;
@@ -1841,11 +1782,7 @@ onActivated(async () => {
 
 .config-section-heading { margin-bottom: 0.35rem; }   /* + .cc-eyebrow */
 .config-params { display: flex; flex-direction: column; }
-.no-params-hint {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  font-style: italic;
-}
+.no-params-hint { font-style: italic; }
 
 /* ── Run table ────────────────────────────────────────────────────────────── */
 .run-table-section {
@@ -1857,7 +1794,7 @@ onActivated(async () => {
   background: var(--cc-bg);
 }
 
-.run-section-heading { padding: 0.45rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-eyebrow-2xs */
+.run-section-heading { padding: 0.45rem 0.65rem 0.2rem; }   /* + .cc-eyebrow .cc-fs-2xs */
 
 .run-set-select {
   margin: 0 0.45rem 0.3rem;
@@ -1907,26 +1844,14 @@ onActivated(async () => {
 .run-row:not(.active) .run-check-icon { color: var(--cc-border); }
 .run-row-all .run-check-icon { color: var(--cc-accent); }
 
-.run-all-label {
-  font-size: var(--cc-fs-sm);
-  font-weight: 600;
-  color: var(--cc-text-dim);
-  flex: 1;
-}
+.run-all-label { font-weight: 600; flex: 1; }
 .run-sel-count {
   font-size: var(--cc-fs-2xs);
   font-family: var(--cc-mono);
   color: var(--cc-accent);
 }
 
-.run-img-name {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 130px;
-}
+.run-img-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 130px; }
 
 .run-chain-btn {
   display: flex;

--- a/frontend/src/modules/MoviesModule.vue
+++ b/frontend/src/modules/MoviesModule.vue
@@ -217,7 +217,7 @@ function movieTime(mtime: number): string {
           <i class="pi pi-video mov-item-ico" />
           <span class="mov-item-body">
             <span class="mov-item-name">{{ movieDisplayName(m.name) }}</span>
-            <span class="mov-item-meta cc-muted cc-muted-xs">{{ formatBytes(m.size) }} · {{ movieTime(m.mtime) }}</span>
+            <span class="mov-item-meta cc-muted cc-fs-xs">{{ formatBytes(m.size) }} · {{ movieTime(m.mtime) }}</span>
           </span>
         </button>
       </aside>

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -342,7 +342,7 @@ async function switchWt(path: string) {
         </div>
       </template>
 
-      <p v-else class="no-project">No project open. Open or create a project first.</p>
+      <p v-else class="no-project cc-muted cc-fs-md">No project open. Open or create a project first.</p>
     </section>
 
     <!-- ── Interface ───────────────────────────────────────────────────── -->
@@ -378,7 +378,7 @@ async function switchWt(path: string) {
             {{ appCtl.updateChecking ? 'Checking…' : 'Check' }}
           </button>
         </div>
-        <span v-if="!appCtl.updateAvailable && appCtl.updateCurrent && !appCtl.updateMsg" class="field-hint">
+        <span v-if="!appCtl.updateAvailable && appCtl.updateCurrent && !appCtl.updateMsg" class="field-hint cc-muted cc-fs-xs">
           You're on the latest version.
         </span>
       </div>
@@ -397,12 +397,12 @@ async function switchWt(path: string) {
       </div>
 
       <!-- shared system-wide install: updates are admin-only (see docs/todo/ONBOARDING_PLAN.md D4/D5) -->
-      <span v-else-if="appCtl.updateAvailable && appCtl.updateScope === 'system'" class="field-hint">
+      <span v-else-if="appCtl.updateAvailable && appCtl.updateScope === 'system'" class="field-hint cc-muted cc-fs-xs">
         {{ appCtl.updateLatest }} is available. This is a shared installation — updates must be run by
         an administrator (re-run the install-system script).
       </span>
 
-      <span v-if="appCtl.updateMsg" class="field-hint">{{ appCtl.updateMsg }}</span>
+      <span v-if="appCtl.updateMsg" class="field-hint cc-muted cc-fs-xs">{{ appCtl.updateMsg }}</span>
     </section>
 
     <!-- ── Custom modules ──────────────────────────────────────────────── -->
@@ -418,10 +418,10 @@ async function switchWt(path: string) {
             {{ storage ? 'Re-scan' : 'Scan storage' }}
           </button>
         </div>
-        <span v-if="!storage && !storageScan" class="field-hint">
+        <span v-if="!storage && !storageScan" class="field-hint cc-muted cc-fs-xs">
           Scan to see disk usage and superseded image versions that can be freed (everything except the active one).
         </span>
-        <span v-if="storageError" class="field-hint" style="color: var(--cc-sev-fail);">{{ storageError }}</span>
+        <span v-if="storageError" class="field-hint cc-muted cc-fs-xs" style="color: var(--cc-sev-fail);">{{ storageError }}</span>
       </div>
 
       <template v-if="storage">
@@ -434,18 +434,18 @@ async function switchWt(path: string) {
         <div v-if="storage.reclaimable.length" class="stor-reclaim">
           <div class="stor-reclaim-head">
             Reclaimable <strong>{{ formatBytes(storage.reclaimableBytes) }}</strong>
-            <span class="field-hint">({{ storage.reclaimable.length }} image{{ storage.reclaimable.length > 1 ? 's' : '' }} with superseded versions; the active version is kept)</span>
+            <span class="field-hint cc-muted cc-fs-xs">({{ storage.reclaimable.length }} image{{ storage.reclaimable.length > 1 ? 's' : '' }} with superseded versions; the active version is kept)</span>
           </div>
           <ul class="stor-list">
             <li v-for="r in storage.reclaimable.slice(0, 8)" :key="r.imageUid">
               <span class="stor-name">{{ r.name || r.imageUid }}</span>
               <span class="stor-size">{{ formatBytes(r.bytes) }}</span>
-              <span class="field-hint"
+              <span class="field-hint cc-muted cc-fs-xs"
                     v-tooltip.top="'Frees: ' + (r.versions?.map(v => v.valueName).join(', ') ?? '') + ' — keeps ' + r.activeVersion">
                 → keeps {{ r.activeVersion }}
               </span>
             </li>
-            <li v-if="storage.reclaimable.length > 8" class="field-hint">…{{ storage.reclaimable.length - 8 }} more</li>
+            <li v-if="storage.reclaimable.length > 8" class="field-hint cc-muted cc-fs-xs">…{{ storage.reclaimable.length - 8 }} more</li>
           </ul>
           <ConfirmButton @confirm="reclaimAll" v-slot="{ armed, arm, confirm, cancel }">
             <button v-if="!armed" class="save-btn danger" :disabled="storageBusy" @click="arm"
@@ -460,7 +460,7 @@ async function switchWt(path: string) {
             </template>
           </ConfirmButton>
         </div>
-        <span v-else class="field-hint">Nothing to reclaim — every image has only its active version.</span>
+        <span v-else class="field-hint cc-muted cc-fs-xs">Nothing to reclaim — every image has only its active version.</span>
       </template>
     </section>
 
@@ -480,7 +480,7 @@ async function switchWt(path: string) {
             {{ customModules.loading ? 'Reloading…' : 'Reload' }}
           </button>
         </div>
-        <span class="field-hint">
+        <span class="field-hint cc-muted cc-fs-xs">
           Drop tasks into this folder to add them without a rebuild — see docs/CUSTOM_MODULES.md.
         </span>
       </div>
@@ -493,14 +493,14 @@ async function switchWt(path: string) {
           <span class="cm-path mono" v-tooltip.top="m.error || m.path">{{ shortModulePath(m.path) }}</span>
         </div>
       </div>
-      <span v-else class="field-hint">No custom modules loaded.</span>
+      <span v-else class="field-hint cc-muted cc-fs-xs">No custom modules loaded.</span>
     </section>
 
     <!-- ── Data patches (project-scoped maintenance scripts) ──────────────── -->
     <section class="settings-section">
       <h2 class="section-title">Data patches</h2>
-      <p class="field-hint">One-off fixes applied to the currently open project's data. Dry-run first to see what would change.</p>
-      <div v-if="!projectMeta.current" class="field-hint">Open a project to run patches.</div>
+      <p class="field-hint cc-muted cc-fs-xs">One-off fixes applied to the currently open project's data. Dry-run first to see what would change.</p>
+      <div v-if="!projectMeta.current" class="field-hint cc-muted cc-fs-xs">Open a project to run patches.</div>
       <div v-for="p in patches" :key="p.id" class="patch-row">
         <div class="patch-head">
           <span class="patch-title">{{ p.title }}</span>
@@ -520,12 +520,12 @@ async function switchWt(path: string) {
             <button v-if="patchBusy(p.id)" class="save-btn ghost" @click="cancelPatch(p.id)"><i class="pi pi-times" /> Stop</button>
           </span>
         </div>
-        <span class="field-hint">{{ p.description }}</span>
+        <span class="field-hint cc-muted cc-fs-xs">{{ p.description }}</span>
         <div v-if="patchRun(p.id)" class="patch-run">
           <div v-if="patchRun(p.id)!.progress != null" class="patch-bar">
             <span :style="{ width: (patchRun(p.id)!.progress! * 100) + '%' }" /></div>
           <pre class="repl-log patch-log">{{ patchRun(p.id)!.log.join('\n') }}</pre>
-          <span class="field-hint">status: {{ patchRun(p.id)!.status }}</span>
+          <span class="field-hint cc-muted cc-fs-xs">status: {{ patchRun(p.id)!.status }}</span>
         </div>
       </div>
     </section>
@@ -542,7 +542,7 @@ async function switchWt(path: string) {
       <div class="svc-row">
         <span class="svc-name">Application</span>
         <span class="svc-pill ok"><span class="dot" /> Running</span>
-        <span class="svc-port" v-tooltip.top="'Backend HTTP/WS server'">:{{ diag?.port ?? '8080' }}</span>
+        <span class="svc-port cc-muted cc-fs-xs" v-tooltip.top="'Backend HTTP/WS server'">:{{ diag?.port ?? '8080' }}</span>
         <span class="svc-actions">
           <button v-if="diag?.dev" class="save-btn" :disabled="appCtl.busy" @click="appRestart"
                   v-tooltip.top="'Restart the backend server (dev): the supervisor relaunches it, page reconnects when it is back'">
@@ -579,7 +579,7 @@ async function switchWt(path: string) {
       <div class="svc-row">
         <span class="svc-name">Napari viewer</span>
         <span class="svc-pill" :class="stateInfo(napariSt).tone"><span class="dot" /> {{ stateInfo(napariSt).label }}</span>
-        <span class="svc-port" v-tooltip.top="'Napari bridge WebSocket'">:{{ diag?.napariPort ?? '7655' }}</span>
+        <span class="svc-port cc-muted cc-fs-xs" v-tooltip.top="'Napari bridge WebSocket'">:{{ diag?.napariPort ?? '7655' }}</span>
         <span class="svc-actions">
           <button class="save-btn" :disabled="svcBusy === 'napari'" @click="napariAction('restart')"
                   v-tooltip.top="'Close and relaunch the napari bridge (picks up bridge code changes)'">
@@ -601,7 +601,7 @@ async function switchWt(path: string) {
           Use discrete GPU for napari
           <i v-if="gpuBusy" class="pi pi-spin pi-cog" style="font-size:var(--cc-fs-xs);" />
         </CcToggle>
-        <span v-if="!gpuSupported" class="field-hint">
+        <span v-if="!gpuSupported" class="field-hint cc-muted cc-fs-xs">
           Only configurable on Linux — on this system the GPU is selected by the OS/driver.
         </span>
       </div>
@@ -609,7 +609,7 @@ async function switchWt(path: string) {
       <div class="svc-row">
         <span class="svc-name">Notebooks</span>
         <span class="svc-pill" :class="stateInfo(notebooksSt).tone"><span class="dot" /> {{ stateInfo(notebooksSt).label }}</span>
-        <span class="svc-port" v-tooltip.top="'Pluto notebook server'">:{{ diag?.notebooksPort ?? '7660' }}</span>
+        <span class="svc-port cc-muted cc-fs-xs" v-tooltip.top="'Pluto notebook server'">:{{ diag?.notebooksPort ?? '7660' }}</span>
         <span class="svc-actions">
           <button v-if="notebooksSt === 'stopped'" class="save-btn" :disabled="svcBusy === 'notebooks' || !projectUid"
                   @click="notebooksAction('start')"
@@ -631,11 +631,11 @@ async function switchWt(path: string) {
       <div class="svc-row">
         <span class="svc-name">Frontend (GUI)</span>
         <span class="svc-pill ok"><span class="dot" /> This window</span>
-        <span class="svc-port" v-tooltip.top="diag?.dev ? 'Vite dev server (proxies to the backend)' : 'served by the backend'">:{{ guiPort }}</span>
+        <span class="svc-port cc-muted cc-fs-xs" v-tooltip.top="diag?.dev ? 'Vite dev server (proxies to the backend)' : 'served by the backend'">:{{ guiPort }}</span>
       </div>
 
-      <span class="field-hint">Cecelia occupies these ports — don't bind other services (e.g. a Jupyter kernel) to them.</span>
-      <span v-if="svcMsg" class="field-hint">{{ svcMsg }}</span>
+      <span class="field-hint cc-muted cc-fs-xs">Cecelia occupies these ports — don't bind other services (e.g. a Jupyter kernel) to them.</span>
+      <span v-if="svcMsg" class="field-hint cc-muted cc-fs-xs">{{ svcMsg }}</span>
     </section>
 
     <!-- ── Diagnostics ─────────────────────────────────────────────────── -->
@@ -677,8 +677,8 @@ async function switchWt(path: string) {
           <i class="pi pi-box" /> Packages…
         </button>
       </div>
-      <span v-if="diag && diag.threads > 1" class="field-hint">Multithreaded API active ({{ diag.threads }} threads).</span>
-      <span v-else-if="diag" class="field-hint">Single-threaded — relaunch the API with <code>-t auto</code> for parallelism.</span>
+      <span v-if="diag && diag.threads > 1" class="field-hint cc-muted cc-fs-xs">Multithreaded API active ({{ diag.threads }} threads).</span>
+      <span v-else-if="diag" class="field-hint cc-muted cc-fs-xs">Single-threaded — relaunch the API with <code>-t auto</code> for parallelism.</span>
     </section>
 
     <!-- ── Developer ───────────────────────────────────────────────────── -->
@@ -692,7 +692,7 @@ async function switchWt(path: string) {
       </div>
 
       <!-- toggle is on but the server is network-bound → eval is refused server-side (loopback required) -->
-      <span v-if="replToggle && !diag.loopback" class="field-hint">
+      <span v-if="replToggle && !diag.loopback" class="field-hint cc-muted cc-fs-xs">
         The server is bound to <code>{{ diag.host }}</code>, so the console is disabled for safety.
         Relaunch loopback-only to use it: <code>CECELIA_HOST=127.0.0.1 CECELIA_REPL=1 pixi run dev</code>.
       </span>
@@ -701,7 +701,7 @@ async function switchWt(path: string) {
     <!-- ── Debug console — only when BOTH gates pass: flag on AND loopback bind ─── -->
     <section v-if="diag?.replAvailable" class="settings-section">
       <h2 class="section-title">Debug console</h2>
-      <span class="field-hint">
+      <span class="field-hint cc-muted cc-fs-xs">
         Evaluates Julia in the running server — full access, use with care.
         Concurrent task logs may briefly appear here during a run.
       </span>
@@ -808,12 +808,7 @@ async function switchWt(path: string) {
 .field-input[readonly] { color: var(--cc-text-dim); cursor: default; }
 .field-input.mono { font-family: var(--cc-mono); }
 
-.field-hint {
-  display: block;
-  font-size: var(--cc-fs-xs);
-  color: var(--cc-text-dim);
-  margin-top: 0.25rem;
-}
+.field-hint { display: block; margin-top: 0.25rem; }
 
 /* Storage box */
 .stor-line {
@@ -878,11 +873,6 @@ async function switchWt(path: string) {
 .toggle-row.disabled { opacity: 0.5; cursor: not-allowed; }
 .toggle-row.disabled input { cursor: not-allowed; }
 
-.no-project {
-  font-size: var(--cc-fs-md);
-  color: var(--cc-text-dim);
-}
-
 /* system control panel: aligned grid — name · status pill · port · actions */
 .svc-row { display: grid; grid-template-columns: 8rem 7rem 3.5rem 1fr; align-items: center;
   column-gap: 0.6rem; margin-bottom: 0.55rem; }
@@ -897,7 +887,7 @@ async function switchWt(path: string) {
 .svc-pill.idle .dot { background: var(--cc-text-dim); }
 .svc-tag { font-size: var(--cc-fs-2xs); font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
   color: var(--cc-accent); border: 1px solid var(--cc-accent); border-radius: var(--cc-radius-xs); padding: 0 0.3rem; }
-.svc-port { justify-self: start; font-family: var(--cc-mono); font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+.svc-port { justify-self: start; font-family: var(--cc-mono); }
 .svc-actions { display: flex; gap: 0.4rem; justify-content: flex-end; }
 .save-btn.ghost { background: transparent; color: var(--cc-text-dim); border-color: var(--cc-border); }
 .save-btn.ghost:not(:disabled):hover { color: var(--cc-text); }

--- a/frontend/src/modules/SetupModule.vue
+++ b/frontend/src/modules/SetupModule.vue
@@ -86,13 +86,13 @@ async function waitForBackend(timeoutMs = 60000) {
       <h1 class="setup-title">Welcome to Cecelia</h1>
       <p class="setup-sub cc-muted">Where would you like to store your projects?</p>
 
-      <label class="setup-label cc-muted cc-muted-md" for="setup-path">Projects folder</label>
+      <label class="setup-label cc-muted cc-fs-md" for="setup-path">Projects folder</label>
       <input id="setup-path" v-model="path" class="setup-input" type="text" spellcheck="false"
              autocomplete="off" placeholder="~/cecelia-projects"
              @keyup.enter="submit" />
 
       <!-- validation hint: neutral until checked, green when usable, danger when not -->
-      <p class="setup-hint cc-muted cc-muted-md" :class="check ? (check.ok ? 'ok' : 'bad') : ''">
+      <p class="setup-hint cc-muted cc-fs-md" :class="check ? (check.ok ? 'ok' : 'bad') : ''">
         <template v-if="check">
           <i :class="check.ok ? 'pi pi-check-circle' : 'pi pi-exclamation-circle'" />
           {{ check.message }}

--- a/frontend/src/modules/TasksModule.vue
+++ b/frontend/src/modules/TasksModule.vue
@@ -163,12 +163,12 @@ const FILTERS: ChipOption[] = [
                 <i class="pi pi-sitemap" />{{ t.chainName || t.chainRunId }}
               </span>
               <span class="row-label">
-                <span class="row-seq">#{{ t.seq }}</span>
+                <span class="row-seq cc-muted cc-fs-2xs">#{{ t.seq }}</span>
                 {{ t.label }}
               </span>
-              <span v-if="elapsed(t)" class="row-elapsed">{{ elapsed(t) }}</span>
+              <span v-if="elapsed(t)" class="row-elapsed cc-muted cc-fs-2xs">{{ elapsed(t) }}</span>
             </div>
-            <div class="row-image">{{ t.imageName }}</div>
+            <div class="row-image cc-muted cc-fs-xs">{{ t.imageName }}</div>
           </div>
 
           <div class="row-actions" @click.stop>
@@ -203,9 +203,9 @@ const FILTERS: ChipOption[] = [
                   <i class="pi pi-sitemap" />{{ selected.chainName || selected.chainRunId }}
                 </span>
               </div>
-              <span class="log-image">{{ selected.imageName }}</span>
+              <span class="log-image cc-muted cc-fs-xs">{{ selected.imageName }}</span>
             </div>
-            <span v-if="elapsed(selected)" class="log-elapsed">{{ elapsed(selected) }}</span>
+            <span v-if="elapsed(selected)" class="log-elapsed cc-muted cc-fs-xs">{{ elapsed(selected) }}</span>
             <div class="log-actions">
               <button class="ra-btn cc-btn cc-btn-bare cc-btn-icon" @click="copyLog" v-tooltip.left="copied ? 'Copied!' : 'Copy log'">
                 <i :class="['pi', copied ? 'pi-check' : 'pi-copy']" />
@@ -229,7 +229,7 @@ const FILTERS: ChipOption[] = [
           <pre ref="logEl" class="log-body">{{ selected.log.join('\n') || '— no output yet —' }}</pre>
         </template>
 
-        <div v-else class="log-empty">
+        <div v-else class="log-empty cc-empty">
           <i class="pi pi-list-check" />
           <span>Select a task to view its log.</span>
         </div>
@@ -352,7 +352,7 @@ const FILTERS: ChipOption[] = [
   text-overflow: ellipsis;
   flex: 1;
 }
-.row-seq { font-size: var(--cc-fs-2xs); font-family: var(--cc-mono); color: var(--cc-text-dim); margin-right: 0.2rem; }
+.row-seq { font-family: var(--cc-mono); margin-right: 0.2rem; }
 .chain-pill {
   display: inline-flex;
   align-items: center;
@@ -374,8 +374,8 @@ const FILTERS: ChipOption[] = [
 .chain-pill .pi { font-size: var(--cc-fs-3xs); flex-shrink: 0; }
 .chain-pill.sm { font-size: var(--cc-fs-2xs); padding: 0.1rem 0.4rem; max-width: 10rem; }
 .log-title-row { display: flex; align-items: center; gap: 0.4rem; min-width: 0; }
-.row-elapsed { font-size: var(--cc-fs-2xs); font-family: var(--cc-mono); color: var(--cc-text-dim); flex-shrink: 0; }
-.row-image { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.row-elapsed { font-family: var(--cc-mono); flex-shrink: 0; }
+.row-image { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 .row-actions {
   display: flex;
@@ -394,16 +394,7 @@ const FILTERS: ChipOption[] = [
   overflow: hidden;
   background: var(--cc-bg);
 }
-.log-empty {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  color: var(--cc-text-dim);
-  font-size: var(--cc-fs-md);
-}
+.log-empty { flex: 1; }
 .log-empty .pi { font-size: 1.5rem; opacity: 0.3; }
 
 .log-header {
@@ -420,8 +411,8 @@ const FILTERS: ChipOption[] = [
 
 .log-title-block { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 .log-title { font-size: var(--cc-fs-md); font-weight: 600; color: var(--cc-text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.log-image { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.log-elapsed { font-size: var(--cc-fs-xs); font-family: var(--cc-mono); color: var(--cc-text-dim); flex-shrink: 0; }
+.log-image { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.log-elapsed { font-family: var(--cc-mono); flex-shrink: 0; }
 .log-actions { display: flex; gap: 0.15rem; flex-shrink: 0; }
 
 .log-progress {

--- a/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
+++ b/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
@@ -217,7 +217,7 @@ async function previewOpen() {
 
 <template>
   <div class="bm">
-    <p v-if="!selectedUids.length" class="bm-hint">Select one or more images (left) to author a batch of movies.</p>
+    <p v-if="!selectedUids.length" class="bm-hint cc-muted">Select one or more images (left) to author a batch of movies.</p>
 
     <template v-else>
       <!-- BUSY banner: the batch takes over the single napari viewer -->
@@ -229,13 +229,13 @@ async function previewOpen() {
       <!-- Channels -->
       <section class="bm-sec">
         <h4>
-          Channels <span class="bm-sub">shown channels + colormap (others hidden)</span>
+          Channels <span class="bm-sub cc-muted">shown channels + colormap (others hidden)</span>
           <button class="bm-link" :disabled="seeding || !project.napariImageUid" @click="fillFromView(true)"
                   title="Copy the channel colours + overlays from the image currently open in napari">
             <i class="pi pi-sync" /> fill from view
           </button>
         </h4>
-        <p v-if="!channelList.length" class="bm-hint">No channel names on the selected images.</p>
+        <p v-if="!channelList.length" class="bm-hint cc-muted">No channel names on the selected images.</p>
         <div v-for="ch in channelList" :key="ch" class="bm-row">
           <span class="bm-ch">{{ ch }}</span>
           <SwatchSelect :model-value="channels[ch] ?? ''" :options="colormapOpts"
@@ -245,11 +245,11 @@ async function previewOpen() {
 
       <!-- Overlays -->
       <section class="bm-sec">
-        <h4>Overlays <span class="bm-sub">click to toggle</span></h4>
+        <h4>Overlays <span class="bm-sub cc-muted">click to toggle</span></h4>
         <ChipSelect class="bm-toggles" multiple :options="OVERLAY_OPTIONS" v-model="overlaysModel"
                     aria-label="Movie overlays" />
         <div v-if="showTracks" class="bm-inset">
-          <span class="bm-lbl">tail</span>
+          <span class="bm-lbl cc-muted">tail</span>
           <input type="range" min="1" max="20" step="1" v-model.number="tailWidth" />
           <span class="bm-val">{{ tailWidth }}</span>
         </div>
@@ -258,7 +258,7 @@ async function previewOpen() {
             <option value="flow">gating</option>
             <option value="clust">clusters</option>
           </select>
-          <span class="bm-lbl">size</span>
+          <span class="bm-lbl cc-muted">size</span>
           <input type="range" min="1" max="20" step="1" v-model.number="pointsSize" />
           <span class="bm-val">{{ pointsSize }}</span>
         </div>
@@ -266,7 +266,7 @@ async function previewOpen() {
 
       <!-- Colour by -->
       <section class="bm-sec">
-        <h4>Colour by <span class="bm-sub">measure used to colour tracks / labels</span></h4>
+        <h4>Colour by <span class="bm-sub cc-muted">measure used to colour tracks / labels</span></h4>
         <select v-model="colourBy">
           <option value="">— none (population / default colour) —</option>
           <option v-for="c in obsCols" :key="c" :value="c">{{ c }}</option>
@@ -286,20 +286,20 @@ async function previewOpen() {
       <section class="bm-sec">
         <h4>Output</h4>
         <div class="bm-inset">
-          <span class="bm-lbl">fps</span>
+          <span class="bm-lbl cc-muted">fps</span>
           <input type="range" min="1" max="60" step="1" v-model.number="fps" />
           <span class="bm-val">{{ fps }}</span>
-          <span class="bm-lbl">res</span>
+          <span class="bm-lbl cc-muted">res</span>
           <input type="range" min="1" max="3" step="1" v-model.number="scale" />
           <span class="bm-val">{{ scale }}×</span>
         </div>
         <div class="bm-attrs">
-          <span class="bm-lbl">filename attrs <span class="bm-sub">click to include · drag to reorder</span></span>
+          <span class="bm-lbl cc-muted">filename attrs <span class="bm-sub cc-muted">click to include · drag to reorder</span></span>
           <ChipSelect v-if="attrOptions.length" v-model="fileAttrs" :options="attrOptions" multiple reorderable
                       aria-label="Filename attributes" />
-          <span v-else class="bm-hint">no attributes — files named by uid</span>
+          <span v-else class="bm-hint cc-muted">no attributes — files named by uid</span>
         </div>
-        <p class="bm-preview">→ movies/<b>{{ filenamePreview }}</b></p>
+        <p class="bm-preview cc-muted">→ movies/<b>{{ filenamePreview }}</b></p>
       </section>
 
       <!-- Title card (Phase H) — auto description slide prepended to each movie -->
@@ -335,7 +335,7 @@ async function previewOpen() {
 
 <style scoped>
 .bm { display: flex; flex-direction: column; gap: 7px; flex: 1; min-width: 0; padding: 2px; }
-.bm-hint { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); margin: 2px 0; }
+.bm-hint { margin: 2px 0; }
 /* A resource-contention advisory — "the batch has taken over the single napari viewer" — NOT the job's
    progress (the scheduler reports that in TasksModule). It states the condition of a resource, so it is
    a severity and takes the CVD-safe amber, same as ViewerPanel's stale-bridge strip. */
@@ -345,7 +345,7 @@ async function previewOpen() {
 .bm-sec { border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); padding: 6px 8px; background: var(--cc-surface-1); }
 .bm-sec h4 { display: flex; align-items: baseline; margin: 0 0 4px; font-size: var(--cc-fs-md); font-weight: 700; }
 .bm-mini { min-width: 0; padding: 0.2rem 1.4rem 0.2rem 0.4rem; }
-.bm-sub { font-weight: 400; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); margin-left: 6px; }
+.bm-sub { margin-left: 6px; }
 .bm-link { float: right; font-size: var(--cc-fs-xs); color: var(--cc-accent); background: none; border: none;
   cursor: pointer; padding: 0; display: inline-flex; align-items: center; gap: 3px; }
 .bm-link:hover:not(:disabled) { text-decoration: underline; }
@@ -359,10 +359,10 @@ async function previewOpen() {
 /* range inputs default to a fixed intrinsic width (~129px) and don't shrink, so two on one row
    (fps + res) overflow the sidebar. Let them flex down to share the available width. */
 .bm-inset input[type="range"] { flex: 1; min-width: 0; }
-.bm-lbl { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+
 .bm-val { font-size: var(--cc-fs-sm); min-width: 1.6rem; }
 .bm-attrs { margin-top: 6px; display: flex; flex-direction: column; gap: 4px; }
-.bm-preview { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin: 6px 0 0; word-break: break-all; }
+.bm-preview { margin: 6px 0 0; word-break: break-all; }
 .bm-preview b { color: var(--cc-text); }
 .bm-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 .bm-title-row { display: flex; align-items: center; gap: 0.5rem; }

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -215,7 +215,7 @@ watch(ckey, () => { if (panels.value.length === 0) { addKind('umap'); addKind('h
           </button>
         </div>
         <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
-        <span class="cp-hint cc-muted cc-muted-xs">drag plots by their title · resize from the corner</span>
+        <span class="cp-hint cc-muted cc-fs-xs">drag plots by their title · resize from the corner</span>
       </div>
 
       <!-- membership: cluster pops only apply to images that were in the run (carry clusters.{suffix}).

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -371,7 +371,7 @@ useDataRefresh(() => (g.imageUid ? [g.imageUid] : []), () => { fetchPlot() })
         <label class="ax-row cc-muted"><span class="ax-lbl">pop</span>
           <select class="ax-chan" v-model="parent" v-tooltip.bottom="'Population to display; new gates are its children'">
           <option v-for="p in parentOptions" :key="p" :value="p">{{ p }}</option></select>
-          <span v-if="mode !== 'off' && !pending" class="gate-hint cc-muted cc-muted-2xs">hold <kbd>Shift</kbd> to adjust gates</span></label>
+          <span v-if="mode !== 'off' && !pending" class="gate-hint cc-muted cc-fs-2xs">hold <kbd>Shift</kbd> to adjust gates</span></label>
       </div>
     </template>
     <!-- utility actions (export) in the footer, like the summary / cluster panels -->

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -267,7 +267,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
         <button class="cc-btn" v-tooltip.bottom="'Copy this gating to other images in the set'"
                 @click="showCopy = true"><i class="pi pi-copy" /> Copy</button>
         <CanvasZoomControl :zoom="zoom" @update:zoom="setZoom" @fit-width="fitWidth" @fit-height="fitHeight" @reset="resetZoom" />
-        <span class="gp-hint cc-muted cc-muted-xs">drag plots by their title · resize from the corner</span>
+        <span class="gp-hint cc-muted cc-fs-xs">drag plots by their title · resize from the corner</span>
       </div>
       <div ref="canvasRef" class="gp-canvas">
         <!-- scaled workspace: the plots zoom together; the population manager stays full-size (below) -->

--- a/frontend/src/modules/metadata/MetadataPanel.vue
+++ b/frontend/src/modules/metadata/MetadataPanel.vue
@@ -281,7 +281,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 
     <!-- ── Physical size & timing ───────────────────────────────── -->
     <section class="panel-section">
-      <div class="section-title">Physical size &amp; timing</div>
+      <div class="section-title cc-eyebrow">Physical size &amp; timing</div>
       <button class="cc-btn cc-btn-ghost" :disabled="!physFocusUid" @click="showPhysDialog = true"
         v-tooltip.bottom="'View or fix voxel size and frame interval for the selected image(s).'">
         <i class="pi pi-ruler" /> Open editor
@@ -294,7 +294,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 
     <!-- ── Attribute management ─────────────────────────────────── -->
     <section class="panel-section">
-      <div class="section-title">Attributes</div>
+      <div class="section-title cc-eyebrow">Attributes</div>
 
       <!-- create -->
       <div class="field-row">
@@ -324,7 +324,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 
     <!-- ── Assign single value ─────────────────────────────────── -->
     <section class="panel-section" :class="{ disabled: attrDisabled }">
-      <div class="section-title">Assign value</div>
+      <div class="section-title cc-eyebrow">Assign value</div>
       <div class="field-row">
         <input class="field-input flex1" v-model="singleValue" placeholder="Value…"
           :disabled="attrDisabled"
@@ -340,7 +340,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 
     <!-- ── Regex ──────────────────────────────────────────────── -->
     <section class="panel-section" :class="{ disabled: attrDisabled }">
-      <div class="section-title">Extract via regex</div>
+      <div class="section-title cc-eyebrow">Extract via regex</div>
       <div class="field-row">
         <input class="field-input flex1" v-model="regexpValue" placeholder="Regular expression…"
           :disabled="attrDisabled"
@@ -379,7 +379,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
       </button>
       <div v-if="builderOpen" class="builder" :class="{ disabled: attrDisabled }">
         <div class="field-row">
-          <span class="builder-label">Mode</span>
+          <span class="builder-label cc-muted">Mode</span>
           <select class="field-input" v-model="builderMode" @change="applyBuilder" :disabled="attrDisabled">
             <option value="field">Split into fields</option>
             <option value="around">Around a marker</option>
@@ -389,7 +389,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
         <!-- Field mode: split by a separator, take a field -->
         <template v-if="builderMode === 'field'">
           <div class="field-row">
-            <span class="builder-label">Split by</span>
+            <span class="builder-label cc-muted">Split by</span>
             <select class="field-input" v-model="builderSep" @change="applyBuilder" :disabled="attrDisabled">
               <option value="-">- dash</option>
               <option value="_">_ underscore</option>
@@ -401,7 +401,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
               v-model="builderCustomSep" @input="applyBuilder" maxlength="4" placeholder="sep" :disabled="attrDisabled" />
           </div>
           <div class="field-row">
-            <span class="builder-label">Take</span>
+            <span class="builder-label cc-muted">Take</span>
             <select class="field-input" v-model="builderPos" @change="applyBuilder" :disabled="attrDisabled">
               <option value="first">1st field</option>
               <option value="second">2nd field</option>
@@ -417,7 +417,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
         <!-- Look-around mode: extract a token bounded by context — e.g. "M1a" → digits after "M" → 1 -->
         <template v-else>
           <div class="field-row">
-            <span class="builder-label">Preceded by</span>
+            <span class="builder-label cc-muted">Preceded by</span>
             <input type="text" class="field-input flex1"
               v-model="beforeText" @input="applyBuilder" placeholder="text, e.g. M" :disabled="attrDisabled" />
             <select class="field-input" v-model="beforeCls" @change="applyBuilder" :disabled="attrDisabled"
@@ -430,7 +430,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
             </select>
           </div>
           <div class="field-row">
-            <span class="builder-label">Extract</span>
+            <span class="builder-label cc-muted">Extract</span>
             <select class="field-input" v-model="extractKind" @change="applyBuilder" :disabled="attrDisabled">
               <option value="digits">a number</option>
               <option value="letters">letters</option>
@@ -443,7 +443,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
               v-model="extractText" @input="applyBuilder" placeholder="e.g. [a-d]" :disabled="attrDisabled" />
           </div>
           <div class="field-row">
-            <span class="builder-label">Followed by</span>
+            <span class="builder-label cc-muted">Followed by</span>
             <input type="text" class="field-input flex1"
               v-model="afterText" @input="applyBuilder" placeholder="text, e.g. -" :disabled="attrDisabled" />
             <select class="field-input" v-model="afterCls" @change="applyBuilder" :disabled="attrDisabled"
@@ -457,17 +457,17 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
           </div>
         </template>
 
-        <p v-if="builderMode === 'around'" class="builder-hint">
+        <p v-if="builderMode === 'around'" class="builder-hint cc-muted">
           Each side: fixed text + a part that varies (<em>+ number</em>, <em>+ letters</em>).
         </p>
-        <p class="builder-hint">Adjusts the pattern above — watch the preview, then <strong>Apply</strong>.</p>
+        <p class="builder-hint cc-muted">Adjusts the pattern above — watch the preview, then <strong>Apply</strong>.</p>
       </div>
     </section>
 
     <!-- ── Group sequences ────────────────────────────────────── -->
     <section class="panel-section">
-      <div class="section-title">Group sequences</div>
-      <p class="section-hint">Numbers images within each attribute group (<strong>GroupSeq</strong>).</p>
+      <div class="section-title cc-eyebrow">Group sequences</div>
+      <p class="section-hint cc-muted">Numbers images within each attribute group (<strong>GroupSeq</strong>).</p>
       <button class="cc-btn cc-btn-ghost" @click="assignGroupSequences"
         :disabled="attrNames.length === 0"
         v-tooltip.bottom="'Assign GroupSeq from the current attribute values.'">
@@ -477,7 +477,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 
     <!-- ── Channel names ──────────────────────────────────────── -->
     <section class="panel-section">
-      <div class="section-title">Channel names</div>
+      <div class="section-title cc-eyebrow">Channel names</div>
 
       <div class="field-col">
         <textarea class="field-textarea" v-model="channelNameList" rows="4"
@@ -492,7 +492,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
         </div>
       </div>
 
-      <p class="section-hint">Or edit channel names directly in the image table.</p>
+      <p class="section-hint cc-muted">Or edit channel names directly in the image table.</p>
     </section>
 
     </div>
@@ -531,19 +531,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 }
 .panel-section.disabled { opacity: 0.45; pointer-events: none; }
 
-.section-title {
-  font-size: var(--cc-fs-xs);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--cc-text-dim);
-}
-.section-hint {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  margin: 0;
-  line-height: 1.5;
-}
+.section-hint { margin: 0; line-height: 1.5; }
 
 .field-row {
   display: flex;
@@ -602,11 +590,11 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
 }
 .builder.disabled { opacity: 0.5; pointer-events: none; }
 /* fixed label width + flexible controls → every select/input lines up down the builder */
-.builder-label { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); flex: 0 0 5rem; white-space: nowrap; }
+.builder-label { flex: 0 0 5rem; white-space: nowrap; }
 .builder .field-input { flex: 1 1 0; min-width: 0; }
 .builder .builder-custom { flex: 0 0 3.5rem; }
 
-.builder-hint { font-size: var(--cc-fs-sm); color: var(--cc-text-dim); margin: 0; line-height: 1.4; }
+.builder-hint { margin: 0; line-height: 1.4; }
 
 /* single preview for the regex field (typed or built) */
 .regex-preview { display: flex; align-items: center; gap: 0.3rem; font-size: var(--cc-fs-sm); min-width: 0; }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -343,11 +343,6 @@ body {
 /* Secondary / de-emphasised text — hints, subtitles, captions, meta lines. The modifier picks the tier;
    the role (dim, secondary) is what the base class means and does not change with size. */
 .cc-muted { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
-.cc-muted-lg  { font-size: var(--cc-fs-lg); }
-.cc-muted-md  { font-size: var(--cc-fs-md); }
-.cc-muted-xs  { font-size: var(--cc-fs-xs); }
-.cc-muted-2xs { font-size: var(--cc-fs-2xs); }
-.cc-muted-3xs { font-size: var(--cc-fs-3xs); }
 
 /* Empty / placeholder state — "nothing here yet" message. Centred, muted, padded; drop an icon /
    title / CTA inside for the rich variant (it's a flex column).
@@ -372,8 +367,6 @@ body {
    step for an inline readout in dense chrome. */
 .cc-readout { font-variant-numeric: tabular-nums; color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
 .cc-readout-strong { color: var(--cc-text); font-weight: 600; }
-.cc-readout-xs  { font-size: var(--cc-fs-xs); }
-.cc-readout-2xs { font-size: var(--cc-fs-2xs); }
 
 /* Eyebrow / section label — small uppercase dim heading above a group of controls. Note the base is a
    tier smaller than `.cc-muted`'s: an eyebrow is chrome, not prose. */
@@ -381,10 +374,6 @@ body {
   font-size: var(--cc-fs-xs); font-weight: 600; letter-spacing: 0.06em;
   text-transform: uppercase; color: var(--cc-text-dim);
 }
-.cc-eyebrow-2xs { font-size: var(--cc-fs-2xs); }
-/* The bottom step is why the whiteboard nodes (start/scope labels, the QC footer) kept their own 9px
-   uppercase rule for so long — the axis simply stopped above them. */
-.cc-eyebrow-3xs { font-size: var(--cc-fs-3xs); }
 
 /* Surface / container chrome — a card/panel body (hairline border + md radius). Surface is the axis:
    the base is the recessed surface-1, `.cc-card-2` the raised surface-2 (a card sitting ON a
@@ -392,6 +381,30 @@ body {
    scale, so -sm/-md are the only two steps worth having. */
 .cc-card { background: var(--cc-surface-1); border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md); }
 .cc-card-2 { background: var(--cc-surface-2); }
+
+/* ONE density scale, composed with any text scenario: `.cc-muted .cc-fs-xs`, `.cc-eyebrow .cc-fs-2xs`,
+   `.cc-readout .cc-fs-2xs`, `.cc-empty-inline .cc-fs-3xs`.
+   Each scenario used to carry its own ladder — `.cc-muted-2xs`, `.cc-eyebrow-2xs` and
+   `.cc-readout-2xs` were three names for `font-size: var(--cc-fs-2xs)`; ten classes holding six
+   declarations. Naming them per scenario never made them scenario-specific, it only made you guess
+   which to reach for, and two sites had already guessed: `ChainQcNode` and `PopulationManager` put
+   `.cc-muted-3xs`/`-2xs` on elements that are `.cc-empty-inline`, not muted. That worked, because the
+   modifier was always just a font-size — so now it is the documented way, and `.cc-empty` gets the
+   density axis it never had without three more classes.
+   Modifiers carrying real semantics stay on their scenario: `.cc-readout-strong` is prominence,
+   `.cc-empty-inline` is layout. Only the size ladder is shared.
+
+   DECLARED LAST, AND THAT IS LOAD-BEARING. `.cc-muted`, `.cc-empty`, `.cc-readout` and `.cc-eyebrow`
+   each set a font-size of their own, and a scenario base and a size class have the SAME specificity
+   (0,1,0) — so the winner is whichever comes later in this file. The first cut of this collapse put
+   the ladder above them: markup right, class names right, and every `.cc-eyebrow .cc-fs-2xs` silently
+   rendering at the eyebrow's 11px. `cssScenarios.test.ts` asserts this ordering. */
+.cc-fs-lg  { font-size: var(--cc-fs-lg); }
+.cc-fs-md  { font-size: var(--cc-fs-md); }
+.cc-fs-sm  { font-size: var(--cc-fs-sm); }
+.cc-fs-xs  { font-size: var(--cc-fs-xs); }
+.cc-fs-2xs { font-size: var(--cc-fs-2xs); }
+.cc-fs-3xs { font-size: var(--cc-fs-3xs); }
 
 /* ── Form controls — modern, consistent base for ALL native inputs ─────────── */
 /* Applies app-wide so bare <select>/<input> look the same everywhere. Components  */

--- a/frontend/src/tasks/ParamRenderer.vue
+++ b/frontend/src/tasks/ParamRenderer.vue
@@ -508,11 +508,11 @@ const pct = computed(() => {
     <!-- popSelection (multi / across segmentations): chip list of value_name-prefixed populations -->
     <div v-else-if="param.type === 'popSelection' && popAcross" class="channel-select-wrap"
       v-tooltip.right="param.tip ?? 'Select populations across segmentations.'">
-      <div v-if="popMultiOptions.length === 0" class="channel-empty">
+      <div v-if="popMultiOptions.length === 0" class="channel-empty cc-muted">
         No populations — select an image first.
       </div>
       <div v-for="grp in popMultiGroups" v-else :key="grp.title" class="col-group">
-        <div v-if="grp.title" class="col-group-title">{{ grp.title }}</div>
+        <div v-if="grp.title" class="col-group-title cc-eyebrow cc-fs-2xs">{{ grp.title }}</div>
         <ChipSelect multiple :options="grp.opts"
           :model-value="chipGroupSel(grp.opts.map(o => o.value))"
           @update:model-value="v => chipGroupUpdate(popAllValues, grp.opts.map(o => o.value), v as string[])" />
@@ -532,11 +532,11 @@ const pct = computed(() => {
     <!-- labelPropsColsSelection: grouped (Tracking / Object) multi-select chip lists -->
     <div v-else-if="param.type === 'labelPropsColsSelection'" class="channel-select-wrap"
       v-tooltip.right="param.tip ?? 'Select measurement columns.'">
-      <div v-if="colGroups.length === 0" class="channel-empty">
+      <div v-if="colGroups.length === 0" class="channel-empty cc-muted">
         No measures — select a population first.
       </div>
       <div v-for="g in colGroups" :key="g.title" class="col-group">
-        <div v-if="g.title" class="col-group-title">{{ g.title }}</div>
+        <div v-if="g.title" class="col-group-title cc-eyebrow cc-fs-2xs">{{ g.title }}</div>
         <ChipSelect multiple :options="g.opts"
           :model-value="chipGroupSel(g.opts.map(o => o.value))"
           @update:model-value="v => chipGroupUpdate(colAllValues, g.opts.map(o => o.value), v as string[])" />
@@ -552,8 +552,8 @@ const pct = computed(() => {
         <option value="2D">2D (in-plane)</option>
         <option value="3D">3D</option>
       </select>
-      <div v-if="motionLoading" class="md-note">checking z…</div>
-      <div v-else-if="motionDims" class="md-note"
+      <div v-if="motionLoading" class="md-note cc-muted">checking z…</div>
+      <div v-else-if="motionDims" class="md-note cc-muted"
            :class="{ warn: motionWarn }" v-tooltip.right="motionTip">
         <i :class="['pi', motionWarn ? 'pi-exclamation-triangle' : 'pi-check-circle']" />
         {{ motionMsg }}
@@ -569,7 +569,7 @@ const pct = computed(() => {
     <!-- channelSelection: togglable chip list from image context -->
     <div v-else-if="param.type === 'channelSelection'" class="channel-select-wrap"
       v-tooltip.right="param.tip ?? 'Select channels to process.'">
-      <div v-if="availableChannels.length === 0" class="channel-empty">
+      <div v-if="availableChannels.length === 0" class="channel-empty cc-muted">
         No channels — select images first.
       </div>
       <ChipSelect v-else multiple :options="channelOptions"
@@ -586,7 +586,7 @@ const pct = computed(() => {
 
   <!-- section rendered outside .param-row so it spans full width -->
   <div v-if="param.type === 'section'" class="param-section">
-    <button class="section-toggle cc-section-toggle cc-eyebrow" @click="sectionOpen = !sectionOpen"
+    <button class="section-toggle cc-section-toggle cc-eyebrow cc-fs-sm" @click="sectionOpen = !sectionOpen"
       v-tooltip.left="sectionOpen ? 'Collapse advanced parameters.' : 'Expand advanced parameters.'">
       <i :class="['pi', sectionOpen ? 'pi-chevron-down' : 'pi-chevron-right']" />
       {{ param.label }}
@@ -606,7 +606,7 @@ const pct = computed(() => {
   <!-- group: repeatable set of sub-params keyed by string index -->
   <div v-if="param.type === 'group'" class="param-group">
     <div class="group-header">
-      <span class="group-title">{{ param.label }}</span>
+      <span class="group-title cc-eyebrow cc-fs-sm">{{ param.label }}</span>
       <button v-if="param.repeatable" class="group-add-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-micro" type="button"
         @click="addGroupEntry()"
         v-tooltip.right="'Add another entry'">
@@ -614,7 +614,7 @@ const pct = computed(() => {
       </button>
     </div>
 
-    <div v-if="groupEntries.length === 0" class="group-empty">
+    <div v-if="groupEntries.length === 0" class="group-empty cc-muted">
       No entries — click + to add one.
     </div>
 
@@ -734,7 +734,7 @@ const pct = computed(() => {
 .param-section { border-bottom: 1px solid var(--cc-border); }
 /* + cc-section-toggle (row) + cc-eyebrow (label tier). Only the padding and the one-step-larger
    size are this site's: an advanced-params header sits above body text, not inside dense chrome. */
-.section-toggle { padding: 0.45rem 0; font-size: var(--cc-fs-sm); }
+.section-toggle { padding: 0.45rem 0; }
 .section-body { padding-left: 0.5rem; border-left: 2px solid var(--cc-border); margin-left: 0.25rem; }
 
 .picker-placeholder {
@@ -751,15 +751,10 @@ const pct = computed(() => {
 
 /* channel selection */
 .channel-select-wrap { width: 100%; }
-.channel-empty {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  font-style: italic;
-  padding: 0.2rem 0;
-}
+.channel-empty { font-style: italic; padding: 0.2rem 0; }
 /* motion-dims selector + recommendation note (gap keeps the note off the dropdown) */
 .motion-dims { display: flex; flex-direction: column; gap: 0.4rem; width: 100%; }
-.md-note { display: inline-flex; align-items: center; gap: 0.3rem; font-size: var(--cc-fs-sm); color: var(--cc-text-dim); }
+.md-note { display: inline-flex; align-items: center; gap: 0.3rem; }
 .md-note .pi { font-size: var(--cc-fs-sm); }
 .md-note.warn { color: #fbbf24; }
 /* traffic-light flag: how usable is the z-axis (ok real 3D · warn borderline · fail jitter). A
@@ -768,14 +763,7 @@ const pct = computed(() => {
 
 .col-group { margin-bottom: 0.4rem; }
 .col-group:last-child { margin-bottom: 0; }
-.col-group-title {
-  font-size: var(--cc-fs-2xs);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--cc-text-dim);
-  margin: 0.15rem 0 0.25rem;
-}
+.col-group-title { margin: 0.15rem 0 0.25rem; }
 /* group */
 .param-group {
   border-bottom: 1px solid var(--cc-border);
@@ -787,21 +775,10 @@ const pct = computed(() => {
   justify-content: space-between;
   padding: 0.45rem 0 0.3rem;
 }
-.group-title {
-  font-size: var(--cc-fs-sm);
-  font-weight: 600;
-  color: var(--cc-text-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
+
 .group-add-btn { transition: background 0.1s, border-color 0.1s; }   /* + cc-btn cc-btn-ghost cc-btn-icon cc-btn-micro */
 .group-add-btn:hover { background: var(--cc-accent); border-color: var(--cc-accent); color: #fff; }
-.group-empty {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  font-style: italic;
-  padding: 0.3rem 0;
-}
+.group-empty { font-style: italic; padding: 0.3rem 0; }
 .group-entry {
   margin-bottom: 0.4rem;
   border: 1px solid var(--cc-border);

--- a/frontend/src/tasks/TaskList.vue
+++ b/frontend/src/tasks/TaskList.vue
@@ -84,7 +84,7 @@ function elapsed(t: TaskEntry) {
 
 <template>
   <div class="task-list">
-    <div v-if="items.length === 0" class="task-empty">
+    <div v-if="items.length === 0" class="task-empty cc-muted">
       No tasks yet — select images and click Run.
     </div>
 
@@ -104,18 +104,18 @@ function elapsed(t: TaskEntry) {
             <button class="jump-btn cc-btn cc-btn-bare cc-btn-icon cc-btn-lg" @click.stop="jumpToTask(t)" v-tooltip.right="'Open in task manager'">
               <i class="pi pi-arrow-left" />
             </button>
-            <span class="task-seq">#{{ t.seq }}</span>
+            <span class="task-seq cc-muted cc-fs-2xs">#{{ t.seq }}</span>
             <i v-if="t.chainRunId" class="pi pi-sitemap chain-badge"
                v-tooltip.right="`Chain: ${t.chainName ?? t.chainRunId} / ${t.chainRunId}`" />
             {{ t.label }}
           </span>
-          <span class="task-image" v-tooltip.right="`UID: ${t.imageUid}`">
+          <span class="task-image cc-muted cc-fs-xs" v-tooltip.right="`UID: ${t.imageUid}`">
             <span class="task-uid">{{ t.imageUid }}</span>
             {{ t.imageName }}
           </span>
         </div>
 
-        <span v-if="elapsed(t)" class="task-elapsed"
+        <span v-if="elapsed(t)" class="task-elapsed cc-muted cc-fs-xs"
           v-tooltip.left="t.startedAt ? `Started ${t.startedAt.toLocaleTimeString()}` : ''">
           {{ elapsed(t) }}
         </span>
@@ -175,7 +175,7 @@ function elapsed(t: TaskEntry) {
 
       <!-- log -->
       <pre v-if="expanded.has(t.id) && t.log.length" class="task-log">{{ t.log.join('\n') }}</pre>
-      <div v-else-if="expanded.has(t.id)" class="task-log dim">No log output yet.</div>
+      <div v-else-if="expanded.has(t.id)" class="task-log">No log output yet.</div>
     </div>
   </div>
 </template>
@@ -187,12 +187,7 @@ function elapsed(t: TaskEntry) {
   gap: 0.3rem;
 }
 
-.task-empty {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
-  text-align: center;
-  padding: 1.5rem 0.5rem;
-}
+.task-empty { padding: 1.5rem 0.5rem; }
 
 .task-item {
   border-radius: var(--cc-radius-md);
@@ -227,28 +222,13 @@ function elapsed(t: TaskEntry) {
   align-items: center;
   gap: 0.3rem;
 }
-.task-seq {
-  font-size: var(--cc-fs-2xs);
-  font-family: var(--cc-mono);
-  font-weight: 700;
-  color: var(--cc-text-dim);
-  flex-shrink: 0;
-}
+.task-seq { font-family: var(--cc-mono); flex-shrink: 0; }
 .chain-badge {
   font-size: var(--cc-fs-2xs);
   color: var(--cc-accent);
   flex-shrink: 0;
 }
-.task-image {
-  font-size: var(--cc-fs-xs);
-  color: var(--cc-text-dim);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-}
+.task-image { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; gap: 0.3rem; }
 .task-uid {
   font-family: var(--cc-mono);
   font-size: var(--cc-fs-2xs);
@@ -260,12 +240,7 @@ function elapsed(t: TaskEntry) {
   border-radius: var(--cc-radius-xs);
 }
 
-.task-elapsed {
-  font-size: var(--cc-fs-xs);
-  font-family: var(--cc-mono);
-  color: var(--cc-text-dim);
-  flex-shrink: 0;
-}
+.task-elapsed { font-family: var(--cc-mono); flex-shrink: 0; }
 
 .task-actions { display: flex; gap: 0.15rem; flex-shrink: 0; }
 
@@ -301,5 +276,5 @@ function elapsed(t: TaskEntry) {
   word-break: break-all;
   border-top: 1px solid var(--cc-border);
 }
-.dim { color: var(--cc-text-dim); font-size: var(--cc-fs-sm); }
+
 </style>

--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -311,7 +311,7 @@ const { width: sidebarWidth, onResizeStart } =
 
     <!-- ── Function selector ── -->
     <section v-if="defs.length" class="runner-section">
-      <h3 class="section-heading cc-eyebrow cc-eyebrow-2xs">Function</h3>
+      <h3 class="section-heading cc-eyebrow cc-fs-2xs">Function</h3>
       <select
         class="fn-select"
         v-model="selectedTask"
@@ -334,7 +334,7 @@ const { width: sidebarWidth, onResizeStart } =
 
     <!-- ── Parameters ── -->
     <section class="runner-section params-section" v-if="taskDef">
-      <h3 class="section-heading cc-eyebrow cc-eyebrow-2xs">Parameters</h3>
+      <h3 class="section-heading cc-eyebrow cc-fs-2xs">Parameters</h3>
       <div class="params-list">
         <ParamRenderer
           v-for="p in taskDef.params"
@@ -362,7 +362,7 @@ const { width: sidebarWidth, onResizeStart } =
       </button>
 
       <div class="pool-row" v-if="pools.length > 0">
-        <span class="pool-label cc-muted cc-muted-xs"
+        <span class="pool-label cc-muted cc-fs-xs"
           v-tooltip.right="'Resource pool controls how many tasks share a concurrency slot. GPU tasks should use the gpu pool to avoid running multiple models at once.'">
           Pool
         </span>
@@ -382,7 +382,7 @@ const { width: sidebarWidth, onResizeStart } =
     <!-- ── Task list ── -->
     <section class="runner-section tasks-section">
       <div class="tasks-heading">
-        <h3 class="section-heading cc-eyebrow cc-eyebrow-2xs">Tasks</h3>
+        <h3 class="section-heading cc-eyebrow cc-fs-2xs">Tasks</h3>
         <div class="tasks-heading-actions">
           <button
             v-if="activeTasks.length"

--- a/frontend/src/utils/cssScenarios.test.ts
+++ b/frontend/src/utils/cssScenarios.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   styleBlocks, cssRules, scenarioFor, findReimplementedScenarios, findRawValues,
   findHandRolledIconButtons, findRawColours, colourTokens, findRestatedInputBase, inputBase,
-  findScopedUtilityOverride, utilityRules, SCENARIO_HINT,
+  findScopedUtilityOverride, utilityRules, SCENARIO_HINT, findShadowedUtilities,
 } from './cssScenarios'
 
 describe('styleBlocks', () => {
@@ -169,80 +169,45 @@ describe('inputBase', () => {
   })
 })
 
-// ── The ratchet ───────────────────────────────────────────────────────────────────────────────────
+// ── Hand-rolled scenarios: an exact list, and it is down to one ───────────────────────────────────
 //
-// ~130 rules still hand-roll a scenario that `docs/UI.md` has a utility for. Migrating them all at once
-// would be a churn diff across 45 files, and the plan explicitly warns off that. But the thing actually
-// worth preventing is NEW divergence, and that doesn't require the backlog to be empty first — it
-// requires the count to never rise. So: a per-file baseline that may shrink and must never grow.
+// This was a per-file BASELINE of ~310 rules that "may shrink and must never grow", because migrating
+// them all at once would have been a churn diff across 45 files. It is now empty except for one
+// genuinely un-adoptable site, so the ratchet has become what it was always converging on: an exact
+// list. That is a stronger bar — a count-based baseline silently permits swapping one violation for
+// another within a file, and it stops meaning anything once it reaches zero.
 //
-// Touching a file in this list? Migrate its rules and lower the number. Adding a file? Use the utility
-// instead. The failure message tells you which.
-//
-// The four chain-node files that briefly appeared here are gone again, and how they showed up is worth
-// remembering: the `muted` matcher keys on `color: var(--cc-text-dim)` and never matched the
-// `color: var(--cc-text-dim, #8b8ca7)` spelling, so stripping the dead hex fallbacks revealed six
-// long-standing rules this check had been blind to. That was the third blind spot of one shape — a
-// matcher pinned to ONE spelling of a value the codebase writes more than one way (the others: only
-// reading <style> blocks, so inline `style="font-size:…"` was invisible; and keying on a *literal*
-// size, so tokenising a rule silently un-flagged it). When adding a matcher, ask which other spellings
-// of the same declaration exist: token vs literal, with fallback vs without, scoped vs inline.
-const BASELINE: Record<string, number> = {
-  'components/ImageMetadataDialog.vue': 3,
-  'components/ImageTable.vue': 3,
-  'components/LabLogPanel.vue': 5,
-  'components/ModuleLayout.vue': 5,
-  'components/PackagesDialog.vue': 4,
-  'components/ProjectPanel.vue': 5,
-  'components/ViewerPanel.vue': 5,
-  'components/canvas/LayoutCanvas.vue': 3,
-  'components/canvas/PlateBuilder.vue': 3,
-  'components/canvas/PopulationManager.vue': 4,
-  'components/canvas/SummaryPanel.vue': 3,
-  'components/plots/GateScatterCell.vue': 3,
-  'modules/AnimationModule.vue': 6,
-  'modules/ChainModule.vue': 11,
-  'modules/SettingsModule.vue': 3,
-  'modules/TasksModule.vue': 6,
-  'modules/batchmovies/BatchMoviesPanel.vue': 4,
-  'modules/metadata/MetadataPanel.vue': 4,
-  'tasks/ParamRenderer.vue': 5,
-  'tasks/TaskList.vue': 5,
-}
+// It is now EMPTY. The last survivor was `AnimationModule`'s `.tl-group .tl-rowhead`, exempted on the
+// grounds that the base `.tl-rowhead` set both `color` and `font-size` so no global utility could win.
+// That was true but it was the wrong conclusion: the base had no business owning either — the colour
+// was redundant (nothing above the timeline dims) and the size belonged on the cells. Asking "why is
+// this one different?" was enough to dissolve it. Treat a new entry here the same way: "the utility
+// cannot apply" is usually a fact about the *base* rule, and the base rule is yours to change.
+const ALLOWED_SCENARIOS: string[] = []
 
 const RAW = import.meta.glob('/src/**/*.{vue,css}', {
   query: '?raw', import: 'default', eager: true,
 }) as Record<string, string>
 
 describe('hand-rolled UX scenarios', () => {
-  it('never increase — see docs/UI.md for the canonical utility', () => {
+  it('do not exist — every one is migrated', () => {
     const sources = Object.entries(RAW)
       .filter(([path]) => path !== '/src/style.css')          // style.css DEFINES the utilities
       .map(([path, text]) => ({ path: path.replace('/src/', ''), text }))
 
     expect(sources.length).toBeGreaterThan(100)               // the glob resolved
 
-    const counts: Record<string, number> = {}
-    const rules: Record<string, string[]> = {}
-    for (const hit of findReimplementedScenarios(sources)) {
-      counts[hit.path] = (counts[hit.path] ?? 0) + 1
-      ;(rules[hit.path] ??= []).push(`${hit.selector} → ${SCENARIO_HINT[hit.scenario]}`)
-    }
+    // Name the rule AND the utility it wants: a file and a count leave the next reader re-deriving
+    // which rule moved and where it should go — by grep, which got a wrong number every time.
+    const found = findReimplementedScenarios(sources)
+      .map(h => `${h.path} :: ${h.scenario} :: ${h.selector}`)
+    const extra = found.filter(f => !ALLOWED_SCENARIOS.includes(f))
+      .map(f => `${f}  → use ${SCENARIO_HINT[findReimplementedScenarios(sources)
+        .find(h => `${h.path} :: ${h.scenario} :: ${h.selector}` === f)!.scenario]}`)
 
-    const regressions: string[] = []
-    const improvements: string[] = []
-    for (const path of new Set([...Object.keys(BASELINE), ...Object.keys(counts)])) {
-      const was = BASELINE[path] ?? 0
-      const now = counts[path] ?? 0
-      // Name the rules, not just the delta: a file and a count leave you re-deriving which rule moved
-      // and which utility it wants — by grep, which is how every count in this area got wrong before.
-      if (now > was) regressions.push(`${path}: ${was} → ${now}\n    ${rules[path].join('\n    ')}`)
-      if (now < was) improvements.push(`${path}: ${was} → ${now} (lower the BASELINE entry)`)
-    }
-
-    expect(regressions).toEqual([])
-    // Improvements fail too, on purpose: an un-updated baseline silently stops ratcheting.
-    expect(improvements).toEqual([])
+    expect(extra).toEqual([])
+    // Fails on improvement too: if the survivor is ever restructured, drop it from the list.
+    expect(found.sort()).toEqual([...ALLOWED_SCENARIOS].sort())
   })
 })
 
@@ -267,6 +232,70 @@ describe('scoped overrides of a global utility', () => {
     const found = findScopedUtilityOverride(sources, utils)
       .map(r => `${r.path} | ${r.selector} | ${r.decl}`)
     expect(found.sort()).toEqual([])
+  })
+})
+
+describe('the shared size ladder', () => {
+  // Two classes of equal specificity are decided by SOURCE ORDER, and `.cc-muted`, `.cc-empty`,
+  // `.cc-readout` and `.cc-eyebrow` each set a font-size of their own. So `.cc-fs-*` only wins if it
+  // is declared after all of them. The first cut of the collapse put the ladder above them: markup
+  // right, class names right, and every `.cc-eyebrow .cc-fs-2xs` silently rendering at the eyebrow's
+  // 11px. Nothing caught it — the classes were all present and correct, which is all the other checks
+  // look at. Hence an explicit ordering assertion.
+  it('is declared after every scenario that sets a font-size of its own', () => {
+    const css = RAW['/src/style.css'] ?? ''
+    const at = (sel: string) => {
+      const i = css.search(new RegExp(`^\\${sel}\\s*\\{`, 'm'))
+      expect(i, `${sel} not found in style.css`).toBeGreaterThan(-1)
+      return i
+    }
+    const firstStep = at('.cc-fs-lg')
+    for (const scenario of ['.cc-muted', '.cc-empty', '.cc-readout', '.cc-eyebrow']) {
+      expect(at(scenario), `${scenario} must be declared BEFORE the .cc-fs-* ladder, or it wins the ` +
+        'equal-specificity tie and the size modifier silently does nothing').toBeLessThan(firstStep)
+    }
+  })
+})
+
+describe('shadowed utilities', () => {
+  // The failure mode that adopting a utility INTRODUCES. Scoped CSS weighs (0,2,0) with Vue's
+  // [data-v-…]; a global utility weighs (0,1,0). So a scoped class that used to win a same-specificity
+  // tie on source order starts winning outright — and the utility you just added does nothing.
+  // `TaskList`'s log placeholder hit this during the migration that emptied the list above.
+  //
+  // An exact list: the check cannot distinguish a deliberate override from an accident, so each
+  // survivor says which it is. All of these deliberately set a DIFFERENT value.
+  const ALLOWED = [
+    // hints that are muted in colour but italic and a tier down — the file comments say so
+    'components/CopyDialog.vue | cc-muted shadowed by copy-hint on font-size',
+    'components/CropPanel.vue | cc-muted shadowed by crop-hint on font-size',
+    'components/ProjectPanel.vue | cc-muted shadowed by pp-io-hint on font-size',
+    'modules/cluster/ClusterHeatmapPanel.vue | cc-muted shadowed by feat-empty on font-size',
+    // an error line: muted layout, danger colour
+    'components/canvas/SummaryPanel.vue | cc-muted shadowed by sp-err on color',
+    // deliberately CANCELS the eyebrow's caps for the one toggle that shares the label class
+    'components/ViewerPanel.vue | cc-eyebrow shadowed by movie-title-toggle on letter-spacing,text-transform',
+    // tick labels size off the dynamic --gate-font, so only the colour comes from the utility
+    'components/plots/GateScatterCell.vue | cc-muted shadowed by xtick-lbl on font-size',
+    'components/plots/GateScatterCell.vue | cc-muted shadowed by ytick-lbl on font-size',
+    // `color: inherit` on purpose — the label follows the section header's colour, which changes on
+    // hover and when open, rather than sitting at the eyebrow's fixed dim.
+    'components/CollapsibleSection.vue | cc-eyebrow shadowed by cs-label on color',
+    // Same VALUE as the utility's base, so the shadow changes nothing — and load-bearing for the two
+    // sibling spans that carry `.sel-count` without `.cc-muted` and would otherwise inherit body size.
+    // (Its `color` was NOT deliberate and is gone: it was silently un-dimming the placeholder.)
+    'components/FileBrowser.vue | cc-muted shadowed by sel-count on font-size',
+  ]
+
+  it('are all deliberate — a utility that loses to its own element is a no-op', () => {
+    const utils = utilityRules(RAW['/src/style.css'] ?? '')
+    const sources = Object.entries(RAW)
+      .filter(([path]) => path !== '/src/style.css')
+      .map(([path, text]) => ({ path: path.replace('/src/', ''), text }))
+
+    const found = findShadowedUtilities(sources, utils)
+      .map(s => `${s.path} | ${s.utility} shadowed by ${s.by} on ${s.props.join(',')}`)
+    expect(found.sort()).toEqual([...ALLOWED].sort())
   })
 })
 

--- a/frontend/src/utils/cssScenarios.ts
+++ b/frontend/src/utils/cssScenarios.ts
@@ -230,6 +230,89 @@ export function findHandRolledIconButtons(
   return out
 }
 
+// ── Utilities shadowed by a scoped class on the same element ──────────────────────────────────────
+
+/** A global utility that another class on the same element overrides, so it does nothing. */
+export interface ShadowedUtility {
+  path:     string
+  utility:  string
+  by:       string
+  props:    string[]
+}
+
+/**
+ * A utility class that a scoped class on the SAME element beats on the utility's own properties.
+ *
+ * This is the failure mode adopting a utility *introduces*, and it is invisible: scoped CSS weighs
+ * (0,2,0) once Vue adds `[data-v-…]`, a global utility weighs (0,1,0). So a rule that used to win a
+ * same-specificity tie on SOURCE ORDER starts losing outright the moment the class it was tying with
+ * becomes a utility. `TaskList`'s log placeholder did exactly this — `.dim` sat after `.task-log` and
+ * won; migrating `.dim` to `.cc-muted` silently handed the property back to `.task-log`.
+ *
+ * The check cannot tell a deliberate override from an accidental one — both are "a scoped class sets
+ * the same property" — so it pins an exact list and each survivor states why it is intentional. That
+ * is the same shape as the icon-button and input-base lists, and those have held.
+ *
+ * Deliberately narrow, and the first cut of it was not: run across every utility it flagged ~30 sites,
+ * nearly all `.cc-btn` overridden on `padding`/`transition`/`gap`. That is not a defect — composing a
+ * button and adjusting its geometry is exactly what the button vocabulary is for. Only the TEXT
+ * scenarios have a role that a shadow silently cancels, and only on the properties that ARE the role.
+ * Same precision-over-recall call that dropped the `card` matcher.
+ */
+const SHADOW_UTILS = new Set(['cc-muted', 'cc-eyebrow', 'cc-readout', 'cc-empty'])
+const SHADOW_PROPS = new Set([
+  'color', 'font-size', 'font-weight', 'text-transform', 'letter-spacing', 'font-variant-numeric',
+])
+
+export function findShadowedUtilities(
+  sources: Array<{ path: string, text: string }>,
+  utilProps: Record<string, Set<string>>,
+): ShadowedUtility[] {
+  const out: ShadowedUtility[] = []
+  for (const { path, text } of sources) {
+    const si = text.indexOf('<style')
+    if (si < 0) continue
+    const template = text.slice(0, si)
+
+    // scoped rules keyed by a BARE single class → the properties they set
+    const scoped: Record<string, Set<string>> = {}
+    for (const rule of cssRules(text.slice(si))) {
+      for (const part of rule.selector.split(',')) {
+        const m = /^\.([\w-]+)$/.exec(part.trim())
+        if (!m) continue
+        const props = (scoped[m[1]] ??= new Set<string>())
+        for (const d of rule.body.split(';')) {
+          const i = d.indexOf(':')
+          if (i > 0) props.add(d.slice(0, i).trim())
+        }
+      }
+    }
+
+    const seen = new Set<string>()
+    for (const m of template.matchAll(/\bclass="([^"]*)"/g)) {
+      const names = m[1].split(/\s+/).filter(Boolean)
+      for (const util of names) {
+        // only the BASE utility carries declarations worth shadowing; a modifier sets one property
+        // and is meant to be overridden by the site
+        if (!SHADOW_UTILS.has(util)) continue
+        const own = utilProps[util]
+        if (!own) continue
+        for (const other of names) {
+          if (other === util || other.startsWith('cc-')) continue
+          const clash = [...(scoped[other] ?? [])]
+            .filter(p => own.has(p) && SHADOW_PROPS.has(p)).sort()
+          if (!clash.length) continue
+          const key = `${util}|${other}|${clash.join(',')}`
+          if (seen.has(key)) continue
+          seen.add(key)
+          out.push({ path, utility: util, by: other, props: clash })
+        }
+      }
+    }
+  }
+  return out
+}
+
 // ── Form controls ─────────────────────────────────────────────────────────────────────────────────
 
 /** A scoped declaration on an input/select/textarea that re-states what the global base already gives. */


### PR DESCRIPTION
The scenario backlog is done: **~310 → 132 → 90 → 0**. The ratchet is now an exact (empty) list rather
than a per-file count baseline — a stronger bar, since a count silently permits swapping one violation
for another inside a file and stops meaning anything at zero.

| | session start | now |
|---|---|---|
| hand-rolled scenario rules | ~310 | **0** |
| files carrying them | 45 | **0** |
| density modifier classes | 10 (6 distinct declarations) | **6 shared** |

## Two structural gaps closed first

Both the same "the axis stops too early" trap that stranded sites as bespoke before:

- `.cc-eyebrow` had no step **above** its own base, so 12px eyebrows had nowhere to land.
- **Ten density classes held six distinct declarations.** `.cc-muted-2xs`, `.cc-eyebrow-2xs` and
  `.cc-readout-2xs` were three names for `font-size: var(--cc-fs-2xs)`. Naming them per scenario never
  made them scenario-specific, it only made you guess which to reach for — and two sites had already
  guessed, putting `.cc-muted-3xs` on elements that are `.cc-empty-inline`, not muted. Collapsed to one
  shared `.cc-fs-*` ladder, so the rule is **pick a scenario, then a size**, and `.cc-empty` gets the
  density axis it never had without three more classes. Modifiers carrying real semantics stay on their
  scenario (`-strong` is prominence, `-inline` is layout).

## Three cascade bugs, all invisible to a check that only looks at class presence

- **`findShadowedUtilities` (new).** Migrating a class to a utility is a specificity *downgrade* —
  scoped is (0,2,0) with `[data-v-…]`, a global utility (0,1,0) — so a scoped class that used to win a
  same-specificity tie on source order starts winning outright, and the utility does nothing. This bit
  `TaskList`'s log placeholder here and, **one PR earlier and unnoticed, `FileBrowser`'s "No files
  selected", which had silently stopped being dim**. Held as an exact list of 9 deliberate overrides.
- **The ladder collapse shipped broken and green.** The first cut declared `.cc-fs-*` *above* the
  scenario bases, which each set their own font-size at the same specificity. Markup right, classes
  right, all tests passing, and every `.cc-eyebrow .cc-fs-2xs` rendering at the eyebrow's 11px. Order is
  part of the contract when two global classes are designed to compose, so it is asserted now.
- **The last exemption dissolved when questioned.** `.tl-rowhead` was written off as un-migratable
  because it set `color` and `font-size` so no utility could outrank it. True, and the wrong conclusion:
  the base had no business owning either — the colour was redundant (nothing above the timeline dims)
  and the size belonged on the cells. *"The utility cannot apply" is usually a fact about the base rule,
  and the base rule is yours to change.*

## Verification

`pixi run test-frontend` 381 passed (52 files) · `npm run typecheck` clean · 50 files, −73 net lines.
Every `.cc-*` class used in markup is confirmed to exist in `style.css`.

## Reservations

1. **`.tl-rowhead` losing `color`/`font-size` is the least-verified edit** — the four data cells now
   take 12px from `.cc-fs-sm` and their colour by inheritance. I confirmed nothing above the timeline
   sets a text colour, but that is the same reasoning used for `.sel-count`, applied twice today on
   inspection alone.
2. **The ladder-order bug is the kind that ships green.** It was found by accident. Now asserted — but
   it means an earlier "tests green" report was true while the app was wrong.
3. **Third API rename this session** (`-dense`/`-micro` → step names → shared `.cc-fs-*`). In-flight
   branches touching these will conflict at every step.
4. **Eyebrow normalisation is the visible change**: tracking to 0.06em (sites had 0.03–0.08), weight to
   600 (four had 700). Uppercase headings read slightly lighter.
5. Unchanged and deliberate: 9 `font-style: italic` one-liners stay scoped (emphasis, not a tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
