### PR TITLE
feat(plots): show which test `auto` picked in the stats options

### DIFF
--- a/docs/todo/STATS_ANNOTATIONS_PLAN.md
+++ b/docs/todo/STATS_ANNOTATIONS_PLAN.md
@@ -120,6 +120,10 @@ sketch engine ([`SKETCH_ENGINE_PLAN.md`](SKETCH_ENGINE_PLAN.md)).
   7. **Test-name annotation on the chart**: **NO**. Prism omits it and pushes the test identity
      into the figure legend / methods section. Match that. Method note reaches the user via the
      CSV comment lines (S5) and the `[Cecelia]` lab-log entry (S6), not the plot itself.
+     *(Follow-up: with `auto` the test is resolved server-side from the group count, so the
+     picker also can't show it. `SummaryPanel` reports the result's `methodNote` up via a
+     `stats-note` emit and the shared `PlotOptions` → Stats block echoes it under the Test select
+     for the ACTIVE plot — a control-panel readout, still nothing on the chart.)*
   8. **Colour**: black lines, black text. Do NOT tint by `--cc-*` tokens — Prism's convention is
      black-on-white for the annotation layer regardless of theme. On the dark theme, keep the
      annotation black on the plot's own light background (cecelia plots are light-themed for

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -239,6 +239,12 @@ function setVis(patch: Partial<VisProps>) {
 }
 const panelSeries = (c: SlotContent): SeriesTarget[] => panelSel(c).map(parseTkey)
 
+// the stats test each summary slot's last result actually ran (`auto` resolves it server-side from the
+// group count) — the rail shows the ACTIVE slot's, so the user can see what `auto` chose. Keyed by slot
+// index; a readout of the current result, not a persisted setting.
+const statsNotes = ref<Record<number, string>>({})
+const activeStatsNote = computed(() => statsNotes.value[entry.value.activeIndex] ?? '')
+
 // ── cluster context: ONE clustering run per board (board-level popType + suffix in the shared bag) so
 // the singleton gating store is driven unambiguously; only active when a cluster slot exists. ─────────
 const hasClusterSlot = computed(() => entry.value.contents.some(isClusterSlot))
@@ -513,7 +519,8 @@ defineExpose({ capturePage, collectCsvs })
                           :group-attr="panelGroupAttr" :series="panelSeries(entry.contents[i]!)" :series-color="seriesColor"
                           :vis="panelVis(entry.contents[i]!)" :ui="entry.contents[i]!.state" :collapse-series="poolGroups"
                           :reload-token="reloadToken" :persist-key="`${canvasKey}:slot:${i}`"
-                          @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)" />
+                          @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)"
+                          @stats-note="statsNotes[i] = $event" />
             <!-- cluster PANEL (heatmap / HMM …) — rendered GENERICALLY from the CLUSTER_PANELS registry
                  (docked, board's single cluster run); no per-plot branch -->
             <component v-else-if="entry.contents[i] && isClusterPanel(entry.contents[i]!.ref)"
@@ -563,6 +570,7 @@ defineExpose({ capturePage, collectCsvs })
                              :suffix="clustSuffix" :vis="activeVis"
                              @update:scope="scope = $event" @update:vis="setVis" @toggle-highlight="toggleClustHl" />
           <SeriesPicker v-else :groups="segPops" :selected="activeSel" :scope="scope" :vis="activeVis" :docked="true"
+                        :stats-note="activeStatsNote"
                         @toggle="toggleTarget" @update:scope="scope = $event" @update:vis="setVis" />
         </div>
       </div>

--- a/frontend/src/components/canvas/PlotOptions.vue
+++ b/frontend/src/components/canvas/PlotOptions.vue
@@ -16,7 +16,10 @@ import CcToggle from '../CcToggle.vue'
 const props = withDefaults(defineProps<{
   vis: VisProps
   sections?: ('layout' | 'points' | 'colours' | 'labels' | 'stats')[]
-}>(), { sections: () => ['layout', 'points', 'colours', 'labels'] })
+  // `auto` resolves the test server-side from the group count, so the user can't tell which one ran.
+  // The active plot's last result reports it back here (methodNote) and we echo it under the Test select.
+  statsNote?: string
+}>(), { sections: () => ['layout', 'points', 'colours', 'labels'], statsNote: '' })
 const emit = defineEmits<{ 'update:vis': [patch: Partial<VisProps>] }>()
 
 const open = ref<Record<string, boolean>>({ layout: false, points: false, colours: false, labels: false, stats: false })
@@ -120,6 +123,8 @@ const has = (s: string) => props.sections.includes(s as 'layout')
             <option value="kruskal">Kruskal-Wallis</option>
             <option value="anova">One-way ANOVA</option>
           </select></label>
