### PR TITLE
Resolve python_bin_path to an absolute interpreter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,8 +275,11 @@ Do not add a `useGPU` param to task JSON or Julia handlers.
 All code must run on Linux, macOS, and Windows. Each of these has already caused a real bug —
 use the named helper, don't re-derive the platform branch inline:
 
-- **Python venv path** differs (`bin/python3` vs `Scripts\python.exe`) — always branch on
-  `Sys.iswindows()`, never hardcode one.
+- **Python interpreter** — use `python_bin_path()` in `config.jl`; never hardcode an interpreter name
+  or venv layout (`bin/python3` vs `Scripts\python.exe`). It resolves to an **absolute** path and tries
+  the platform's spellings (Windows conda envs ship `python.exe` and often no `python3` at all). A bare
+  name is not good enough for any string that leaves the `pixi run` environment — the observer
+  registers this value into the user's own Claude Code config, launched from a plain shell.
 - **bioformats2raw binary name** — use `bioformats2raw_bin()` in `config.jl`, don't hardcode
   `.bat` vs no-extension.
 - **Leading `~` in a path** — use `expand_user()` in `config.jl`, never `Base.expanduser`, which is

--- a/app/src/config.jl
+++ b/app/src/config.jl
@@ -286,7 +286,56 @@ function bioformats2raw_bin()::String
     joinpath(_cfg_dir("bioformats2raw", "/path/to/bioformats2raw"), "bin", exe)
 end
 
-python_bin_path()::String = _cfg_dir("python", "python3")
+# The shipped `[dirs] python` value. Must match `app/config.toml` — it is the sentinel for "nobody
+# chose this", the same role `_PROJECTS_DIR_PLACEHOLDER` plays for the projects dir.
+const _PYTHON_BIN_DEFAULT = "python3"
+
+# Interpreter names to try, in order. PURE and parameterised on `iswin` so BOTH platforms' behaviour is
+# testable from any host. Windows conda/pixi envs ship `python.exe` and frequently no `python3` at all,
+# so `python` must be tried there; on Unix `python3` is the unambiguous one.
+#
+# A name the user DELIBERATELY configured is the only candidate: resolve it to an absolute path if we
+# can, but never silently substitute a different interpreter. Falling back would run tasks under an
+# interpreter that lacks the analysis deps and report nothing about why — worse than failing on the
+# name they asked for. The shipped default is not a deliberate choice, so it does get the fallbacks.
+_python_bin_candidates(configured::AbstractString, iswin::Bool)::Vector{String} =
+    let c = String(strip(String(configured)))
+        (isempty(c) || c == _PYTHON_BIN_DEFAULT) ?
+            (iswin ? String["python", "python3"] : String["python3", "python"]) :
+            String[c]
+    end
+
+"""
+    python_bin_path() -> String
+
+The Python interpreter the engine's subprocesses run — **resolved to an absolute path** whenever it
+can be found on `PATH`.
+
+Absolute, not the bare `"python3"` it used to return, because the string escapes the activated
+environment. `pixi run` puts the Pixi env first on `PATH`, so a bare name resolves correctly for
+anything *Julia* spawns (`run_py`, the napari bridge) — but the observer's MCP spec registers this
+value into the user's **own** Claude Code config, where it is launched from a plain shell with no Pixi
+activation. There, a bare `python3` is the *system* python, which has neither `mcp` nor `websockets`,
+so the observer's tools failed to start in exactly the sessions the one-click setup was meant to
+enable. It also could not work on Windows at all, where `python3` frequently does not exist.
+
+Resolution: an explicitly configured `dirs.python` **path** (anything with a directory component) is
+used verbatim — the user has said precisely which interpreter. A bare *name* (including the shipped
+default `"python3"`) is resolved through `PATH`, falling back to the platform's other spellings. If
+nothing resolves, the configured/legacy bare name is returned unchanged, so behaviour never gets
+worse than before.
+"""
+function python_bin_path()::String
+    raw  = strip(string(get(get(cecelia_conf(), "dirs", Dict{String,Any}()), "python", "")))
+    conf = isempty(raw) ? "" : expand_user(String(raw))
+    # An explicit PATH wins verbatim; a bare NAME falls through to resolution below.
+    isempty(conf) || isempty(dirname(conf)) || return conf
+    for cand in _python_bin_candidates(conf, Sys.iswindows())
+        p = Sys.which(cand)
+        isnothing(p) || return String(p)
+    end
+    isempty(conf) ? "python3" : conf
+end
 
 # Default for launching the napari bridge on the discrete GPU (hybrid-graphics machines). Reads
 # `[napari].discreteGpu`; the api layer holds the runtime toggle (Settings) and seeds it from this.

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -85,6 +85,49 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         @test custom_toml_path("/tmp/ceceliatest") == joinpath("/tmp/ceceliatest", "custom.toml")
     end
 
