### PR TITLE
chore(whats-new): drop unused feijoa scaffolding from cecelia

### DIFF
--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -64,6 +64,8 @@ If it fits in a paragraph and needs no design, it's a `docs/TODO.md` item, not a
   reused by `WHATS_NEW_PLAN.md` and `SKETCH_ENGINE_PLAN.md`. Supersedes
   `docs/prompts/stats-on-plots-prompt.md`.
 - `SKETCH_ENGINE_PLAN.md` — the **feijoa** play repo
-  (`github.com/schienstockd/feijoa`, `~/cc-workspace/feijoa`) wired into cecelia's
-  `/sketchbook` route via a Vite alias. Rough.js + animejs; sketches are JSON. Ports the R
-  Cecelia logo as the first seed. Supersedes `docs/prompts/sketch-engine-prompt.md`.
+  (`github.com/schienstockd/feijoa`, `~/cc-workspace/feijoa`) where sketches are authored for
+  cecelia's tip cards. Not yet wired into cecelia — the plan documents the git-dep + conditional
+  Vite alias to add at the first commit that swaps a WhatNewCard's grey placeholder for
+  `<SketchCanvas>`. Rough.js + animejs; sketches are JSON; R Cecelia logo is the smoke-test port.
+  Supersedes `docs/prompts/sketch-engine-prompt.md`.

--- a/docs/todo/SKETCH_ENGINE_PLAN.md
+++ b/docs/todo/SKETCH_ENGINE_PLAN.md
@@ -1,6 +1,6 @@
 # Sketchbook (feijoa) — authoring tool for cecelia explainers
 
-Status: seeded, blue-sky · repo `github.com/schienstockd/feijoa` · no user-facing page in cecelia **yet**
+Status: seeded, blue-sky · repo `github.com/schienstockd/feijoa` · not yet wired into cecelia
 
 ## What this is today
 
@@ -8,9 +8,9 @@ A sibling play repo where sketches are authored for cecelia's tip-of-the-day and
 modals. Whether the engine holds together at all is still an open question — this is exploration,
 not a commitment.
 
-Sketches surface in cecelia today only via:
-- Tip-of-the-day card on launch (see `WHATS_NEW_PLAN.md`) — opt-out.
-- Release-notes cards in the What's New modal.
+Cecelia has NO dep on feijoa yet. Tip cards render a grey `Animation coming soon` placeholder
+where a sketch would go. The moment we swap that for a real `<SketchCanvas>` import, feijoa
+becomes a real dep — see *Wiring* below.
 
 ## What it could become (blue sky, later)
 
@@ -20,40 +20,48 @@ for their own analyses, or cecelia auto-generates sketch-style summaries from re
 (`StatsResult` → sketch, populations → sketch). That's not on the table now; the point of the
 current phase is to find out whether it's worth taking seriously.
 
-## Layout
+## Wiring — when we actually consume feijoa in cecelia
 
-- **`~/cc-workspace/feijoa/`** — the play/authoring repo. Its own Vite site
-  (`npm run dev` → `:5174`) where sketches are previewed while being written.
-- **`cecelia-pineapple/frontend/`** — imports `SketchCanvas` + `sketchList` from feijoa via a
-  Vite alias. Cards in the What's New modal instantiate `<SketchCanvas>` when their
-  `sketchAnimation?` field is populated.
+The pattern is a **git dependency + conditional Vite alias** — fresh clones and CI installs
+resolve feijoa via `npm install` from GitHub; sibling checkouts additionally get hot-reload from
+the local source. This works for both `install.sh` channels:
 
