### PR TITLE
fix(lablog): stop caret overlapping model name in Ask Claude picker

### DIFF
--- a/frontend/src/components/LabLogPanel.vue
+++ b/frontend/src/components/LabLogPanel.vue
@@ -431,7 +431,11 @@ async function dismissEntry(entry: LabLogEntry) {
 .ll-help:hover { color: var(--cc-accent); }
 .ll-auto { display: inline-flex; align-items: center; gap: 0.25rem; font-size: var(--cc-fs-xs); color: var(--cc-text-dim); cursor: pointer; }
 .ll-model {
-  font-size: var(--cc-fs-xs); color: var(--cc-text-dim); cursor: pointer; padding: 0.05rem 0.2rem;
+  font-size: var(--cc-fs-xs); color: var(--cc-text-dim); cursor: pointer;
+  /* Longhand padding, NOT the shorthand: the global `select` rule sets padding-right: 1.6rem
+     to reserve room for the caret, and a `padding:` shorthand here would clobber it — leaving
+     the chevron painted on top of the model name. Same reasoning as background-color below. */
+  padding-top: 0.05rem; padding-bottom: 0.05rem; padding-left: 0.2rem;
   /* background-COLOR, not the shorthand: the global `select` rule paints the custom caret via
      background-image, and a shorthand here would reset it to none (leaving an arrowless select). */
   background-color: var(--cc-surface-2); border-radius: var(--cc-radius-xs);


### PR DESCRIPTION
## Summary
- `.ll-model <select>` in `LabLogPanel.vue` used the `padding` shorthand, which reset the global `select` rule's `padding-right: 1.6rem` (reserved for the custom SVG caret at `right 0.55rem`, `background-size: 0.62rem`) down to `0.2rem`. Result: the chevron rendered on top of the model name (e.g. "sonnet").
- Switched to `padding-top` / `-bottom` / `-left` longhands so the global right-padding reservation stands and the caret gets clearance.
- Same shorthand-clobbers-global-rule trap already noted in the neighbouring `background-color` comment.

## Test plan
- [x] Reload frontend, confirm chevron sits to the right of the model name with clear spacing (visually verified by Dominik).
- [ ] Double-check other model values (`opus`, longer names) still fit without truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
