### PR TITLE
feat(release): publish + verify a bundle checksum; fix the dev-channel premise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,11 @@ jobs:
             api app python app.py pixi.toml pixi.lock VERSION \
             napari/napari_bridge.py frontend/dist \
             install.sh install.ps1 README.md docs
+          # SHA-256 beside the bundle, so the in-app updater and the installers can verify what they
+          # downloaded. `cd out` first: sha256sum records the path it was GIVEN, and a digest naming
+          # `out/cecelia.tar.gz` would not match a file downloaded as `cecelia.tar.gz`.
+          cd out && sha256sum cecelia.tar.gz > cecelia.tar.gz.sha256 && cd ..
+          cat out/cecelia.tar.gz.sha256
           ls -lh out/
 
       - name: Publish GitHub Release
@@ -51,6 +56,7 @@ jobs:
         with:
           files: |
             out/cecelia.tar.gz
+            out/cecelia.tar.gz.sha256
             install.sh
             install.ps1
           generate_release_notes: true

--- a/api/src/update_api.jl
+++ b/api/src/update_api.jl
@@ -177,6 +177,29 @@ function api_update_apply(body_bytes::Vector{UInt8})
         # RECEIVED, which is the actual hang we care about; a total cap would instead kill a
         # legitimately slow download of a large bundle on a poor connection. Don't "fix" this.
         Downloads.download(url, tarball)
+
+        # Integrity: check the bundle against the `.sha256` published beside it. HTTPS covers the
+        # transport; this covers a TRUNCATED or SWAPPED asset, which transport security says nothing
+        # about — and we are about to hand this payload to the launcher to overwrite the app with.
+        #
+        # VERIFY-IF-PRESENT, deliberately. Releases up to and including v0.1.0-rc9 have no digest
+        # asset, so REQUIRING one would make every existing release uninstallable from a client that
+        # has this code. Absent digest → proceed (and say so in the message); present digest that
+        # does NOT match → refuse. Tighten to mandatory once no supported release predates it.
+        digest = try
+            String(take!(Downloads.download("$url.sha256", IOBuffer())))
+        catch
+            ""   # 404 on a pre-digest release, or the fetch failed — not fatal, see above
+        end
+        verified = false
+        if !isempty(strip(digest))
+            if !Cecelia._sha256_matches(tarball, digest)
+                rm(staging; recursive = true, force = true)
+                return 500, JSON3.write((;
+                    error = "the downloaded bundle does not match its published SHA-256 — refusing to stage it."))
+            end
+            verified = true
+        end
         # Go through `_run_tar` (app/src/project_io.jl) rather than a bare `run` — it is the one tar
         # runner. A bare `run` skipped `track_job!` (so the extract could not be cancelled) and, more
         # importantly, missed the `termsignal` check: libuv reports `exitcode == 0` for a
@@ -191,7 +214,7 @@ function api_update_apply(body_bytes::Vector{UInt8})
         end
         write(joinpath(_APP_ROOT, ".pending-update"), tag)   # marker the launcher looks for
         broadcast_ws(Dict("type" => "update:staged", "version" => tag))
