### PR TITLE
docs(ui): the plot docs described a rendering engine that no longer exists

### DIFF
--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -467,8 +467,7 @@ client-side; the server persistence was already correct.
   `GET /api/gating/density` (2D-histogram fallback); `GET /api/gating/stats`;
   `GET /api/gating/membership` (label IDs; **binary `Int32`** for large pops).
 - **WS**: `gating:popmap` broadcast after any mutation (reuses `broadcast_ws`).
-- **Frontend**: `regl-scatterplot` (WebGL, millions of points) + a `canvas2D` overlay for
-  gate drawing; density heatmap fallback above a point threshold; **re-entrancy guard**
+- **Frontend**: a 2D-canvas dot plot + a `canvas2D` overlay for gate drawing; density heatmap fallback above a point threshold; **re-entrancy guard**
   (`listeningToGating`) so server pushes don't re-emit gate mutations; multiple
   simultaneous panels; hierarchical population tree (generic for all 3 types). **No
   Plotly** for gating.
@@ -494,7 +493,7 @@ client-side; the server persistence was already correct.
 ## Scale
 
 10⁶ cells is a real target (static large images; live ~1000 cells × 180 timepoints).
-Implications: WebGL rendering with density fallback; binary `Float32`/`Int32` transfer;
+Implications: 2D-canvas rendering with a density fallback; binary `Float32`/`Int32` transfer;
 per-image measurement + membership caching in Julia; lazy column reads in `label_props`.
 
 ## Out of scope (this phase)
@@ -507,31 +506,33 @@ are later phases; only `flow` is wired to the gating UI now.
 
 ## Gating plot — rendering & UX hacks
 
-Deliberate shortcuts in the plot stack (`components/plots/{ScatterGL,PlotLayers,GateOverlay}.vue`).
-Know them before changing those components. Moved here from `docs/UI.md`, which kept UI *conventions*
-while these are gating-model internals.
+Deliberate shortcuts in the plot stack (`components/plots/{PlotLayers,GateOverlay}.vue`, composited by
+`GateScatterCell`). Know them before changing those components. Both layers are **2D canvas** — the
+WebGL/regl layer these notes originally described was removed; see `docs/PLOTS.md` §0.
 
 
-
-- **Pseudocolour is computed client-side, smoothed.** ScatterGL bins the transformed points into
-  a 160×160 grid, **box-blurs** it (≈ KDE), log-scales, then **bilinear-samples** the grid per
-  point → regl's `colorBy:'valueA'`. The FlowJo **blue-heat ramp** (R `.flowColorRampBlueHeat`,
-  `flowHelpers.R:775`) is interpolated to **256 stops** so the gradient is smooth (not 5 bands),
-  and the low end is lifted off pure black (`#0b1a4d`) so sparse points stay visible on the dark
-  background. No server density call for points.
-- **Contours are client-side too.** PlotLayers builds a 64×64 (lightly box-blurred ≈ KDE)
-  density grid and runs **marching squares** at normalised z = `1 − [0.95,0.90,0.75,0.5]`
-  (R `.flowContourLines`, `flowHelpers.R:46`). The `/api/gating/density` endpoint exists but
-  the canvas path doesn't use it.
+- **Pseudocolour is computed client-side, per point.** `plots/density.ts` `pointDensities` bins the
+  transformed points onto a `DOT_GRID` (160²) grid, box-blurs it (≈ KDE) and samples it back per point,
+  so **each dot is coloured by its own local density** — that per-point colouring is the FlowJo/OMIQ
+  look, and a binned raster instead showed visible rectangles. The **blue-heat ramp**
+  (`plots/flowColors.ts` `BLUE_HEAT_ANCHORS`, from R `.flowColorRampBlueHeat`, `flowHelpers.R:775`) is
+  interpolated to 256 stops so the gradient is smooth, with the low end lifted off pure black
+  (`#0b1a4d`) so sparse points stay visible on the dark theme. No server density call.
+- **Contours are client-side too, on their own grid.** `plots/contour.ts` runs **d3-contour** over a
+  separate, more heavily blurred `DENSITY_GRID` (128²) at `CONTOUR_LEVELS`
+  (`[0.05, 0.12, 0.24, 0.42, 0.65, 0.88]`) — d3-contour gives clean connected rings where the earlier
+  marching-squares pass gave broken ones. Dots and contours deliberately use different grids/blurs
+  (`DOT_*` vs `CONTOUR_*`) because the dot pass wants detail and the ring pass wants smoothness. The
+  `/api/gating/density` endpoint exists but this path doesn't use it.
 - **Population overlay reuses `plotdata`, no new endpoint.** For each highlighted pop, the panel
   GETs `plotdata?pop=<path>` — Julia still owns membership; the client only colours the returned
   subset (dots in `points` mode, a contour in `contour` mode). Heavy for very large/low-
   selectivity pops (canvas2D dots) — acceptable for gated subpops.
