### PR TITLE
Put the feijoa on the README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cecelia Feijoa
+# <img src="frontend/public/feijoa.svg" alt="" width="30" align="top"> Cecelia Feijoa
 
 [![CI](https://github.com/schienstockd/cecelia/actions/workflows/ci.yml/badge.svg)](https://github.com/schienstockd/cecelia/actions/workflows/ci.yml)
 [![Release](https://github.com/schienstockd/cecelia/actions/workflows/release.yml/badge.svg)](https://github.com/schienstockd/cecelia/actions/workflows/release.yml)


### PR DESCRIPTION
The 🍍 was dropped in the Pineapple → Feijoa rename (#394) but nothing replaced it, leaving the README title bare. Puts the mark back — the same `frontend/public/feijoa.svg` used for the favicon, header brand mark and setup wizard.

Stranded off #394: that PR was merged while this was still in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)