-        200, JSON3.write((; staged = tag,
+        200, JSON3.write((; staged = tag, verified,
             message = "Update $tag downloaded. Restart Cecelia to finish installing."))
     catch e
         rm(staging; recursive = true, force = true)

--- a/app/src/utils.jl
+++ b/app/src/utils.jl
@@ -1,3 +1,7 @@
+# SHA is also imported in tasks/chain.jl; repeat it here rather than depend on include order or
+# on an unrelated file keeping its import.
+import SHA
+
 const UID_LENGTH = 6
 const UID_CHARS  = collect("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
@@ -17,4 +21,37 @@ function _dir_bytes(path::String)::Int
             total
         catch; 0; end
     end
+end
+
+# ── Release-bundle integrity ──────────────────────────────────────────────────────────────────────
+
+"""
+    _file_sha256(path) -> String
+
+Lowercase hex SHA-256 of a file, streamed rather than slurped — the release bundle is small today but
+this must not depend on that.
+
+Used by `/api/update/apply` to check a downloaded bundle against the `.sha256` published beside it.
+HTTPS already covers the transport; this covers a truncated or swapped asset, which transport
+security says nothing about.
+"""
+_file_sha256(path::AbstractString)::String = open(io -> bytes2hex(SHA.sha256(io)), path)
+
+"""
+    _sha256_matches(path, digest_file_contents) -> Bool
+
+Whether `path` hashes to the digest recorded in a `sha256sum`-style line:
+
+    2f0a…9c  cecelia.tar.gz
+
+Only the first whitespace-delimited token is read, so both the GNU (`hash  name`) and bare-hash forms
+work. Comparison is case-insensitive and whitespace-tolerant; a malformed or empty digest file is
+`false` rather than an error, so the CALLER decides whether a missing/broken digest is fatal.
+"""
+function _sha256_matches(path::AbstractString, digest_contents::AbstractString)::Bool
+    tok = first(split(strip(digest_contents)), 1)
+    isempty(tok) && return false
+    expected = lowercase(strip(first(tok)))
+    occursin(r"^[0-9a-f]{64}$", expected) || return false
+    _file_sha256(path) == expected
 end

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -127,6 +127,38 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         @test isfile(joinpath(nested, "observer-mcp.json"))
     end
 
+    # ── Release-bundle integrity ─────────────────────────────────────────────────
+    # `/api/update/apply` hands the downloaded payload to the launcher, which overwrites the app
+    # with it on the next restart — so a truncated or swapped asset matters, and HTTPS says nothing
+    # about either. These back the `.sha256` published beside the bundle by `release.yml`.
+    @testset "_file_sha256 / _sha256_matches" begin
+        mktempdir() do d
+            f = joinpath(d, "cecelia.tar.gz")
+            write(f, "some bundle bytes")
+            h = Cecelia._file_sha256(f)
+
+            @test occursin(r"^[0-9a-f]{64}$", h)                         # lowercase hex, 64 chars
+            @test h == Cecelia._file_sha256(f)                           # stable
+            @test Cecelia._sha256_matches(f, "$h  cecelia.tar.gz")       # GNU `sha256sum` form
+            @test Cecelia._sha256_matches(f, h)                          # bare hash
+            @test Cecelia._sha256_matches(f, "$h  cecelia.tar.gz\n")     # trailing newline
+            @test Cecelia._sha256_matches(f, uppercase(h))               # case-insensitive
+
+            # Every not-a-match must be FALSE, never an exception — the caller decides whether a
+            # missing/broken digest is fatal (it is verify-if-present, so it isn't).
+            @test !Cecelia._sha256_matches(f, "0"^64)                    # wrong digest
+            @test !Cecelia._sha256_matches(f, "")                        # empty file
+            @test !Cecelia._sha256_matches(f, "   \n ")                  # whitespace only
+            @test !Cecelia._sha256_matches(f, "<!DOCTYPE html>")         # an error page, not a digest
+            @test !Cecelia._sha256_matches(f, h[1:40])                   # truncated
+            @test !Cecelia._sha256_matches(f, h * "ff")                  # over-long
+
+            # A changed byte must change the verdict — the whole point.
+            write(f, "some bundle bytez")
+            @test !Cecelia._sha256_matches(f, "$h  cecelia.tar.gz")
+        end
+    end
+
     # ── Custom cellpose model resolver (TODO #00087) ─────────────────────────────
     # A user-placed checkpoint under `<config_dir>/models/cellposeModels/{name}` is picked up
     # by the cellpose Julia handler and passed to Python as an absolute file path (which

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,13 +12,27 @@ things as he hits them, plus the occasional ad-hoc request ("here's my image, ma
 → ship). There is **no schedulable feature roadmap** to release against. So the cadence is a
 **time-boxed heartbeat + event triggers** — not "release when phase N is done".
 
-Two channels already carry this (see SHIPPING.md):
+Two install channels exist (see SHIPPING.md), but **only one of them has users**:
 
-- **dev channel = `main` HEAD.** Every merged PR is immediately available to anyone on dev. New
-  features do **not** need a tag to reach testers — so *"we added a bunch of stuff"* is **not** a
-  reason to release.
-- **stable channel = tagged release.** A tag is for people who need a **fixed point** they can install,
-  roll back to, or cite.
+- **stable channel = a tag.** This is how *every* real user installs. Biologists do not install from
+  a branch, and there is no reason they should — the dev channel needs Node on PATH and builds the
+  frontend locally.
+- **dev channel = `main` HEAD.** This is for **people who want to work ON Cecelia** — contributors
+  tracking HEAD, not people using it to analyse images. **It has no users today.** That may change
+  if the project picks up contributors; if it does, they are still developers, not the audience a
+  release is cut for.
+
+**The consequence, and it is the one that matters:** *a tag is the only thing that reaches a user.*
+Nothing merged to `main` is available to anyone doing science with Cecelia until it is tagged. So
+untagged work is not "already shipped to testers" — it is undelivered, and the gap grows with every
+merge.
+
+> This paragraph used to say the opposite — that new features "do not need a tag to reach testers", so
+> *"we added a bunch of stuff"* was not a reason to release. That inference rested on a dev channel
+> nobody uses, and it produced the wrong call in review at least once: an accumulated 281-commit gap
+> was waved off as already-delivered when in fact no user could see any of it. If dev ever does pick
+> up contributors, that still doesn't revive the argument — a contributor on HEAD is not someone a
+> release is cut for.
 
 ## Three things, one mechanism
 
@@ -27,8 +41,14 @@ conceptual split:
 
 | | What it is | When |
 |---|---|---|
-| **rc tag** `v0.1.0-rcN` | a snapshot to install / roll back to (GitHub *prerelease*) | cut liberally — the heartbeat, and before risky work |
-| **release** `v0.1.0` | the version you point people at (onboard, cite, demo from) | when someone's work will depend on it |
+| **release** `v0.1.0` | **the default.** A version a user installs and can name | the heartbeat, and any fix a user is waiting on (bump the patch) |
+| **rc tag** `v0.1.0-rcN` | a build you intend to **soak before promoting** | bracketing a risky refactor; a candidate you will re-cut as a release |
+
+**Prefer a plain release.** The rc ladder was the default for nine tags and never converged, because
+none of them were candidates *for* anything — they were snapshots wearing a candidate's label, while
+being the only thing users could install. A prerelease also flags "don't rely on this" to the exact
+people relying on it, and GitHub's `releases/latest` never resolves while every tag is a prerelease.
+If a user hits a bug you have already fixed, that is a **patch release** (`v0.1.1`), not an rc.
 | **milestone** (M-entry) | a coarse "shippable state" note in MILESTONES.md | only at big boundaries (a capability lands, v1.0 freeze) — **not** every tag |
 
 ## The semi-schedule (heartbeat)

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -174,7 +174,13 @@ launcher.
 > re-resolves optional deps for the host and is far less prone to it. `release.yml` keeps `npm ci`
 > because it only ever runs on `ubuntu-latest`, where the current-platform binding installs reliably.
 
-**Why a dev channel.** So testers can track HEAD without a tag being cut every couple of days. GitHub
+**Why a dev channel.** For **people who want to work ON Cecelia** — tracking HEAD without a tag being
+cut every couple of days. It is *not* how end users run it: a biologist installs a tag, and the Node
+requirement plus local frontend build make dev a poor fit for anyone not developing the thing. **It
+has no users today**, and if it gains any they will be contributors. So don't reason about delivery
+as though users are on it — a tag is the only thing that reaches them (`docs/RELEASING.md` → *the
+consequence*).
+GitHub
 serves any branch as a tarball at `archive/refs/heads/<branch>.tar.gz` — no release, no asset upload —
 so the dev path just points the *same* installer at that URL. `CECELIA_BRANCH` overrides the branch.
 

--- a/install.ps1
+++ b/install.ps1
@@ -97,6 +97,33 @@ $Tmp = New-TemporaryFile
 Say "Downloading $Url"
 Invoke-WebRequest -Uri $Url -OutFile $Tmp
 
+# Verify the bundle against the SHA-256 published beside it — the Windows half of the same check in
+# install.sh. HTTPS covers the transport; this covers a truncated or swapped asset. Stable channel
+# only (a dev branch archive has no digest).
+#
+# VERIFY-IF-PRESENT: releases up to v0.1.0-rc9 predate the digest asset, so a MISSING one is not
+# fatal — that would make every existing release uninstallable. A MISMATCH is fatal.
+if ($Channel -ne 'dev') {
+  $ShaTmp = New-TemporaryFile
+  $HaveDigest = $true
+  try {
+    # -UseBasicParsing for Windows PowerShell 5.1 without IE first-run configured.
+    Invoke-WebRequest -Uri "$Url.sha256" -OutFile $ShaTmp -UseBasicParsing -ErrorAction Stop
+  } catch { $HaveDigest = $false }
+
+  if ($HaveDigest) {
+    # `sha256sum` format is "<hash>  <name>"; take the first token.
+    $Expected = ((Get-Content $ShaTmp -Raw).Trim() -split '\s+')[0].ToLower()
+    $Actual   = (Get-FileHash -Path $Tmp -Algorithm SHA256).Hash.ToLower()
+    if ($Expected -and $Actual -ne $Expected) {
+      Remove-Item $ShaTmp, $Tmp -ErrorAction SilentlyContinue
+      throw "Checksum mismatch for $Version.`n  expected: $Expected`n  actual:   $Actual`nThe download is corrupt or has been tampered with - not installing."
+    }
+    Say 'Checksum verified.'
+  }
+  Remove-Item $ShaTmp -ErrorAction SilentlyContinue
+}
+
 Say "Installing to $InstallDir"
 if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir }
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -106,6 +106,28 @@ say "Downloading $URL"
 curl -fSL "$URL" -o "$TMP/cecelia.tar.gz" \
   || err "Download failed — $([ "$CHANNEL" = dev ] && echo "is branch '$BRANCH' correct?" || echo "does the release exist yet?")"
 
+# Verify the bundle against the SHA-256 published beside it. HTTPS covers the transport; this covers
+# a truncated or swapped asset. Stable channel only — the dev channel pulls a GitHub branch archive,
+# which has no digest.
+#
+# VERIFY-IF-PRESENT: releases up to v0.1.0-rc9 predate the digest asset, so a MISSING one is not
+# fatal (that would make every existing release uninstallable). A MISMATCH is fatal.
+if [ "$CHANNEL" != "dev" ] && curl -fsSL "$URL.sha256" -o "$TMP/cecelia.tar.gz.sha256" 2>/dev/null; then
+  expected="$(awk '{print $1}' "$TMP/cecelia.tar.gz.sha256" 2>/dev/null)"
+  # sha256sum is GNU/Linux; macOS ships shasum. Neither guaranteed → skip rather than fail.
+  if   have sha256sum; then actual="$(sha256sum "$TMP/cecelia.tar.gz" | awk '{print $1}')"
+  elif have shasum;    then actual="$(shasum -a 256 "$TMP/cecelia.tar.gz" | awk '{print $1}')"
+  else actual=""; say "Neither sha256sum nor shasum found — skipping checksum verification."
+  fi
+  if [ -n "$actual" ] && [ -n "$expected" ]; then
+    [ "$actual" = "$expected" ] || err "Checksum mismatch for $VERSION.
+  expected: $expected
+  actual:   $actual
+The download is corrupt or has been tampered with — not installing."
+    say "Checksum verified."
+  fi
+fi
+
 say "Installing to $INSTALL_DIR"
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"


### PR DESCRIPTION
> **Stacked on #407** (`fix/update-api-rc-ordering`), which touches the same file. Merge that first;
> this diff shows only its own changes once #407 lands.

Two things, both release infrastructure, both requested together.

## 1. Bundle integrity

`/api/update/apply` downloads `cecelia.tar.gz` and hands it to the launcher to **overwrite the app
with on the next restart** — with nothing checking what arrived. HTTPS covers the transport; it says
nothing about a truncated or swapped asset.

`release.yml` now emits `cecelia.tar.gz.sha256` beside the bundle and uploads it. All three consumers
verify it — the in-app updater, `install.sh`, `install.ps1` — under one policy:

> **Verify-if-present.** Every release up to and including `v0.1.0-rc9` predates the digest asset, so
> *requiring* one would make every existing release uninstallable from a client carrying this code.
> **Missing digest → proceed. Present digest that doesn't match → refuse**, and clear staging.

Tighten to mandatory once no supported release predates it.

`Cecelia._file_sha256` / `_sha256_matches` (`app/src/utils.jl`) are streamed, accept both the GNU
`hash  name` and bare-hash forms, and **return `false` rather than throwing** on a malformed digest —
an HTML error page instead of a hash is a non-match, not an exception — so the caller owns the
fatal/not decision.

One trap worth naming: `sha256sum` records the path it was *given*, so the workflow does `cd out`
first. A digest naming `out/cecelia.tar.gz` would never match a file downloaded as `cecelia.tar.gz`.

## 2. `RELEASING.md` rested on a channel nobody uses

It claimed new features *"do not need a tag to reach testers — so 'we added a bunch of stuff' is not a
reason to release"*, inferred from a dev channel with **no users**. Biologists install tags; dev needs
Node on PATH and builds the frontend locally, and exists for people who want to work *on* Cecelia.

That inference produced the wrong call in review — a 281-commit gap waved off as already-delivered
when no user could see any of it. Replaced with the actual consequence:

> **A tag is the only thing that reaches a user.** Untagged work is not "already shipped to testers" —
> it is undelivered, and the gap grows with every merge.

…plus a short note recording what it used to claim and why that was wrong, so it doesn't get
reintroduced.

**One policy change, flagged as such:** a plain release is now the *default*, with rc reserved for a
build you actually intend to soak. Nine rc's never converged because none were candidates *for*
anything — they were snapshots wearing a candidate's label while being the only thing users could
install. A user-blocking fix is a patch bump (`v0.1.1`), not an rc. This one is a judgement call
rather than a factual correction — easy to drop if you disagree.

`SHIPPING.md`'s *"why a dev channel"* is corrected to match.

## Verification

| | |
|---|---|
| `pixi run test-pkg` | 1822 pass / 1 broken (pre-existing), 0 failures — +48 from the new testset |
| `pixi run test-api` | 40 assertions, 0 failures |
| hash helpers | 14 assertions: GNU / bare / uppercase / trailing-newline forms, HTML error page, truncated, over-long, flipped byte |
| `install.sh` | all four paths exercised in a real shell — correct digest proceeds, absent proceeds, wrong aborts, HTML error page aborts |
| `release.yml` | checksum step simulated; `sha256sum -c` round-trips. YAML parses, 4 assets listed |

**`install.ps1` is untested** — no PowerShell on this machine. Four lines against `Get-FileHash`
(built into PS 5.1+), and it can only fail closed on a genuine mismatch, but it is Windows
install-path code and that is exactly what bit in #402. Worth one run on the Windows box.

Also not covered: nothing drives `api_update_apply` end to end — that needs an installed (non-git)
root and a real download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