-- **Gate editing without stealing pan/zoom.** regl (below) owns pan/zoom. In edit (off) mode the
+- **Gate editing without swallowing clicks on the plot.** In edit (off) mode the
   overlay sets its own `pointer-events:'auto'` ONLY while the cursor is over a gate handle/body —
-  detected via a *bubbled* `mousemove` on the parent container (events bubble up from the regl
+  detected via a *bubbled* `mousemove` on the parent container (events bubble up from the base
   canvas even though the overlay is `'none'`) — and `'none'` otherwise, so empty-space clicks
-  reach regl. During a drag it shows a local `draft` gate; on release it emits `edit` and keeps
+  reach the base canvas. During a drag it shows a local `draft` gate; on release it emits `edit` and keeps
   the draft until the authoritative tree arrives (a `gates`-prop watch clears it) → no snap-back
   flash.
 - **Smooth cross-plot propagation via per-pop versions.** Editing pop A's gate in plot 1 must
@@ -539,7 +540,7 @@ while these are gating-model internals.
   update through `setTree()`, which diffs gate/filter signatures vs the previous tree and bumps a
   per-path `popVersion` for changed pops **and their descendants** (parent∩child). Each panel
   watches the version of its displayed parent (→ refetch base points only, no `plotmeta`, so no
-  axis flicker) and of its highlighted pops (→ refetch just those layers). regl redraw is
+  axis flicker) and of its highlighted pops (→ refetch just those layers). A canvas redraw is
   instant, so it's smooth. `setTree` is the *single* tree-update entry (HTTP response **and** WS
   broadcast both call it) — the diff is idempotent, so the duplicate doesn't double-fire.
 - **Scope governs ALL manager options.** A bottom-of-manager toggle — **icons only** (globe =
@@ -578,19 +579,15 @@ while these are gating-model internals.
   titles don't sit on the box edge.
 - **Smoother pseudocolour**: see the density bullet above (160² grid, box-blurred, bilinear-
   sampled, 256-stop ramp, lifted low end).
-- **Fixed camera → exact overlay alignment (pan/zoom disabled).** Getting the WebGL points to
-  line up with the canvas2D overlays under regl's camera/aspect/scale machinery proved fragile
-  (providing x/y scales made regl re-fit the camera and zoom in, drifting dots off the gates so
-  gating caught no cells). The robust fix: **no x/y scales**, `aspectRatio = w/h` (uniform fill),
-  and `cameraIsFixed: true` — the camera stays at identity, so `[-1,1]` maps straight to the
-  canvas edges and the overlays' plain extents mapping matches exactly. `viewExtents` therefore
-  always equals `extents`. Trade-off: **no interactive pan/zoom** for now; re-enabling it needs
-  the overlays to replicate regl's full `projectionLocal·cameraView·model` transform (the
-  `view`-event camera matrix), not a domain readout. (The contour grid's binning and `cellToData`
-  must still use the same `/G` bin-centre convention.)
-- **Selection is suppressed.** regl single-click selection would paint points blue, which we
-  don't want. ScatterGL subscribes to `select` and immediately `deselect()`s, and sets
-  `pointColorActive`/`pointColorHover` to the neutral colour. Pan/zoom stay enabled.
+- **Overlay alignment is by construction, not by fighting a camera.** Both the base dots and the gate
+  overlay are 2D canvases that map data→pixel through the same `viewExtents`, so they cannot drift
+  apart. This replaced a fragile WebGL arrangement where providing x/y scales made regl re-fit its
+  camera and zoom in, sliding the dots off the gates so gating caught the wrong cells; the workaround
+  was a fixed identity camera. That whole class of bug is gone with the GPU layer.
+- **Still no interactive pan/zoom.** The layers redraw on any `viewExtents` change, so the plumbing is
+  there, but no wheel/drag handler is wired to change the extents (the canvas-level zoom in
+  `useCanvasZoom` is a CSS transform over the whole panel, a different thing). `docs/TODO.md` #00003
+  tracks re-enabling it and still describes the removed regl camera — re-scope it before picking it up.
 - **Active panel + manager link.** `GatingPlots` tracks an `activePanel` index (orange border
   via `.panel.active`); clicking a panel activates it; the active panel watches `selectedPop`
   and sets its parent so the manager selection "shows up on the plot".

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -936,38 +936,38 @@ deduping so a multi-node chain run only sends one `chain:cancel`).
 
 ## Adding a plot or visualization panel
 
-Plots go either **in the left column** (below the image table, for compact summary visualizations) or **in the right panel** (alongside or instead of `TaskRunner`).
+**First: is it a summary plot?** If the data is server-aggregated, you do not write a component at all —
+drop a `app/src/plotDefinitions/<id>.json` and it appears in every "+ Plot" picker. See `docs/PLOTS.md`
+→ *Hosting — ONE way*. The rest of this section is for the cases that need their own component.
 