-## Wiring — how cecelia sees feijoa
+- **stable install** — ships a prebuilt frontend `dist/`; feijoa is bundled at CI build time
+  (CI's `npm install` pulls it from GitHub).
+- **dev install** — runs `npm install && npm run build` locally; same GitHub fetch.
 
-1. `frontend/vite.config.ts` → `resolve.alias.feijoa` = `../../feijoa/src/lib/index.ts` +
-   `resolve.dedupe = ['vue']`.
-2. `frontend/tsconfig.app.json` → `paths.feijoa` + `include` extended so `vue-tsc` sees feijoa's
-   sources.
-3. Cards that carry a sketch do `import { SketchCanvas } from 'feijoa'`; nothing else in cecelia
-   references feijoa.
-4. Vite bundles feijoa's `.ts`/`.vue` files during cecelia's dev/build.
-5. Feijoa's runtime deps (roughjs, animejs) resolve via feijoa's own `node_modules/` — install
-   once in feijoa, not in cecelia.
-6. `vue` is a **peerDependency** in feijoa; the deduped one from cecelia is used at runtime.
-
-Edit a sketch in feijoa → cecelia's Vite HMRs the change (as long as feijoa is on disk).
-
-## Setup on a fresh machine (one-time)
-
-```bash
-git clone https://github.com/schienstockd/feijoa.git ~/cc-workspace/feijoa
-cd ~/cc-workspace/feijoa && npm install
+**Add to `frontend/package.json`**:
+```jsonc
+"dependencies": {
+  "feijoa": "github:schienstockd/feijoa#main"   // main branch, not a tag
+  // package-lock.json pins the resolved sha for reproducibility
+  // `npm update feijoa` advances to the latest main commit
+}
 ```
 
-If feijoa isn't present, cecelia's build fails with an obvious `cannot resolve 'feijoa'`. That's
-deliberate — better loud than silently invisible.
+**Add to `frontend/vite.config.ts`** (conditional — sibling override only when present):
+```ts
+import { existsSync } from 'node:fs'
+import { fileURLToPath, URL } from 'node:url'
 
-## Sketch format
+const feijoaSibling = fileURLToPath(new URL('../../feijoa/src/lib/index.ts', import.meta.url))
+const feijoaAlias = existsSync(feijoaSibling) ? { feijoa: feijoaSibling } : {}
+
+export default defineConfig({
+  resolve: {
+    alias: feijoaAlias,   // hot-reload from sibling; else falls through to node_modules
+    dedupe: ['vue'],      // feijoa marks vue as peer; ensure one instance across both apps
+  },
+  // …
+})
+```
+
+**No tsconfig `paths` needed** — `feijoa`'s `package.json` `exports` point at `src/lib/index.ts`,
+so `vue-tsc` resolves it via `node_modules/feijoa/…` in the standard way.
+
+**Do this at the same commit that first imports `from 'feijoa'`** — earlier is unused scaffolding.
+
+## Sketch format (in feijoa)
 
 ```ts
 interface SketchDefinition { id, title, width, height, durationSec, acts: SketchAct[] }
@@ -75,7 +83,8 @@ JSON-serialisable. Sketches live in `~/cc-workspace/feijoa/src/sketches/*.ts`.
 
 ## References
 
-- `frontend/vite.config.ts` — alias.
-- `frontend/tsconfig.app.json` — paths + include.
+- `docs/prompts/sketch-engine-prompt.md` — the original Sonnet draft (superseded).
+- `frontend/src/lib/whatsNew.ts` — the `WhatNewCard.sketchAnimation?` slot (unused today).
+- `frontend/src/components/WhatNewCard.vue` — where the grey placeholder currently renders.
 - `WHATS_NEW_PLAN.md` — the consumer (tip-of-the-day + release notes).
 - `old-R-shiny-version/im/cciaLogo.png` — logo source of truth.

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -8,12 +8,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-
-    /* Mirrors the Vite alias in vite.config.ts — see docs/todo/SKETCH_ENGINE_PLAN.md */
-    "paths": {
-      "feijoa": ["../../feijoa/src/lib/index.ts"]
-    }
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "../../feijoa/src/**/*.ts", "../../feijoa/src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,22 +2,9 @@
 // build behaviour is identical.
 import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
-import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [vue()],
-  resolve: {
-    alias: {
-      // Sibling play repo: https://github.com/schienstockd/feijoa
-      // Cecelia imports feijoa's source directly. Feijoa's own node_modules (roughjs,
-      // animejs) is used at bundle time — Vite walks the resolution chain from the
-      // aliased file's location. Run `npm install` in feijoa once; edits then hot-
-      // reload through cecelia's Vite. Vue is deduped so both apps share one instance.
-      // See docs/todo/SKETCH_ENGINE_PLAN.md.
-      feijoa: fileURLToPath(new URL('../../feijoa/src/lib/index.ts', import.meta.url)),
-    },
-    dedupe: ['vue'],
-  },
   // Vitest stubs CSS imports to '' by default, which would make the design-token guard in
   // utils/cssTokens.test.ts read an empty style.css and pass vacuously. No test mounts components,
   // so processing CSS costs nothing else.


### PR DESCRIPTION
## Summary

- Nothing in cecelia imports `'feijoa'` today — tip cards render a grey placeholder for the sketch slot. The Vite alias, tsconfig `paths`, and tsconfig `include` glob that pointed at `../../feijoa/src/**` were unused noise, so they're removed.
- `docs/todo/SKETCH_ENGINE_PLAN.md` rewritten with the future-wiring recipe: `"feijoa": "github:schienstockd/feijoa#main"` in `package.json` + a conditional Vite alias (sibling override only when `~/cc-workspace/feijoa` exists). To apply at the first commit that swaps the placeholder for `<SketchCanvas>`.
- `docs/todo/README.md` descriptor for the plan updated to match.

## Why

- Fresh clones + `install.sh --dev` invocations don't have `~/cc-workspace/feijoa`. The alias was a no-op today but a landmine the moment cecelia actually imports feijoa.
- Cleaner to add the git-dep wiring at the commit that first uses it, not scaffolding-ahead.

## Test plan

- [ ] `cd frontend && npm install && npm run typecheck` still passes
- [ ] `npm run dev` still boots and the What's New modal still renders (tips show the grey "Animation coming soon" placeholder as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
