### PR TITLE
chore(ui): shorten over-long tooltip literals

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -200,7 +200,7 @@ function isNavDisabled(item: NavItem): boolean {
          populations, tracks, colour-by — so it must be noticeable), not a dim group heading. -->
     <button class="viewer-cta" :class="{ 'viewer-on': settings.viewerPanelOpen }"
             @click="settings.viewerPanelOpen = !settings.viewerPanelOpen"
-            v-tooltip.right="'Napari viewer controls: populations, tracks, colour-by. Floating panel — drag it anywhere.'">
+            v-tooltip.right="'Napari viewer controls: populations, tracks, colour-by'">
       <i class="pi pi-sliders-h viewer-cta-icon" />
       <span class="viewer-cta-title">Viewer controls</span>
       <i :class="['pi', settings.viewerPanelOpen ? 'pi-eye' : 'pi-eye-slash', 'viewer-cta-state']" />
@@ -214,7 +214,7 @@ function isNavDisabled(item: NavItem): boolean {
             @click="settings.labLogPanelOpen = !settings.labLogPanelOpen"
             v-tooltip.right="settings.labLogUnseen
               ? ((settings.labLogUnseenKind === 'cecelia' ? 'Cecelia: ' : 'Claude noted: ') + settings.labLogUnseen)
-              : 'Lab log: append-only analysis notes for this project (you + Claude). Floating panel — drag it anywhere.'">
+              : 'Lab log — analysis notes for this project (you + Claude)'">
       <i class="pi pi-book viewer-cta-icon" />
       <span class="viewer-cta-title">Lab log</span>
       <!-- badge: Claude (sparkles) or Cecelia (bell, coloured by severity) added something while the

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -615,7 +615,7 @@ onUnmounted(stopResize)
   <div v-if="deleteUid" class="delete-confirm">
     <span>Remove <strong>{{ images.find(i => i.uid === deleteUid)?.name }}</strong>?</span>
     <button class="cc-btn cc-btn-danger-ghost" @click="doDelete"
-      v-tooltip.right="'Remove this image from the set. The original file is not deleted.'">
+      v-tooltip.right="'Remove from the set; the original file is not deleted'">
       Remove
     </button>
     <button class="cc-btn cc-btn-ghost" @click="deleteUid = null">Cancel</button>
@@ -677,7 +677,7 @@ onUnmounted(stopResize)
           <button v-if="flaggedUids.length && (module === 'metadata' || module === 'import')"
             class="select-flagged-btn cc-btn cc-btn-bare cc-btn-icon" :disabled="resyncing"
             @click.stop="resyncFlagged"
-            v-tooltip.bottom="`Re-read physical size & timing from file for all ${flaggedUids.length} flagged image(s) — use if they were imported before this check existed and are actually fine.`">
+            v-tooltip.bottom="`Re-read size & timing from file for ${flaggedUids.length} flagged image(s)`">
             <i :class="['pi', resyncing ? 'pi-spin pi-spinner' : 'pi-sync']" />
           </button>
           <div class="resize-handle" @mousedown.stop.prevent="startResize('name', $event)" />

--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -275,7 +275,7 @@ async function dismissEntry(entry: LabLogEntry) {
           v-tooltip.top="'Auto-capture Cecelia activity digests — when this project opens and after tasks finish'" />
         <!-- image refs are stored as stable UIDs; opt in to showing current names -->
         <CcToggle v-if="projectUid && hasImageNames" class="ll-auto" v-model="settings.labLogShowNames" label="Show names"
-          v-tooltip.top="'Image references are stored as stable IDs (names can change). Show their current names instead.'" />
+          v-tooltip.top="'Show current image names instead of stable IDs'" />
       </div>
 
       <span class="ll-tb-sep" aria-hidden="true" />
@@ -289,19 +289,19 @@ async function dismissEntry(entry: LabLogEntry) {
         <button class="ll-capture" :disabled="!projectUid || observerBusy || !observerAvailable"
                 @click="askClaude"
                 v-tooltip.top="observerAvailable
-                  ? 'Ask the assistant to review recent activity and note anything worth flagging in the lab log'
-                  : 'Needs Claude Code — with it, an assistant can watch your analysis and note things in the lab log'">
+                  ? 'Review recent activity and note anything worth flagging'
+                  : 'Needs Claude Code'">
           <i class="pi pi-sparkles" /> {{ observerBusy ? 'Asking…' : 'Ask Claude' }}
         </button>
         <select v-if="observerAvailable" class="ll-model" v-model="settings.labLogObserverModel"
-                v-tooltip.top="'Which model Ask Claude runs. Sonnet is the default; Haiku is cheapest, Opus is overkill here.'">
+                v-tooltip.top="'Model Ask Claude runs'">
           <option v-for="m in observerModels" :key="m" :value="m">{{ m }}</option>
         </select>
         <!-- Chat to Claude: hand off to a FULL external session (any MCP assistant), not the in-app
              one-shot. Copies a starter prompt; no `claude` install needed. -->
         <button class="ll-capture" :class="{ copied: chatCopied }" :disabled="!projectUid" @click="chatToClaude"
                 v-tooltip.top="chatCopied ? 'Prompt copied — paste it into Claude (or any MCP chat bot)'
-                  : 'Copy a starter prompt to your clipboard — paste it into Claude Code (or any MCP assistant) for a full chat about this project'">
+                  : 'Copy a starter prompt for a full chat in Claude Code'">
           <i :class="['pi', chatCopied ? 'pi-check' : 'pi-comments']" /> {{ chatCopied ? 'Copied' : 'Chat to Claude' }}
         </button>
         <span v-if="observerTokens" class="ll-tokens cc-muted cc-fs-xs"

--- a/frontend/src/components/PhysicalSizeDialog.vue
+++ b/frontend/src/components/PhysicalSizeDialog.vue
@@ -254,7 +254,7 @@ async function fillFlagged() {
     <template #title>
       <i class="pi pi-ruler" /> Physical size &amp; timing
       <i class="pi pi-info-circle info-dot"
-         v-tooltip.bottom="'Read from the file at import when possible. A flagged value means we couldn\'t find it, or it looked unusual — check Fiji (Image ▸ Properties) or your acquisition settings.'" />
+         v-tooltip.bottom="'Flagged = missing or unusual; check Fiji (Image ▸ Properties)'" />
     </template>
 
       <div class="pp-form">
@@ -305,7 +305,7 @@ async function fillFlagged() {
 
     <template #footer>
       <button class="cc-btn cc-btn-ghost" :disabled="propagating" @click="fillFlagged"
-        v-tooltip.top="'Fill this image\'s values into the OTHER selected images that are flagged — same-session acquisitions usually match exactly.'">
+        v-tooltip.top="'Fill these values into the other flagged selected images'">
         <i v-if="propagating" class="pi pi-spin pi-cog" /><i v-else class="pi pi-share-alt" />
         Fill flagged
       </button>
@@ -317,7 +317,7 @@ async function fillFlagged() {
       <span class="footer-spacer" />
       <button class="cc-btn cc-btn-ghost" @click="emit('close')">Cancel</button>
       <button class="cc-btn cc-btn-primary" :disabled="saving" @click="apply"
-        v-tooltip.top="`Apply to ${targetUids.length} image(s). Doesn't retroactively recompute derived measures (e.g. track speed).`">
+        v-tooltip.top="`Apply to ${targetUids.length} image(s); derived measures are not recomputed`">
         <i v-if="saving" class="pi pi-spin pi-cog" /><i v-else class="pi pi-check" />
         Apply
       </button>

--- a/frontend/src/components/ProjectPanel.vue
+++ b/frontend/src/components/ProjectPanel.vue
@@ -302,7 +302,7 @@ const typeColour: Record<ProjectType, string> = {
 
         <div class="form-row">
           <label class="form-label"
-            v-tooltip.right="'A short, descriptive name for this project. It does not have to match the folder name.'">
+            v-tooltip.right="'Name for this project; need not match the folder name'">
             Project name
           </label>
           <input
@@ -318,7 +318,7 @@ const typeColour: Record<ProjectType, string> = {
 
         <div class="form-row">
           <label class="form-label"
-            v-tooltip.right="'Static: fixed-tissue microscopy. Live: time-lapse with cell tracking. Flow: flow/mass cytometry without images.'">
+            v-tooltip.right="'Static (fixed tissue), Live (time-lapse + tracking), Flow (no images)'">
             Project type
           </label>
           <ChipSelect
@@ -331,7 +331,7 @@ const typeColour: Record<ProjectType, string> = {
 
         <div class="form-row">
           <span class="field-hint cc-muted"
-            v-tooltip.right="'Override with the CECELIA_PROJECTS_DIR environment variable when starting the Julia server.'">
+            v-tooltip.right="'Override with CECELIA_PROJECTS_DIR'">
             <i class="pi pi-folder" />
             <template v-if="projectMeta.projectsDir">
               Project will be created in

--- a/frontend/src/components/SetBar.vue
+++ b/frontend/src/components/SetBar.vue
@@ -93,7 +93,7 @@ async function deleteSet() {
   <div class="set-bar">
     <div class="set-selector">
       <label class="set-label"
-        v-tooltip.bottom="'The active image set. All operations apply to images in this set.'">
+        v-tooltip.bottom="'The active image set — all operations apply to it'">
         Set
       </label>
       <select
@@ -145,7 +145,7 @@ async function deleteSet() {
 
       <template v-if="activeSet && !confirmDelete">
         <button class="cc-btn cc-btn-danger-ghost" @click="confirmDelete = true"
-          v-tooltip.bottom="`Delete set '${activeSet.name}' and all its images. This cannot be undone.`">
+          v-tooltip.bottom="`Delete set '${activeSet.name}' and all its images — cannot be undone`">
           <i class="pi pi-trash" /> Delete set
         </button>
       </template>

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -607,13 +607,13 @@ onUnmounted(() => {
         <button
           class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ 'cc-btn-on cc-btn-on-tint': settings.napariResetOnReload }"
           @click="settings.napariResetOnReload = !settings.napariResetOnReload"
-          v-tooltip.bottom="'Reset on reload: reopen the whole image (not just data) when reloading — needed when a task changed the image pixels (drift/denoise). Off = reload data only.'"
+          v-tooltip.bottom="'Reopen the whole image, not just data — needed after pixels change'"
         ><i class="pi pi-image" /></button>
 
         <button
           class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ 'cc-btn-on cc-btn-on-tint': settings.napariAutoSaveLayerProps }"
           @click="settings.napariAutoSaveLayerProps = !settings.napariAutoSaveLayerProps"
-          v-tooltip.bottom="'Auto-save layer props: save brightness/contrast, colormap and the T/Z slider the moment you change them (survives navigation and crashes); reload on next open'"
+          v-tooltip.bottom="'Save contrast, colormap and T/Z as you change them'"
         ><i class="pi pi-bookmark" /></button>
 
         <button
@@ -625,7 +625,7 @@ onUnmounted(() => {
         <button
           class="opt-btn cc-btn cc-btn-ghost cc-btn-icon" :class="{ 'cc-btn-on cc-btn-on-tint': settings.napariAsDask }"
           @click="settings.napariAsDask = !settings.napariAsDask"
-          v-tooltip.bottom="'Lazy load (Dask): fast open, slices computed on demand. Untick to load full zarr into memory — slower to open but smoother viewing.'"
+          v-tooltip.bottom="'Fast open, slices on demand; untick for smoother viewing'"
         ><i class="pi pi-database" /></button>
       </div>
     </div>
@@ -705,7 +705,7 @@ onUnmounted(() => {
       <div v-if="obsCols.length" class="viewer-section">
         <div class="viewer-section-title cc-eyebrow cc-fs-2xs">Colour by</div>
         <select class="opt-colourby" :value="colourByCol" @change="onColourBy"
-                v-tooltip.right="'Colour tracks + labels by a cell property (e.g. HMM state). Values matching a population use its colour.'">
+                v-tooltip.right="'Colour tracks + labels by a cell property (e.g. HMM state)'">
           <option value="">default</option>
           <option v-for="c in obsCols" :key="c" :value="c">{{ c }}</option>
         </select>

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -414,7 +414,7 @@ defineExpose({ capturePage, collectCsvs })
           </div>
           <!-- A4 sheet lock: keep the board at page proportions (WYSIWYG with the PDF) or let it fill -->
           <ChipSelect variant="segmented" :options="SHEET_OPTIONS" :model-value="sheet" aria-label="Sheet size"
-                      v-tooltip.bottom="'Sheet — A4 locks the board to page proportions (what you see is the exported page); Free fills the width'"
+                      v-tooltip.bottom="'A4 locks the board to page proportions; Free fills the width'"
                       @update:model-value="v => sheet = v as 'free' | 'a4-portrait' | 'a4-landscape'" />
           <!-- fit-to-view zoom (visual only; the exported page is unchanged) -->
           <CanvasZoomControl v-if="sheet !== 'free'" :zoom="zoom"

--- a/frontend/src/components/canvas/PopulationManager.vue
+++ b/frontend/src/components/canvas/PopulationManager.vue
@@ -236,7 +236,7 @@ const popFilterSummary = (p: FlatPop) => filterSummary(p.filter, g.colLabel)
            Same form creates AND edits (fpEditPath) — editing is not a special path. -->
       <div v-if="!readonly && !clusterMode" class="pm-add">
         <button class="pm-add-btn" @click="showFilterForm ? (showFilterForm = false) : openCreateFilter()"
-                v-tooltip.bottom="'Define a population by filtering on obs measures (region, cluster, aggregate, intensity, speed…)'">
+                v-tooltip.bottom="'Define a population by filtering on obs measures'">
           <i class="pi pi-filter" /> New filter population
         </button>
       </div>

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -137,7 +137,7 @@ watch(segPops, () => {
         </select>
         <!-- compare cluster: mode + (by attribute) its attribute selects, kept tight in one group -->
         <div v-if="canCompare" class="sc-compare"
-             v-tooltip.bottom="'Compare across the selected images: this image, one series per image, pooled, or grouped by an image attribute (e.g. Treatment × Mouse)'">
+             v-tooltip.bottom="'How to compare across the selected images'">
           <span class="sc-lbl">compare</span>
           <select v-model="compareMode" class="sc-cmp">
             <option value="image">this image</option>
@@ -159,7 +159,7 @@ watch(segPops, () => {
           </template>
         </div>
         <CcToggle class="sc-pool" v-model="poolGroups" label="pool to groups"
-          v-tooltip.bottom="'Pool across populations and images so each plot shows one series per Split-by group only (no separation by population or image)'" />
+          v-tooltip.bottom="'Pool populations and images — one series per Split-by group'" />
         <div class="cc-btn-group" v-tooltip.bottom="'Arrange windows'">
           <button class="cc-btn cc-btn-bare cc-btn-icon" v-tooltip.bottom="'Tile in a grid'"
                   @click="arrangeGrid"><i class="pi pi-th-large" /></button>

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -526,7 +526,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
           </label>
           <!-- statistical unit: each cell/track, or one point per image (its mean) — "each dot an image" -->
           <label v-if="canStatUnit" class="sp-pop-row cc-muted"
-                 v-tooltip.left="'Individual: every cell/track is a datapoint. Image mean: each image contributes one point (its mean) — one dot per image (n = images, pseudoreplication-safe).'">
+                 v-tooltip.left="'Individual cells/tracks, or one point per image (n = images)'">
             <span>Datapoint</span>
             <select v-model="statUnit">
               <option value="individual">individual</option>
@@ -534,7 +534,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
             </select>
           </label>
           <label v-if="canStatUnit && statUnit === 'image'" class="sp-pop-row cc-muted"
-                 v-tooltip.left="'How to collapse each image to its one point: mean (average) or median (robust to outliers).'">
+                 v-tooltip.left="'How to collapse each image to one point'">
             <span>Per image</span>
             <select v-model="imageAgg">
               <option value="mean">mean</option>
@@ -561,7 +561,7 @@ defineExpose({ getCsv, csvName, exportImage, exportSvg })
               </select>
             </label>
             <div v-if="matrixMode === 'profile'" class="sp-pop-row cc-muted"
-                   v-tooltip.left="'Off: rescale each feature to 0–1 (viridis). On: z-score rows → diverging above/below-mean (RdBu).'">
+                   v-tooltip.left="'Off = 0–1 per feature; on = z-score rows'">
               <span>Z-score rows</span>
               <CcToggle v-model="zscore" />
             </div>

--- a/frontend/src/components/canvas/TabbedCanvas.vue
+++ b/frontend/src/components/canvas/TabbedCanvas.vue
@@ -234,8 +234,7 @@ function exportBoard(kind: string) {
         <option value="csv">CSV only</option>
       </select>
       <!-- opens LEFT (into the page): this is the rightmost control, a bottom tooltip would clip the edge -->
-      <i class="tab-info pi pi-info-circle" v-tooltip.left="'PDF: raster, for viewing/printing. ' +
-         'SVG: vector, editable in Illustrator. CSV: data → Prism. Image + HMM panels stay raster; huge point clouds warn.'" />
+      <i class="tab-info pi pi-info-circle" v-tooltip.left="'PDF raster, SVG vector, CSV data'" />
     </div>
 
     <!-- only the active board is mounted; keyed by its canvas key so a tab switch re-binds the layout -->

--- a/frontend/src/components/plots/ImageStripView.vue
+++ b/frontend/src/components/plots/ImageStripView.vue
@@ -322,7 +322,7 @@ defineExpose({ exportImage })
             <CcToggle class="is-check cc-muted cc-fs-xs" label="legend (channels · pops · colour-by)"
               :model-value="showLegend" @update:model-value="showLegend = $event" />
             <CcToggle class="is-check cc-muted cc-fs-xs" label="clean capture"
-              v-tooltip.bottom="'Hide napari\'s scale bar + timestamp when capturing, for a clean publication still (add your own externally)'"
+              v-tooltip.bottom="'Hide napari\'s scale bar + timestamp when capturing'"
               :model-value="settings.cleanCapture" @update:model-value="settings.cleanCapture = $event" />
             <CcToggle class="is-check cc-muted cc-fs-xs" label="scale bar"
               v-tooltip.bottom="'Draw a vector scale bar on each frame (from the image\'s physical pixel size)'"

--- a/frontend/src/modules/ChainModule.vue
+++ b/frontend/src/modules/ChainModule.vue
@@ -1089,7 +1089,7 @@ onActivated(async () => {
             ? 'Run is still in progress'
             : restartLabel
               ? `Re-run from “${restartLabel}” and everything downstream (upstream stays done)`
-              : 'Resume: re-run failed / unfinished / changed nodes. Click a node to re-run from there instead.'"
+              : 'Re-run failed, unfinished or changed nodes'"
         >
           <i class="pi pi-play" />
         </button>
@@ -1211,7 +1211,7 @@ onActivated(async () => {
             class="wb-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-dense"
             :disabled="!activeChain || hasStartNode"
             @click="addStartNode"
-            v-tooltip.right="'Add a start node — link it to the task(s) a run begins from. Only tasks reachable from it run; the rest stay as drafts.'"
+            v-tooltip.right="'Add a start node — only tasks reachable from it run'"
           >
             <i class="pi pi-circle-fill" />
           </button>
@@ -1424,7 +1424,7 @@ onActivated(async () => {
             class="config-select"
             :value="selectedNode.data.scope"
             @change="updateSelectedNodeData({ scope: ($event.target as HTMLSelectElement).value })"
-            v-tooltip.left="'image: runs once per image in parallel. set: synchronises all images (picnic node). incremental: event-driven plot watcher.'"
+            v-tooltip.left="'image = per image, set = synchronised, incremental = event-driven'"
           >
             <option value="image">image</option>
             <option value="set">set (picnic)</option>
@@ -1437,7 +1437,7 @@ onActivated(async () => {
               class="config-select"
               :value="selectedNode.data.barrier_policy"
               @change="updateSelectedNodeData({ barrier_policy: ($event.target as HTMLSelectElement).value })"
-              v-tooltip.left="'all: run regardless of upstream failures. require_all: abort if any image failed. successful_only: skip failed images.'"
+              v-tooltip.left="'all = ignore failures, require_all = abort, successful_only = skip'"
             >
               <option value="all">all</option>
               <option value="require_all">require_all</option>
@@ -1450,7 +1450,7 @@ onActivated(async () => {
             class="config-select"
             :value="selectedNode.data.resource_pool"
             @change="updateSelectedNodeData({ resource_pool: ($event.target as HTMLSelectElement).value })"
-            v-tooltip.left="'Limits how many nodes share a concurrency slot. GPU tasks should use the gpu pool (limit: 1) to avoid running multiple models at once.'"
+            v-tooltip.left="'How many nodes share a concurrency slot; GPU tasks use the gpu pool'"
           >
             <option value="">— none (unbounded) —</option>
             <option v-for="p in pools" :key="p.name" :value="p.name">

--- a/frontend/src/modules/MoviesModule.vue
+++ b/frontend/src/modules/MoviesModule.vue
@@ -171,7 +171,7 @@ function movieTime(mtime: number): string {
           <option v-for="s in SPEEDS" :key="s" :value="s">{{ s }}×</option>
         </select>
       </label>
-      <label class="mov-ctl cc-muted" v-tooltip.bottom="'Zoom the video. Shift + mouse wheel zooms to the cursor; Shift +/− and Shift + 0 (reset) also work. Scroll/pan when zoomed in.'">
+      <label class="mov-ctl cc-muted" v-tooltip.bottom="'Zoom the video (Shift + wheel, Shift +/−, Shift + 0 to reset)'">
         <i class="pi pi-search-plus" />
         <input type="range" :min="MOVIES_ZOOM_MIN" :max="MOVIES_ZOOM_MAX" step="0.25" :value="settings.moviesZoom"
                @input="onZoomSlider(($event.target as HTMLInputElement).valueAsNumber)" class="mov-range" />

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -356,7 +356,7 @@ async function switchWt(path: string) {
 
       <div class="field">
         <CcToggle class="toggle-row" v-model="settings.autoRefreshOnTask" label="Auto-refresh plots when tasks finish"
-          v-tooltip.right="'Keep plots in sync with your data: when a task finishes, any plot or population list showing the affected image(s) reloads on its own. Turn off to keep plots steady while you work — they update next time you open or change them.'" />
+          v-tooltip.right="'Reload plots automatically when a task finishes'" />
       </div>
     </section>
 
@@ -449,7 +449,7 @@ async function switchWt(path: string) {
           </ul>
           <ConfirmButton @confirm="reclaimAll" v-slot="{ armed, arm, confirm, cancel }">
             <button v-if="!armed" class="save-btn danger" :disabled="storageBusy" @click="arm"
-                    v-tooltip.top="'Delete every non-active image version (incl. the original import); the active version is kept'">
+                    v-tooltip.top="'Delete every non-active image version'">
               <i :class="['pi', storageBusy ? 'pi-spin pi-cog' : 'pi-trash']" /> Free up space
             </button>
             <template v-else>
@@ -474,7 +474,7 @@ async function switchWt(path: string) {
             class="save-btn"
             :disabled="customModules.loading"
             @click="customModules.reload"
-            v-tooltip.right="'Rescan for newly dropped modules. Edits to already-loaded modules need a server restart.'"
+            v-tooltip.right="'Rescan for newly dropped modules; edits need a server restart'"
           >
             <i :class="['pi', customModules.loading ? 'pi-spin pi-cog' : 'pi-refresh']" />
             {{ customModules.loading ? 'Reloading…' : 'Reload' }}
@@ -545,7 +545,7 @@ async function switchWt(path: string) {
         <span class="svc-port cc-muted cc-fs-xs" v-tooltip.top="'Backend HTTP/WS server'">:{{ diag?.port ?? '8080' }}</span>
         <span class="svc-actions">
           <button v-if="diag?.dev" class="save-btn" :disabled="appCtl.busy" @click="appRestart"
-                  v-tooltip.top="'Restart the backend server (dev): the supervisor relaunches it, page reconnects when it is back'">
+                  v-tooltip.top="'Restart the backend (dev); the page reconnects'">
             <i :class="['pi', appCtl.busy ? 'pi-spin pi-cog' : 'pi-refresh']" /> Restart
           </button>
           <ConfirmButton @confirm="quitApp" v-slot="{ armed, arm, confirm, cancel }">
@@ -569,7 +569,7 @@ async function switchWt(path: string) {
         <select class="wt-select" :disabled="appCtl.busy"
                 :value="appCtl.worktrees.find(w => w.current)?.path ?? ''"
                 @change="switchWt(($event.target as HTMLSelectElement).value)"
-                v-tooltip.top="'Relaunch the backend from another git worktree (dev). The page reconnects when it is back.'">
+                v-tooltip.top="'Relaunch the backend from another git worktree (dev)'">
           <option v-for="w in appCtl.worktrees" :key="w.path" :value="w.path">
             {{ wtFolder(w.path) }} — {{ w.branch }}{{ w.primary ? ' (main)' : '' }}{{ w.current ? ' (current)' : '' }}
           </option>
@@ -597,7 +597,7 @@ async function switchWt(path: string) {
         <CcToggle class="toggle-row" :disabled="!gpuSupported || gpuBusy"
                :model-value="settings.napariDiscreteGpu"
                @update:model-value="settings.napariDiscreteGpu = $event; toggleGpu()"
-               v-tooltip.right="'Render napari on the discrete GPU (hybrid graphics). Restarts napari to apply. Linux only.'">
+               v-tooltip.right="'Render napari on the discrete GPU; restarts napari (Linux only)'">
           Use discrete GPU for napari
           <i v-if="gpuBusy" class="pi pi-spin pi-cog" style="font-size:var(--cc-fs-xs);" />
         </CcToggle>
@@ -648,7 +648,7 @@ async function switchWt(path: string) {
         <span v-if="diag.commit" class="mono" :class="{ 'diag-stale': diag.stale }">
           {{ diag.commit }}
           <span v-if="diag.stale" class="diag-stale-note"
-                v-tooltip.bottom="`Backend runs an older commit than your files (HEAD ${diag.commitCurrent}) — restart it to load the latest.`">
+                v-tooltip.bottom="`Backend is behind your files (HEAD ${diag.commitCurrent}) — restart it`">
             <i class="pi pi-exclamation-triangle" /> stale
           </span>
         </span>
@@ -688,7 +688,7 @@ async function switchWt(path: string) {
       <div class="field">
         <CcToggle class="toggle-row" label="Enable debug console"
           :model-value="replToggle" @update:model-value="replToggle = $event; toggleRepl()"
-          v-tooltip.right="'Show a Julia console that evaluates code in the running server. Only works when the server is loopback-bound (127.0.0.1); a network-bound server refuses it regardless.'" />
+          v-tooltip.right="'Julia console in the running server; loopback-bound only'" />
       </div>
 
       <!-- toggle is on but the server is network-bound → eval is refused server-side (loopback required) -->

--- a/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHeatmapPanel.vue
@@ -143,7 +143,7 @@ defineExpose({ exportImage, getCsv, exportSvg })
         </div>
       </details>
       <select v-model="heatmapScale" class="hm-sel"
-              v-tooltip.bottom="'Colour scale: 0–1 rescales each feature to its min→max (viridis); z-score shows above/below the feature mean (diverging)'">
+              v-tooltip.bottom="'0–1 rescales each feature; z-score shows above/below its mean'">
         <option value="minmax">0–1</option>
         <option value="zscore">z-score</option>
       </select>

--- a/frontend/src/modules/gate/GatingPlots.vue
+++ b/frontend/src/modules/gate/GatingPlots.vue
@@ -219,7 +219,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
         <button class="cc-btn cc-btn-primary" v-tooltip.bottom="'Add a plot'" @click="add">
           <i class="pi pi-plus" /> Plot
         </button>
-        <button class="cc-btn cc-btn-primary" v-tooltip.bottom="'Add a read-only channel-pairs matrix (ggpairs): compare a set of channels against each other'"
+        <button class="cc-btn cc-btn-primary" v-tooltip.bottom="'Add a read-only channel-pairs matrix'"
                 @click="addPairs">
           <i class="pi pi-plus" /> Pairs
         </button>
@@ -242,7 +242,7 @@ onUnmounted(() => ws.off('gating:popmap', onBroadcast))
           </button>
         </div>
         <label v-if="!isTrack && g.napariZMode === 'slice'" class="zwin"
-               v-tooltip.bottom="'z-slice window: include cells within ± this many slices of the current z (0 = current slice only)'">
+               v-tooltip.bottom="'Include cells within ± this many z-slices (0 = current only)'">
           ±<input type="number" min="0" max="50" step="1" v-model.number="g.napariZWindow" />
         </label>
         <div class="cc-btn-group" v-tooltip.bottom="'Arrange windows'">

--- a/frontend/src/modules/metadata/MetadataPanel.vue
+++ b/frontend/src/modules/metadata/MetadataPanel.vue
@@ -345,7 +345,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
         <input class="field-input flex1" v-model="regexpValue" placeholder="Regular expression…"
           :disabled="attrDisabled"
           @keydown.enter="assignRegexp"
-          v-tooltip.bottom="'Regex over the name; a (group) if present, else the whole match. e.g. M(\\d+)→4. New to regex? Use the builder.'" />
+          v-tooltip.bottom="'Regex over the name; a (group) if present, e.g. M(\\d+)→4'" />
         <button class="cc-btn cc-btn-ghost" :disabled="attrDisabled || !regexpValue"
           @click="assignRegexp"
           v-tooltip.bottom="'Extract a value from each image filename or path.'">

--- a/frontend/src/tasks/TaskRunner.vue
+++ b/frontend/src/tasks/TaskRunner.vue
@@ -363,7 +363,7 @@ const { width: sidebarWidth, onResizeStart } =
 
       <div class="pool-row" v-if="pools.length > 0">
         <span class="pool-label cc-muted cc-fs-xs"
-          v-tooltip.right="'Resource pool controls how many tasks share a concurrency slot. GPU tasks should use the gpu pool to avoid running multiple models at once.'">
+          v-tooltip.right="'How many tasks share a concurrency slot; GPU tasks use the gpu pool'">
           Pool
         </span>
         <ChipSelect class="pool-chips" v-model="selectedPool" :options="poolOptions" aria-label="Resource pool" />


### PR DESCRIPTION
Second pass of the copy rule (#368), over `v-tooltip` string literals in `.vue` files. Text only — no binding, condition or modifier changed.

## Before / after

| | before | after |
|---|---|---|
| Tooltip strings over 90 chars | **41** of 568 | **0** |
| Longest | 228 | 90 |
| Over 150 chars | 7 | 0 |
| Multi-sentence tooltips | 9 | 1 (deliberate) |

Worst offender was the task-refresh setting, at 228 characters:

> *"Keep plots in sync with your data: when a task finishes, any plot or population list showing the affected image(s) reloads on its own. Turn off to keep plots steady while you work — they update next time you open or change them."*

→ *"Reload plots automatically when a task finishes"*

Also folded 8 tooltips that passed a length check but still explained themselves in two or three sentences — the discrete-GPU toggle managed three (*"Render napari on the discrete GPU (hybrid graphics). Restarts napari to apply. Linux only."* → *"Render napari on the discrete GPU; restarts napari (Linux only)"*).

**One is left as-is on purpose:** `AppHeader`'s *"Update available — {version}. Open Settings to install."* is a status plus a call to action, not explanatory prose, and it's 68 characters.

## A correction to my own measurement

I previously quoted 53 and then 73 long literals. Both were wrong — those greps measured the **whole binding expression**, so a ternary counted as one long string even when each branch a user actually sees is short (e.g. `flaggedActive ? 'Deselect flagged images' : 'Select all N flagged image(s)'`). Counting the rendered string literals inside each binding gives **41**, and the ternaries with short branches were correctly left alone.

## Nothing is lost

Checked before cutting; every removed explanation is documented:

- pseudoreplication / image-mean → `docs/PLOTS.md`
- chain failure policies + node scopes (`require_all`, `successful_only`, picnic/incremental) → `docs/SCHEDULER.md`
- resource pools → `docs/MODULES.md`
- loopback-only REPL → `docs/DEV.md`, `docs/API.md`
- task-refresh + napari reset-on-reload → `docs/UI.md`, `docs/todo/TASK_DATA_REFRESH_PLAN.md`

The regex-builder example in `MetadataPanel` was kept, since `docs/UI.md` explicitly says that tooltip carries an example for people who don't know regex.

## Drift fixed

Two sibling sidebar tooltips had come apart — the previous pass shortened the lab-log one and left the napari one carrying *"Floating panel — drag it anywhere."* Both read the same way again.

## Verification

- `npm run build` succeeds (the real check for `.vue` templates; the one warning is a pre-existing `INEFFECTIVE_DYNAMIC_IMPORT`)
- `npm run typecheck` (`vue-tsc -b`) clean
- `npx vitest run` — 52 files / 381 tests pass

Not viewed in the app. The template-literal tooltips kept their `${…}` interpolation, and the build would fail on a broken one, but the rendered wording is unverified visually.

## What's left on this rule

Empty states (`.cc-empty`) and QC finding text — the remaining surfaces named in the rule's table — are still unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