-**Left column** — put the plot canvas in the `#plots` slot (ModuleLayout wraps it in the shared collapsible section — see above); reserve `#below-table` for rare extra custom content. Best for summary/gating/cluster canvases that sit naturally next to the image list.
+**Where it goes.** Left column (`#plots` slot — `ModuleLayout` wraps it in the shared collapsible
+section) for canvases that belong beside the image list; `#right` slot for a panel alongside or instead
+of `TaskRunner`. Both slots hand you `setUid` / `selectedUids` / `selectedNames`, so a panel needs no
+refs of its own. Reserve `#below-table` for rare extra custom content. Fetch over REST in
+`onMounted`/`watch`, or subscribe with `ws.on` (see *WS events*).
 
-**Right panel** — use the `#right` slot:
-
-1. Create a panel component, e.g. `frontend/src/modules/gating/GatingPanel.vue`.
-2. Use it in the module's `#right` slot — you have access to `setUid` and `selectedUids` from slot props.
-3. Data comes from the backend via either:
-   - **REST** — `fetch('/api/...')` inside `onMounted` / `watch`.
-   - **WebSocket event** — `ws.on('myEvent', handler)` in `onMounted`, `ws.off(...)` in `onUnmounted`.
-     See `ARCHITECTURE.md` (Napari → Julia event flow) for the WS event pattern.
-
-Plot libraries in use — **two engines, split by job**:
-- **regl-scatterplot** (WebGL) — **per-cell scatter**: gating plots + UMAP. Renders 100k–1M+ points
-  at 60fps with lasso/rectangle select; gate shapes are a canvas2D overlay in data coords on top
-  (`ScatterGL` + `PlotLayers` + `GateOverlay`). Used wherever **every cell** is drawn and/or gates
-  are sketched. See "Gating page (WebGL scatter + gate overlay)" and `docs/POPULATION.md`.
+Plot libraries in use — **two renderers, split by job**:
+- **2D canvas** (no library) — **per-cell dot plots**: the gating scatter and the UMAP. Every point is
+  drawn coloured by its LOCAL density (`plots/density.ts` `pointDensities` → the blue-heat ramp in
+  `plots/flowColors.ts`) — that per-point colouring is the FlowJo/OMIQ look; contours come from
+  **d3-contour** (`plots/contour.ts`). `PlotLayers` draws dots-or-contours plus population overlays and
+  `GateScatterCell` composites it with `GateOverlay`. There is **no WebGL**: regl-scatterplot was
+  removed (it survives only as an unused `package.json` entry). A 2D canvas suffices because the cloud
+  is non-interactive, and export re-renders the same content at any scale instead of screen-grabbing a
+  GPU buffer. See *Gating page* and `docs/PLOTS.md` §0.
 - **Observable Plot** (`@observablehq/plot`, SVG) — **summary charts**: histogram, box/violin/beeswarm,
   bar, frequency/stacked, and (roadmap) heatmaps/tiled maps via `Plot.cell`/`Plot.raster`. Used
   wherever the data is **server-aggregated** (tiny payloads) and the ggplot `theme_classic` look /
   beeswarm / resize matter more than raw point throughput. See "Analysis-plot canvas (summary plots,
   Observable Plot)" and `docs/PLOTS.md` §0.
 
-Why two: WebGL is necessary to render every cell and draw gates interactively; an SVG grammar-of-
-graphics lib gives the cleaner publication look for pre-aggregated summaries. Neither does the other's
-job well, so we keep both. Never add or swap a charting library without updating this doc, `docs/PLOTS.md`,
-and the `cecelia-charting-decision` rationale.
+Why two: a per-point renderer is needed to draw every cell and sketch gates on it; an SVG
+grammar-of-graphics library gives the cleaner publication look for pre-aggregated summaries. Never add
+or swap a charting library without updating `docs/PLOTS.md` §0 (which owns the rationale) and this list.
 
 ### Plot loading state — delayed spinner
 
-Heavy plots (a slow `/api/plot_data`, a big WebGL point fetch) must show they're working — a blank
+Heavy plots (a slow `/api/plot_data`, a big point fetch) must show they're working — a blank
 panel reads as "frozen". But a spinner that flashes on every quick plot is worse noise. So the rule:
 **a delayed spinner, never an immediate one.**
 
@@ -986,22 +986,20 @@ full-size `GateScatterCell` (Gate page); `UmapView` has its own empty-state whee
 these two primitives.
 
 **Gate scatters — one renderer, three hosts.** `components/plots/GateScatterCell.vue` is the ONE