+    # ── python_bin_path: resolved, not a bare name ───────────────────────────────
+    # It used to return the config default `"python3"` verbatim. That works for anything JULIA spawns
+    # (pixi run puts the env first on PATH) but not for the string the observer registers into the
+    # user's OWN Claude Code config: launched from a plain shell, bare `python3` is the SYSTEM python,
+    # which has neither `mcp` nor `websockets` — so the observer's tools failed in exactly the sessions
+    # one-click setup exists to enable. And on Windows `python3` frequently doesn't exist at all.
+    @testset "python_bin_path resolution" begin
+        # candidate order — `iswin` explicit so the Windows list is asserted from any host
+        @test Cecelia._python_bin_candidates("", false) == ["python3", "python"]
+        @test Cecelia._python_bin_candidates("", true)  == ["python", "python3"]   # conda ships python.exe
+        # the SHIPPED default is not a deliberate choice, so it gets the platform fallbacks
+        @test Cecelia._python_bin_candidates(Cecelia._PYTHON_BIN_DEFAULT, true) == ["python", "python3"]
+        @test Cecelia._python_bin_candidates("  python3  ", false) == ["python3", "python"]  # trimmed
+        # a DELIBERATELY configured name is the only candidate — resolve it, never substitute another
+        # interpreter (that would run tasks under something lacking the analysis deps, silently)
+        @test Cecelia._python_bin_candidates("mypy-thon", false) == ["mypy-thon"]
+        @test Cecelia._python_bin_candidates("python", false) == ["python"]
+        @test Cecelia._PYTHON_BIN_DEFAULT == "python3"          # must match app/config.toml [dirs]
+
+        # the live resolver: with no explicit path configured it must return something ABSOLUTE that
+        # exists — that is the whole point (the old bare name failed `isfile`).
+        conf = cecelia_conf(); dirs = get!(conf, "dirs", Dict{String,Any}())
+        had = haskey(dirs, "python"); old = get(dirs, "python", nothing)
+        try
+            dirs["python"] = "python3"          # the shipped default → must resolve, not pass through
+            let p = python_bin_path()
+                @test isabspath(p)
+                @test isfile(p)
+            end
+            # an explicitly configured PATH is honoured verbatim — the user named an exact interpreter
+            dirs["python"] = "/opt/custom/bin/python3.11"
+            @test python_bin_path() == "/opt/custom/bin/python3.11"
+            # …including through a leading ~
+            dirs["python"] = joinpath("~", "venv", "bin", "python")
+            @test python_bin_path() == joinpath(homedir(), "venv", "bin", "python")
+            # an unresolvable bare name degrades to itself rather than to nothing
+            dirs["python"] = "cecelia-no-such-interpreter-42"
+            @test python_bin_path() == "cecelia-no-such-interpreter-42"
+        finally
+            had ? (dirs["python"] = old) : delete!(dirs, "python")
+        end
+    end
+
     # ── expand_user: portable leading-~ expansion ────────────────────────────────
     # Base.expanduser is documented Unix-only and silently returns the path unchanged on Windows, so
     # every stored `~`-prefixed path (custom.toml dirs, .env CECELIA_DEV_DIR) went through unexpanded

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -276,11 +276,25 @@ measure, btrack, the label-props writer, **and** the napari bridge. It now lives
 **`.pixi/`** (managed by Pixi), not under `napari/`. `napari/` keeps only `napari_bridge.py`.
 
 ### The "run via `pixi run`" rule (no hardcoded env paths)
