### PR TITLE
docs: give TODO.md an edge, so it stops collecting things nobody will do

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ See also:
 - [`docs/PLOTS.md`](docs/PLOTS.md) — summary-plot design: chart types × data source (one/multi/pooled) × measure type (numeric/categorical), encoding model, the agreed renderer spec
 - [`docs/ANALYSIS.md`](docs/ANALYSIS.md) — the Analysis board (`/analysis`): tabs + comic-plate layout + persistence keys, the registry-driven plot families (summary/interactive/cluster/image), the read-only cluster manager, the gating-strategy plot, and PDF/CSV export (light theme, shared hi-res raster path)
 - [`docs/NOTEBOOKS.md`](docs/NOTEBOOKS.md) — the Notebooks Playground (`/notebooks`): pure-Julia Pluto downstream analysis; the `pluto/` engine env, `CeceliaNb` helpers, per-project registry + snapshot/restore versioning, the deps/full sysimage, and the `/api/notebooks/*` routes
-- [`docs/FUTURE.md`](docs/FUTURE.md) — deliberately deferred optimisations (known-better alternatives set aside): what, why deferred, when to revisit
+- [`docs/FUTURE.md`](docs/FUTURE.md) — **deliberately deferred**: known-better alternatives, product non-goals, and work gated on a trigger that may never fire. What, why deferred, when to revisit. If nobody should act on it, it goes here, not in `docs/TODO.md`
 - [`docs/ROADMAP.md`](docs/ROADMAP.md) — temporary forward goals: phases (behaviour/HMM → clustering → freeze v1.0 → packaging/distribution → self-update) + post-v1 backlog. Consult before starting a new phase.
 - [`docs/MILESTONES.md`](docs/MILESTONES.md) — durable, append-only ledger of what landed and how it was packaged (the counterpart to the throwaway roadmap). Add an entry at each freeze/release.
 - [`docs/SHIPPING.md`](docs/SHIPPING.md) — distribution architecture & rationale: Pixi/constructor + browser stack (Julia serves the built frontend; no Tauri/Electron), packaging/update model, and non-obvious env decisions (cellpose-v3 pin, dropped coastal, GPU/RAPIDS parked, run-via-`pixi run`). The *why*, paired with INSTALL.md's *how*.
@@ -49,7 +49,7 @@ See also:
 | AnnData, cell-level data storage and access | `docs/DATAMODEL.md` |
 | Population manager, gating engine, pop_df, gate↔track | `docs/POPULATION.md` |
 | HTTP/WS routes, request/response shapes, binary responses | `docs/API.md` |
-| Deferring a known-better approach (ecosystem/scale not ready) | `docs/FUTURE.md` |
+| Deferring a known-better approach, or recording a non-goal | `docs/FUTURE.md` |
 | Packaging, distribution, env rationale (Pixi/constructor, why) | `docs/SHIPPING.md` |
 | Branching, commits, PRs, release tagging (dev workflow) | `docs/DEV.md` |
 | Release cadence/policy — when to tag, versioning, rc-vs-release | `docs/RELEASING.md` |
@@ -99,11 +99,16 @@ Completed prompt files are kept in a `previous-prompts/` folder in the **workspa
 
 ## TODO.md
 
-`docs/TODO.md` tracks **open work only**.
+`docs/TODO.md` tracks **open work only** — things someone intends to do.
 - When an item is done, **delete it** — don't keep a "Fixed" log. What changed is recorded in git
   history, merged PRs, and the GitHub Releases notes (auto-generated from PRs at each tag). Keeping a
   hand-maintained fixed list duplicated that and caused recurring merge conflicts.
-- IDs are permanent — never renumber; add new items by incrementing the highest existing ID.
+- **A fact worth recording that nobody should act on is not a TODO item.** This is the tracker with
+  the loosest edges, so orphans drift into it: a deliberate non-goal, or something conditional on a
+  trigger that may never fire, belongs in `docs/FUTURE.md`. There's a routing table at the top of
+  `docs/TODO.md` — check it before adding an entry.
+- IDs are stable so code comments can cite them (`# see TODO #00020`) — increment the highest. They
+  are not sacred: renumber to resolve a collision, and note it in the item.
 
 ## Parked plans (`docs/todo/`)
 

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -1,13 +1,15 @@
-# Future Optimisations
+# Deliberately Deferred
 
-This document tracks known optimisation opportunities that are deliberately deferred — not
-forgotten, not ruled out, just not worth the complexity at the current scale or ecosystem
-maturity. Each entry states what it is, why it was deferred, and the concrete condition under
-which it becomes worth revisiting.
+Things that are **not forgotten and not ruled out — just consciously set aside**: an optimisation not
+worth the complexity at the current scale, a library the ecosystem hasn't caught up with, a product
+non-goal, or work gated on a trigger that may never fire. Each entry states what it is, why it was
+deferred, and the concrete condition under which it becomes worth revisiting.
 
