### PR TITLE
fix(settings): wrap What's new @click so event isn't passed as opts

### DIFF
--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -406,7 +406,7 @@ async function switchWt(path: string) {
       <span v-if="appCtl.updateMsg" class="field-hint cc-muted cc-fs-xs">{{ appCtl.updateMsg }}</span>
 
       <div class="field">
-        <button class="save-btn" @click="openWhatsNew"
+        <button class="save-btn" @click="openWhatsNew()"
                 v-tooltip.right="'Release notes for the latest version'">
           <i class="pi pi-sparkles" />
           What's new


### PR DESCRIPTION
## Summary
- `openWhatsNew` was widened to `(opts?: { withTip?: boolean }) => void` when the dev "with today's tip" button was added (#381). The bare `@click="openWhatsNew"` then failed `vue-tsc` with **TS2345** (PointerEvent vs opts), breaking CI on all 3 OS jobs on `main` after #381/#382.
- Call it with `()` to discard the event. One-line change.

## Test plan
- [x] `npm run typecheck` passes locally
- [ ] CI green on ubuntu/macos/windows
- [ ] "What's new" button in Settings still opens the modal (no tip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
