### PR TITLE
Fix feijoa sibling Vite alias (three hops, not two)

### DIFF
--- a/docs/todo/SKETCH_ENGINE_PLAN.md
+++ b/docs/todo/SKETCH_ENGINE_PLAN.md
@@ -47,7 +47,8 @@ the local source. This works for both `install.sh` channels:
 import { existsSync } from 'node:fs'
 import { fileURLToPath, URL } from 'node:url'
 
-const feijoaSibling = fileURLToPath(new URL('../../feijoa/src/lib/index.ts', import.meta.url))
+// Four hops up: frontend → cecelia-pineapple → cecelia → cc-workspace → feijoa
+const feijoaSibling = fileURLToPath(new URL('../../../feijoa/src/lib/index.ts', import.meta.url))
 const feijoaAlias = existsSync(feijoaSibling) ? { feijoa: feijoaSibling } : {}
 
 export default defineConfig({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,9 +5,12 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 
-// Sibling checkout of ../../feijoa gets hot-reload from the local source; otherwise Vite resolves
-// `feijoa` via node_modules (github:schienstockd/feijoa#main). See docs/todo/SKETCH_ENGINE_PLAN.md.
-const feijoaSibling = fileURLToPath(new URL('../../feijoa/src/lib/index.ts', import.meta.url))
+// Sibling checkout of `~/cc-workspace/feijoa` gets hot-reload from the local source; otherwise
+// Vite resolves `feijoa` via node_modules (github:schienstockd/feijoa#main). Note the FOUR levels:
+// frontend → cecelia-pineapple → cecelia → cc-workspace → feijoa (the cecelia repo has an inner
+// cecelia-pineapple/ dir, so feijoa is three "../" hops away, not two).
+// See docs/todo/SKETCH_ENGINE_PLAN.md.
+const feijoaSibling = fileURLToPath(new URL('../../../feijoa/src/lib/index.ts', import.meta.url))
 const feijoaAlias: Record<string, string> = existsSync(feijoaSibling) ? { feijoa: feijoaSibling } : {}
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- `vite.config.ts` had `../../feijoa/src/lib/index.ts` relative to `frontend/vite.config.ts`, which resolves to `cecelia/feijoa/...` — but feijoa lives at `~/cc-workspace/feijoa`, a sibling of `cecelia/`, not of `cecelia-pineapple/`. Correct path is `../../../feijoa/...` (four hops: frontend → cecelia-pineapple → cecelia → cc-workspace → feijoa).
- Effect on dev: `existsSync()` was silently false, the sibling alias was never applied, so edits to `~/cc-workspace/feijoa/src/lib/*` had no effect on `pixi run dev` — Vite kept serving the pinned copy from `node_modules/feijoa`.
- Effect on normal users (install.sh): none. `existsSync()` is still false for a user without a sibling checkout (as before), so Vite falls back to `node_modules/feijoa` from the `package.json` git-dep — identical behaviour to today's main. Verified by temporarily disabling the alias and rebuilding cleanly.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` with alias on (sibling checkout) — succeeds
- [x] `npm run build` with alias off (simulated missing sibling) — succeeds; feijoa resolved from `node_modules/feijoa`
- [x] `npm test` — 404 tests passing
- [ ] Restart `pixi run dev`, open the What's New modal, confirm feijoa edits hot-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