-This is distinct from `docs/TODO.md`: TODO is the working backlog of things we intend to do;
-FUTURE is the set of known-better alternatives we have consciously *set aside*. Do not implement
-anything listed here without explicit instruction — this is a reference document, not a backlog.
+This is distinct from `docs/TODO.md`: TODO is the working backlog of things we intend to do; FUTURE is
+what we have consciously **set aside** — a known-better alternative, a deliberate non-goal, or work
+gated on a trigger that may never fire. If nobody should act on it, it belongs here rather than in the
+backlog. Do not implement anything listed here without explicit instruction — this is a reference
+document, not a backlog.
 
 When generating or updating documentation, include a pointer to this file for any decision that
 involved a known-better alternative being deliberately set aside.
@@ -119,10 +121,54 @@ not hold.
 
 ---
 
+## Interactive pan/zoom on the gating plots
+
+**What:** Let the user pan/zoom the gating scatter, changing the visible data range rather than just
+scaling the whole panel (which is what the canvas-level `useCanvasZoom` CSS transform does today).
+
+**Why deferred:** Deliberate product decision — the gating plots should not have zoom for now
+(Dominik, 2026-07-27), and they don't. Recorded here because the *reason it was hard has gone away*
+and that is worth not re-deriving: the old blocker was the WebGL layer, where the overlays would have
+had to replicate regl's `projectionLocal · cameraView · model` transform and invert it for gate
+hit-testing. That layer was removed. The dots and the gate overlay are now both 2D canvases mapping
+data→px through the same `viewExtents`, and every layer already redraws when it changes.
+
+**Revisit when:** someone actually wants it. The work is then a wheel/drag handler that edits
+`viewExtents` — not a matrix-replication job. Hit-testing needs no change (`GateOverlay` already maps
+through the same extents).
+
+**Reference:** `docs/POPULATION.md` → *Gating plot — rendering & UX hacks*. (Was `docs/TODO.md`
+`#00087`, and before that a duplicate `#00003`; moved here because a deliberate non-goal is not open
+work.)
+
+---
+
+## Observer summary set roll-up mode
+
+**What:** An optional set-scope roll-up for the observer's summary tools (`get_measure_summary`,
+`get_cluster_summary`): per-population median-across-images + range, instead of per-image detail.
+
+**Why deferred:** Set-scoped calls return per-image detail × many measures — large enough that the
+observer offloads them to a subagent (~80k tokens). But the first-pass payload trim (dedupe cluster
+`features` → `featuresByRun`, drop `mean`, round to 4 significant figures) is expected to shrink that
+a lot on its own, so the roll-up may never be needed. It is also **not obviously correct**: behaviour
+and phenotype vary *within* an image per population, so a median-per-image roll-up flattens real
+structure the observer needs in order to spot outliers (Dominik).
+
+**Revisit when:** the payload trim proves insufficient in practice. Then add it as an explicit opt-in
+for the "compare T vs B across the set" question only — per-image stays the default.
+
+**Reference:** `docs/ai-assist/OBSERVER.md`. (Was `docs/TODO.md` `#00084`; moved here because it is
+conditional on something that may never happen.)
+
+---
+
 ## Adding entries
 