-scatter+gate body (WebGL points + contour/pop-colour layer + canvas2D gate overlay). The interactive
-Gate page (`GatePlotPanel`, `mode` = rectangle/polygon) and every read-only montage tile (`mode="off"`)
-share it. **Render modes** (`points` | `contour` | `outliers`, chosen via the shared
-`components/plots/RenderModeToggle.vue`): `points` = WebGL pseudocolour cloud; `contour` = density
-contours only, with the WebGL cloud SKIPPED (`GateScatterCell` passes `null` points to `ScatterGL`) so
-it's the fast path; `outliers` = contours + individual dots for the sparse tail (FlowJo / old-R
-"contour ± outliers"). The contour/outlier maths (density grid + low-density subset) is the pure,
-unit-tested `plots/density.ts`, shared by `PlotLayers`. Montages of tiles go through `components/plots/GateMontage.vue` — a grid of `GateScatterCell`
-tiles that owns the per-tile fetch (`plotmeta`/`plotdata`/`stats`), transpose reuse, optional coloured
-population overlays (`highlight`), and PNG/PDF export. It has two tile producers: `GatingStrategyView`
-(tree-derived, responsive wrap) and `GatePairsPanel` (a `ggpairs` matrix, `cols` set). A tile carries a
-`role`: `scatter` (fetches + renders — the default, so tree-derived defs need no role), `diagonal` (a
-labelled name cell, no fetch), or `corr` (an upper-triangle Pearson-r cell reusing its mirror scatter's
-points, no fetch). In matrix mode `GateScatterCell` gets `hideAxisLabels` (the diagonal names each
-channel, so per-tile axis labels only clutter/clip). Add a new gate-montage view by building `PanelDef[]`
-and rendering `<GateMontage>` — never a second gate renderer.
+scatter+gate body (2D-canvas dots + contour/pop-colour layer + gate overlay). The interactive Gate page
+(`GatePlotPanel`, `mode` = rectangle/polygon) and every read-only montage tile (`mode="off"`) share it.
+**Render modes** via the shared `RenderModeToggle.vue`: `points` (per-point pseudocolour), `contour`
+(rings only — the fast path, dot pass skipped), `outliers` (rings + dots for the sparse tail, FlowJo /
+old-R "contour ± outliers"). The maths is the pure, unit-tested `plots/density.ts` + `plots/contour.ts`.
+
+Montages go through `components/plots/GateMontage.vue` — a grid of `GateScatterCell` tiles owning the
+per-tile fetch (`plotmeta`/`plotdata`/`stats`), transpose reuse, optional coloured population overlays
+and PNG/PDF export. Two tile producers: `GatingStrategyView` (tree-derived, responsive wrap) and
+`GatePairsPanel` (a `ggpairs` matrix, `cols` set). A tile's `role` is `scatter` (fetch + render, the
+default — so tree-derived defs need no role), `diagonal` (a labelled name cell, no fetch) or `corr` (an
+upper-triangle Pearson-r cell reusing its mirror's points, no fetch). In matrix mode tiles get
+`hideAxisLabels`, since the diagonal already names each channel. **Add a new gate-montage view by
+building `PanelDef[]` and rendering `<GateMontage>` — never a second gate renderer.**
 
 The gate scatter's axis chrome is HTML (tick labels + rotated axis names), so it doesn't inherit
 Plot's `style.fontSize`. It takes an explicit **`fontSize`** prop (default 11) exposed as the
@@ -1028,31 +1026,21 @@ the **chain whiteboard** (`docs/SCHEDULER.md`) — via a flag. **No per-plot hos
   `exportFormats`/`exportAs`.)
 
 **Two registries carry the surface "checkboxes":**
-- `components/canvas/interactiveViews.ts` — WebGL/interactive VIEWS (hosted by `InteractivePanel`), flags
+- `components/canvas/interactiveViews.ts` — interactive VIEWS (hosted by `InteractivePanel`), flags
   `clusterPage` / `analysisBoard`.
 - `modules/cluster/clusterPanels.ts` — summary-family cluster PANELS (wrap `CanvasPanel`), flags
   `analysisBoard` / `trackOnly` / `needsCols`, plus a `props(ctx)` mapper so the host binds panel-specific
   props generically.
 
-**Hosts render from the registries**: each builds its `+Plot` picker by filtering on its own flag, and
-renders each slot with one generic `<component :is v-bind>`. Adding a plot to a surface = write the
-component to the contract + one registry line + tick the flag. When you add the chain-whiteboard as a
-host, it consumes the *same* registries + contract — do not re-wire plots per node.
+**Hosts render from the registries**: each builds its `+Plot` picker by filtering on its own flag and
+renders every slot with one generic `<component :is v-bind>`. So adding a plot to a surface = write the
+component to the contract + one registry line + tick the flag. The cluster page (`ClusterPlots.vue`) and
+the board (`LayoutCanvas.vue`) do this identically — there is no "cluster page way" and "board way", and
+a future chain-whiteboard host consumes the same registries rather than re-wiring plots per node.
 
