### PR TITLE
docs(ui): make "keep UI copy short" an explicit rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,6 +507,8 @@ WS upgrades. Full stream-handler/WS-upgrade/response conventions are in
 
 See [`docs/UI.md`](docs/UI.md) for the full reference: design tokens, button utilities, module page authoring, component catalog, plot integration, and WS event patterns.
 
+**Keep UI copy short.** Default to NO explanatory text in the app — no page subtitles, no paragraph tooltips, no prose QC findings. Where orientation genuinely isn't self-evident, one phrase under ~10 words, never two sentences. Long in-app prose is noise forever for the person who uses the page daily, and is the most reliable tell that a screen was generated. The explanation goes in the relevant `docs/<AREA>.md`. Per-surface budgets: `docs/UI.md` → *UI copy — keep it short*.
+
 **Persist every user-settable option.** Any option on a module page / canvas (chart type, scope, compare mode, highlights, sliders, …) MUST live in persisted view state (`useViewState` over a store-backed bag / panel `state`), never a bare `ref()` — a `ref()` resets on remount, so options vanish when the user navigates away and back. This is a hard convention for new pages; see `docs/MODULES.md` → "RULE: persist every user-settable option" and `docs/UI.md` → "Persisting view state".
 
 ---

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -137,6 +137,31 @@ to `INVENTORY.md` in the same change.
 
 ---
 
+## UI copy — keep it short (mandatory)
+
+**Default to no explanatory text.** A page title plus its controls almost always says what the page
+is. Where orientation genuinely isn't self-evident, one short phrase — **under ~10 words, never two
+sentences**.
+
+Why: a paragraph written to explain a feature once sits permanently on a page its owner uses daily,
+so it buys clarity once and costs noise forever. Verbose in-app prose is also the most reliable tell
+that a screen was generated rather than designed — it makes the whole app read that way. The real
+explanation belongs in `docs/`, which is where it actually gets looked up.
+
+| Surface | Budget |
+|---|---|
+| Page / panel subtitle | none by default; a short phrase only if the page is genuinely opaque |
+| Tooltip (`v-tooltip`) | one line — what the control does, not why it exists |
+| Task-JSON `tip` | omit unless the param is non-obvious; then one short line |
+| QC finding | short = the problem, long = the action, imperative (`docs/MODULES.md`) |
+| Empty state (`.cc-empty`) | one line; a following action, not a rationale |
+| First-use hint (`HintCallout`) | one line, by construction |
+
+Rewriting long copy short is always in scope — it does not need its own task. When you catch yourself
+explaining, put it in the relevant `docs/<AREA>.md` and leave the UI silent.
+
+---
+
 ## Design tokens
 
 All tokens live in `frontend/src/style.css` under `.cc-dark` (always applied at the `<body>` level).
@@ -207,7 +232,8 @@ UI imports these; do not hand-pick a green/amber/red or a coloured dot. See
 ## Hard requirements
 
 Every interactive element must carry a `v-tooltip.right="'Description'"`.
-CellProfiler is the reference for tooltip density — if a button does something non-obvious, it has a tooltip.
+CellProfiler is the reference for tooltip *density* — if a button does something non-obvious, it has a
+tooltip. Density, not length: one line each, per *UI copy — keep it short* above.
 
 All errors go to `useLogStore().error(msg, { source, detail })`.
 Task failures must never be silent — errors must reach the console bar visible to the user.


### PR DESCRIPTION
The UX-primitive catalog says which control to render. Nothing said what to *write* in it — so each fresh session re-derived a house style and landed on explanatory paragraphs. This has now been flagged three times: QC warnings, tooltips, and the Animation page subtitle ("this sounds very ai").

## What's added

A mandatory **UI copy — keep it short** section in `docs/UI.md`, sitting directly after the primitive catalog (same "check before building" block, the copy half of it):

- Default to **no** explanatory text. A page title plus its controls almost always says what the page is.
- Where orientation genuinely isn't self-evident: one phrase, **under ~10 words, never two sentences**.
- A per-surface budget table — page subtitle, `v-tooltip`, task-JSON `tip`, QC finding, `.cc-empty`, `HintCallout`.
- The reason, stated once: prose written to orient a first-time reader sits permanently on a page its owner uses daily, so it buys clarity once and costs noise forever — and it's the most reliable tell that a screen was generated rather than designed.

Two supporting edits:

- **Hard requirements** was being read as a licence for length. CellProfiler is the reference for tooltip *density* — every non-obvious control has one — not for tooltip length. Now says so explicitly.
- **`CLAUDE.md`** gets the rule in one paragraph, because that is the file a fresh session actually loads. In `docs/UI.md` alone it risks never being read at the moment it matters.

## Scope

**Rule only — existing long copy is not swept.** The Animation subtitle, `segment/measure_labels.json`'s sentence-long tips, and the `PhysicalSizeDialog` note are all untouched. A sweep is a separate change; the section says rewriting long copy short is always in scope and needs no task of its own.

Not enforced by a test, unlike the CSS scenario/token rules — this is review-only. A lint on task-JSON `tip` length would be possible if the rule keeps getting missed.

The ~10-word budget is extrapolated from the three flagged cases, not a previously stated number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
