### PR TITLE
fix(ui): stop tooltips collapsing into a vertical strip near a panel edge

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -131,7 +131,18 @@ body {
   border: 1px solid #30363d;
   color: #e6edf3;
   border-radius: var(--cc-radius-sm);
-  max-width: 280px;
+  /* `width: max-content` is load-bearing, not cosmetic. PrimeVue positions the tooltip by setting
+     `style.left` on an element absolutely positioned in `document.body` and gives it no width, so with
+     only a `max-width` the box shrink-wraps to whatever space is LEFT of the viewport edge. Near the
+     right edge (e.g. the 280px TaskRunner panel) that is ~25px, and the text wraps one character per
+     line into a vertical strip.
+     Worse, it disabled the library's own escape hatch: `align()` tries right → left → top → bottom,
+     testing `isOutOfBounds` each time — but that measures the ALREADY-collapsed width, which fits, so
+     it reported in-bounds and never flipped. Sizing to content keeps the measurement honest, so the
+     flip fires and the tooltip lands on the target's left instead.
+     Clamp the cap to the viewport too, so a narrow window shortens the line rather than overflowing. */
+  width: max-content;
+  max-width: min(280px, calc(100vw - 1rem));
   line-height: 1.45;
 }
 .p-tooltip-arrow { display: none; }


### PR DESCRIPTION
Tooltips near the right edge of the window — e.g. any ⓘ in the 280px TaskRunner panel — collapsed into a one-character-wide vertical strip instead of showing on the other side.

## Cause

Two things compounding:

1. PrimeVue positions the tooltip by setting `style.left` on an element it absolutely positions in `document.body`, and gives it **no width**. Our override (`style.css`) set only `max-width: 280px`, so the box shrink-wrapped to the space remaining before the viewport edge — ~25px beside the runner panel — and the text wrapped one character per line.
2. That **disabled PrimeVue's own escape hatch.** `align()` already tries right → left → top → bottom, testing `isOutOfBounds` at each step. But `isOutOfBounds` measures the *already-collapsed* width: `left + 25px` fits inside the viewport, so it reported in-bounds and the flip never fired. The collapse hid the very condition meant to prevent it.

So this was never a missing feature — the styling defeated existing logic.

## Fix

One declaration does the work: `width: max-content` keeps the box sized to its content regardless of available space, so `isOutOfBounds` measures a truthful width, the flip fires, and the tooltip lands on the target's left. `max-width` is also clamped to the viewport (`min(280px, calc(100vw - 1rem))`) so a narrow window shortens the line rather than overflowing.

The rule carries a comment explaining that `width: max-content` is load-bearing, not cosmetic — it's exactly the kind of declaration a future tidy-up would delete.

## Verification

- `npx vitest run` — 52 files / 381 tests pass, including the `cssScenarios` / `cssTokens` guards.
- `npm run typecheck` (`vue-tsc -b`) clean.
- **Not verified in a browser.** The mechanism is derived from the PrimeVue 4.5.5 tooltip source, not observed. Worth a quick look: hovering an ⓘ in the TaskRunner panel should now put the tooltip to the **left** of the icon.
- Tooltip positioning isn't unit-testable here — it needs a DOM, and the frontend suite is pure-logic by convention.

## Behaviour change worth naming

If a tooltip fits on neither side in a narrow window, PrimeVue exhausts all four placements and the box may now **overflow** the viewport edge rather than collapse. Overflowing-but-readable is the better failure, but it is a different one. Shortening the long tooltips (the copy sweep, separate PR) reduces how often this is reachable at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