-**One mechanism across every surface — no per-page divergence.** The module page and the board host the
-*same* components the *same* way; there is not "the cluster page's way" and "the board's way":
-- **Cluster page** (`ClusterPlots.vue`) and **Analysis board** (`LayoutCanvas.vue`) both discover plots
-  from `INTERACTIVE_VIEWS` + `CLUSTER_PANELS` and render them with the identical generic
-  `<component :is v-bind>` (see each file's `clusterPanelProps`). Panel chrome differs only by `docked`
-  (a grid slot drops its own reload/controls/export; a floating panel keeps them).
-- **Behaviour / summary pages** (`SummaryCanvas.vue`) and the board's summary slots both render every
-  summary plot through one `SummaryPanel` driven by the server plot-spec registry
-  (`GET /api/plots/definitions`) — already a single mechanism.
-- **`docked` is the contract's chrome switch.** A panel reads `docked` to hide anything that only makes
-  sense free-floating (e.g. the per-plot Export dropdown) — the board re-fetches on context change and
-  exports via PDF/CSV, so that chrome is redundant in a slot. `SummaryPanel` and the cluster panels use
-  it; `InteractivePanel` can forward it to a view that needs it (none do today — plots stay fresh via
-  `useDataRefresh`, so there are no per-plot reload buttons to hide).
+**`docked` is the contract's chrome switch** — a panel reads it to hide what only makes sense
+free-floating (its own Export dropdown), since the board exports via PDF/CSV instead. Details:
+`docs/ANALYSIS.md` → *`docked` — the chrome switch*.
 
 **Exception — the gating page (`gate/GatingPlots.vue`) is intentionally NOT registry-hosted.** It is a
 single, *write-capable* gate-drawing workspace (`GatePlotPanel` draws/edits gates), not a multi-type
@@ -1403,8 +1391,7 @@ aggregation is a PACKAGE function, the route is thin, rendering is frontend-only
   `buildPlotOptions(Plot, data, opts)` to get a `Plot.plot()` options object, injects the panel's
   width/height, and appends the node. Resize is trivial (no Vega signal graph): a `ResizeObserver` on
   the host just re-renders with the new size. Exposes `toImageURL('png'|'svg')` — SVG serialises the
-  node (native), PNG rasterises it at the DPR-aware `EXPORT_SCALE`. The summaries equivalent of `ScatterGL` for the big point
-  clouds.
+  node (native), PNG rasterises it at the DPR-aware `EXPORT_SCALE`. The summaries counterpart of the 2D-canvas dot plots.
 
 > **The Analysis board itself is documented in `docs/ANALYSIS.md`** — tabs, the three stores
 > (`analysisTabs` / `analysisLayout` / `canvasPanels`), plate layout, persistence keys, and export. A
@@ -1454,8 +1441,8 @@ page — and the Analysis board — reuses them unchanged:
   style-inlined clone in an SVG `<foreignObject>` (catches an HTML overlay legend alongside the `<svg>`),
   while `plotHostToImageURL` composites every `<canvas>` then the overlay on top — canvas pixels can't
   go through `foreignObject`. Two DPR-aware scales: `EXPORT_SCALE` (vector) and the higher `RASTER_SCALE`,
-  where every stacked canvas **re-renders at export scale** since a WebGL backing store can't be upscaled
-  crisply. Needs `preserveDrawingBuffer` (regl-scatterplot already sets it). Full API + the two subtleties
+  where every stacked canvas **re-renders its content at export scale** rather than being upscaled, so a
+  dot plot exports crisp and cannot clip. Full API + the two subtleties
   that bit us (clearing ancestor backgrounds in the overlay pass; capturing the axis-margin wrapper, not
   the inner plot box) are indexed in `INVENTORY.md` → *Plot export*; board figure export is `docs/ANALYSIS.md`.
 - **`plots/overlays.ts`** — the **shared** themed legend / title overlays (`legendOverlay`,
@@ -1490,7 +1477,7 @@ in the panel and the data scope (single/cross-image) in the canvas. The two comp
 task defs, so adding a plot type is a JSON drop with no UI code. Schema + the current set:
 `docs/PLOTS.md`.
 
-## Gating page (WebGL scatter + gate overlay)
+## Gating page (2D-canvas scatter + gate overlay)
 
 `frontend/src/modules/GatingModule.vue` — route `/gate`. Pick ONE image in the table; the
 gating workspace renders **below the table** (`#plots` slot, wide left column),
@@ -1528,9 +1515,9 @@ Two plot families share the canvas shell; the distinction matters for where a ne
 - **Summary** — server-aggregated (`POST /api/plot_data`), drawn by the ONE generic `PlotChart`
   (Observable Plot). Histogram, bar, boxplot, **heatmap/matrix**, frequency. Add one = drop a
   plot-def JSON (`app/src/plotDefinitions/`); no UI code. Hosted by `SummaryPanel`.
-- **Interactive** — client/WebGL point clouds with per-point interaction (regl `ScatterGL`), each with
-  its own data endpoint + rendering. Gating scatter, **UMAP**. These can't be a single generic
-  renderer, so they live in a **registry** of self-contained view components:
+- **Interactive** — client-side 2D-canvas point clouds with per-point interaction, each with its own
+  data endpoint + rendering. Gating scatter, **UMAP**. These can't be a single generic renderer, so
+  they live in a **registry** of self-contained view components:
   **`components/canvas/interactiveViews.ts`** → `INTERACTIVE_VIEWS = { umap: { label, component } }`.
   A view (e.g. **`components/plots/UmapView.vue`**) fetches + renders + owns its controls; the generic
   **`components/canvas/InteractivePanel.vue`** wraps any view in `CanvasPanel` and spreads the plot
@@ -1652,25 +1639,19 @@ a hard browser reload — same as the panels); cleared on project open/close.
 
 Each **`GatePlotPanel`** is `position:absolute`, **dragged by its title** (clamped on-screen like
 the manager) and **resized from its corner** (`resize:both`; the plot area is `flex:1` and the
-WebGL/canvas2D layers re-render via `ResizeObserver`). Self-contained (own X/Y column + transform
+canvas layers re-render via `ResizeObserver`). Self-contained (own X/Y column + transform
 on **stacked rows**, parent-population select, **render mode**, gate mode) with a **"−"** in the
 header to remove it. New gates are added under that panel's selected parent population. Click a
 panel to make it **active** (orange border); the active panel follows the population you select in
 the manager (sets it as the displayed parent).
 
-Plot stack — three superimposed layers, all mapped data→pixel through the **live** view
-extents so they stay aligned through pan/zoom (`xMin`→left, `xMax`→right, `yMax`→top):
-- **`components/plots/ScatterGL.vue`** — `regl-scatterplot` (WebGL, millions of points).
-  Takes interleaved `Float32Array` `[x,y,…]` (already transformed) + fixed extents and
-  **normalises to `[-1,1]`** for `draw()` — regl positions draw points as DEVICE coords `[-1,1]`,
-  so raw data units would pin every point to the `+1,+1` corner. Sets `aspectRatio = width/height`
-  (updated on resize) so the net x-scale is 1 (regl's default square aspect would letterbox a
-  rectangular plot), and `cameraIsFixed: true` so the identity camera maps `[-1,1]` to the canvas
-  edges — matching the overlays exactly (see the alignment bullet below). Lazy-imports the lib;
-  `destroy()` + `ResizeObserver` cleanup in `onBeforeUnmount`. **First WebGL component — follow it.**
-- **`components/plots/PlotLayers.vue`** — `canvas2D`. Density **contours** (marching squares)
-  and the **population-colour overlay** (per-pop dots or per-pop contours).
-- **`components/plots/GateOverlay.vue`** — `canvas2D` (top). **Draws** new **rectangle** (drag)
+Plot stack — two superimposed 2D canvases, both mapping data→pixel through the same `viewExtents`
+so they stay aligned (`xMin`→left, `xMax`→right, `yMax`→top). There is no third (WebGL) layer any more:
+- **`components/plots/PlotLayers.vue`** — the base. In `points` mode it draws every cell coloured by
+  its local density; in `contour`/`outliers` mode it draws d3-contour rings (plus the sparse tail).
+  Also draws the **population-colour overlay** (per-pop dots or contours). Bucketing points by colour
+  keeps `fillStyle` writes to ~64 rather than one per point.
+- **`components/plots/GateOverlay.vue`** — canvas2D (top). **Draws** new **rectangle** (drag)
   and **polygon** (click vertices, double-click/click-near-start to close; Esc cancels) gates,
   and **edits** existing ones: move / resize rectangles (corner + edge handles), drag polygon
   vertices, double-click an edge to insert a vertex, right-click a vertex to delete. Live local
@@ -1691,7 +1672,7 @@ delete (`pop/delete`, cascades), and per-plot colour **highlight** (see below).
 
 ### Gating plot — rendering & UX hacks
 
-Moved to **`docs/POPULATION.md`** → *Gating plot — rendering & UX hacks*. Those ~30 notes are about the
-plot stack's internals (client-side pseudocolour/contours, the fixed regl camera, gate hit-testing,
-cross-plot propagation), which belong with the gating model rather than the UI conventions. **Read them
-before touching `ScatterGL` / `PlotLayers` / `GateOverlay`.**
+Moved to **`docs/POPULATION.md`** → *Gating plot — rendering & UX hacks*: the client-side density and
+contour maths, gate hit-testing without stealing pointer events, and cross-plot propagation. Those are
+gating-model internals rather than UI conventions. **Read them before touching `PlotLayers` /
+`GateOverlay`.**

