### PR TITLE
fix(update): apply staged updates on every launch, not just the first

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,13 +86,16 @@ RESTART_EXIT_CODE = 42
 
 
 def main() -> int:
-    _apply_pending_update()
     # Production mode: plain include, no Revise. Inherits PATH from the activated env so the
     # server's Python subprocesses use the same env. CECELIA_SUPERVISED tells the server that
     # backend restart is available (we relaunch it on RESTART_EXIT_CODE).
     env = {**os.environ, "CECELIA_SUPERVISED": "1"}
     first = True
     while True:
+        # Apply staged updates every iteration, not just at first launch — Settings → System Restart
+        # re-enters this loop with the Julia backend down, which is the one moment we can swap
+        # api/src/*.jl without a running process locking them.
+        _apply_pending_update()
         proc = subprocess.Popen(
             [_find_julia(), "--project", "src/server.jl"],
             cwd=os.path.join(ROOT, "api"),


### PR DESCRIPTION
## Summary
- Move `_apply_pending_update()` from `main()` entry into the supervisor `while True` loop, so it runs on every relaunch — not only the initial one
- Fixes the case where a user stages an update via `POST /api/update/apply`, clicks Settings → System Restart, and silently keeps running the stale backend

## Why
`Settings → System Restart` returns `RESTART_EXIT_CODE=42` from Julia and continues the `app.py` loop. Before this change, `_apply_pending_update()` ran only once — before the loop — so the marker + staged tarball sat on disk forever until the user fully quit `app.py` and relaunched. Concretely: an rc8 install served the rc8 frontend (with the new "Migrate legacy project" dialog) against an rc7 Julia backend that had no `/api/import/scan-legacy` route → the "Not found: /api/import/scan-legacy" a user hit today.

The loop iteration is the safe moment to apply the update: Julia is down, `api/src/*.jl` isn't locked.

## Test plan
- [ ] Stage a fake `.pending-update` + `.update-staging/payload/` in an installed copy
- [ ] `POST /api/app/restart` (or Settings → System Restart)
- [ ] Confirm the payload is applied and the marker is removed before Julia re-launches
- [ ] Confirm the no-marker case is still a cheap early-return on every restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)