### PR TITLE
feat(whats-new): release-notes modal + tip-of-the-day on launch

### DIFF
--- a/api/src/update_api.jl
+++ b/api/src/update_api.jl
@@ -5,12 +5,19 @@
 # next restart, when nothing is using the files. Apply is refused in a dev/git checkout so it can
 # never clobber source. See docs/SHIPPING.md.
 #
-# Testing knobs (env): CECELIA_VERSION overrides the reported running version;
-# CECELIA_UPDATE_INCLUDE_PRERELEASE=1 makes the check also consider prereleases.
+# Testing knobs (env): CECELIA_VERSION overrides the reported running version.
+#
+# Prereleases are treated as releases: Cecelia ships RC tags as its actual releases (the install
+# script defaults to the newest RC — see docs/SHIPPING.md), and major/stable releases are rare.
+# So the check considers ALL non-draft releases; there's no separate "stable-only" track.
 
 using Downloads
 
 const _UPDATE_REPO = "schienstockd/cecelia"
+
+# GitHub release notes come as markdown. The `releaseNotes` field is passed through raw; the
+# frontend renders it with `marked` for full GitHub-flavoured markdown parity (task lists,
+# strikethrough, tables). Julia's Markdown stdlib is incomplete for GFM so we don't use it.
 const _APP_ROOT    = abspath(joinpath(@__DIR__, "..", ".."))   # api/src → repo / install root
 
 # Running version: env override (testing) → VERSION file (written into release bundles) → "dev".
@@ -50,10 +57,9 @@ function api_version(::HTTP.Request)
 end
 
 # GET /api/update/check — compare the running version to the newest GitHub release.
-# Stable releases only, unless CECELIA_UPDATE_INCLUDE_PRERELEASE=1.
+# All non-draft releases considered (RCs are shipped as releases — see header comment).
 function api_update_check(::HTTP.Request)
     current = _running_version()
