### PR TITLE
Fix CI: create the config dir before writing, and expand ~ on Windows

### DIFF
--- a/api/src/observer_api.jl
+++ b/api/src/observer_api.jl
@@ -37,7 +37,7 @@ end
 # (Re)write the MCP config the spawned agent loads — cheap, keeps the resolved paths current.
 function _write_observer_mcp_config()::String
     cfg  = observer_mcp_config(_observer_mcp_dir(), python_bin_path(), _observer_api_url())
-    path = joinpath(config_dir(), "observer-mcp.json")
+    path = joinpath(ensure_config_dir(), "observer-mcp.json")   # may be a machine's first ever write
     open(path, "w") do io; JSON3.write(io, cfg); end
     path
 end

--- a/api/src/setup_api.jl
+++ b/api/src/setup_api.jl
@@ -13,7 +13,7 @@ _dir_writable(dir::AbstractString)::Bool =
 # Can `dir` serve as the projects directory? → (ok, message, willCreate). Pure check, no side
 # effects (the actual mkpath happens in /init), so it's safe to call live on every keystroke.
 function _check_projects_dir(dir::AbstractString)
-    path = expanduser(strip(String(dir)))
+    path = expand_user(strip(String(dir)))
     isempty(path)      && return (false, "Enter a folder path.", false)
     isabspath(path)    || return (false, "Use an absolute path (or one starting with ~).", false)
     if ispath(path)
@@ -32,10 +32,10 @@ function _check_projects_dir(dir::AbstractString)
 end
 
 # GET /api/setup/defaults → { projectsDir } — the wizard pre-fill. A leading `~` is kept literal so it
-# stays per-user portable when stored (D1); `expanduser` resolves it (incl. to %USERPROFILE% on
+# stays per-user portable when stored (D1); `expand_user` resolves it (incl. to %USERPROFILE% on
 # Windows) on validate/create/read. `homedir()` fallback only if `~` somehow won't expand here.
 function api_setup_defaults(::HTTP.Request)
-    default = expanduser("~") == "~" ? joinpath(homedir(), "cecelia-projects") : "~/cecelia-projects"
+    default = "~/cecelia-projects"
     200, JSON3.write((; projectsDir = default))
 end
 
@@ -60,7 +60,7 @@ function api_setup_init(body_bytes::Vector{UInt8})
     ok, message, _ = _check_projects_dir(raw)
     ok || return 400, JSON3.write((; error = message))
     try
-        mkpath(expanduser(raw))
+        mkpath(expand_user(raw))
     catch e
         return 400, JSON3.write((; error = "Could not create folder: $(sprint(showerror, e))"))
     end

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -1,7 +1,7 @@
 module Cecelia
 
 # ── Config ────────────────────────────────────────────────────────────────────
-export init_cecelia!, cecelia_conf, config_dir, custom_toml_path
+export init_cecelia!, cecelia_conf, config_dir, ensure_config_dir, custom_toml_path, expand_user
 export cellpose_models_dir, cellpose_model_path, list_cellpose_models
 export projects_dir, setup_required, set_projects_dir!
 export bioformats2raw_bin, python_bin_path, tasks_concurrent_limit, napari_discrete_gpu

--- a/app/src/config.jl
+++ b/app/src/config.jl
@@ -14,7 +14,7 @@ function _deep_merge(a::Dict, b::Dict)::Dict
 end
 
 # Read KEY=value pairs from a .env file. Skips comments and blank lines.
-# Values are NOT shell-expanded; use expanduser() on the result.
+# Values are NOT shell-expanded; use expand_user() on the result.
 function _read_dotenv(path::String)::Dict{String,String}
     out = Dict{String,String}()
     isfile(path) || return out
@@ -27,15 +27,36 @@ function _read_dotenv(path::String)::Dict{String,String}
     out
 end
 