--- a/frontend/src/components/canvas/interactiveViews.ts
+++ b/frontend/src/components/canvas/interactiveViews.ts
@@ -4,7 +4,7 @@ import GatingStrategyView from '../plots/GatingStrategyView.vue'
 import ImageStripView from '../plots/ImageStripView.vue'
 
 // Registry of INTERACTIVE plot views (client/WebGL point clouds with per-point interaction, e.g.
-// regl ScatterGL), keyed by a stable view id. This is the counterpart to SUMMARY plots — those are
+// 2D-canvas dot plots), keyed by a stable view id. This is the counterpart to SUMMARY plots — those are
 // server-aggregated plot-def JSONs rendered by the one generic PlotChart; interactive plots each
 // need their own renderer + data endpoint, so they live here as self-contained view components.
 //

--- a/frontend/src/components/plots/GateOverlay.vue
+++ b/frontend/src/components/plots/GateOverlay.vue
@@ -1,5 +1,5 @@
 <!--
-  canvas2D gate layer over ScatterGL. Two jobs:
+  canvas2D gate layer over the base dot canvas (PlotLayers). Two jobs:
    1. DRAW new gates (mode = rectangle | polygon) — drag a rect, or click polygon vertices
       (double-click / click-near-start to close, Esc cancels). Emits `draw` on completion.
    2. EDIT existing gates (mode = off) — move / resize rectangles (corner + edge handles),