-    include_pre = lowercase(get(ENV, "CECELIA_UPDATE_INCLUDE_PRERELEASE", "")) in ("1", "true", "yes")
     releases = try
         resp = HTTP.get("https://api.github.com/repos/$_UPDATE_REPO/releases?per_page=20";
                         headers = ["Accept" => "application/vnd.github+json", "User-Agent" => "cecelia"],
@@ -63,21 +69,27 @@ function api_update_check(::HTTP.Request)
         return 200, JSON3.write((; current, latest = nothing, updateAvailable = false,
                                    error = "could not reach GitHub: $(sprint(showerror, e))"))
     end
-    best_tag = nothing; best_ver = nothing; best_url = ""
+    best_tag = nothing; best_ver = nothing; best_url = ""; best_body = ""; best_at = ""
     for r in releases
         get(r, :draft, false) === true && continue
-        (get(r, :prerelease, false) === true && !include_pre) && continue
         v = _parse_ver(String(get(r, :tag_name, "")))
         v === nothing && continue
         if best_ver === nothing || v > best_ver
-            best_ver = v; best_tag = String(r.tag_name); best_url = String(get(r, :html_url, ""))
+            best_ver  = v
+            best_tag  = String(r.tag_name)
+            best_url  = String(get(r, :html_url,      ""))
+            best_body = String(get(r, :body,          ""))
+            best_at   = String(get(r, :published_at,  ""))
         end
     end
     cur = _parse_ver(current)
     avail = best_ver !== nothing && cur !== nothing && best_ver > cur
     # scope tells the UI whether the user can apply in-app: only "user" installs self-update; a
     # "system" install shows an admin note, a "dev" checkout hides the control entirely.
+    # releaseNotes/publishedAt are shown in the What's New modal (WHATS_NEW_PLAN.md) — the older
+    # header badge/Settings surfaces ignore them.
     200, JSON3.write((; current, latest = best_tag, updateAvailable = avail, url = best_url,
+                        releaseNotes = best_body, publishedAt = best_at,
                         scope = _install_scope()))
 end
 

--- a/docs/prompts/sketch-engine-prompt.md
+++ b/docs/prompts/sketch-engine-prompt.md
@@ -1,0 +1,173 @@
+# Prompt 3: Pastel Sketch Animation Engine
+
+Opus planning pass first, then Sonnet execution. This is the hardest prompt — it defines a new creative framework that the other two prompts depend on. Read `docs/UI.md` (design tokens, Observable Plot section), `INVENTORY.md`, `docs/PLOTS.md`, and the outputs of Prompt 1 (`WhatNewCard.sketchAnimation`) and Prompt 2 (`StatsResult`) before designing anything.
+
+---
+
+## The vision
+
+A sketch animation system that draws scientific concepts and data-driven explanations in a hand-drawn pastel style — as if someone is sketching while explaining to you. Think: a researcher at a whiteboard, except the whiteboard is clean, soft, and animated. Not a presentation tool. Not a screensaver. A scientific communication medium.
+
+The north star: you have analysed your data, made observations, and now you need to explain "cells in treatment A arrest more than treatment B" to someone in 10 seconds. The sketch engine takes your actual data (`StatsResult`) and a concept definition and produces an animated sketch that shows the claim with its evidence.
+
+The first release is **pineapple** — fresh, crisp, light. The aesthetic should reflect that. Pastels. Clean lines that wobble slightly. Nothing heavy or corporate.
+
+---
+
+## Technology decisions (Opus to confirm or challenge)
+
+**Rough.js** — hand-drawn SVG primitives. Lines wobble. Circles look drawn. Fills are light crosshatch or solid pastel. This is the aesthetic foundation.
+
+**GSAP** — animation timeline sequencing. Elements draw in, pause, continue. The "someone is sketching this" effect comes from GSAP sequencing Rough.js path draws.
+
+**D3** — data binding. When `StatsResult` drives a sketch, D3 maps data to positions. The bars in a sketch bar chart are Rough.js rectangles positioned by D3 scales.
+
+**Vue component wrapper** — `SketchCanvas.vue` wraps all three. Takes a `SketchDefinition` object and plays it. Self-contained, no external dependencies beyond the three libraries.
+
+Opus: challenge this stack if there's a better option. Specifically: is there a more maintained SVG animation library than GSAP for this use case? Is Rough.js still actively maintained? Any Vue 3-native alternative that avoids the GSAP license cost (GSAP Club is paid for some features)?
+
+---
+
+## The `SketchDefinition` format
+
+A sketch is defined as a sequence of `SketchAct`s — each act adds something to the canvas. The definition is data (JSON-serialisable), not code.
+
+```typescript
+interface SketchDefinition {
+  id: string
+  title: string
+  duration: number          // total seconds
+  palette: SketchPalette    // colour scheme
+  acts: SketchAct[]
+}
+
+type SketchAct =
+  | DrawLineAct             // draw a line or arrow
+  | DrawShapeAct            // circle, rect, ellipse (Rough.js)
+  | DrawTextAct             // handwritten-style label
+  | DrawDataBarAct          // a bar driven by a data value
+  | DrawBracketAct          // significance bracket (from StatsResult)
+  | DrawCellAct             // a simplified cell icon (circle + nucleus)
+  | PauseAct                // hold current state
+  | WipeAct                 // clear and start next scene
+
+interface SketchPalette {
+  background: string        // e.g. "#fafaf8" (near-white)
+  stroke: string            // line colour
+  fills: string[]           // pastel fill colours, one per data group
+  accent: string            // highlight colour
+  text: string              // label colour
+}
+```
+
+**The pineapple palette** (first release):
+- Background: `#fafaf8` (warm white)
+- Stroke: `#4a4a4a` (soft charcoal, not black)
+- Fills: `["#a8e6cf", "#ffd3b6", "#ff8b94", "#a8d8ea", "#fddb3a"]` (soft pastels)
+- Accent: `#6c63ff` (soft violet, matches `--cc-accent`)
+- Text: `#4a4a4a`
+
+---
+
+## `SketchCanvas.vue` component
+
+```vue
+<SketchCanvas
+  :definition="mySketch"
+  :autoplay="true"
+  :loop="false"
+  :stats="statsResult"        // optional: drives data-bound acts
+  width="400"
+  height="220"
+/>
+```
+
+- Renders to an inline SVG
+- `autoplay`: starts animation on mount
+- `loop`: replays after finish
+- `stats`: optional `StatsResult` — if present, `DrawDataBarAct` and `DrawBracketAct` use real values
+- Exposes `play()`, `pause()`, `reset()` for manual control
+- Respects `prefers-reduced-motion` — if set, shows final frame only, no animation
+
+---
+
+## What slots into Prompt 1 (WhatNewCard)
+
+`WhatNewCard.sketchAnimation` is a `SketchDefinition`. The card renders `<SketchCanvas>` instead of the grey placeholder box from Prompt 1. No changes to the card API — the slot was designed for this.
+
+---
+
+## What slots into Prompt 2 (StatsResult)
+
+`DrawBracketAct` and `DrawDataBarAct` accept a `StatsResult`. A data-driven sketch showing "WT vs KO cell speed" renders Rough.js bars at the correct relative heights, bracket at the top, significance stars. The bars look drawn, not printed. Real data, sketch aesthetic.
+
+---
+
+## The logo
+
+The Cecelia logo in sketch style. Old logo: two cells emerging from an imaging window, "cecelia" text beside it.
+
+New logo sketch definition:
+- Two cells (circles with smaller inner circles for nuclei), drawn one at a time in pastel
+- A soft rectangular frame (the "imaging window") drawn around them, slightly wobbly
+- "cecelia" text in a clean but slightly informal font (not handwritten, but not corporate either)
+- The pineapple palette
+- Animation: frame draws first, then cells appear inside it, then text
+
+This is a `SketchDefinition` JSON — not a static SVG. It can be animated on the splash screen / setup wizard, or shown statically as `loop=false` `autoplay=false` after the first play.
+
+---
+
+## The sketchbook page
+
+A new route `/sketchbook` — a canvas page (same shell as Analysis board) where sketch animations live as panels. Three initial sketches:
+
+1. **How HMM behaviour works** — cells moving, arrows showing state transitions (Arrested, Directed, Meandering), state bars appearing below
+2. **How gating works** — scatter plot sketch, polygon gate drawing in, cells inside highlighted
+3. **Cell tracking** — a cell path across frames, track drawn frame by frame
+
+Each is a `SketchDefinition` in `lib/sketches.ts`. The sketchbook route shows them in a grid of `SketchCanvas` panels — same grid mechanism as Analysis board, same `FloatingPanel` infrastructure.
+
+---
+
+## Framework rules (Opus must include in the Sonnet prompt)
+
+1. **One sketch engine** — `SketchCanvas.vue` is the only renderer. Never render Rough.js or GSAP outside it.
+2. **Definitions are data** — `SketchDefinition` is JSON-serialisable. No code in definitions. This means sketches can eventually be authored in the UI or generated by Claude.
+3. **Real data when available** — a sketch with `stats` prop shows real values. Never hardcode sample data in a definition that's used with real data.
+4. **Palette is a first-class parameter** — never hardcode colours. Every colour reference goes through `SketchPalette`. The pineapple palette is the default but future releases can have different palettes.
+5. **Respect motion preferences** — always check `prefers-reduced-motion`.
+6. **Add to `INVENTORY.md`** — `SketchCanvas`, `SketchDefinition`, `lib/sketches.ts` must be documented.
+
+---
+
+## Build order
+
+1. Rough.js + GSAP integration prototype — draw one shape, animate it, confirm the stack works
+2. `SketchCanvas.vue` with 4-5 act types (line, shape, text, pause, wipe)
+3. Pineapple palette + logo definition
+4. `DrawDataBarAct` + `DrawBracketAct` connected to `StatsResult` (Prompt 2 integration)
+5. `WhatNewCard.sketchAnimation` slot connected (Prompt 1 integration)
+6. Three initial concept sketches for the sketchbook
+7. Sketchbook page (`/sketchbook` route)
+
+---
+
+## Verify
+
+- Logo renders in sketch style, plays animation, loops if set
+- A tip card in What's New shows a sketch animation instead of grey placeholder
+- A summary plot with stats → sketch shows data bars at correct relative heights + bracket with p-value
+- Sketchbook page shows three concept sketches in panels
+- `prefers-reduced-motion` shows final frame only
+- `SketchDefinition` is valid JSON (serialise/deserialise round-trip)
+- All three prompts' outputs work together: tip card → sketch animation → driven by real stats data
+
+---
+
+## Out of scope
+
+- User-authored sketch definitions (later — UI for building SketchDefinitions)
+- Export to video/GIF (later)
+- Claude-generated sketch definitions (Phase 3 observer — but the JSON format is ready for it)
+- 3D or particle effects (keep it flat and simple)

--- a/docs/prompts/stats-on-plots-prompt.md
+++ b/docs/prompts/stats-on-plots-prompt.md
@@ -1,0 +1,135 @@
+# Prompt 2: Statistical Annotations on Plots
+
+Sonnet execution prompt. Read `INVENTORY.md`, `docs/UI.md`, `docs/PLOTS.md`, `docs/POPULATION.md`, and `CLAUDE.md` before writing any code. Check what already exists before building anything.
+
+---
+
+## What this builds
+
+Statistical test results (t-test, Mann-Whitney U, one-way ANOVA) computed server-side in Julia and displayed as annotations on existing Observable Plot summary charts. Results are also available as structured data — designed to be consumed by the sketch animation engine (Prompt 3) and the What's New card system (Prompt 1).
+
+---
+
+## Step 1 — Julia stats engine
+
+In `Cecelia.jl`, using `HypothesisTests.jl`:
+
+```julia
+# Supported tests
+run_stats(data::Dict{String,Vector{Float64}}; test::Symbol) -> StatsResult
+
+struct StatsResult
+  test::Symbol              # :ttest, :mannwhitney, :anova, :kruskal
+  groups::Vector{String}    # group labels
+  n::Vector{Int}            # n per group
+  means::Vector{Float64}    # mean per group
+  medians::Vector{Float64}  # median per group
+  p_value::Float64
+  statistic::Float64
+  significance::String      # "ns", "*", "**", "***", "****"
+  comparison_pairs::Vector{Tuple{String,String,Float64}}  # for multi-group: pairwise p-values
+  method_note::String       # "Welch's t-test", "Mann-Whitney U", etc.
+end
+```
+
+Test selection logic:
+- 2 groups → Mann-Whitney U (non-parametric default, appropriate for small n microscopy data)
+- 2 groups, user requests parametric → Welch's t-test
+- >2 groups → Kruskal-Wallis (non-parametric default)
+- >2 groups, user requests parametric → one-way ANOVA
+
+Pairwise post-hoc for >2 groups: Dunn's test (non-parametric) or Tukey HSD (parametric), Bonferroni-corrected p-values.
+
+**No linear models for now.** LM/mixed models are a separate phase. Keep scope narrow.
+
+---
+
+## Step 2 — API endpoint
+
+`POST /api/stats/compare`
+```json
+{
+  "projectUid": "...",
+  "imageUids": ["uid1", "uid2"],
+  "measure": "live.cell.speed",
+  "groupBy": "attr:treatment",   // or "pop:cd4+" or "image"
+  "popType": "live",
+  "pops": ["tcells/tracked"],
+  "test": "auto"                 // or "ttest", "mannwhitney", "anova", "kruskal"
+}
+```
+
+Returns `StatsResult` as JSON. Computation is fast (< 1s for typical n) — synchronous, no task queue needed.
+
+---
+
+## Step 3 — Population manager Stats panel
+
+The population manager already has rendering options. Add a "Stats" section (collapsible, after the existing options):
+
+- **Compare groups by**: dropdown — `None`, `Image`, `Attribute: [attr name]`, `Population`
+- **Test**: `Auto (recommended)`, `Mann-Whitney U`, `Welch's t-test`, `Kruskal-Wallis`, `ANOVA`
+- **Show on plot**: toggle — when on, fetches stats and passes result to the active plot
+
+The population manager provides `statsConfig` (the test parameters) to any connected plot via the existing plot context. Check how the population manager currently passes data to plots before designing this — do not create a new data flow.
+
+---
+
+## Step 4 — Observable Plot annotations
+
+When a `StatsResult` is available, overlay significance annotations on the existing bar/box/violin plots in `PlotChart.vue`:
+
+For 2 groups:
+```
+Group A    Group B
+  │           │
+  └─────┬─────┘
+        p = 0.003 **
+```
+
+For >2 groups: bracket pairs for significant comparisons only (suppress `ns` pairs to avoid clutter). Use `significance` string ("*", "**", "***", "****", "ns").
+
+Implementation: annotations are SVG elements overlaid on the Observable Plot SVG. `plots/statsAnnotations.ts` — pure function: `annotate(plotNode: SVGElement, result: StatsResult, opts) → void`. Called in `PlotChart.vue` after `Plot.plot()` renders.
+
+The annotation style:
+- Thin lines, `--cc-text-dim` colour
+- p-value text: `cc-fs-2xs cc-muted`
+- Significance stars: `cc-fs-xs` accent colour
+- No brackets for `ns` pairs (clutter) unless user toggles "show all"
+
+**Weave with Prompt 1 (What's New cards):** `StatsResult` is the `statsAnnotation` field type in `WhatNewCard`. When a tip card shows a plot with stats, the annotation data comes from here.
+
+**Weave with Prompt 3 (sketch engine):** `StatsResult` is the input data for sketch annotations — "cells A have significantly different behaviour" becomes a sketch bracket + stars drawn by Rough.js. The `StatsResult` JSON format is the contract between this prompt and Prompt 3. Do not change it after Prompt 3 is built.
+
+---
+
+## Step 5 — CSV export of stats
+
+Add stats results to the existing plot CSV export:
+
+```csv
+# Stats: Mann-Whitney U, p = 0.003 **
+# Groups: WT (n=8, mean=4.2), KO (n=7, mean=6.1)
+label,value,group,...
+```
+
+Comment lines at the top of the CSV, so it's importable by Prism without modification.
+
+---
+
+## Verify
+
+- Open a summary plot with 2 treatment groups → population manager Stats section appears
+- Enable "Show on plot" → brackets + p-value appear on the plot
+- >2 groups → only significant pairs shown with brackets
+- CSV export includes stats comment lines
+- Stats result logged to lab log as `[Cecelia]` entry when run: "Stats: Mann-Whitney U on live.cell.speed (WT vs KO): p = 0.003 **"
+- `StatsResult` JSON structure matches the `statsAnnotation` field type in `WhatNewCard` (Prompt 1)
+
+---
+
+## Out of scope
+
+- Linear models, mixed effects models — later
+- Multiple comparison methods beyond Bonferroni/Dunn/Tukey — later
+- Automatic test selection based on normality testing — later (assume non-parametric by default)

--- a/docs/prompts/update-modal-prompt.md
+++ b/docs/prompts/update-modal-prompt.md
@@ -1,0 +1,128 @@
+# Prompt 1: Update Notification + What's New System
+
+Sonnet execution prompt. Read `INVENTORY.md`, `docs/UI.md` (UX primitive catalog), and `CLAUDE.md` before writing any code. This is narrow and well-defined — use existing components, do not build new ones except where explicitly specified.
+
+---
+
+## What this builds
+
+A proactive update notification system and a "What's New / Tips" card system. Two things that share the same card format — updates are just cards marked `badge: "NEW"`. The card format is designed from the start to accept a `SketchAnimation` slot (the animation engine from Prompt 3 will slot in here — leave a clearly marked placeholder).
+
+---
+
+## Step 1 — Version check (Julia API)
+
+Add `GET /api/app/version/check` endpoint:
+- On startup and every 4 hours, Julia fetches `https://api.github.com/repos/schienstockd/cecelia/releases/latest`
+- Extracts: `tag_name`, `body` (release notes markdown), `published_at`, `html_url`
+- Compares to current running version (already in config)
+- Stores result in memory: `{ hasUpdate, latestVersion, releaseNotes, releaseUrl, checkedAt }`
+- Returns this state on `GET /api/app/version/check`
+- Do NOT call GitHub on every request — return cached state, refresh only when cache is stale (>4h)
+
+---
+
+## Step 2 — Sidebar badge
+
+When `hasUpdate` is true, the Settings sidebar entry shows a persistent accent badge (small dot, `--cc-accent` colour). This is NOT a toast — it persists until the user opens the What's New modal or dismisses. Use the existing sidebar badge mechanism if one exists; check `INVENTORY.md` first.
+
+The badge clears when the user:
+- Opens the What's New modal and sees the update card
+- Clicks "Update now"
+- Clicks "Dismiss"
+
+Dismissed state persisted in `localStorage` keyed by `cc.dismissed-update:{version}` so it doesn't re-appear for the same version after dismissal.
+
+---
+
+## Step 3 — What's New modal
+
+Built on `BaseModal` (mandatory — do not use PrimeVue Dialog or a hand-rolled overlay).
+
+Opened from:
+- Clicking the Settings sidebar badge
+- A "What's New" button in Settings
+
+Content: a scrollable list of `WhatNewCard` components (see Step 4). First card is the update card if `hasUpdate`, followed by tip cards.
+
+Footer:
+- "File a bug" → opens `https://github.com/schienstockd/cecelia/issues/new` in a new tab
+- "Close" button
+- If update available: "Update now" button → calls existing update mechanism
+
+---
+
+## Step 4 — Card format (`WhatNewCard.vue`)
+
+Each card covers one feature, tip, or concept. Same component for update announcements and tips.
+
+```typescript
+interface WhatNewCard {
+  id: string                    // stable id for dismissal/feedback tracking
+  badge?: "NEW" | "TIP" | "FIX" // shown as a small chip on the card
+  title: string                 // short, < 8 words
+  description: string           // one paragraph, plain language
+  steps?: string[]              // "Try it:" numbered steps
+  feedbackEnabled?: boolean     // show thumbs up/down
+  issueUrl?: string             // "Report a problem" → opens GitHub issue
+  sketchAnimation?: object      // PLACEHOLDER — sketch engine (Prompt 3) slots here
+                                // for now: if present, render a grey placeholder box
+                                // with text "Animation coming soon"
+  releaseVersion?: string       // which release this was introduced in
+  releaseUrl?: string           // link to GitHub release
+}
+```
+
+**Card layout:**
+```
+┌─────────────────────────────────────┐
+│ [NEW]  Title                        │
+│                                     │
+│ [sketch placeholder or animation]   │
+│ 170px tall, rounded, --cc-surface-2 │
+│                                     │
+│ Description paragraph               │
+│                                     │
+│ Try it:                             │
+│ 1. Step one                         │
+│ 2. Step two                         │
+│                                     │
+│ 👍  👎    [Report a problem ↗]      │
+└─────────────────────────────────────┘
+```
+
+Thumbs feedback: `POST /api/feedback` `{ cardId, thumbs: "up"|"down", version }` — Julia logs to the lab log as a `[Cecelia]` entry. No external service. The feedback endpoint is a stub for now (logs and returns ok).
+
+---
+
+## Step 5 — Tip of the day
+
+A separate small non-modal callout in the app (not the What's New modal). Shows one tip card per day. Rotates through a static array of `WhatNewCard` objects defined in `lib/tips.ts`. New tips get `badge: "NEW"`. Shown in a `FloatingPanel` or a pinned strip — check existing surfaces in `INVENTORY.md` before choosing placement.
+
+The tip array starts with 3-5 cards covering:
+- How HMM behaviour states work
+- How to assign cluster labels to populations
+- How to gate on cells and cross-reference in Napari
+- How to use the chain whiteboard
+
+Each tip card has `steps` and a `sketchAnimation` placeholder (grey box for now).
+
+Dismissed per-tip in `localStorage` (`cc.tip-seen:{id}`). "Next tip" button cycles manually.
+
+---
+
+## Step 6 — Weave with stats (Prompt 2)
+
+Stats results (t-test p-values, ANOVA) will eventually appear as data in tip/sketch cards. For now: leave a `statsAnnotation?: object` field in `WhatNewCard` (unused, just typed). This is the hook Prompt 3's sketch engine will read to overlay stats on a sketch.
+
+---
+
+## Verify
+
+- Start app with a stale version → sidebar Settings badge appears
+- Click badge → What's New modal opens, update card is first
+- Dismiss → badge clears, doesn't reappear for this version on restart
+- "File a bug" → GitHub issues opens in new tab
+- Tip of the day rotates, dismisses per-tip, "NEW" badge on recent tips
+- Thumbs feedback → lab log entry appears
+- No new notification mechanism created (check: still exactly four surfaces — toast, badge, lab log, traffic light)

--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -54,3 +54,16 @@ If it fits in a paragraph and needs no design, it's a `docs/TODO.md` item, not a
   `pyproject.toml` + extras, editable pixi install) so external consumers (`coastal`) can
   `import cecelia.utils.*` without a `sys.path` hack. Touches `app/src/py_runner.jl` (1 line),
   19 Python imports, `pixi.toml`.
+- `WHATS_NEW_PLAN.md` — surface release notes + tips inside the app; reuses the existing
+  `/api/update/check` plumbing (only the release-notes `body` field is new). No new notification
+  surface, no in-app feedback capture (GitHub issue link instead). Supersedes
+  `docs/prompts/update-modal-prompt.md`.
+- `STATS_ANNOTATIONS_PLAN.md` — server-side hypothesis tests (Mann-Whitney / Kruskal-Wallis
+  defaults, t/ANOVA opt-in) rendered as marks inside existing Observable Plot summary charts;
+  extends `PlotDataResponse` with `comparisons?` — no new route. Sets the `StatsResult` contract
+  reused by `WHATS_NEW_PLAN.md` and `SKETCH_ENGINE_PLAN.md`. Supersedes
+  `docs/prompts/stats-on-plots-prompt.md`.
+- `SKETCH_ENGINE_PLAN.md` — the **feijoa** play repo
+  (`github.com/schienstockd/feijoa`, `~/cc-workspace/feijoa`) wired into cecelia's
+  `/sketchbook` route via a Vite alias. Rough.js + animejs; sketches are JSON. Ports the R
+  Cecelia logo as the first seed. Supersedes `docs/prompts/sketch-engine-prompt.md`.

--- a/docs/todo/SKETCH_ENGINE_PLAN.md
+++ b/docs/todo/SKETCH_ENGINE_PLAN.md
@@ -1,0 +1,81 @@
+# Sketchbook (feijoa) — authoring tool for cecelia explainers
+
+Status: seeded, blue-sky · repo `github.com/schienstockd/feijoa` · no user-facing page in cecelia **yet**
+
+## What this is today
+
+A sibling play repo where sketches are authored for cecelia's tip-of-the-day and update-notes
+modals. Whether the engine holds together at all is still an open question — this is exploration,
+not a commitment.
+
+Sketches surface in cecelia today only via:
+- Tip-of-the-day card on launch (see `WHATS_NEW_PLAN.md`) — opt-out.
+- Release-notes cards in the What's New modal.
+
+## What it could become (blue sky, later)
+
+If the engine matures — the aesthetic works, the format holds up, sketches feel like something
+people actually understand — the door opens to a user-facing sketchbook: users author schematics
+for their own analyses, or cecelia auto-generates sketch-style summaries from real data
+(`StatsResult` → sketch, populations → sketch). That's not on the table now; the point of the
+current phase is to find out whether it's worth taking seriously.
+
+## Layout
+
+- **`~/cc-workspace/feijoa/`** — the play/authoring repo. Its own Vite site
+  (`npm run dev` → `:5174`) where sketches are previewed while being written.
+- **`cecelia-pineapple/frontend/`** — imports `SketchCanvas` + `sketchList` from feijoa via a
+  Vite alias. Cards in the What's New modal instantiate `<SketchCanvas>` when their
+  `sketchAnimation?` field is populated.
+
+## Wiring — how cecelia sees feijoa
+
+1. `frontend/vite.config.ts` → `resolve.alias.feijoa` = `../../feijoa/src/lib/index.ts` +
+   `resolve.dedupe = ['vue']`.
+2. `frontend/tsconfig.app.json` → `paths.feijoa` + `include` extended so `vue-tsc` sees feijoa's
+   sources.
+3. Cards that carry a sketch do `import { SketchCanvas } from 'feijoa'`; nothing else in cecelia
+   references feijoa.
+4. Vite bundles feijoa's `.ts`/`.vue` files during cecelia's dev/build.
+5. Feijoa's runtime deps (roughjs, animejs) resolve via feijoa's own `node_modules/` — install
+   once in feijoa, not in cecelia.
+6. `vue` is a **peerDependency** in feijoa; the deduped one from cecelia is used at runtime.
+
+Edit a sketch in feijoa → cecelia's Vite HMRs the change (as long as feijoa is on disk).
+
+## Setup on a fresh machine (one-time)
+
+```bash
+git clone https://github.com/schienstockd/feijoa.git ~/cc-workspace/feijoa
+cd ~/cc-workspace/feijoa && npm install
+```
+
+If feijoa isn't present, cecelia's build fails with an obvious `cannot resolve 'feijoa'`. That's
+deliberate — better loud than silently invisible.
+
+## Sketch format
+
+```ts
+interface SketchDefinition { id, title, width, height, durationSec, acts: SketchAct[] }
+type SketchAct =
+  | { type: 'line' | 'arrow', from, to, colour?, delayMs?, drawMs? }
+  | { type: 'rect' | 'circle' | 'ellipse' | 'path', ..., fill?, stroke?, ... }
+  | { type: 'text', at, value, size?, weight? }
+  | { type: 'cell', at, r, colour? }
+  | { type: 'pause', ms }
+  | { type: 'wipe' }
+```
+
+JSON-serialisable. Sketches live in `~/cc-workspace/feijoa/src/sketches/*.ts`.
+
+## Seeded sketches
+
+- `logo` — R Cecelia logo ported (smoke test, splash/setup wizard target).
+- `hmm`, `gating`, `tracking` — first-cut concept sketches for tip cards to reference.
+
+## References
+
+- `frontend/vite.config.ts` — alias.
+- `frontend/tsconfig.app.json` — paths + include.
+- `WHATS_NEW_PLAN.md` — the consumer (tip-of-the-day + release notes).
+- `old-R-shiny-version/im/cciaLogo.png` — logo source of truth.

--- a/docs/todo/STATS_ANNOTATIONS_PLAN.md
+++ b/docs/todo/STATS_ANNOTATIONS_PLAN.md
@@ -1,0 +1,132 @@
+# Stats annotations on summary plots
+
+Status: planning · no branch yet · supersedes `docs/prompts/stats-on-plots-prompt.md`
+
+## Goal
+
+Compute pairwise / omnibus hypothesis tests server-side and render them as **marks inside the
+existing Observable Plot summary charts** — so the annotation rides the ONE registry-driven plot
+pipeline (`docs/PLOTS.md`), the ONE CSV export, and the ONE board-SVG export. Result is structured
+data reusable by the What's New card format ([`WHATS_NEW_PLAN.md`](WHATS_NEW_PLAN.md)) and the
+sketch engine ([`SKETCH_ENGINE_PLAN.md`](SKETCH_ENGINE_PLAN.md)).
+
+## Corrections to the Sonnet prompt
+
+- **Not the Population Manager.** `SummaryCanvas` does not consume the pop manager; it uses
+  `SeriesPicker` + `useSummaryData` (`SummaryCanvas.vue:3-5`, `useSummaryData.ts:18-60`). Stats UI
+  lives on the summary canvas.
+- **Not a new `/api/stats/compare` route.** `POST /api/plot_data` is the ONE aggregator
+  (`docs/PLOTS.md:3-17`); extend `PlotDataResponse` with `comparisons?`.
+- **Not a post-render SVG overlay.** `plots/overlays.ts` is HTML-only (legend/title). Marks belong
+  inside the Plot spec so they export as vector automatically via `PlotChart.toImageURL('svg')`.
+- **Not a bespoke CSV serialiser.** `frontend/src/plots/plot.ts:829` `plotDataToCsv` is the ONE
+  serialiser — extend, don't fork.
+- **Not `write_qc`.** Stats are cross-series and ephemeral, with no `value_name` — the QC rail is
+  for per-image sidecars. Add an explicit exemption comment.
+
+## Genuinely new (scope)
+
+1. `HypothesisTests.jl` added to `app/Project.toml` — **triple-instantiate** `app/`, `api/`,
+   `pluto/` (per CLAUDE.md → *Adding a Julia dependency to `app/`*).
+2. `app/src/plotting/stats.jl` — pure Julia stats module with `StatsResult`.
+3. `PlotDataResponse.comparisons?: Comparison[]` — optional field on the existing response.
+4. Marks builder in `frontend/src/plots/plot.ts` — brackets + p-value/star text as native Plot
+   marks (`Plot.ruleY`, `Plot.text`).
+5. `SummaryPanel` gets a small "Compare groups" section (test dropdown + on/off toggle) —
+   state via `useViewState`-persisted `statsConfig` in the panel's shared bag.
+6. `plotDataToCsv` case: `# Stats: …` comment block preceding the tidy table (Prism-compatible).
+
+## Decisions (2026-07-27)
+
+1. **Tests.**
+   - 2 groups → **Mann-Whitney U** default; **Welch's t-test** opt-in.
+   - >2 groups → **Kruskal-Wallis** default; **one-way ANOVA** opt-in.
+   - Pairwise post-hoc with **Bonferroni** p-adjustment (uncontroversial, no extra dep).
+     Dunn / Tukey deferred until requested.
+   - Significance display: `ns / * / ** / *** / ****` from the adjusted p.
+2. **Where compute lives**: `app/src/plotting/stats.jl` — small pure module,
+   `run_stats(groups::Dict{String,Vector{Float64}}; test::Symbol=:auto) → StatsResult`. Imported
+   from `plot_data.jl` only when the request opts in.
+3. **Contract — `StatsResult` JSON** (locked; consumed by Plans 1 & 3):
+   ```jsonc
+   {
+     "test": "mannwhitney",
+     "groups": ["WT", "KO"],
+     "n": [8, 7],
+     "means": [4.2, 6.1],
+     "medians": [4.0, 6.3],
+     "statistic": 12.0,
+     "p_value": 0.003,
+     "significance": "**",
+     "method_note": "Mann-Whitney U (two-sided)",
+     "comparison_pairs": [["WT", "KO", 0.003, "**"]]   // (a, b, p_adj, sig)
+   }
+   ```
+4. **Extend `POST /api/plot_data`, don't add a route.** Request adds an optional
+   `stats: { enabled: bool, test: "auto"|"ttest"|"mannwhitney"|"anova"|"kruskal", showNs?: bool }`;
+   response adds an optional `comparisons: StatsResult`.
+5. **Rendering = Plot marks, not SVG overlay.** Extend `buildPlotOptions` in `plot.ts` to append
+   bracket rules + text marks when `r.comparisons` is present. The existing PlotChart SVG export
+   picks them up automatically (no changes to `PlotChart.vue`).
+6. **UI**: a "Compare groups" collapsible in `SummaryPanel.vue` — test dropdown + on/off toggle +
+   "show `ns`" toggle. State via `useViewState` in the panel's bag; NOT in the pop manager.
+7. **CSV**: extend `plotDataToCsv` with a leading `# Stats: …` block when `comparisons` present.
+   Cover in `plotCsv.test.ts`.
+8. **Lab log** on compute: one `[Cecelia]` line via `lab_log.jl` (mirrors the cohort-check
+   pattern in `CohortCheckButton.vue`). Not per-image QC.
+9. **Clutter control**: hide non-significant brackets by default; the `showNs` toggle reveals them.
+10. **QC exemption comment** in `stats.jl`: "no `write_qc` — cross-series, ephemeral, no value_name".
+
+## Phases (independently shippable)
+
+- **S0 — Prism-parity audit (do this first).** Biologists know Prism. Before writing test code,
+  screenshot / list what Prism does for the four plot kinds we render (bar + SEM, box, violin,
+  scatter): bracket placement, star vs `p =` text, offset from top of highest bar/whisker, "ns"
+  behaviour, colour, multi-comparison layout (stacked brackets vs sloped). Pick the closest
+  Prism-alike as our default for each. Deliverable: a short list of decisions ("brackets black,
+  1px, `p = 0.003 **` centred, positioned at 1.05× tallest whisker per pair") that S3's marks
+  builder implements verbatim. Also cross-check: does the current bar/box/violin/scatter cover
+  everything Prism does that biologists reach for, or is there a chart type we don't render yet
+  that we'd need? If yes, note it — but stats annotation still lands only on what we render.
+- **S1** — Julia: add `HypothesisTests` to `app/Project.toml`; triple-instantiate (`app/`, `api/`,
+  `pluto/`) and commit all three manifests. `app/src/plotting/stats.jl` + `run_stats` +
+  golden-value tests in `app/test/runtests.jl` (Mann-Whitney vs a known reference, Kruskal-Wallis,
+  Bonferroni).
+- **S2** — Wire into `plot_data.jl`: when `stats.enabled`, group the aggregated data by the same
+  key as the chart's colour/facet series and compute pairwise. Extend `PlotDataResponse`.
+- **S3** — Frontend: extend `PlotDataResponse` TS type; marks builder in `plot.ts` (brackets +
+  significance text); unit test the mark placement with a stub dataset.
+- **S4** — `SummaryPanel` "Compare groups" section + `useViewState`-persisted `statsConfig`.
+- **S5** — `plotDataToCsv` case + `plotCsv.test.ts`.
+- **S6** — Lab-log entry on compute (single `[Cecelia]` line).
+
+## Verify
+
+- 2 treatment groups → bracket + `p = 0.00X **` renders on the plot.
+- 3+ groups → only significant pairs shown; toggle reveals `ns`.
+- CSV starts with `# Stats: Mann-Whitney U, p = …` block; remainder unchanged; opens in Prism.
+- Vector SVG export contains the annotations (via existing `PlotChart` path — no new export code).
+- `StatsResult` JSON is the exact shape referenced by `WhatNewCard.statsAnnotation` (Plan 1) and
+  `DrawBracketAct` input (Plan 3).
+- All three manifests resolve after adding `HypothesisTests`.
+
+## Out of scope
+
+- Linear models / mixed effects — separate future phase.
+- Normality-driven auto test selection — assume non-parametric default.
+- Dunn / Tukey post-hoc — Bonferroni suffices for v1.
+- Persistence — cross-series ephemeral; recompute on request.
+
+## References
+
+- `INVENTORY.md:19,71-72,114` — plot flow, aggregator, sole serialiser.
+- `docs/PLOTS.md:3-17` — the ONE plot hosting path.
+- `docs/MODULES.md` → *QC — REQUIRED for every new task* — exemption noted here.
+- `app/src/plotting/plot_data.jl` — server-side aggregator.
+- `api/src/plotting_api.jl:164-299` — `POST /api/plot_data` handler.
+- `frontend/src/plots/plot.ts:829` — `plotDataToCsv` (extend, don't fork).
+- `frontend/src/components/plots/PlotChart.vue` — Plot spec renderer + SVG export.
+- `frontend/src/composables/useSummaryData.ts:18-60` — shared canvas bag.
+- `frontend/src/composables/useViewState.ts` — the persistence primitive.
+- `CLAUDE.md` → *Adding a Julia dependency to `app/`* — triple-manifest rule.
+- `WHATS_NEW_PLAN.md`, `SKETCH_ENGINE_PLAN.md` — downstream consumers of `StatsResult`.

--- a/docs/todo/WHATS_NEW_PLAN.md
+++ b/docs/todo/WHATS_NEW_PLAN.md
@@ -1,0 +1,152 @@
+# What's New — release notes modal + tips
+
+Status: planning · no branch yet · supersedes `docs/prompts/update-modal-prompt.md`
+
+## Goal
+
+Turn the existing "update available" plumbing into an in-app **What's New** modal that shows the
+current release's notes, and add a small **tips** surface for feature onboarding. Reuse the four
+notification surfaces (`docs/UI.md` → *Toast notifications*); no new surface.
+
+## What already exists (do not rebuild)
+
+The Sonnet prompt asked for a version-check endpoint, a check timer, a dismissal store and a
+sidebar badge primitive. All four are already built:
+
+- `api/src/update_api.jl:54` — `api_update_check` calls the GitHub releases API on demand and
+  returns `{ updateAvailable, current, latest, url, scope }`.
+- `api/src/update_api.jl:86` — `api_update_apply` stages the download and writes `.pending-update`.
+- `frontend/src/stores/appControl.ts:43-83` — the ONE store; `checkUpdate`, `applyUpdate`,
+  `dismissUpdate`, plus the reactive `updateAvailable` / `updateDismissed` / `updateLatest` state.
+- `frontend/src/components/AppHeader.vue:42` — the header badge (dismissable pill), routes to
+  Settings on click.
+- `frontend/src/App.vue:46` — the boot-time fire-and-forget check.
+- `INVENTORY.md:19` — flags "App update" as a **one canonical path — do not add a second**.
+
+The gap is not the plumbing; it is the *content*. `api_update_check` reads the release `tag_name`
+and `html_url` and **discards the `body` markdown** (`update_api.jl:79`). And there is no in-app
+place to show release notes or tips.
+
+## What's new here (scope)
+
+1. One-field extension: `releaseNotes: string` on the update-check response (source = the release
+   body).
+2. `WhatsNewDialog.vue` (`BaseModal`) — patterned on `ClaudeOverviewDialog.vue`, opened from
+   Settings and from the header badge.
+3. `WhatNewCard.vue` — one card type for both updates and tips.
+4. Static content in `frontend/src/lib/whatsNew.ts` (update card is generated from the store) and
+   `frontend/src/lib/tips.ts` (a small seed catalogue), both ratcheted by the existing
+   `frontend/src/utils/uiCopy.ts` copy budget.
+5. A "Report a problem ↗" link on each card → the GitHub issues page (new tab). No thumbs, no
+   in-app feedback endpoint (see Decision 4 for why).
+6. Card schema leaves slots for the other two plans (`sketchAnimation?`, `statsAnnotation?`); each
+   renders a grey placeholder box until the owning plan lands.
+
+## Decisions (2026-07-27, draft)
+
+1. **Reuse `/api/update/check`; extend response** with `releaseNotes: string` (source = the
+   currently-discarded GitHub `body`). No new endpoint, no new poll timer.
+2. **Modal on `BaseModal.vue`, patterned after `ClaudeOverviewDialog.vue`.** No new store — the
+   dialog is `v-if`'d locally in `SettingsModule.vue` and in `AppHeader.vue`.
+3. **No new badge primitive.** Reuse the existing header update badge for "update available".
+   Tips do **not** get a persistent badge — they are opt-in from the modal and would otherwise be a
+   fifth surface. Existing per-item badges (`.soon-badge`, `.lock-badge`, `.lablog-badge`) stay
+   ad-hoc; a generic `Badge.vue` is deferred until three surfaces need it.
+4. **No thumbs / in-app feedback capture.** Sonnet suggested thumbs → `POST /api/lablog/append`, but
+   the lab log is a scientific record of work done on the *project* (imports, segmentations,
+   analyses), not a bucket for app-level UX opinions — mixing them muddies the record. Alternatives
+   considered:
+   - Bespoke `/api/feedback` → local `<config_dir>/feedback.log`: works but Cecelia is
+     single-user/single-install; there's no aggregator to send it to, so the file is
+     write-only-forever. Not worth the surface.
+   - Browser `localStorage`-only counter: useful to nobody but the local user.
+   - GitHub issues: already the canonical channel for real problems; adding a link is free.
+
+   **Chosen**: no thumbs. Each card has a "Report a problem ↗" link to
+   `https://github.com/schienstockd/cecelia/issues/new` (opens in a new tab). The card format keeps
+   `feedbackEnabled?: boolean` typed-but-unused so a future opt-in aggregator (if we ever ship one)
+   can flip it on without a schema change.
+5. **Card format is JSON-serialisable data**:
+   ```ts
+   interface WhatNewCard {
+     id: string
+     kind: 'update' | 'tip' | 'fix'
+     title: string           // ≤ 8 words
+     description: string     // ≤ 2 short sentences (uiCopy budget)
+     steps?: string[]        // "Try it:" list
+     feedbackEnabled?: boolean
+     issueUrl?: string
+     sketchAnimation?: object  // Plan 3 (SKETCH_ENGINE_PLAN); placeholder box until then
+     statsAnnotation?: object  // Plan 2 (STATS_ANNOTATIONS_PLAN); unused until then
+     releaseVersion?: string
+     releaseUrl?: string
+   }
+   ```
+   The two `?` slots are the cross-plan contract; do not change without touching Plans 2 & 3.
+6. **Copy budget ratcheted.** All strings in `lib/whatsNew.ts` / `lib/tips.ts` go through the
+   `uiCopy.ts` test surface. Same rule as tooltips: one line, imperative for steps.
+7. **Dismissal**: the update card reuses `appControl.dismissUpdate()`. Per-tip dismissal extends the
+   existing `unseen*` model in `stores/settings.ts` (same shape as `labLogUnseen*`); do not open a
+   new persistence pattern.
+8. **Tip of the day pops on app launch, opt-out.** Same modal shape as What's New; opened once
+   per day (last-shown date in `stores/settings.ts`). A "Don't show tips on launch" checkbox on
+   the card disables it. What's New (release-notes) uses the same modal but opens on-demand from
+   Settings / the header badge. One modal component, two triggers.
+9. **Users don't author sketches.** The animated sketches on tip cards come from the feijoa
+   authoring repo (`SKETCH_ENGINE_PLAN.md`); a card just references a `SketchDefinition` by id.
+   No editing UI in cecelia.
+10. **Tips catalogue seeds** (three, minimum copy):
+    - HMM behaviour states — what they are and how to assign them.
+    - Cluster labels → populations — the two-step and where it lives.
+    - Gate a population and cross-reference in napari — the two-clicks path.
+
+## Phases (independently shippable)
+
+- **W1** — Extend `api_update_check` to include `releaseNotes: body`. Extend `appControl.ts` and
+  the TS response type. Header badge tooltip shows the notes as a hint on hover (optional).
+- **W2** — `WhatNewCard.vue` + `WhatsNewDialog.vue`; `lib/whatsNew.ts` renders the update card
+  from the store. Open from Settings "Software updates" (new "What's new →" link).
+- **W3** — Wire the header badge click to open the modal alongside the existing Settings route
+  (a small dropdown or a click-shift alternative — pick one after seeing it).
+- **W4** — Tip-of-the-day on launch + `lib/tips.ts` with the three seeds. Per-tip dismissal +
+  "don't show on launch" toggle in `stores/settings.ts`.
+- **W5** — "Report a problem ↗" link per card (opens GitHub issues new tab). Card slots for
+  Plans 2/3 render a labelled grey placeholder.
+
+## Verify
+
+- App with a stale local version → header update badge → click → What's New modal → update card
+  first, with release notes rendered from `body`.
+- Dismiss → badge clears; doesn't reappear (reuses `updateDismissed`).
+- Tips tab rotates on Next; per-tip dismissal survives reload.
+- "Report a problem ↗" opens the GitHub issues new-issue page in a new tab.
+- `uiCopy.ts` ratchet passes.
+- The four surfaces (toast / badge / lab-log entry / traffic light) remain exactly four
+  (`docs/UI.md:269-273`); no fifth introduced.
+
+## Out of scope
+
+- User-submittable feature requests inside the modal — link to GitHub issues, done.
+- In-app changelog page — link to the GitHub release, done.
+- Auto-install without consent — already user-gated in `applyUpdate`.
+- Generic `Badge.vue` primitive — deferred until three surfaces need it.
+
+## Cross-plan slots
+
+- `WhatNewCard.statsAnnotation` → `STATS_ANNOTATIONS_PLAN.md` (`StatsResult`). Typed but unused
+  until that plan lands.
+- `WhatNewCard.sketchAnimation` → optional embed hook for the sketchbook play repo
+  (`SKETCH_ENGINE_PLAN.md`). Renders a grey placeholder ("Animation coming soon") or is dropped
+  from the schema entirely if the sketchbook never graduates in-repo. Costs nothing to keep typed.
+
+## References
+
+- `INVENTORY.md:19` — App update canonical flow.
+- `api/src/update_api.jl:54-86` — GitHub release fetch + apply.
+- `frontend/src/stores/appControl.ts:43-83` — the ONE app-lifecycle store.
+- `frontend/src/components/AppHeader.vue:42` — the update badge.
+- `frontend/src/components/ClaudeOverviewDialog.vue` — modal pattern to mirror.
+- `frontend/src/components/BaseModal.vue` — modal primitive.
+- `docs/UI.md:260-273` — Toast + the four surfaces.
+- `frontend/src/utils/uiCopy.ts` — copy budget ratchet.
+- `frontend/src/stores/settings.ts:85-87` — `labLogUnseen*` pattern to mirror for tips.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@primeuix/themes": "^2.0.3",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/core": "^1.48.2",
+        "marked": "^12.0.0",
         "pdf-lib": "^1.17.1",
         "pinia": "^3.0.4",
         "primeicons": "^7.0.0",
@@ -2217,6 +2218,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mitt": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@primeuix/themes": "^2.0.3",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/core": "^1.48.2",
+    "marked": "^12.0.0",
     "pdf-lib": "^1.17.1",
     "pinia": "^3.0.4",
     "primeicons": "^7.0.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,6 +17,9 @@ import LabLogPanel from './components/LabLogPanel.vue'
 import Toast from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import { useTaskStore } from './stores/tasks'
+import WhatsNewDialog from './components/WhatsNewDialog.vue'
+import { isWhatsNewOpen, closeWhatsNew, openWhatsNew } from './lib/whatsNew'
+import { todayKey } from './lib/tips'
 
 const ws = useWsStore()
 const settings = useSettingsStore()
@@ -44,6 +47,15 @@ useLabCaptureStore().installAutoCapture()
 onMounted(async () => {
   ws.connect()
   appCtl.checkUpdate()   // surfaces the header update badge app-wide (fire-and-forget)
+
+  // Tip of the day (WHATS_NEW_PLAN.md W4). Opens the What's New modal once per day with today's
+  // tip on top. The `Don't show tips on launch` checkbox on any tip card sets tipsOnLaunch=false
+  // permanently. We stamp the date BEFORE opening so a crash mid-open doesn't re-trigger.
+  const today = todayKey()
+  if (settings.tipsOnLaunch && settings.tipsLastShown !== today) {
+    settings.tipsLastShown = today
+    openWhatsNew({ withTip: true })
+  }
   // Reconcile the discrete-GPU flag with the backend once at startup. The flag is a launch-time
   // decision (the bridge starts lazily on first open), so it must be right before then.
   //  - explicit user choice saved → push it, so the backend uses it even after a backend restart
@@ -107,6 +119,9 @@ const bare = computed(() => route.meta.bare === true)
     </FloatingPanel>
     <ErrorConsole />
     <Toast position="bottom-right" />
+    <!-- What's New / release-notes modal — one mount, opened from the header badge and Settings.
+         State lives in lib/whatsNew.ts (isWhatsNewOpen); callers just call openWhatsNew(). -->
+    <WhatsNewDialog v-if="isWhatsNewOpen" @close="closeWhatsNew" />
   </div>
 </template>
 

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
 import { useWsStore } from '../stores/ws'
 import { useSettingsStore } from '../stores/settings'
 import { useAppControlStore } from '../stores/appControl'
+import { openWhatsNew } from '../lib/whatsNew'
 
 const ws = useWsStore()
 const settings = useSettingsStore()
 const appCtl = useAppControlStore()
-const router = useRouter()
 
-// Update-available badge: surfaces the shared appControl update check app-wide (Settings owns the
-// actual control). Click → Settings → Software updates. The × dismisses for this session only
-// ("remind me later"). See docs/todo/ONBOARDING_PLAN.md (D5).
-function openUpdate() { router.push('/settings') }
+// Update-available badge → opens the What's New modal (release notes + inline Install button).
+// The modal itself is mounted ONCE in App.vue; we just flip the shared open flag. Settings still
+// hosts the Software updates panel as the durable home for the control. The × dismisses the
+// badge for this session only ("remind me later"). See docs/todo/WHATS_NEW_PLAN.md.
+function openUpdate() { openWhatsNew() }
 
 const statusLabel: Record<string, string> = {
   connected:    'Connected',
@@ -43,7 +43,7 @@ const statusTip: Record<string, string> = {
           @click="openUpdate"
           v-tooltip.bottom="appCtl.updateScope === 'system'
             ? 'Update available — a shared installation must be updated by an administrator'
-            : `Update available — ${appCtl.updateLatest}. Open Settings to install.`">
+            : `Update available — ${appCtl.updateLatest}. See what's new.`">
       <i class="pi pi-arrow-circle-up" />
       Update{{ appCtl.updateLatest ? ' ' + appCtl.updateLatest : '' }}
       <button class="update-x cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" @click.stop="appCtl.dismissUpdate()"

--- a/frontend/src/components/WhatNewCard.vue
+++ b/frontend/src/components/WhatNewCard.vue
@@ -1,0 +1,168 @@
+<!--
+  WhatNewCard — one card in the What's New modal. Used for both release-notes ("update") and
+  tips. Content is driven by `frontend/src/lib/whatsNew.ts`; layout follows the ClaudeOverviewDialog
+  card pattern.
+
+  Slots left in the schema for later plans:
+   - sketchAnimation → SKETCH_ENGINE_PLAN.md (renders a grey placeholder box until then)
+   - statsAnnotation → STATS_ANNOTATIONS_PLAN.md (typed but unused for now)
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import { formatCardDate, renderMarkdown, type WhatNewCard, CECELIA_ISSUES_URL } from '../lib/whatsNew'
+import { useSettingsStore } from '../stores/settings'
+import CcToggle from './CcToggle.vue'
+
+const props = defineProps<{ card: WhatNewCard }>()
+
+const kindLabel = computed(() => (
+  props.card.kind === 'update' ? 'NEW' :
+  props.card.kind === 'fix'    ? 'FIX' :
+                                 'TIP'
+))
+const kindTone = computed(() => 'wn-kind-' + props.card.kind)
+const dateLabel = computed(() => formatCardDate(props.card.publishedAt))
+const issueUrl = computed(() => props.card.issueUrl ?? CECELIA_ISSUES_URL)
+const bodyHtml = computed(() => renderMarkdown(props.card.bodyMd))
+const isTip = computed(() => props.card.kind === 'tip')
+
+// The "show tips on launch" opt-out is a store toggle bound to a checkbox on every tip card.
+// Bound as `!tipsOnLaunch` so the checkbox reads "Don't show tips on launch" (opt-out language).
+const settings = useSettingsStore()
+const tipsOptOut = computed({
+  get: () => !settings.tipsOnLaunch,
+  set: (v: boolean) => { settings.tipsOnLaunch = !v },
+})
+</script>
+
+<template>
+  <article class="wn-card cc-card cc-card-2">
+    <header class="wn-head">
+      <span class="wn-kind" :class="kindTone">{{ kindLabel }}</span>
+      <h3 class="wn-title">{{ card.title }}</h3>
+      <span v-if="card.releaseVersion" class="wn-version">{{ card.releaseVersion }}</span>
+    </header>
+
+    <div v-if="dateLabel" class="wn-date cc-muted">{{ dateLabel }}</div>
+
+    <!-- sketchAnimation slot — placeholder box until SKETCH_ENGINE_PLAN.md content lands. -->
+    <div v-if="card.sketchAnimation" class="wn-sketch">Animation coming soon</div>
+
+    <p v-if="card.description" class="wn-description">{{ card.description }}</p>
+
+    <!-- Client-rendered markdown via marked (GFM). Trusted source: our own release bodies. -->
+    <div v-if="bodyHtml" class="wn-body" v-html="bodyHtml" />
+
+    <div v-if="card.steps?.length" class="wn-steps">
+      <div class="wn-steps-label cc-muted">Try it</div>
+      <ol>
+        <li v-for="(step, i) in card.steps" :key="i">{{ step }}</li>
+      </ol>
+    </div>
+
+    <footer class="wn-foot">
+      <a v-if="card.releaseUrl" :href="card.releaseUrl" target="_blank" rel="noopener" class="wn-link">
+        View on GitHub <i class="pi pi-external-link" />
+      </a>
+      <CcToggle v-if="isTip" v-model="tipsOptOut" label="Don't show tips on launch" class="wn-optout" />
+      <a :href="issueUrl" target="_blank" rel="noopener" class="wn-link wn-link-right">
+        Report a problem <i class="pi pi-external-link" />
+      </a>
+    </footer>
+  </article>
+</template>
+
+<style scoped>
+.wn-card { padding: 14px 16px; }
+
+.wn-head { display: flex; align-items: center; gap: 8px; }
+.wn-kind {
+  font-size: var(--cc-fs-2xs);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  border-radius: var(--cc-radius-sm);
+  color: #ffffff;
+}
+.wn-kind-update { background: var(--cc-accent); }
+.wn-kind-tip    { background: var(--cc-sev-warn); color: #1a1a1a; }
+.wn-kind-fix    { background: var(--cc-sev-ok);   color: #ffffff; }
+.wn-title { flex: 1; margin: 0; font-size: var(--cc-fs-lg); font-weight: 600; color: var(--cc-text); }
+.wn-version {
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  font-size: var(--cc-fs-xs);
+  color: var(--cc-text-dim);
+  padding: 2px 6px;
+  background: var(--cc-surface-2);
+  border-radius: var(--cc-radius-sm);
+}
+
+.wn-date { margin-top: 2px; font-size: var(--cc-fs-2xs); }
+
+.wn-sketch {
+  margin-top: 10px;
+  height: 170px;
+  border-radius: var(--cc-radius-md);
+  background: var(--cc-surface-2);
+  border: 1px dashed var(--cc-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--cc-text-dim);
+  font-size: var(--cc-fs-sm);
+}
+
+.wn-description { margin: 10px 0 6px; color: var(--cc-text); font-size: var(--cc-fs-md); line-height: 1.5; }
+
+.wn-body {
+  margin: 8px 0 0;
+  color: var(--cc-text);
+  font-size: var(--cc-fs-md);
+  line-height: 1.55;
+}
+.wn-body :deep(h1),
+.wn-body :deep(h2),
+.wn-body :deep(h3) { font-size: var(--cc-fs-md); font-weight: 600; margin: 12px 0 4px; }
+.wn-body :deep(p) { margin: 6px 0; }
+.wn-body :deep(ul),
+.wn-body :deep(ol) { margin: 6px 0; padding-left: 20px; }
+.wn-body :deep(li) { margin: 2px 0; }
+.wn-body :deep(a) { color: var(--cc-accent); }
+.wn-body :deep(code) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+  background: var(--cc-surface-2);
+  padding: 0 4px;
+  border-radius: 3px;
+}
+.wn-body :deep(pre) {
+  background: var(--cc-surface-2);
+  padding: 8px 10px;
+  border-radius: var(--cc-radius-sm);
+  overflow-x: auto;
+}
+
+.wn-steps { margin-top: 10px; }
+.wn-steps-label { font-size: var(--cc-fs-xs); margin-bottom: 2px; }
+.wn-steps ol { margin: 0; padding-left: 20px; color: var(--cc-text); font-size: var(--cc-fs-md); line-height: 1.55; }
+
+.wn-foot {
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--cc-border);
+}
+.wn-link {
+  font-size: var(--cc-fs-sm);
+  color: var(--cc-text-dim);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.wn-link:hover { color: var(--cc-accent); }
+.wn-link .pi { font-size: 0.85em; }
+.wn-link-right { margin-left: auto; }
+.wn-optout { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
+</style>

--- a/frontend/src/components/WhatsNewDialog.vue
+++ b/frontend/src/components/WhatsNewDialog.vue
@@ -1,0 +1,86 @@
+<!--
+  WhatsNewDialog — the release-notes + tips modal. Built on BaseModal, patterned after
+  ClaudeOverviewDialog. Opened from Settings and (W3) the header update badge. See
+  docs/todo/WHATS_NEW_PLAN.md.
+
+  Cards come from `lib/whatsNew.ts` (update) and `lib/tips.ts` (tips — W4). Content is data,
+  not code; the layout stays the same regardless of source.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import BaseModal from './BaseModal.vue'
+import WhatNewCard from './WhatNewCard.vue'
+import { useAppControlStore } from '../stores/appControl'
+import { useUpdateCard, openWithTip, debugForceInstallable, type WhatNewCard as WhatNewCardT } from '../lib/whatsNew'
+import { pickDailyTip } from '../lib/tips'
+
+const props = withDefaults(defineProps<{
+  extraCards?: WhatNewCardT[]   // any additional cards a caller wants to prepend
+}>(), { extraCards: () => [] })
+
+defineEmits<{ (e: 'close'): void }>()
+
+const app = useAppControlStore()
+const updateCard = useUpdateCard()
+
+// Today's tip goes to the top when the launch trigger opened the dialog (openWhatsNew({withTip:true}))
+const tipCard = computed<WhatNewCardT | null>(() => openWithTip.value ? pickDailyTip() : null)
+
+const cards = computed<WhatNewCardT[]>(() => {
+  const list: WhatNewCardT[] = []
+  if (tipCard.value)    list.push(tipCard.value)
+  if (updateCard.value) list.push(updateCard.value)
+  list.push(...props.extraCards)
+  return list
+})
+
+// Show an inline "Install {version}" in the dialog footer when the user can self-apply. Uses the
+// same appControl.applyUpdate action as the Settings panel — no divergent update path. The dev
+// override (`debugForceInstallable`) lets dev checkouts preview the button.
+const canInstall = computed(() =>
+  debugForceInstallable.value || (app.updateAvailable && app.canApplyUpdate && !!app.updateLatest)
+)
+</script>
+
+<template>
+  <BaseModal title="What's new" icon="pi-sparkles" width="640px" @close="$emit('close')">
+    <div v-if="cards.length" class="wn-list">
+      <WhatNewCard v-for="c in cards" :key="c.id" :card="c" />
+    </div>
+    <div v-else class="wn-empty cc-muted">
+      Nothing new right now — you're up to date.
+    </div>
+
+    <template #footer>
+      <a href="https://github.com/schienstockd/cecelia/releases" target="_blank" rel="noopener" class="wn-foot-link">
+        All releases <i class="pi pi-external-link" />
+      </a>
+      <span v-if="app.updateMsg" class="wn-foot-msg cc-muted">{{ app.updateMsg }}</span>
+      <button v-if="canInstall" class="cc-btn cc-btn-primary cc-btn-dense wn-install-btn"
+              :disabled="app.updateBusy || !app.updateLatest" @click="app.applyUpdate">
+        <i :class="['pi', app.updateBusy ? 'pi-spin pi-cog' : 'pi-download']" />
+        {{ app.updateBusy ? 'Installing…' : `Install ${app.updateLatest ?? '(no version)'}` }}
+      </button>
+      <button class="cc-btn cc-btn-ghost cc-btn-dense" :class="{ 'wn-close-btn': !canInstall }" @click="$emit('close')">Close</button>
+    </template>
+  </BaseModal>
+</template>
+
+<style scoped>
+.wn-list { display: flex; flex-direction: column; gap: 14px; }
+.wn-empty { padding: 24px 0; text-align: center; font-size: var(--cc-fs-md); }
+
+.wn-foot-link {
+  font-size: var(--cc-fs-sm);
+  color: var(--cc-text-dim);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.wn-foot-link:hover { color: var(--cc-accent); }
+.wn-foot-link .pi { font-size: 0.85em; }
+.wn-foot-msg { margin-left: 12px; font-size: var(--cc-fs-xs); }
+.wn-install-btn { margin-left: auto; }
+.wn-close-btn { margin-left: auto; }
+</style>

--- a/frontend/src/lib/tips.ts
+++ b/frontend/src/lib/tips.ts
@@ -1,0 +1,62 @@
+// Tip-of-the-day catalogue for the What's New modal (WHATS_NEW_PLAN.md W4).
+//
+// Static array. `pickDailyTip(now)` returns the tip for today (deterministic mod day-of-year).
+// The launch trigger lives in App.vue; it only opens the modal once per day and only if the user
+// hasn't opted out. The opt-out lives on the card itself as a checkbox.
+//
+// Tips should read like a one-paragraph hint — brief description, optional 2-4 steps, no walls of
+// text. The `sketchAnimation` slot is prepped for future SketchDefinition content (feijoa) but
+// renders a grey placeholder for now.
+import type { WhatNewCard } from './whatsNew'
+
+export const TIPS: WhatNewCard[] = [
+  {
+    id: 'tip-hmm-behaviour',
+    kind: 'tip',
+    title: 'HMM behaviour states',
+    description: 'Track movement gets classified into hidden states (arrested, directed, meandering) via a Gaussian HMM. States land as a categorical measure on each track.',
+    steps: [
+      'Segment + track cells (Segment → Track).',
+      'Run Behaviour → HMM to fit states.',
+      'Colour tracks by the new state column in napari to see them.',
+    ],
+    sketchAnimation: { pending: 'hmm' },
+  },
+  {
+    id: 'tip-cluster-to-pop',
+    kind: 'tip',
+    title: 'Cluster labels → populations',
+    description: 'Leiden clusters aren\'t populations by default — but you can promote any cluster (or a set of them) into a named population that behaves like any other.',
+    steps: [
+      'Run Cluster cells (or Cluster tracks).',
+      'Open the Cluster panel, pick clusters that share a phenotype.',
+      'Save as population — the new pop appears in the manager.',
+    ],
+    sketchAnimation: { pending: 'clusters' },
+  },
+  {
+    id: 'tip-gate-then-napari',
+    kind: 'tip',
+    title: 'Gate a population, view it in napari',
+    description: 'Populations from the Gate module can be shown as coloured cell centroids in napari — great for cross-referencing gating decisions against the raw image.',
+    steps: [
+      'Draw a polygon gate in the Gate module.',
+      'Open the image in napari.',
+      'Toggle the population\'s "Show" in the Viewer panel.',
+    ],
+    sketchAnimation: { pending: 'gating' },
+  },
+]
+
+/** Deterministic daily pick — same tip everywhere on the same date. Empty catalogue → null. */
+export function pickDailyTip(now: Date = new Date()): WhatNewCard | null {
+  if (TIPS.length === 0) return null
+  const start = new Date(Date.UTC(now.getUTCFullYear(), 0, 0))
+  const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86_400_000)
+  return TIPS[Math.abs(dayOfYear) % TIPS.length]
+}
+
+/** Today's date as YYYY-MM-DD for comparing against the persisted `tipsLastShown`. */
+export function todayKey(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10)
+}

--- a/frontend/src/lib/whatsNew.ts
+++ b/frontend/src/lib/whatsNew.ts
@@ -1,0 +1,97 @@
+// What's New card model + release-notes source + shared open/close state.
+//
+// Two content streams share ONE card shape (updates + tips). The update card is built from the
+// appControl store (release notes come from `/api/update/check` — see WHATS_NEW_PLAN.md). Tips
+// come from `lib/tips.ts` (W4).
+//
+// The dialog is mounted ONCE in App.vue and driven by the shared `isWhatsNewOpen` ref below —
+// any caller (header badge, Settings button, launch tip in W4) calls `openWhatsNew()`. One
+// modal, one state.
+//
+// The `sketchAnimation` / `statsAnnotation` slots are typed but rendered as placeholders until
+// SKETCH_ENGINE_PLAN.md / STATS_ANNOTATIONS_PLAN.md land content.
+import { computed, ref, type ComputedRef } from 'vue'
+import { marked } from 'marked'
+import { useAppControlStore } from '../stores/appControl'
+
+export type WhatNewKind = 'update' | 'tip' | 'fix'
+
+export interface WhatNewCard {
+  id: string
+  kind: WhatNewKind
+  title: string
+  description?: string      // short intro line above the body
+  bodyMd?: string           // raw markdown (release notes / long tip text). Rendered via `marked`.
+  steps?: string[]          // "Try it:" numbered list
+  issueUrl?: string         // "Report a problem" link target (defaults to the cecelia issues page)
+  releaseVersion?: string   // shown as a chip on update cards
+  releaseUrl?: string       // "View on GitHub" link on update cards
+  publishedAt?: string      // ISO date on update cards
+  sketchAnimation?: unknown // slot for SKETCH_ENGINE_PLAN
+  statsAnnotation?: unknown // slot for STATS_ANNOTATIONS_PLAN
+}
+
+export const CECELIA_ISSUES_URL = 'https://github.com/schienstockd/cecelia/issues/new'
+
+// Shared modal state — one dialog mounted in App.vue reads this. GitHub Flavored Markdown is on
+// by default in marked ≥5, so task lists, tables, strikethrough all work. Source is trusted (our
+// own release bodies), so no separate sanitiser.
+export const isWhatsNewOpen = ref(false)
+// When `openWithTip` is true, the dialog prepends today's tip card to the list. Cleared on close.
+// Used by the once-per-day launch trigger in App.vue; the header/Settings entry points open
+// without a tip (release notes only).
+export const openWithTip = ref(false)
+
+export function openWhatsNew(opts?: { withTip?: boolean }) {
+  openWithTip.value = !!opts?.withTip
+  isWhatsNewOpen.value = true
+}
+export function closeWhatsNew() {
+  isWhatsNewOpen.value = false
+  openWithTip.value = false
+}
+
+// Dev knob (Settings → Developer): force the Install button visible in the What's New footer
+// regardless of `updateAvailable` / `canApplyUpdate` — for previewing the install-flow UI on a
+// dev checkout, where those flags are always false. Not persisted (session-only).
+export const debugForceInstallable = ref(false)
+
+marked.setOptions({ gfm: true, breaks: false })
+
+/** Render markdown → HTML for `v-html` in `WhatNewCard`. Sync helper (marked has a sync API). */
+export function renderMarkdown(md: string | undefined | null): string {
+  if (!md) return ''
+  try { return marked.parse(md, { async: false }) as string }
+  catch { return md }
+}
+
+/** Reactive card for the latest release — shown whenever we know a latest version, whether or not
+ *  an upgrade is available (dev checkouts and up-to-date installs still deserve the release notes).
+ *  The install button in the dialog footer is what gates on `updateAvailable + canApplyUpdate`. */
+export function useUpdateCard(): ComputedRef<WhatNewCard | null> {
+  const app = useAppControlStore()
+  return computed(() => {
+    if (!app.updateLatest) return null
+    const description = app.updateAvailable
+      ? (app.updateCurrent ? `You're running ${app.updateCurrent}.` : undefined)
+      : (app.updateCurrent ? `You're up to date (${app.updateCurrent}).` : undefined)
+    return {
+      id: `update-${app.updateLatest}`,
+      kind: 'update',
+      title: `Cecelia ${app.updateLatest}`,
+      description,
+      bodyMd: app.updateNotes || undefined,
+      releaseVersion: app.updateLatest,
+      releaseUrl: app.updateUrl || undefined,
+      publishedAt: app.updatePublished || undefined,
+    }
+  })
+}
+
+/** Format an ISO timestamp as "5 Aug 2026" for compact card display. Empty string on invalid input. */
+export function formatCardDate(iso: string | undefined): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -4,6 +4,7 @@ import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import PackagesDialog from '../components/PackagesDialog.vue'
 import ConfirmButton from '../components/ConfirmButton.vue'
+import { openWhatsNew, debugForceInstallable } from '../lib/whatsNew'
 import { napariState, notebooksState, stateInfo, formatUptime, type ServiceState } from '../utils/serviceStatus'
 import { notebooksApi, napariApi } from '../utils/serviceApi'
 import { useAppControlStore } from '../stores/appControl'
@@ -403,6 +404,44 @@ async function switchWt(path: string) {
       </span>
 
       <span v-if="appCtl.updateMsg" class="field-hint cc-muted cc-fs-xs">{{ appCtl.updateMsg }}</span>
+
+      <div class="field">
+        <button class="save-btn" @click="openWhatsNew"
+                v-tooltip.right="'Release notes for the latest version'">
+          <i class="pi pi-sparkles" />
+          What's new
+        </button>
+      </div>
+    </section>
+
+    <!-- ── Developer (dev only) ────────────────────────────────────────── -->
+    <!-- Only rendered under `pixi run dev`. Levers here bypass conditions the dev checkout
+         normally can't satisfy (update apply, once-per-day tip trigger) so the UI can be tested
+         without shipping a real release. See docs/todo/WHATS_NEW_PLAN.md. -->
+    <section v-if="appCtl.dev" class="settings-section">
+      <h2 class="section-title">Developer</h2>
+
+      <div class="field">
+        <button class="save-btn" @click="openWhatsNew({ withTip: true })"
+                v-tooltip.right="'Open the modal as if it were the daily launch trigger'">
+          <i class="pi pi-sparkles" />
+          What's new with today's tip
+        </button>
+      </div>
+
+      <div class="field">
+        <CcToggle class="toggle-row" v-model="debugForceInstallable"
+          label="Force-show Install button in What's New"
+          v-tooltip.right="'Dev checkouts never satisfy the install gate — this reveals the button so the flow can be previewed.'" />
+      </div>
+
+      <div class="field">
+        <button class="save-btn" @click="settings.tipsLastShown = ''"
+                v-tooltip.right="'Clear the daily-tip stamp so the tip triggers again on next launch'">
+          <i class="pi pi-refresh" />
+          Reset tip-of-the-day
+        </button>
+      </div>
     </section>
 
     <!-- ── Custom modules ──────────────────────────────────────────────── -->

--- a/frontend/src/stores/appControl.ts
+++ b/frontend/src/stores/appControl.ts
@@ -51,6 +51,11 @@ export const useAppControlStore = defineStore('appControl', () => {
   const updateBusy      = ref(false)
   const updateMsg       = ref('')
   const updateDismissed = ref(false)                               // header badge "remind me later" (session)
+  // Release-notes surfacing (What's New modal — WHATS_NEW_PLAN.md). The older header badge +
+  // Settings panel don't read these; they're only for the modal.
+  const updateUrl       = ref('')
+  const updateNotes     = ref('')                                  // GitHub release `body` (markdown)
+  const updatePublished = ref('')                                  // ISO timestamp; empty if unknown
   // in-app apply is only offered for a per-user install (not a shared system install or dev checkout)
   const canApplyUpdate  = computed(() => updateScope.value === 'user')
 
@@ -62,6 +67,9 @@ export const useAppControlStore = defineStore('appControl', () => {
       updateLatest.value    = d.latest ?? null
       updateAvailable.value = !!d.updateAvailable
       updateScope.value     = d.scope ?? ''
+      updateUrl.value       = d.url ?? ''
+      updateNotes.value     = d.releaseNotes ?? ''
+      updatePublished.value = d.publishedAt ?? ''
       if (d.error) updateMsg.value = d.error
     } catch { updateMsg.value = 'Could not reach the update server.' }
     finally { updateChecking.value = false }
@@ -148,6 +156,7 @@ export const useAppControlStore = defineStore('appControl', () => {
 
   return { dev, busy, message, setupRequired, worktrees, canSwitch,
            updateCurrent, updateLatest, updateAvailable, updateScope, updateChecking, updateBusy,
-           updateMsg, updateDismissed, canApplyUpdate, checkUpdate, applyUpdate, dismissUpdate,
+           updateMsg, updateDismissed, updateUrl, updateNotes, updatePublished, canApplyUpdate,
+           checkUpdate, applyUpdate, dismissUpdate,
            refreshDev, refreshStartup, completeSetup, refreshWorktrees, quit, restartBackend, switchWorktree }
 })

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -78,6 +78,13 @@ export const useSettingsStore = defineStore('settings', () => {
   // the observer's work; Haiku is the cheap option. Sent per feedback call; the backend allow-lists it.
   // See app/src/ai/agent_runner.jl OBSERVER_MODELS.
   const labLogObserverModel = ref(localStorage.getItem('cc.labLogObserverModel') || 'sonnet')
+  // Tip of the day (WHATS_NEW_PLAN.md → W4). On app launch, if these say "show + last shown was
+  // not today", the What's New modal opens with today's tip prepended. Opt-out from a checkbox on
+  // the tip card. Default ON — biologists opening the app benefit from a nudge; power users can
+  // switch it off from the card and never see one again.
+  const tipsOnLaunch = ref(localStorage.getItem('cc.tipsOnLaunch') !== 'false')  // default true
+  const tipsLastShown = ref(localStorage.getItem('cc.tipsLastShown') ?? '')      // YYYY-MM-DD
+
   // transient (not persisted): a one-line preview of an unseen lab-log addition — set when Claude
   // (observer) or Cecelia (auto-digest) appends while the panel is closed; drives the sidebar badge,
   // cleared when opened. `kind` picks the badge icon (Claude sparkles vs Cecelia bell); `level` its
@@ -241,9 +248,11 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(labLogAutoContext,        v => localStorage.setItem('cc.labLogAutoContext',        String(v)))
   watch(labLogShowNames,          v => localStorage.setItem('cc.labLogShowNames',          String(v)))
   watch(labLogObserverModel,      v => localStorage.setItem('cc.labLogObserverModel',      v))
+  watch(tipsOnLaunch,             v => localStorage.setItem('cc.tipsOnLaunch',             String(v)))
+  watch(tipsLastShown,            v => localStorage.setItem('cc.tipsLastShown',            v))
   watch(labLogPanelOpen, open => { if (open) {          // opening clears the badge (all facets)
     labLogUnseen.value = ''; labLogUnseenKind.value = ''; labLogUnseenLevel.value = ''
   } })
 
-  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, cleanCapture, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, napariDiscreteGpu, moviesPlaybackRate, moviesZoom, moviesAutoplay, moviesLoop, sidebarCollapsed, rightPanelCollapsed, viewerPanelOpen, labLogPanelOpen, labLogAutoContext, labLogShowNames, labLogObserverModel, labLogUnseen, labLogUnseenKind, labLogUnseenLevel, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible, getColourOverrides, setColourOverride, clearColourOverrides, getMovieConfig, setMovieConfig, getCropZ, setCropZ, getCropT, setCropT, getBatchMovieConfig, setBatchMovieConfig }
+  return { taskListAutoFollow, autoRefreshOnTask, napariUpdateImage, cleanCapture, napariResetOnReload, napariAutoSaveLayerProps, napariAsDask, napariDiscreteGpu, moviesPlaybackRate, moviesZoom, moviesAutoplay, moviesLoop, sidebarCollapsed, rightPanelCollapsed, viewerPanelOpen, labLogPanelOpen, labLogAutoContext, labLogShowNames, labLogObserverModel, labLogUnseen, labLogUnseenKind, labLogUnseenLevel, tipsOnLaunch, tipsLastShown, getLabelVisibility, setLabelVisibility, getTrackVisibility, setTrackVisibility, getColourBy, setColourBy, getShow3D, setShow3D, getShowGatedTracks, setShowGatedTracks, getPointSize, setPointSize, getPopVisible, setPopVisible, getColourOverrides, setColourOverride, clearColourOverrides, getMovieConfig, setMovieConfig, getCropZ, setCropZ, getCropT, setCropT, getBatchMovieConfig, setBatchMovieConfig }
 })

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -8,7 +8,12 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    /* Mirrors the Vite alias in vite.config.ts — see docs/todo/SKETCH_ENGINE_PLAN.md */
+    "paths": {
+      "feijoa": ["../../feijoa/src/lib/index.ts"]
+    }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "../../feijoa/src/**/*.ts", "../../feijoa/src/**/*.vue"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,9 +2,22 @@
 // build behaviour is identical.
 import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      // Sibling play repo: https://github.com/schienstockd/feijoa
+      // Cecelia imports feijoa's source directly. Feijoa's own node_modules (roughjs,
+      // animejs) is used at bundle time — Vite walks the resolution chain from the
+      // aliased file's location. Run `npm install` in feijoa once; edits then hot-
+      // reload through cecelia's Vite. Vue is deduped so both apps share one instance.
+      // See docs/todo/SKETCH_ENGINE_PLAN.md.
+      feijoa: fileURLToPath(new URL('../../feijoa/src/lib/index.ts', import.meta.url)),
+    },
+    dedupe: ['vue'],
+  },
   // Vitest stubs CSS imports to '' by default, which would make the design-token guard in
   // utils/cssTokens.test.ts read an empty style.css and pass vacuously. No test mounts components,
   // so processing CSS costs nothing else.


### PR DESCRIPTION
## Summary

- Turns the existing `/api/update/check` plumbing into an in-app What's New modal that shows GitHub release notes (rendered client-side with `marked`, GFM on) and prompts the user with today's tip on launch.
- New content pieces are **data**: `WhatNewCard` schema is JSON-serialisable; three seed tips live in `lib/tips.ts`; typed slots for `sketchAnimation` and `statsAnnotation` are ready for the sibling plans.
- Sibling `feijoa` sketch repo wired in via Vite alias + tsconfig paths (grey placeholder box in tip cards for now; SKETCH_ENGINE_PLAN.md covers the eventual swap).

## Reservations

- Not typechecked (`npm run typecheck` not run on this branch). No test suite runs performed.
- No unit tests added — `pickDailyTip` determinism, `renderMarkdown` sanity, `useUpdateCard` behavior are all uncovered.
- feijoa repo assumed at `~/cc-workspace/feijoa`. A clone without it fails the frontend build (Vite alias resolution). Documented in `docs/todo/SKETCH_ENGINE_PLAN.md`.
- Behavior change: header update badge click now opens the modal instead of routing to `/settings`.
- `marked` new dep (~30KB gz), trusted-source rendering (no sanitiser; source = our own release bodies).
- Dropped the `CECELIA_UPDATE_INCLUDE_PRERELEASE` env knob (no-op after collapsing to one release track). No repo references remained (grep clean).

## Test plan

- [ ] `cd frontend && npm install && npm run typecheck`
- [ ] `pixi run stop && pixi run dev`, load the app
- [ ] Header "Update" pill appears if any release is newer than the running version; click → What's New modal shows the latest release-notes card
- [ ] Settings → Software updates → "What's new" button opens the modal without a tip
- [ ] First launch of the day: modal auto-opens with today's tip on top of the release-notes card
- [ ] Second launch same day: modal does NOT auto-open
- [ ] Tip card → "Don't show tips on launch" toggle persists across restart
- [ ] Settings → Developer section (dev only) → "What's new with today's tip" opens with tip; "Force-show Install button" reveals it on dev; "Reset tip-of-the-day" clears the stamp
- [ ] Markdown body renders GFM (tables, task lists, links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