+"""
+    expand_user(path) -> String
+
+Replace a leading `~` with the user's home directory, **on every platform**.
+
+Use this instead of `Base.expanduser`, which is documented as Unix-only ("On Unix systems, replace
+a tilde character…") and is a **silent no-op on Windows** — a `~`-prefixed path then survives
+verbatim into `joinpath`/`open`, producing paths like `~/.cecelia\\observer-mcp.json` that no
+Windows API resolves. Every stored path in `custom.toml`/`.env` may legitimately start with `~`
+(that is what keeps them portable across users), so this is the one expansion helper they all
+go through. `homedir()` is correct on Windows (it honours `USERPROFILE`).
+"""
+function expand_user(path::AbstractString)::String
+    s = String(path)
+    s == "~"            && return homedir()
+    startswith(s, "~/")  && return joinpath(homedir(), s[3:end])
+    # Windows users may type either separator
+    Sys.iswindows() && startswith(s, "~\\") && return joinpath(homedir(), s[3:end])
+    s
+end
+
 # Pure resolver (unit-testable, no env/file reads): given the three ordered signals, pick the dir.
 # Order: explicit arg → CECELIA_DEV_DIR env → CECELIA_DEV_DIR in .env → ~/.cecelia default.
 function _resolve_config_dir(dev_dir::Union{AbstractString,Nothing},
                              env_val::Union{AbstractString,Nothing},
                              dotenv_val::Union{AbstractString,Nothing})::String
-    isnothing(dev_dir)    || return expanduser(String(dev_dir))
-    isnothing(env_val)    || return expanduser(String(env_val))
-    isnothing(dotenv_val) || return expanduser(String(dotenv_val))
-    expanduser("~/.cecelia")
+    isnothing(dev_dir)    || return expand_user(String(dev_dir))
+    isnothing(env_val)    || return expand_user(String(env_val))
+    isnothing(dotenv_val) || return expand_user(String(dotenv_val))
+    expand_user("~/.cecelia")
 end
 
 """
@@ -59,6 +80,23 @@ function config_dir(dev_dir::Union{String,Nothing} = nothing)::String
     _resolve_config_dir(dev_dir,
                         get(ENV, "CECELIA_DEV_DIR", nothing),
                         get(dotenv, "CECELIA_DEV_DIR", nothing))
+end
+
+"""
+    ensure_config_dir([dev_dir]) -> String
+
+[`config_dir`](@ref), created if it does not exist yet. Use this — not bare `config_dir()` — before
+**writing** anything into it.
+
+`config_dir()` is a pure path computation: on a machine that has never run the setup wizard the
+directory genuinely does not exist, so `open(joinpath(config_dir(), …), "w")` fails with
+`SystemError: No such file or directory`. That is not hypothetical — it broke CI on all three
+platforms once the observer wrote its MCP config on every status call.
+"""
+function ensure_config_dir(dev_dir::Union{String,Nothing} = nothing)::String
+    d = config_dir(dev_dir)
+    mkpath(d)
+    d
 end
 
 """
@@ -186,7 +224,7 @@ end
 
 function _cfg_dir(key::String, default::String)::String
     d = get(cecelia_conf(), "dirs", Dict{String,Any}())
-    expanduser(string(get(d, key, default)))
+    expand_user(string(get(d, key, default)))
 end
 
 const _PROJECTS_DIR_PLACEHOLDER = "/path/to/projects"