+        <div v-if="vis.statsEnabled && (vis.statsTest ?? 'auto') === 'auto' && statsNote"
+             class="po-note cc-muted cc-fs-2xs" v-tooltip.left="'Test the active plot ran'">{{ statsNote }}</div>
         <div v-if="vis.statsEnabled" class="po-row cc-muted cc-fs-xs" v-tooltip.left="'One letter per group; shared letter = no difference'"><span>Compact letters</span>
           <CcToggle :model-value="!!vis.statsUseLetters" @update:model-value="set({ statsUseLetters: $event })" /></div>
         <div v-if="vis.statsEnabled && !vis.statsUseLetters" class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Also show non-significant brackets'"><span>Show ns</span>
@@ -162,6 +167,8 @@ const has = (s: string) => props.sections.includes(s as 'layout')
 .po-sel { font-size: var(--cc-fs-xs); max-width: 7rem; }
 .po-txt { font-size: var(--cc-fs-xs); width: 4rem; padding: 1px 4px; }
 .po-txt.wide { width: 100%; }
+/* readout under the Test select — the test `auto` actually resolved to (right-aligned to the select) */
+.po-note { margin-top: -5px; text-align: right; }
 .po-col { flex-direction: column; align-items: stretch; gap: 3px; }
 .po-col > span:first-child { flex: none; }
 </style>

