### PR TITLE
fix(whats-new): route WhatNew components onto .cc-muted / .cc-fs-* utilities

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -43,7 +43,7 @@ const statusTip: Record<string, string> = {
           @click="openUpdate"
           v-tooltip.bottom="appCtl.updateScope === 'system'
             ? 'Update available — a shared installation must be updated by an administrator'
-            : `Update available — ${appCtl.updateLatest}. See what's new.`">
+            : `Update ${appCtl.updateLatest} — see what's new`">
       <i class="pi pi-arrow-circle-up" />
       Update{{ appCtl.updateLatest ? ' ' + appCtl.updateLatest : '' }}
       <button class="update-x cc-btn cc-btn-bare cc-btn-icon cc-btn-micro" @click.stop="appCtl.dismissUpdate()"

--- a/frontend/src/components/WhatNewCard.vue
+++ b/frontend/src/components/WhatNewCard.vue
@@ -43,7 +43,7 @@ const tipsOptOut = computed({
       <span v-if="card.releaseVersion" class="wn-version">{{ card.releaseVersion }}</span>
     </header>
 
-    <div v-if="dateLabel" class="wn-date cc-muted">{{ dateLabel }}</div>
+    <div v-if="dateLabel" class="wn-date cc-muted cc-fs-2xs">{{ dateLabel }}</div>
 
     <!-- sketchAnimation slot — placeholder box until SKETCH_ENGINE_PLAN.md content lands. -->
     <div v-if="card.sketchAnimation" class="wn-sketch">Animation coming soon</div>
@@ -54,18 +54,18 @@ const tipsOptOut = computed({
     <div v-if="bodyHtml" class="wn-body" v-html="bodyHtml" />
 
     <div v-if="card.steps?.length" class="wn-steps">
-      <div class="wn-steps-label cc-muted">Try it</div>
+      <div class="wn-steps-label cc-muted cc-fs-xs">Try it</div>
       <ol>
         <li v-for="(step, i) in card.steps" :key="i">{{ step }}</li>
       </ol>
     </div>
 
     <footer class="wn-foot">
-      <a v-if="card.releaseUrl" :href="card.releaseUrl" target="_blank" rel="noopener" class="wn-link">
+      <a v-if="card.releaseUrl" :href="card.releaseUrl" target="_blank" rel="noopener" class="wn-link cc-muted">
         View on GitHub <i class="pi pi-external-link" />
       </a>
-      <CcToggle v-if="isTip" v-model="tipsOptOut" label="Don't show tips on launch" class="wn-optout" />
-      <a :href="issueUrl" target="_blank" rel="noopener" class="wn-link wn-link-right">
+      <CcToggle v-if="isTip" v-model="tipsOptOut" label="Don't show tips on launch" class="wn-optout cc-muted cc-fs-xs" />
+      <a :href="issueUrl" target="_blank" rel="noopener" class="wn-link wn-link-right cc-muted">
         Report a problem <i class="pi pi-external-link" />
       </a>
     </footer>
@@ -97,7 +97,7 @@ const tipsOptOut = computed({
   border-radius: var(--cc-radius-sm);
 }
 
-.wn-date { margin-top: 2px; font-size: var(--cc-fs-2xs); }
+.wn-date { margin-top: 2px; }
 
 .wn-sketch {
   margin-top: 10px;
@@ -133,7 +133,7 @@ const tipsOptOut = computed({
   font-size: 0.9em;
   background: var(--cc-surface-2);
   padding: 0 4px;
-  border-radius: 3px;
+  border-radius: var(--cc-radius-xs);
 }
 .wn-body :deep(pre) {
   background: var(--cc-surface-2);
@@ -143,7 +143,7 @@ const tipsOptOut = computed({
 }
 
 .wn-steps { margin-top: 10px; }
-.wn-steps-label { font-size: var(--cc-fs-xs); margin-bottom: 2px; }
+.wn-steps-label { margin-bottom: 2px; }
 .wn-steps ol { margin: 0; padding-left: 20px; color: var(--cc-text); font-size: var(--cc-fs-md); line-height: 1.55; }
 
 .wn-foot {
@@ -154,8 +154,6 @@ const tipsOptOut = computed({
   border-top: 1px solid var(--cc-border);
 }
 .wn-link {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
   text-decoration: none;
   display: inline-flex;
   align-items: center;
@@ -164,5 +162,4 @@ const tipsOptOut = computed({
 .wn-link:hover { color: var(--cc-accent); }
 .wn-link .pi { font-size: 0.85em; }
 .wn-link-right { margin-left: auto; }
-.wn-optout { font-size: var(--cc-fs-xs); color: var(--cc-text-dim); }
 </style>

--- a/frontend/src/components/WhatsNewDialog.vue
+++ b/frontend/src/components/WhatsNewDialog.vue
@@ -47,15 +47,15 @@ const canInstall = computed(() =>
     <div v-if="cards.length" class="wn-list">
       <WhatNewCard v-for="c in cards" :key="c.id" :card="c" />
     </div>
-    <div v-else class="wn-empty cc-muted">
+    <div v-else class="wn-empty cc-muted cc-fs-md">
       Nothing new right now — you're up to date.
     </div>
 
     <template #footer>
-      <a href="https://github.com/schienstockd/cecelia/releases" target="_blank" rel="noopener" class="wn-foot-link">
+      <a href="https://github.com/schienstockd/cecelia/releases" target="_blank" rel="noopener" class="wn-foot-link cc-muted">
         All releases <i class="pi pi-external-link" />
       </a>
-      <span v-if="app.updateMsg" class="wn-foot-msg cc-muted">{{ app.updateMsg }}</span>
+      <span v-if="app.updateMsg" class="wn-foot-msg cc-muted cc-fs-xs">{{ app.updateMsg }}</span>
       <button v-if="canInstall" class="cc-btn cc-btn-primary cc-btn-dense wn-install-btn"
               :disabled="app.updateBusy || !app.updateLatest" @click="app.applyUpdate">
         <i :class="['pi', app.updateBusy ? 'pi-spin pi-cog' : 'pi-download']" />
@@ -68,11 +68,9 @@ const canInstall = computed(() =>
 
 <style scoped>
 .wn-list { display: flex; flex-direction: column; gap: 14px; }
-.wn-empty { padding: 24px 0; text-align: center; font-size: var(--cc-fs-md); }
+.wn-empty { padding: 24px 0; text-align: center; }
 
 .wn-foot-link {
-  font-size: var(--cc-fs-sm);
-  color: var(--cc-text-dim);
   text-decoration: none;
   display: inline-flex;
   align-items: center;
@@ -80,7 +78,7 @@ const canInstall = computed(() =>
 }
 .wn-foot-link:hover { color: var(--cc-accent); }
 .wn-foot-link .pi { font-size: 0.85em; }
-.wn-foot-msg { margin-left: 12px; font-size: var(--cc-fs-xs); }
+.wn-foot-msg { margin-left: 12px; }
 .wn-install-btn { margin-left: auto; }
 .wn-close-btn { margin-left: auto; }
 </style>

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -432,7 +432,7 @@ async function switchWt(path: string) {
       <div class="field">
         <CcToggle class="toggle-row" v-model="debugForceInstallable"
           label="Force-show Install button in What's New"
-          v-tooltip.right="'Dev checkouts never satisfy the install gate — this reveals the button so the flow can be previewed.'" />
+          v-tooltip.right="'Preview the install button in dev checkouts'" />
       </div>
 
       <div class="field">


### PR DESCRIPTION
## Summary
- Green main. The What's New PRs (#381/#382/#383) each hand-rolled scoped `font-size` + `color` for the same "muted text at a smaller step" scenario, and shadowed `.cc-muted` where they did apply it — `cssScenarios.test.ts` caught it. Two `uiCopy.test.ts` misses too.
- **CSS:** `.wn-date`, `.wn-steps-label`, `.wn-link`, `.wn-optout` (WhatNewCard.vue) and `.wn-empty`, `.wn-foot-link`, `.wn-foot-msg` (WhatsNewDialog.vue) now compose `.cc-muted` + the density step; scoped rules keep layout only. Inline-code radius `3px` → `var(--cc-radius-xs)`.
- **Copy:** AppHeader update-badge tooltip collapsed from two sentences to one (`Update ${latest} — see what's new`). SettingsModule dev-only "Force-show Install" tooltip trimmed from 100 chars to `Preview the install button in dev checkouts`.

## Reservations
- Not run in a browser. Sizes/colours are equivalent by construction (`--cc-fs-sm` base of `.cc-muted` matches the sites' prior `--cc-fs-sm`; `.wn-empty` explicitly re-adds `.cc-fs-md`), and `.wn-link:hover` still beats `.cc-muted` on specificity — but you'll want to eyeball the modal once.
- SettingsModule tooltip lost the "why" (dev checkouts don't satisfy the install gate). Matches the tooltip-copy budget; if you'd like the rationale preserved, we can drop a `<!-- -->` in the SFC.

## Test plan
- [x] `npm test` — 399/399 green (was 5 failing on main)
- [x] `npm run build` — `vue-tsc -b && vite build` clean
- [ ] Eyeball the What's New modal (opened from Settings and from the header badge) in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)