@@ -212,14 +250,14 @@ end
 Persist `path` as `dirs.projects` in the user's `custom.toml` (creating the file/dir if needed,
 **merging** so other keys survive) and hot-reload config. Writer half of the config pair — it
 targets the same [`custom_toml_path`](@ref) the reader uses. The literal string is stored (so a
-leading `~` stays portable across users); `expanduser` happens on read in `_cfg_dir`. Returns the
+leading `~` stays portable across users); `expand_user` happens on read in `_cfg_dir`. Returns the
 stored path. Creating/validating the projects directory itself is the caller's job (the setup
 endpoint). See `docs/todo/ONBOARDING_PLAN.md` (D1/D3).
 """
 function set_projects_dir!(path::AbstractString)::String
     stored   = strip(String(path))
+    ensure_config_dir()
     cfg_path = custom_toml_path()
-    mkpath(dirname(cfg_path))
     cfg = isfile(cfg_path) ? TOML.parsefile(cfg_path) : Dict{String,Any}()
     dirs = get(cfg, "dirs", Dict{String,Any}())
     dirs["projects"] = stored
@@ -239,7 +277,7 @@ function bioformats2raw_bin()::String
     exe = Sys.iswindows() ? "bioformats2raw.bat" : "bioformats2raw"
     d   = get(get(cecelia_conf(), "dirs", Dict{String,Any}()), "bioformats2raw", "")
     if !isempty(string(d)) && string(d) != "/path/to/bioformats2raw"
-        return joinpath(expanduser(string(d)), "bin", exe)
+        return joinpath(expand_user(string(d)), "bin", exe)
     end
     bundled = joinpath(@__DIR__, "..", "..", "bioformats2raw", "bin", exe)   # repo/install root
     isfile(bundled) && return bundled

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -71,12 +71,60 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         @test Cecelia._resolve_config_dir("/x", "/y", "/z") == "/x"       # explicit wins
         @test Cecelia._resolve_config_dir(nothing, "/y", "/z") == "/y"    # env beats .env
         @test Cecelia._resolve_config_dir(nothing, nothing, "/z") == "/z" # .env beats default
+        # `expand_user`, NOT Base.expanduser: the latter is a no-op on Windows, so asserting against
+        # it would compare two unexpanded strings and pass vacuously there.
         @test Cecelia._resolve_config_dir(nothing, nothing, nothing) ==   # installed-app default
-              expanduser("~/.cecelia")
-        @test Cecelia._resolve_config_dir("~/foo", nothing, nothing) == expanduser("~/foo")
+              expand_user("~/.cecelia")
+        @test Cecelia._resolve_config_dir("~/foo", nothing, nothing) == expand_user("~/foo")
+        # …and the resolved default must be a real absolute path on EVERY platform — a surviving `~`
+        # is the Windows bug that produced `~/.cecelia\observer-mcp.json` in CI.
+        @test isabspath(Cecelia._resolve_config_dir(nothing, nothing, nothing))
+        @test !startswith(Cecelia._resolve_config_dir(nothing, nothing, nothing), "~")
         # public composition
         @test config_dir("/tmp/ceceliatest") == "/tmp/ceceliatest"
         @test custom_toml_path("/tmp/ceceliatest") == joinpath("/tmp/ceceliatest", "custom.toml")
+    end
+
+    # ── expand_user: portable leading-~ expansion ────────────────────────────────
+    # Base.expanduser is documented Unix-only and silently returns the path unchanged on Windows, so
+    # every stored `~`-prefixed path (custom.toml dirs, .env CECELIA_DEV_DIR) went through unexpanded
+    # there. These assertions hold on all three platforms.
+    @testset "expand_user" begin
+        @test expand_user("~") == homedir()
+        @test expand_user("~/foo") == joinpath(homedir(), "foo")
+        @test expand_user("~/foo/bar") == joinpath(homedir(), "foo", "bar")
+        # never leaves a tilde behind
+        @test !startswith(expand_user("~/foo"), "~")
+        # absolute + relative paths pass through untouched
+        @test expand_user("/abs/path") == "/abs/path"
+        @test expand_user("relative/path") == "relative/path"
+        @test expand_user("") == ""
+        # a tilde that isn't a leading path component is a legitimate filename character
+        @test expand_user("/tmp/a~b") == "/tmp/a~b"
+        @test expand_user("~notauser/foo") == "~notauser/foo"
+        # Windows accepts either separator after the tilde
+        if Sys.iswindows()
+            @test expand_user("~\\foo") == joinpath(homedir(), "foo")
+        end
+    end
+
+    # ── ensure_config_dir: safe to WRITE into ────────────────────────────────────
+    # config_dir() is a pure path computation, so on a machine that has never run the setup wizard
+    # the directory does not exist and `open(joinpath(config_dir(), …), "w")` throws. That broke CI
+    # on all three platforms when the observer began writing its MCP config on every status call.
+    @testset "ensure_config_dir" begin
+        base = mktempdir()
+        target = joinpath(base, "never-created")
+        @test !isdir(target)
+        @test ensure_config_dir(target) == target
+        @test isdir(target)                              # created
+        @test ensure_config_dir(target) == target        # idempotent on an existing dir
+        @test isdir(target)
+        # and a file can actually be written into it — the thing the observer needs
+        nested = joinpath(base, "a", "b", "c")           # several levels missing
+        ensure_config_dir(nested)
+        write(joinpath(nested, "observer-mcp.json"), "{}")
+        @test isfile(joinpath(nested, "observer-mcp.json"))
     end
 
     # ── Custom cellpose model resolver (TODO #00087) ─────────────────────────────


### PR DESCRIPTION
CI has been red on all three platforms since #398 (#397 was the last green run). `api/test/runtests.jl:891` errors with:

```
SystemError: opening file "~/.cecelia/observer-mcp.json": No such file or directory
```

Two separate bugs, both about resolving the per-user config dir.

## 1. The config dir may not exist

`config_dir()` is a pure path computation, so on a machine that has never run the setup wizard the directory genuinely does not exist. `_write_observer_mcp_config` opens `<config_dir>/observer-mcp.json` for write on **every** status call, which fails there.

It passed locally only because a dev checkout's `.env` points `CECELIA_DEV_DIR` at a directory that already exists — which is exactly why this slipped through to CI.

Adds **`ensure_config_dir()`** (mkpath + return) as the one helper to use before writing into the config dir. The observer writer and `set_projects_dir!` both go through it.

## 2. `Base.expanduser` is a no-op on Windows

It's documented Unix-only — *"On Unix systems, replace a tilde character…"* — and silently returns the path unchanged on Windows, so a leading `~` survived verbatim into `joinpath`/`open`. That's the literal `~/.cecelia\observer-mcp.json` in the Windows log. Every stored path in `custom.toml`/`.env` may legitimately start with `~`; that's what keeps them portable across users.

Adds **`expand_user()`** and uses it at all **7** call sites in `app/src` + `api/src`. This also removes the hand-rolled workaround already sitting at `setup_api.jl:38`:

```julia
default = expanduser("~") == "~" ? joinpath(homedir(), "cecelia-projects") : "~/cecelia-projects"
```

Someone had already hit this and patched one site. The platform branch now lives in one named helper, per the Windows rules in `CLAUDE.md`.

## Two existing assertions were passing vacuously

`_resolve_config_dir` was asserted against `expanduser("~/.cecelia")` — on Windows **both sides** were unexpanded, so the test passed without checking anything, and would have started failing with this change. They now use `expand_user`, plus new assertions that the resolved default is absolute and carries no surviving `~`.

## Verification

1. **Reproduced the CI condition** locally (`CECELIA_DEV_DIR` → a nonexistent directory): observer testset **13/13 pass**, directory and `observer-mcp.json` created.
2. **Proved causality** — stashed the changes, same condition: unmodified `main` throws the exact CI error, exit 1.
3. `pixi run test-pkg` **1789 pass / 0 fail**; `pixi run test-api` clean. (Grepped for `did not pass` / `Test Failed` / `Error During Test` — not tailed, since the pixi task can exit 0 with failing Julia tests.)

## Reservations

- Windows behaviour is reasoned from Julia's docs and `base/sysinfo.jl`, **not run on a Windows host**. The new tests are what will exercise it in the Windows CI job.
- `expand_user` changes Windows behaviour for every stored `~` path (projects dir, bioformats2raw, config dir) from "silently literal" to "resolved". That's the intent, but it is a behaviour change on that platform.
- `/api/observer/status` now creates `~/.cecelia` on machines without a dev `.env`. It already wrote a file there, so not a new class of side effect, but the directory creation is new.

## Found while investigating, NOT fixed here

The Claude MCP **auto-setup does not work on Windows** for npm-installed Claude Code, for two independent reasons:

1. `agent_available` uses `Sys.which("claude")`. Julia's `Sys.which` tries only the bare name plus `.exe` and `.com` on Windows — never `.cmd`/`.bat`. npm ships `claude.cmd`, so detection returns `nothing`, `available` is `false`, and "Set up my terminal" tells a user who *has* Claude Code: *"No assistant CLI found. Install Claude Code to enable this."*
2. Even with the path resolved, `run(Cmd(["claude.cmd", …]))` can't work — Windows `CreateProcess` cannot execute `.cmd`/`.bat` directly, it needs `cmd /c`.

Only the native installer (`claude.exe`) works today. Tracked separately; it needs a Windows host to verify a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
