### PR TITLE
fix(update): rc10 sorted below rc9, stranding every client on rc9

### DIFF
--- a/api/src/update_api.jl
+++ b/api/src/update_api.jl
@@ -47,13 +47,68 @@ function _install_scope(root::AbstractString = _APP_ROOT)::String
     (isfile(f) && strip(read(f, String)) == "system") ? "system" : "user"
 end
 
-# "v0.1.0-rc1" → VersionNumber; nothing if unparseable (e.g. "dev").
+# A prerelease identifier that is LETTERS IMMEDIATELY FOLLOWED BY DIGITS (`rc10`) is one opaque
+# string to `VersionNumber`, so it compares LEXICOGRAPHICALLY: `"rc10" < "rc9"`. Splitting it into
+# `rc.10` makes the number a numeric identifier, which compares numerically — the semver rule.
+const _RC_SPLIT = r"-([A-Za-z]+)(\d+)" => s"-\1.\2"
+
+"""
+    _parse_ver(tag) -> VersionNumber | nothing
+
+`"v0.1.0-rc1"` → a `VersionNumber`; `nothing` if unparseable (e.g. `"dev"`).
+
+**Why the rewrite.** Julia parses `v"0.1.0-rc10"`'s prerelease as the single STRING `("rc10",)`, not
+`("rc", 10)`, and strings compare lexicographically — so `"rc10" < "rc9"` and **rc10 sorted BELOW
+rc9**. `api_update_check` picks the max release, so once rc10 existed the max stayed rc9: every
+client was told rc9 was the newest release, anyone on rc9 saw "up to date", and anyone older was
+updated *to* rc9 and then stuck there permanently. Silent — no error anywhere. Latent from rc1,
+triggered at the 9→10 boundary.
+
+Rewriting `-rc10` → `-rc.10` before parsing makes the digits a numeric identifier:
+
+    v"0.1.0-rc.10" > v"0.1.0-rc.9"   # true — what we want
+    v"0.1.0-rc10"  > v"0.1.0-rc9"    # false — the bug
+
+Both sides of every comparison go through here, so the normalisation is self-consistent; it changes
+relative order only where the lexicographic result was already wrong. A prerelease still sorts below
+its release (`0.1.0-rc.9 < 0.1.0`), which is what lets a stable tag supersede any rc.
+
+NOTE this cannot rescue clients ALREADY running an affected build — they compare with their own copy
+of this function. The next tag has to outrank `v0.1.0-rc9` under the OLD comparator (`v0.1.0`,
+`v0.2.0`, or `v0.1.0-rc9.N`) to reach them at all.
+"""
 function _parse_ver(tag::AbstractString)
-    try VersionNumber(lstrip(strip(tag), ['v', 'V'])) catch; nothing end
+    s = lstrip(strip(tag), ['v', 'V'])
+    try VersionNumber(replace(s, _RC_SPLIT)) catch; nothing end
 end
 
 function api_version(::HTTP.Request)
     200, JSON3.write((; version=_running_version(), installed=_is_installed()))
+end
+
+# A release tag, and nothing else. `tag` arrives in the POST body and is interpolated into the
+# download URL and written to `.pending-update` for the launcher, so it must not be free-form: a
+# value containing `../` or a query string would point the download at some other path in the repo.
+# Anchored, so it matches the WHOLE string.
+const _TAG_RE = r"^v?\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$"
+
+_valid_tag(tag::AbstractString)::Bool = occursin(_TAG_RE, tag)
+
+"""
+    _apply_precheck(tag; scope, installed) -> nothing | (status, error_message)
+
+The guard rails on `/api/update/apply`, separated from the download so they can be tested without a
+network or an installed root — the endpoint itself refuses to run in a git checkout, which is
+exactly where the tests live, so nothing could reach the body otherwise.
+
+`nothing` means "cleared to download".
+"""
+function _apply_precheck(tag::AbstractString; scope::AbstractString, installed::Bool)
+    scope == "system" && return (403, "This is a shared (system-wide) installation — updates must be run by an administrator (re-run the install-system script).")
+    installed || return (400, "Updates apply only to an installed copy, not a dev/git checkout.")
+    isempty(tag) && return (400, "version (tag) required")
+    _valid_tag(tag) || return (400, "not a valid release tag: $(repr(tag))")
+    nothing
 end
 
 # GET /api/update/check — compare the running version to the newest GitHub release.