-When deferring a known-better approach during implementation, add an entry here with:
-- What the approach is
-- Why it was deferred (complexity, ecosystem maturity, not needed at current scale)
-- The concrete condition under which it becomes worth adopting
-- A reference to the relevant doc or external resource
+Add an entry when you set something aside — a known-better approach, a non-goal, or work waiting on a
+trigger. Each one carries:
+- **What** it is
+- **Why deferred** — complexity, ecosystem maturity, not needed at this scale, or an explicit decision
+- **Revisit when** — the concrete condition that would change the answer (for a non-goal: "someone
+  wants it", plus what the work actually is now, so the next reader doesn't re-derive it)
+- A **reference** to the relevant doc or external resource

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,16 +1,32 @@
 # TODO
 
-IDs are permanent — never renumber. Add new items by incrementing the highest existing ID.
-This file tracks **open work only**. When an item is done, **delete it** — the record of what changed
-lives in git history / merged PRs / the GitHub Releases notes (auto-generated at each tag), not here.
+**Open work only — things someone intends to do.** When an item is done, **delete it**; what changed
+is recorded in git history, merged PRs and the release notes, not here.
 
-Items marked **🔹 needs-input** can't be finished without something only you (D) can provide — a
-test asset, a domain-specific expected value, or a decision an agent shouldn't make alone.
-Grep `needs-input` to list them.
+**Does it belong here?** This is the tracker with the loosest edges, so it collects orphans. Before
+adding, check the others:
+
+| If the item is… | It goes in |
+|---|---|
+| a deliberate **non-goal**, or conditional on something that may never happen | `docs/FUTURE.md` |
+| a **known-better approach set aside** (scale/ecosystem not ready) | `docs/FUTURE.md` |
+| big enough to need **locked decisions + phases** before building | a `docs/todo/<FEATURE>_PLAN.md` |
+| a **phase goal** for the current arc | `docs/ROADMAP.md` |
+| something that **already shipped** | `docs/MILESTONES.md` (or nowhere — git has it) |
+| **how a built subsystem works** | the relevant `docs/<AREA>.md` |
+
+A fact you want recorded but that nobody should act on is **not** a TODO item. That is the drift this
+table exists to stop: something worth knowing turns up, has no obvious home, and lands in the backlog.
+
+**IDs** are stable so code comments can cite them (`# see TODO #00020`); increment the highest. They
+are not sacred — renumber to resolve a collision, and say so in the item.
+
+Items marked **🔹 needs-input** need something only Dominik can provide — a test asset, a
+domain-specific expected value, or a decision an agent shouldn't make alone. Grep `needs-input`.
 
 ---
 
-## High priority
+## Next up
 
 **#00003** — **Per-image lockfiles wired into task commit sites**
 Today's `with_transaction` (in `model/project.jl`) is a deliberately naive *project-scoped*
@@ -38,10 +54,6 @@ Recommended approach (better than the original on two counts):
 
 Deferred: with only per-image tasks today, this collision does not occur in practice — implement
 when a set-level mutating task lands.
-
----
-
-## Medium priority
 
 **#00057** — **Update README for the install / run / update flow (and switch to versioned releases)**
 Once the shipping functions are all in — the installer (constructor/pixi-pack), the `pixi run app`
@@ -84,8 +96,6 @@ select; (b) a resampling step that emits overlapping sub-tracks as first-class r
 per-image frame-interval normalisation so cross-rate comparison needs no manual skip. Settle the
 storage/UX before building. Not urgent.
 
----
-
 **#00020** — **Set-scope / incremental node subprocesses not killed on chain cancel**
 The per-image cancel path (#00016) kills running subprocesses. Set-scope (`_run_set_scope_node!`)
 and incremental (`_run_incremental_node!`) runners call the multi-image `_run_task` directly with
@@ -94,8 +104,6 @@ reach their subprocesses mid-run (the between-node flag still stops not-yet-star
 set-scope subprocess task exists yet (only mock/plot tasks), so impact is currently nil. When the
 first real set-scope subprocess task lands (e.g. HMM training), give the multi-image `_run_task`
 path a `TaskRecord` + `chain_run_id` so it's cancellable like the per-image path. Low priority.
-
----
 
 **#00086** — **Port `createBranching` (skeleton/branch analysis) from the old R version**
 Skeletonise a segmentation into a branch/path network for fibrous non-cell structures (collagen/SHG,
@@ -109,21 +117,7 @@ interact with the `{vn}__branch.h5ad` sidecar (plan Decision 6). 🔹 needs-inpu
 
 ---
 
-## Low priority
-
-**#00087** — **Pan/zoom on gating plots — deliberately absent** (was a duplicate `#00003`)
-Gating plots have no pan/zoom, and shouldn't for now: this is the intended state, not a gap. Kept as
-an item only to record that **the reason it was hard has gone away.** The old blocker was the WebGL
-camera — the overlays would have had to replicate regl's `projectionLocal · cameraView · model`
-transform and invert it for gate hit-testing. That layer no longer exists: the dots and the gate
-overlay are both 2D canvases mapping data→px through the same `viewExtents`, and every layer already
-redraws when it changes. So if pan/zoom is ever wanted it is a wheel/drag handler that edits
-`viewExtents` — not a matrix-replication job. Details: `docs/POPULATION.md` → *Gating plot —
-rendering & UX hacks*.
-
-*Renumbered against the "IDs are permanent" rule, deliberately: `#00003` was duplicated by two items
-from the initial commit, and `app/src/model/project.jl` cites `#00003` for the per-image-lockfiles
-one — so that item keeps the ID and this one moved.*
+## Backlog
 
 **#00002** — **Auto-follow in task manager**
 Selecting the newest running task in `TasksModule.vue` (`/tasks`) when a task starts does not
@@ -140,15 +134,3 @@ The test tasks `testTasks.imageTask`/`testTasks.setTask`/`testTasks.incrementalP
 `_fun_name_map` in `task_registry.jl`, the `Cecelia.jl` includes, and any test references. Not
 important (test-only scaffolding, no user-facing impact) but should be fixed for consistency;
 batch it rather than churn standalone.
-
-**#00084** — **Observer summary set roll-up mode (only if payload trim is insufficient)**
-Set-scoped observer calls (`get_measure_summary`, `get_cluster_summary`) return per-image detail ×
-many measures, big enough the observer offloads them to a subagent (~80k tokens). The first-pass trim
-(dedupe cluster `features` → `featuresByRun`, drop `mean`, round to 4 sig figs, `docs/ai-assist/`
-tools) should shrink this a lot. IF that's still too large, consider an OPTIONAL set roll-up mode:
-per-pop median-across-images + range instead of per-image. **Caveat (Dominik):** behaviour/phenotype
-vary *within* an image per population, so a median-per-image roll-up flattens real structure the
-observer needs to catch outliers — so this is a fallback, not obviously correct. Keep per-image as the
-default; a roll-up would be an explicit opt-in for the "compare T vs B across the set" question only.
-
----

--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -11,7 +11,7 @@ thinking survives a context break and anyone (human or agent) can pick it up col
 |-----|-------|-------|
 | `docs/TODO.md` | the backlog | numbered items, one line → one paragraph each |
 | `docs/todo/*_PLAN.md` | **parked plans** | full design doc: decisions + phases + architecture |
-| `docs/FUTURE.md` | deferred *known-better* alternatives (ecosystem/scale not ready) | what/why-deferred/when-to-revisit |
+| `docs/FUTURE.md` | anything **set aside**: known-better alternatives, non-goals, trigger-gated work | what/why-deferred/when-to-revisit |
 | `docs/ROADMAP.md` / `docs/MILESTONES.md` | forward phase goals / shipped ledger | high-level |
 | `docs/<AREA>.md` | how a **built** subsystem works | permanent reference |
 


### PR DESCRIPTION
You said TODO.md felt like a dumping ground and you weren't sure it was worth keeping. I measured it before touching anything, and the numbers say keep it — but they also show what the real problem is.

## It isn't volume

**11 items in 154 lines**, with IDs running to `#00087` — so ~76 items have been created and deleted. The delete-when-done rule is being followed; this is a well-pruned backlog, not a heap.

And **4 of the 11 are cited from source comments** (`#00003` from `app/src/model/project.jl:174`, plus `#00070`, `#00047`, `#00020`). Those need a stable target, which a repo file provides and a GitHub issue wouldn't — for you solo, and for an agent that reads `docs/` for free but needs an API call to see Issues.

## It's the boundary

Five trackers overlap (TODO, `docs/todo/*_PLAN.md`, ROADMAP, MILESTONES, FUTURE) and TODO has the loosest edges, so anything fitting none of the others lands there. That's why it *reads* as a heap while being the smallest of them.

**Two of the eleven weren't open work at all**, against the file's own first line:

- `#00087` — gating pan/zoom, an explicit **non-goal**
- `#00084` — a roll-up mode conditional on a payload trim that may never prove insufficient

Both moved to `FUTURE.md`, rewritten in its *what / why-deferred / revisit-when* form. Worth naming: **I wrote `#00087` two hours ago.** That's exactly the mechanism — a fact worth recording turns up, has no obvious home, and goes in the backlog.

## Changes

- **TODO.md opens with a routing table** — where an item goes if it's a non-goal, a set-aside alternative, a phased feature, a phase goal, shipped, or a description of how something works. That's the actual fix; the moves are just today's instance.
- **Three priority buckets → two** (`Next up`, `Backlog`). High held exactly one item. The split preserves your existing ordering — High+Medium → Next up, Low → Backlog — it does **not** re-prioritise anything.
- **The ID note now says what IDs are for** (code comments cite them) instead of treating permanence as sacred, since a collision has to be resolvable.
- **`FUTURE.md` retitled "Deliberately Deferred"** and its framing widened — it described itself as "known-better alternatives", which excludes a non-goal, so a future reader would have moved these back out. Its three other descriptions (CLAUDE.md ×2, `docs/todo/README.md`) brought into line so all four agree.
- CLAUDE.md's TODO section points at the routing table.

## Verified

- No duplicate IDs remain
- All four source-cited anchors still resolve
- 9 items, 136 lines

## Limits

- **I didn't re-prioritise.** The bucket mapping is mechanical; what's actually urgent is your call.
- **I judged those two items non-work from how they're written.** If you consider either genuinely on the list, moving it back is one paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