--- a/frontend/src/components/canvas/PopulationPanelShell.vue
+++ b/frontend/src/components/canvas/PopulationPanelShell.vue
@@ -27,10 +27,11 @@ const props = withDefaults(defineProps<{
   // when provided, the shared PlotOptions styling block renders above the footer (obeys `scope`)
   vis?: VisProps
   optionsSections?: ('layout' | 'points' | 'colours' | 'labels' | 'stats')[]
+  statsNote?: string               // active plot's resolved test, echoed under the Stats → Test select
   // DOCKED: render in-flow (a fixed rail, e.g. the Analysis-canvas layout) instead of a draggable
   // floating box — no absolute positioning, no drag, full width of its container.
   docked?: boolean
-}>(), { title: 'Populations', count: undefined, vis: undefined, optionsSections: undefined, docked: false })
+}>(), { title: 'Populations', count: undefined, vis: undefined, optionsSections: undefined, statsNote: '', docked: false })
 const emit = defineEmits<{
   'update:scope': ['global' | 'local']
   'update:vis': [patch: Partial<VisProps>]
@@ -69,7 +70,8 @@ function onHeaderDown(e: MouseEvent) { if (!props.docked) startDrag(e) }
 
     <!-- shared plot-styling block (only when the host passes a `vis` bag), obeys the scope below -->
     <div v-show="!collapsed" v-if="vis" class="pm-opts">
-      <PlotOptions :vis="vis" :sections="optionsSections" @update:vis="emit('update:vis', $event)" />
+      <PlotOptions :vis="vis" :sections="optionsSections" :stats-note="statsNote"
+                   @update:vis="emit('update:vis', $event)" />
     </div>
 
     <!-- scope (global = every plot / local = active plot only): icons only, at the very bottom -->

--- a/frontend/src/components/canvas/SeriesPicker.vue
+++ b/frontend/src/components/canvas/SeriesPicker.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   selected: string[]                  // selected target keys (tkey), in the current scope
   scope: 'global' | 'local'
   vis: VisProps                       // visual properties for the current scope
+  statsNote?: string                  // active plot's resolved stats test (methodNote), shown in Stats
   docked?: boolean                    // render in a fixed rail (Analysis board) instead of floating
 }>()
 const emit = defineEmits<{
@@ -36,7 +37,7 @@ const depthOf = (path: string) => Math.max(0, path.split('/').length - 2)
 </script>
 
 <template>
-  <PopulationPanelShell :count="total" :scope="scope" :vis="vis" :docked="docked"
+  <PopulationPanelShell :count="total" :scope="scope" :vis="vis" :docked="docked" :stats-note="statsNote"
                         :options-sections="['layout', 'points', 'colours', 'labels', 'stats']"
                         @update:scope="emit('update:scope', $event)" @update:vis="emit('update:vis', $event)">
     <div v-if="!total" class="pm-empty cc-muted">No populations in the selected segmentations.</div>

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -14,7 +14,7 @@
   module filter off.
 -->
 <script setup lang="ts">
-import { computed, watch, provide, useTemplateRef } from 'vue'
+import { computed, ref, watch, provide, useTemplateRef } from 'vue'
 import { useProjectStore } from '../../stores/project'
 import { useProjectMetaStore } from '../../stores/projectMeta'
 import { useCanvasPanels } from '../../composables/useCanvasPanels'
@@ -82,6 +82,12 @@ const activeSel = computed(() => scope.value === 'global' ? gSel.value : (active
 const panelVis = (s: PanelState) => scope.value === 'global' ? gVis.value : s.vis
 const activeVis = computed(() => scope.value === 'global' ? gVis.value : (activePanel.value?.state.vis ?? defaultVis()))
 const toggle = (arr: string[], v: string) => arr.includes(v) ? arr.filter(x => x !== v) : [...arr, v]
+// the stats test each panel's last result actually ran (`auto` resolves it server-side from the group
+// count) — the picker shows the ACTIVE plot's, so the user can see what `auto` chose. Not persisted:
+// it's a readout of the current result, not a setting.
+const statsNotes = ref<Record<number, string>>({})
+const activeStatsNote = computed(() => statsNotes.value[activeId.value] ?? '')
+function removePanel(id: number) { remove(id); delete statsNotes.value[id] }
 function toggleTarget(valueName: string, pop: string, pt: string) {
   const k = tkey(pt, valueName, pop)
   if (scope.value === 'global') gSel.value = toggle(gSel.value, k)
@@ -189,11 +195,13 @@ watch(segPops, () => {
                         :series="panelSeries(p.state)" :series-color="seriesColor" :vis="panelVis(p.state)"
                         :ui="p.state" :collapse-series="poolGroups"
                         :reload-token="reloadToken" :persist-key="`${ckey}:${p.id}`"
-                        @activate="activeId = p.id" @remove="remove(p.id)"
-                        @duplicate="duplicatePanel(p)" @explode="explodePanel(p, $event)" />
+                        @activate="activeId = p.id" @remove="removePanel(p.id)"
+                        @duplicate="duplicatePanel(p)" @explode="explodePanel(p, $event)"
+                        @stats-note="statsNotes[p.id] = $event" />
         </template>
         </div>
         <SeriesPicker v-if="showManager" :groups="segPops" :selected="activeSel" :scope="scope" :vis="activeVis"
+                      :stats-note="activeStatsNote"
                       @toggle="toggleTarget" @update:scope="scope = $event" @update:vis="setVis" />
       </div>
     </template>

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -44,7 +44,8 @@ const props = defineProps<{
   persistKey?: string                  // CanvasPanel geometry persistence key
   docked?: boolean                     // fill a grid slot (Analysis board) instead of free-floating
 }>()
-const emit = defineEmits<{ activate: [number]; remove: []; duplicate: []; explode: [string[]] }>()
+const emit = defineEmits<{ activate: [number]; remove: []; duplicate: []; explode: [string[]]
+                           'stats-note': [string] }>()
 const plotRef = useTemplateRef<{ toImageURL(t: 'png' | 'svg', light?: boolean): Promise<string | null> }>('plotRef')
 
 const param = (k: string, d: unknown) => props.spec.params?.find(p => p.key === k)?.default ?? d
@@ -400,6 +401,12 @@ watch([() => props.series.map(t => `${t.popType}:${t.valueName}${t.pop}`).join('
        () => !!props.vis?.statsEnabled, () => props.vis?.statsTest ?? 'auto'],
       scheduleFetch)
 onMounted(scheduleFetch)
+
+// Which test the server ACTUALLY ran. With `auto` that's resolved from the group count (Mann-Whitney
+// for 2, Kruskal-Wallis for >2), so the picker can't show it — report it up and the shared Stats
+// options echo it under the Test select for whichever plot is active.
+const statsNote = computed(() => result.value?.comparisons?.methodNote ?? '')
+watch(statsNote, n => emit('stats-note', n), { immediate: true })
 
 const byImage = computed(() => crossImage.value && (props.scope ?? 'per_image') === 'per_image')
 


### PR DESCRIPTION
When `Test = auto`, the hypothesis test is resolved **server-side** from the group count
(`_auto_test` in `app/src/plotting/stats.jl` — Mann-Whitney for 2 groups, Kruskal-Wallis for >2),
so there was nothing in the UI telling you which test actually ran.

Now the Stats options show it: a small muted line under the Test select with the result's
`methodNote` (e.g. `Mann-Whitney U (two-sided)`), tooltip *Test the active plot ran*.

## How

- `SummaryPanel.vue` — new `stats-note` emit carrying `result.comparisons.methodNote` (`''` when a
  plot has no stats); `immediate` so it clears on remount / slot reuse.
- `SummaryCanvas.vue` / `LayoutCanvas.vue` — collect the notes per panel id / slot index and pass
  the **active** plot's down the rail. Not persisted: it's a readout of the current result, not a
  setting.
- `SeriesPicker.vue` → `PopulationPanelShell.vue` → `PlotOptions.vue` — optional `statsNote`
  pass-through + the readout itself.
- `docs/todo/STATS_ANNOTATIONS_PLAN.md` — footnote under decision **S0-7** ("no test name on the
  chart", Prism parity). That decision still stands; this is a control-panel readout, nothing is
  drawn on the plot.

## Notes / limitations

- The Stats block is one shared rail for the whole canvas, but the resolved test is **per plot** —
  the line therefore shows the *active* plot's and changes as you click between plots. Only the
  tooltip says so; the line itself is just the test name (UI-copy budget).
- Shown only for `auto` (redundant once you pick the test explicitly), and only once a result has
  come back — nothing renders during the first fetch.
- In `LayoutCanvas` the notes are keyed by slot index; dragging plots between slots relies on the
  refetch/re-emit to resync — not verified in a browser.

## Verification

- `npm run typecheck` clean.
- `vitest` 405/405 pass, including the UI-copy budget ratchet that globs every `.vue`.
- Not exercised in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