@@ -61,7 +116,11 @@ end
 function api_update_check(::HTTP.Request)
     current = _running_version()
     releases = try
-        resp = HTTP.get("https://api.github.com/repos/$_UPDATE_REPO/releases?per_page=20";
+        # 100 is GitHub's per-page maximum. The winner is the max BY VERSION, but the page is
+        # ordered by DATE, so a bounded page can hide a higher version that was published earlier —
+        # at per_page=20 that was ~20 releases away, i.e. reachable. 100 is years of heartbeat tags;
+        # if this repo ever passes it, this needs real pagination rather than a bigger number.
+        resp = HTTP.get("https://api.github.com/repos/$_UPDATE_REPO/releases?per_page=100";
                         headers = ["Accept" => "application/vnd.github+json", "User-Agent" => "cecelia"],
                         read_idle_timeout = 15, retry = false)
         JSON3.read(resp.body)
@@ -96,22 +155,40 @@ end
 # POST /api/update/apply {version} — download + stage the target release bundle. The launcher
 # applies it on the next restart. Refused in a dev/git checkout.
 function api_update_apply(body_bytes::Vector{UInt8})
-    _install_scope() == "system" && return 403, JSON3.write((;
-        error = "This is a shared (system-wide) installation — updates must be run by an administrator (re-run the install-system script)."))
-    _is_installed() || return 400, JSON3.write((;
-        error = "Updates apply only to an installed copy, not a dev/git checkout."))
     body = try JSON3.read(String(body_bytes)) catch; Dict{Symbol,Any}() end
     tag  = String(get(body, :version, ""))
-    isempty(tag) && return 400, JSON3.write((; error = "version (tag) required"))
+
+    pre = _apply_precheck(tag; scope = _install_scope(), installed = _is_installed())
+    pre === nothing || return pre[1], JSON3.write((; error = pre[2]))
+
+    # `tar` is not guaranteed present (it is on Windows 10+ as bsdtar, but guard rather than emit a
+    # cryptic spawn failure) — same check the project export/import path makes before packing.
+    Cecelia._tar_available() || return 500, JSON3.write((;
+        error = "`tar` was not found on PATH — cannot unpack the update bundle."))
 
     url     = "https://github.com/$_UPDATE_REPO/releases/download/$tag/cecelia.tar.gz"
     staging = joinpath(_APP_ROOT, ".update-staging")
+    job_id  = "update-apply"
     try
         rm(staging; recursive = true, force = true)
         payload = joinpath(staging, "payload"); mkpath(payload)
         tarball = joinpath(staging, "cecelia.tar.gz")
+        # NO total `timeout` on purpose. Downloads.jl already aborts after 20s with NO DATA
+        # RECEIVED, which is the actual hang we care about; a total cap would instead kill a
+        # legitimately slow download of a large bundle on a poor connection. Don't "fix" this.
         Downloads.download(url, tarball)
-        run(`tar -xzf $tarball -C $payload`)
+        # Go through `_run_tar` (app/src/project_io.jl) rather than a bare `run` — it is the one tar
+        # runner. A bare `run` skipped `track_job!` (so the extract could not be cancelled) and, more
+        # importantly, missed the `termsignal` check: libuv reports `exitcode == 0` for a
+        # SIGNAL-KILLED process, so a killed extract read as SUCCESS and we would stage a
+        # half-unpacked payload and mark it pending. See CLAUDE.md → Windows compatibility.
+        if !Cecelia._run_tar(`tar -xzf $tarball -C $payload`, job_id)
+            # Clear the half-unpacked payload BEFORE returning. `.pending-update` is deliberately
+            # not written, so the launcher has nothing to apply on the next restart.
+            rm(staging; recursive = true, force = true)
+            return 500, JSON3.write((;
+                error = "unpacking the update bundle failed (tar exited non-zero or was cancelled)."))
+        end
         write(joinpath(_APP_ROOT, ".pending-update"), tag)   # marker the launcher looks for
         broadcast_ws(Dict("type" => "update:staged", "version" => tag))
         200, JSON3.write((; staged = tag,
@@ -119,5 +196,10 @@ function api_update_apply(body_bytes::Vector{UInt8})
     catch e
         rm(staging; recursive = true, force = true)
         500, JSON3.write((; error = "staging failed: $(sprint(showerror, e))"))
+    finally
+        # `track_job!` auto-creates the registry entry, so drop it however we leave — otherwise
+        # every apply leaks one and a later `cancel_job!("update-apply")` would target dead procs.
+        # Staging is NOT removed here: on success the launcher needs the payload it points at.
+        finish_job!(job_id)
     end
 end

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -70,6 +70,70 @@ end
     @test haskey(JSON3.read(body), :error)
 end
 
+@testset "API: update version ordering (rcN sorts numerically)" begin
+    # THE BUG THIS PINS. Julia parses `v"0.1.0-rc10"`'s prerelease as the single STRING `("rc10",)`,
+    # and strings compare lexicographically — so `"rc10" < "rc9"` and rc10 sorted BELOW rc9.
+    # `api_update_check` reports the MAX release, so once rc10 existed the max stayed rc9: rc9
+    # clients saw "up to date" and older clients were updated *to* rc9 and stuck there. Silent, no
+    # error, latent from rc1, triggered at the 9→10 boundary. `_parse_ver` now rewrites `-rc10` →
+    # `-rc.10` so the digits are a NUMERIC identifier.
+    @test _parse_ver("v0.1.0-rc10") > _parse_ver("v0.1.0-rc9")
+    @test _parse_ver("v0.1.0-rc11") > _parse_ver("v0.1.0-rc2")
+    @test _parse_ver("v0.1.0-rc100") > _parse_ver("v0.1.0-rc99")
+
+    # ...without disturbing the orderings that were already right.
+    @test _parse_ver("v0.1.0-rc9") > _parse_ver("v0.1.0-rc8")
+    @test _parse_ver("v0.1.0") > _parse_ver("v0.1.0-rc10")     # a release outranks its prereleases
+    @test _parse_ver("v0.2.0") > _parse_ver("v0.1.0")
+    @test _parse_ver("v0.1.1") > _parse_ver("v0.1.0")
+
+    # Shape + tolerance: `v`/`V` prefix and surrounding space are stripped, junk is `nothing`
+    # (so a "dev" checkout never reports an update rather than erroring).
+    @test _parse_ver("V0.1.0") == _parse_ver(" v0.1.0 ") == VersionNumber("0.1.0")
+    @test _parse_ver("dev") === nothing
+    @test _parse_ver("") === nothing
+    @test _parse_ver("v0.1.0-rc10").prerelease == ("rc", 10)   # numeric identifier, not "rc10"
+
+    # An already-dotted tag must not be rewritten twice.
+    @test _parse_ver("v0.1.0-rc.10") == _parse_ver("v0.1.0-rc10")
+
+    # End-to-end over a release LIST, the way `api_update_check` picks a winner: the newest tag must
+    # win regardless of the order GitHub returns it in.
+    pick(tags) = argmax(t -> _parse_ver(t), tags)
+    @test pick(["v0.1.0-rc8", "v0.1.0-rc10", "v0.1.0-rc9"]) == "v0.1.0-rc10"
+    @test pick(["v0.1.0-rc10", "v0.1.0", "v0.1.0-rc9"]) == "v0.1.0"
+end
+
+@testset "API: update apply guard rails" begin
+    # `api_update_apply` refuses to run in a git checkout — which is where these tests live — so the
+    # guards are extracted into `_apply_precheck` to be reachable at all. Pure: no network, no root.
+    ok(tag) = _apply_precheck(tag; scope = "user", installed = true)
+
+    @test ok("v0.1.0") === nothing              # cleared to download
+    @test ok("v0.1.0-rc9") === nothing
+    @test ok("v0.1.0-rc.10") === nothing
+    @test ok("0.1.0") === nothing               # the `v` is optional
+
+    # Scope/install guards still fire, and in priority order — a system install is refused even
+    # with a perfectly good tag.
+    @test _apply_precheck("v0.1.0"; scope = "system", installed = true)[1] == 403
+    @test _apply_precheck("v0.1.0"; scope = "dev", installed = false)[1] == 400
+    @test _apply_precheck(""; scope = "user", installed = true)[1] == 400
+
+    # `tag` is interpolated into the download URL and written to `.pending-update`, so free-form
+    # input must not survive: traversal, a second path segment, a query string or whitespace would
+    # each point the download somewhere other than this release's asset.
+    for bad in ["../../etc/passwd", "v0.1.0/../../other", "v0.1.0?x=1", "v0.1.0 rm -rf",
+                "latest", "main", "v0.1", "v0.1.0;whoami", "v0.1.0\nx", "https://evil/x"]
+        r = _apply_precheck(bad; scope = "user", installed = true)
+        @test r !== nothing && r[1] == 400
+    end
+
+    # Anchoring: a valid tag with junk appended must NOT pass (an unanchored regex would let it).
+    @test _apply_precheck("v0.1.0/evil"; scope = "user", installed = true) !== nothing
+    @test _apply_precheck("xv0.1.0"; scope = "user", installed = true) !== nothing
+end
+
 @testset "API: setup wizard" begin
     st, body = api_setup_defaults(HTTP.Request("GET", "/api/setup/defaults"))
     @test st == 200

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -60,6 +60,26 @@ cycle if nothing changed). This is the whole schedule. It gives you:
 acknowledgements (celltrackR GPL-2) — TODO #00060. Fine to skip for personal rc's; required the moment
 someone else installs it.
 
+### One-time constraint: everything shipped so far is stuck behind `v0.1.0-rc9`
+
+`api/src/update_api.jl` compares tags with Julia's `VersionNumber`, which parses `rc10`'s prerelease
+as the single **string** `"rc10"` — and `"rc10" < "rc9"` lexicographically. `_parse_ver` now rewrites
+`-rc10` → `-rc.10` so the digits compare numerically, **but that fix only helps clients that already
+have it.** Anyone running `v0.1.0-rc9` compares with their own copy of the old function, so:
+
+| Next tag | Reaches an rc9 client? |
+|---|---|
+| `v0.1.0-rc10` (…and rc11 … rc19) | **no** — sorts *below* rc9; the GUI says "up to date" |
+| `v0.1.0` / `v0.2.0` / any release | **yes** — a release always outranks its own prereleases |
+| `v0.1.0-rc9.1` | yes, but it is an unreadable version to hand anyone |
+
+Worse, an rc8 client offered the "newest" release is sent to **rc9** and then dead-ends there, so
+rc9 is a terminal state for every existing install until a tag outranks it.
+
+**So the next tag must be a plain release** (`v0.1.0` or higher). After that the ladder is safe and
+`-rcN` works normally again. This also fixes `releases/latest`, which only ever resolves to a
+non-prerelease and has therefore never worked (`docs/SHIPPING.md` → *Install channels*).
+
 ## Cutting a release — the short checklist
 
 1. CI matrix green on `main` (all three OSes).


### PR DESCRIPTION
## The bug

`_parse_ver` compares tags with Julia's `VersionNumber`, which parses `v"0.1.0-rc10"`'s prerelease as
the single **string** `("rc10",)` — not `("rc", 10)`. Strings compare lexicographically, so
`"rc10" < "rc9"`.

`api_update_check` reports the **max** release, so the moment rc10 exists the max stays rc9:

| Client on | GUI shows | Applies |
|---|---|---|
| rc9 | "up to date" | — (rc10 invisible) |
| rc8 or older | "update available: **rc9**" | rc9 → then stuck permanently |

**rc9 becomes a terminal state for every install**, silently — no error, no log. Latent since rc1; it
detonates exactly at the 9→10 boundary.

Verified by simulating the comparator *as shipped in rc9* over a release list.

## The fix, and its limit

`-rc10` → `-rc.10` before parsing, making the digits a numeric identifier. Both sides of every
comparison go through `_parse_ver`, so the normalisation is self-consistent and only reorders pairs
the lexicographic result already had wrong. A prerelease still sorts below its release.

**It cannot rescue clients already running an affected build** — they compare with their own copy of
the function. The next tag has to outrank `v0.1.0-rc9` under the OLD comparator:

| Next tag | Reaches an rc9 client? |
|---|---|
| `v0.1.0-rc10` … `rc19` | **no** — sorts below rc9 |
| `v0.1.0` / `v0.2.0` | **yes** — a release always outranks its own prereleases |
| `v0.1.0-rc9.1` | yes, but unreadable to hand anyone |

So **the next tag must be a plain release.** Written into `docs/RELEASING.md` — it constrains the
next tag and isn't a thing to rediscover. (It also fixes `releases/latest`, which only ever resolves
to a non-prerelease and has therefore never worked.)

## Also in this pass

A full read of the file turned up four more, fixed together rather than listed as caveats:

- **`api_update_apply` shelled out to a bare `run(tar …)`** instead of `Cecelia._run_tar`. The
  `termsignal` check is the substance: libuv reports `exitcode == 0` for a **signal-killed** process,
  so a cancelled extract read as *success* — staging a half-unpacked payload and writing
  `.pending-update` for the launcher to apply on the next restart. Now the canonical runner, plus
  `_tar_available()`, staging cleanup on the tar-failure path, and `finish_job!` in a `finally`.
- **`per_page=20` bounded the scan.** The winner is the max *by version* but the page is ordered by
  *date*, so a higher version published earlier could fall off. Raised to 100 (GitHub's max), bound
  stated.
- **`tag` was unvalidated** — straight from the POST body into the download URL and into
  `.pending-update`. `../` or a query string would point the download elsewhere in the repo. Now an
  anchored `_TAG_RE`, with 12 hostile inputs tested.
- **Guard rails extracted to a pure `_apply_precheck`** so they're testable at all: the endpoint
  refuses to run in a git checkout, which is where the tests live, so nothing could previously reach
  them. That's exactly why the injection hole went unnoticed.

## Deliberately NOT changed

**No total `timeout` on the download.** I flagged this as a bug and was wrong: `Downloads.jl` already
aborts after 20s with no data received, which is the real hang. A total cap would instead kill a
legitimately slow download of a large bundle on a poor connection. Left at the default and documented
in place so it doesn't get "fixed".

**Bundle integrity is still open** — hardening, not a bug. `release.yml` publishes no checksum, so it
needs a pipeline change plus a verify-if-present migration (a client that *requires* a checksum
couldn't install any existing release). Its own PR, not one to ride along with a release-critical fix.

## Verification

`pixi run test-api` — exit 0, 0 failure markers.

| Testset | |
|---|---|
| `update version ordering (rcN sorts numerically)` | 14 |
| `update apply guard rails` | 19 |
| `update scope` (existing, no regression) | 7 |

Also exercised `Cecelia._run_tar` directly against a good and a corrupt tarball: no test reaches the
apply body, and Julia resolves names at call time, so a typo in `Cecelia._run_tar` would have shipped
silently and surfaced on a real user's update.

Not covered: nothing drives `api_update_apply` end to end — that needs an installed (non-git) root
and a real download, and I didn't want to weaken the guard to fake it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
