### PR TITLE
docs(todo): retire the pan/zoom item's dead rationale, and un-duplicate #00003

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -111,14 +111,19 @@ interact with the `{vn}__branch.h5ad` sidecar (plan Decision 6). 🔹 needs-inpu
 
 ## Low priority
 
-**#00003** — **Re-enable interactive pan/zoom on gating plots**
-Gating plots currently lock the regl camera (`cameraIsFixed: true`, no x/y scales) so the WebGL
-points align exactly with the canvas2D overlays (contours, gates) — providing scales made regl
-re-fit/zoom and drift the dots off the gates. To restore pan/zoom with correct alignment, the
-overlays (`PlotLayers`, `GateOverlay`) must replicate regl's full screen transform
-(`projectionLocal · cameraView · model`, from the `view`-event camera matrix + `viewAspectRatio`)
-instead of the plain extents mapping, and invert it for gate hit-testing. See the alignment bullet
-in `docs/UI.md`.
+**#00087** — **Pan/zoom on gating plots — deliberately absent** (was a duplicate `#00003`)
+Gating plots have no pan/zoom, and shouldn't for now: this is the intended state, not a gap. Kept as
+an item only to record that **the reason it was hard has gone away.** The old blocker was the WebGL
+camera — the overlays would have had to replicate regl's `projectionLocal · cameraView · model`
+transform and invert it for gate hit-testing. That layer no longer exists: the dots and the gate
+overlay are both 2D canvases mapping data→px through the same `viewExtents`, and every layer already
+redraws when it changes. So if pan/zoom is ever wanted it is a wheel/drag handler that edits
+`viewExtents` — not a matrix-replication job. Details: `docs/POPULATION.md` → *Gating plot —
+rendering & UX hacks*.
+
+*Renumbered against the "IDs are permanent" rule, deliberately: `#00003` was duplicated by two items
+from the initial commit, and `app/src/model/project.jl` cites `#00003` for the per-image-lockfiles
+one — so that item keeps the ID and this one moved.*
 
 **#00002** — **Auto-follow in task manager**
 Selecting the newest running task in `TasksModule.vue` (`/tasks`) when a task starts does not


### PR DESCRIPTION
Follows #378. You confirmed gating plots shouldn't have zoom for now and don't — which left the TODO item saying something different, and with a second problem I hadn't noticed.

## Two problems

**1. `#00003` was a duplicate.** Two entries used it, both from the initial commit: *Per-image lockfiles* (high priority) and *Re-enable interactive pan/zoom* (low). `app/src/model/project.jl:174` cites `#00003` for the lockfiles item, so that one keeps the ID and pan/zoom moves to **`#00087`**.

This knowingly breaks the file's own *"IDs are permanent — never renumber"* rule. The rule exists so a reference stays valid; a duplicate already defeats that, and one of the two had to move. The reasoning is recorded inline so the next reader doesn't undo it. **If you'd rather keep the collision, this is the bit to drop.**

**2. The item's entire rationale described removed machinery** — `cameraIsFixed: true`, replicating regl's `projectionLocal · cameraView · model` transform in the overlays, inverting it for gate hit-testing, and a pointer to a `docs/UI.md` alignment bullet that #378 deletes. None of that exists.

## Rewritten to what's true

- **No pan/zoom is the intended state** and stays that way for now — not a gap someone should close.
- Kept as an item only to record the useful part: **the reason it was hard has gone away.** With the GPU layer removed, the dots and the gate overlay are both 2D canvases mapping data→px through the same `viewExtents`, and every layer already redraws when it changes. So if it's ever wanted it's a wheel/drag handler that edits `viewExtents` — not a matrix-replication job.
- Points at `docs/POPULATION.md` → *Gating plot — rendering & UX hacks* instead of the deleted bullet.

## Notes

- Verified no duplicate IDs remain.
- Based on `main` (pre-#378) and touches only `docs/TODO.md`, so no conflict with that PR either way.
- The "it'd just be a wheel handler now" line is inferred from the layers redrawing on `viewExtents` change — I didn't implement or test it, and the item stays a non-goal regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