-`pixi run <task>` prepends `.pixi/envs/default/bin` to `PATH`, so `python_bin_path()` stays at its
-config default `"python3"` (no `custom.toml` override) and resolves to the Pixi env python inside an
-activated run. `app/src/napari.jl` no longer hardcodes a venv path; `NAPARI_PYTHON` routes through
-`python_bin_path()`. **Always launch via `pixi run`** (`dev`/`prod`/`app`/`napari`) — launching
-`julia` directly outside the env makes subprocesses fall back to system `python3` and fail.
+`pixi run <task>` prepends `.pixi/envs/default/bin` to `PATH`, so `python_bin_path()` needs no
+`custom.toml` override — it finds the Pixi env python inside an activated run. `app/src/napari.jl` no
+longer hardcodes a venv path; `NAPARI_PYTHON` routes through `python_bin_path()`. **Always launch via
+`pixi run`** (`dev`/`prod`/`app`/`napari`) — launching `julia` directly outside the env makes
+subprocesses fall back to system `python3` and fail.
+
+`python_bin_path()` **resolves to an absolute path** (via `Sys.which`), it does not return the bare
+config default. Two reasons the bare name wasn't enough:
+
+- The string **escapes the activated environment.** The observer registers it into the user's own
+  Claude Code config (`claude mcp add-json`), which launches it from a plain shell with no Pixi
+  activation — where bare `python3` is the *system* python, with neither `mcp` nor `websockets`. The
+  observer's tools failed to start in exactly the sessions one-click setup exists to enable.
+- **Windows** conda/pixi envs ship `python.exe` and frequently no `python3` at all, so the name has to
+  be tried per-platform (`_python_bin_candidates`).
+
+An explicitly configured `dirs.python` **path** is still used verbatim. A deliberately configured
+bare *name* is resolved but never substituted — falling back would run tasks under an interpreter
+lacking the analysis deps and say nothing about why. Only the shipped default gets the fallbacks.
 
 ### Julia and Node are not in Pixi (deliberate, for dev)
 Pixi scopes to the **Python** env. Julia stays on **juliaup + Manifest**, Node on **fnm**; `pixi run`


### PR DESCRIPTION
Filed as "check `python_bin_path` on Windows"; the investigation found it broader than that.

## The bug

`python_bin_path()` returned the bare config default `"python3"`. Fine for anything **Julia** spawns — `pixi run` prepends the env to `PATH` — but the value doesn't stay inside the activated environment:

- **The observer registers it into the user's own Claude Code config** (`claude mcp add-json`), which launches it from a plain shell with **no Pixi activation**. There, bare `python3` is the *system* python, which has neither `mcp` nor `websockets`, so `cecelia_mcp.server` could not start. The observer's tools failed in exactly the terminal sessions one-click setup exists to enable — **on every platform**, not just Windows.
- **On Windows** it's worse: conda/pixi envs ship `python.exe` and frequently no `python3` at all, so the name couldn't resolve even inside the env.

```jsonc
// before
"command": "python3"
// after
"command": ".../.pixi/envs/default/bin/python3"   // isfile() == true
```

## Fix

Resolved through `Sys.which` to an absolute path, with per-platform spellings in `_python_bin_candidates` — pure and parameterised on `iswin`, so the Windows ordering is asserted from a Linux host (same approach as #405).

Resolution rules:

| `dirs.python` | Behaviour |
|---|---|
| a **path** (has a directory component) | used verbatim — the user named an exact interpreter |
| the **shipped default** (`"python3"`) | resolved, with platform fallbacks |
| a deliberately configured **bare name** | resolved, but **never substituted** |

That last row was a real design flaw in my first version, caught by a test: it fell through the candidate list even for a deliberate choice, so `dirs.python = "mypython"` would silently run tasks under `python3` instead. Falling back means running under an interpreter lacking the analysis deps and saying nothing about why — worse than failing on the name you asked for. Only the shipped default (`_PYTHON_BIN_DEFAULT`, the sentinel for "nobody chose this") gets fallbacks.

## A dormant test woke up

`test-pkg`: **1807 pass + 1 broken → 1828 pass + 0 broken.**

The `LabelProps Julia/Python parity` testset — which runs the Julia `LabelProps` reader and the Python `LabelPropsView` against the same fixture to catch spec drift — gates on `isfile(python_bin_path())`. That is false for a bare name, so it had been silently `@test_skip`ping. It now executes (7/7).

`test-api` clean, observer 13/13 under a nonexistent config dir.

## Reservations

- **Existing registrations become `stale`.** `observer_registration_state` compares the registered command against the wanted one, so anyone who already ran one-click setup sees "Fix terminal setup" until they click once. Correct — their old entry was broken — but it is user-visible churn.
- **Windows resolution is still unverified** (no Windows host). The candidate-order logic is what the tests pin, not the `Sys.which` outcome.
- `python_bin_path()` now does a `Sys.which` per call instead of returning a constant. It's called per subprocess spawn, so the cost is noise next to the spawn, but it is no longer a pure config read.
- The parity test now running is itself a CI behaviour change: if that fixture or the Python reader has drifted on another platform, this is where it surfaces. Passes locally.

## Docs

`SHIPPING.md`'s *"run via `pixi run`" rule* stated the old bare-name behaviour as a deliberate design point — corrected, with why a bare name isn't sufficient for a string that leaves the environment. `CLAUDE.md`'s Windows list now names `python_bin_path()` as the helper instead of just saying "branch on `Sys.iswindows()`".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