@@ -11,9 +11,9 @@
 
   Everything is mapped data→px through the LIVE (zoom-synced) extents, so gates track pan/zoom.
 
-  Pan/zoom belong to regl below us. To not steal them, in edit (off) mode the overlay sets its
-  own pointer-events to 'auto' ONLY while the cursor is over a gate handle/body (detected via a
-  bubbled mousemove on the parent), and 'none' otherwise — so clicks in empty space reach regl.
+  We sit above the base dot canvas and must not swallow its clicks: in edit (off) mode the overlay
+  sets its own pointer-events to 'auto' ONLY while the cursor is over a gate handle/body (detected
+  via a bubbled mousemove on the parent), and 'none' otherwise, so empty-space clicks pass through.
 -->
 <script setup lang="ts">
 import { ref, watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -1,5 +1,5 @@
 <!--
-  The shared scatter+gate PLOT BODY: a WebGL scatter (ScatterGL) + contour/population layer
+  The shared scatter+gate PLOT BODY: a 2D-canvas dot/contour + population layer (PlotLayers)
   (PlotLayers) + canvas2D gate layer (GateOverlay), with axis lines/ticks/labels and PNG export. This
   is the ONE gate-scatter renderer — extracted from GatePlotPanel so the read-only gating-strategy plot
   (Analysis board) reuses it instead of forking a second one (feedback_use_existing_framework).
@@ -25,7 +25,7 @@ type Ext = { xMin: number; xMax: number; yMin: number; yMax: number }
 
 const props = withDefaults(defineProps<{
   points: Float32Array | null
-  extents: Ext                                   // fixed full-data range (ScatterGL)
+  extents: Ext                                   // fixed full-data range (base layer)
   viewExtents: Ext                               // live (zoom-synced) extents (PlotLayers/GateOverlay/ticks)
   xTicks: { pos: number; label: string }[]
   yTicks: { pos: number; label: string }[]

--- a/frontend/src/components/plots/UmapView.vue
+++ b/frontend/src/components/plots/UmapView.vue
@@ -63,9 +63,9 @@ const unit = computed(() => (props.popType === 'trackclust' ? 'tracks' : 'cells'
 // like the cluster panels. It re-themes the OVERLAYS (label chips, legend ink) + the composite ground,
 // but deliberately NOT the WebGL scatter's own background (see `scatterGround`).
 const forceLight = ref(false)
-// On-screen scatter ground — the WebGL layer's background. Deliberately independent of `forceLight`:
-// changing ScatterGL's background prop fires an async re-render that races `exportCanvas` and snapshots
-// a BLANK point cloud. The export goes light via the composite `bg` arg + transparent host instead
+// On-screen scatter ground. Deliberately independent of `forceLight`: changing the base canvas's
+// background prop fires an async re-render that races `exportCanvas` and snapshots a BLANK point
+// cloud. The export goes light via the composite `bg` arg + transparent host instead
 // (exactly like the gating cell, which never re-grounds its scatter for export).
 const screenDark = computed(() => props.vis?.darkTheme !== false)
 const scatterGround = computed(() => (screenDark.value ? '#0d0b1a' : '#ffffff'))

--- a/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
@@ -9,7 +9,7 @@
   Data: the shared `frequency` aggregation (POST /api/plot_data, popType=trackclust,
   granularity=cell → member cells carry their HMM state; scope=summarised pools images). Per-cluster
   mode adds groupBy=clusters.<suffix> + collapseSeries (one series per cluster, over root). Rendering
-  is self-contained (lazy Observable Plot, like UmapView/ScatterGL) because the layout is a transpose
+  is self-contained (lazy Observable Plot, like UmapView) because the layout is a transpose
   of the generic stacked bar (x = group, fill = state) — not worth a new shared chart type.
 -->
 <script setup lang="ts">

--- a/frontend/src/modules/gate/GatePlotPanel.vue
+++ b/frontend/src/modules/gate/GatePlotPanel.vue
@@ -1,6 +1,6 @@
 <!--
   One modular gating plot (mirrors the old flowPlotManager "gating box"): its own X/Y column +
-  transform, parent-population select, render mode + gate-draw tools, a WebGL scatter (ScatterGL)
+  transform, parent-population select, render mode + gate-draw tools, a 2D-canvas dot plot
   with a contour/population layer (PlotLayers) and a canvas2D gate overlay (GateOverlay), plus
   inline naming to persist a drawn shape.
 

--- a/frontend/src/plots/export.ts
+++ b/frontend/src/plots/export.ts
@@ -20,7 +20,7 @@ const DPR = (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1)
 // DPR×2 (capped 4×) is plenty and keeps file sizes sane.
 const EXPORT_SCALE = Math.min(4, 2 * DPR)
 // Raster/WebGL composites (UMAP + gate scatter) have NO vector fallback — the point cloud is a
-// bitmap. ScatterGL.exportCanvas re-renders it at this scale, so push it higher for a crisp PNG.
+// bitmap. The canvas layers re-render at this scale, so push it higher for a crisp PNG.
 const RASTER_SCALE = Math.min(8, 4 * DPR)
 
 // rasterise an SVG data URL onto a hi-DPI canvas over a white ground → PNG data URL
@@ -106,7 +106,7 @@ export function loadImg(url: string): Promise<HTMLImageElement | null> {
 //   2. draw the HTML/SVG overlay layer on top (canvases blanked so they don't cover pass 1).
 // Returns a PNG data URL (raster; SVG makes no sense for a rasterised point cloud).
 // `opts.hiRes(cv, scale)` lets a caller supply a HIGHER-RESOLUTION replacement for a specific canvas
-// (ScatterGL.exportCanvas re-renders the WebGL point cloud at `scale`× — its on-screen backing store
+// (each canvas layer re-renders its content at `scale`× — the on-screen backing store
 // is only CSS×DPR, so drawing the live canvas would upscale and pixelate). Resolver returns null →
 // composite the live canvas as-is (canvas2D overlays with no hi-res path).
 export async function plotHostToImageURL(host: HTMLElement | null, bg: string,


### PR DESCRIPTION
Went in to condense the 183-line *Adding a plot or visualization panel* section. Found something bigger first.

## UI.md documented a rendering engine that has been removed

It described the point clouds as **WebGL / regl-scatterplot** throughout. That layer is gone:

- **Nothing imports `regl-scatterplot`** — three historical comments and an unused `package.json` entry are all that remain.
- **`ScatterGL.vue` does not exist**, yet UI.md carried a ten-line spec for it ("**First WebGL component — follow it.**").
- **`PlotLayers.vue:4`** says it sits between *"the (now-removed) WebGL layer"* and the gate overlay.
- **`PLOTS.md` §0** has documented the 2D-canvas dot plot for a while.

So the two docs disagreed and UI.md was the wrong one — down to a section heading, *"Gating page (WebGL scatter + gate overlay)"*. Anyone reading it to work on the plot stack would have gone looking for a GPU layer and a component that isn't there.

## What's corrected

**UI.md** — the two-renderers list, the gate-scatter body, the render modes, the interactive-view family, an export note claiming a `preserveDrawingBuffer` dependency, and the plot-stack layer list (three layers → two, the `ScatterGL` entry replaced by what `PlotLayers` actually does).

**POPULATION.md** — #376 relocated some of these notes there, so it inherited the staleness. Now accurate against the source:

| Claim | Was | Is |
|---|---|---|
| Pseudocolour | ScatterGL bins to 160², samples → regl `colorBy:'valueA'` | `pointDensities` on `DOT_GRID` (160²), sampled back **per point** on a 2D canvas |
| Contours | marching squares, 4 levels | **d3-contour**, separate `DENSITY_GRID` (128²), 6 `CONTOUR_LEVELS` |
| Overlay alignment | a fragile regl camera fixed with `cameraIsFixed` | two canvases sharing `viewExtents` — cannot drift; the bug class is gone |
| Selection | "regl selection is suppressed via `deselect()`" | removed (regl-specific) |
| Pan/zoom | "disabled by the fixed camera" | still unwired, stated as a fact; **TODO #00003 needs re-scoping** — it names the removed camera as the blocker |

**Seven source comments** named the deleted component — which is how the docs got this wrong in the first place. Corrected (comment-only; the diff is verified line-by-line and touches nothing executable).

## The original errand

185 → 171 lines: summary plots now point at `PLOTS.md`'s hosting rule up front (if the data is server-aggregated you write no component at all), the registry contract stops restating `ANALYSIS.md`'s `docked` section, and the gate-scatter paragraph is tighter. **UI.md 1697 → 1679.** Condensing became secondary once the correctness problem surfaced.

## Verification

- `npx vitest run` 399 pass · `npm run typecheck` (`vue-tsc -b`) clean · `npm run build` succeeds
- All 13 externally-cited section anchors verified still present, so no referring file needed touching
- Every component/util name checked still mentioned (no rule dropped)
- `grep ScatterGL frontend/src` → clean

## Limits

- The engine facts come from reading the source, not from watching a plot render. I'm confident (no import, no file, the component's own comment) but I haven't seen it on screen.
- **Left alone deliberately:** `docs/prompts/` and `docs/todo/ANALYSIS_CANVAS_PLAN.md` still mention `ScatterGL`. Prompts are historical by convention; the parked plan is live and may mislead — flagging rather than silently rewriting someone's design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
