### PR TITLE
Run the Julia package tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,21 @@ jobs:
       - name: Instantiate Julia (server env)
         run: julia --project=api -e 'using Pkg; Pkg.instantiate()'
 
+      # Julia PACKAGE tests (app/test/runtests.jl) — the data model, ccid.json round-trip, versioned
+      # fields, task dispatch, param validation, the gating engine, config/path resolution. Needs app/
+      # instantiated in its own right (the step above instantiates api/, which only path-SOURCES
+      # Cecelia). This is the largest suite and used to run nowhere but a dev machine, which is how
+      # Windows-only path bugs shipped: `Sys.which` never finding `claude.cmd`, `Base.expanduser`
+      # being a no-op on Windows, `python3` not existing there. Those fixes are asserted by
+      # `iswin`-parameterised helpers precisely so a Windows runner can check them — it has to run here
+      # for that to mean anything. Fixture-dependent testsets self-skip (`have_fixture`), so a CI
+      # checkout without test-data/ still passes.
+      - name: Instantiate Julia (package env)
+        run: pixi run julia-instantiate
+
+      - name: Package tests
+        run: pixi run test-pkg
+
       # API-layer unit tests: load the handlers with CECELIA_NO_SERVE (no socket) and exercise them
       # directly. Fixture-free, so it runs on every OS in the matrix.
       - name: API tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,8 +444,10 @@ Revise reloads function bodies on save. Struct/macro changes still need a restar
 
 ## Testing
 
-**Four test categories — one per layer. All four run in CI on every OS, and each has a `pixi run`
-task that runs the whole suite. Write AND run the matching category in the same change as the code:**
+**Four test categories — one per layer. All four run in CI on every OS (one step per category in
+`.github/workflows/ci.yml` — keep it that way; the package suite was missing for a long time, which is
+how three Windows-only path bugs shipped), and each has a `pixi run` task that runs the whole suite.
+Write AND run the matching category in the same change as the code:**
 
 | You changed… | Write/run | Command |
 |---|---|---|


### PR DESCRIPTION
> Stacked on #406 (base `fix/python-bin-path-resolution`), deliberately: that branch is what un-skips the `LabelProps` parity testset and adds the `python_bin_path` resolution assertions, so this CI run is the first time either faces Windows or macOS.

## The gap

`ci.yml` ran `test-api`, `test-py`, `test-mcp` and the frontend suite — but **not `test-pkg`**. So `app/test/runtests.jl` (**1828 tests**: data model, `ccid.json` round-trip, versioned fields, task dispatch, param validation, the gating engine, config/path resolution) had only ever run on a dev machine, Linux-only. The largest suite, covering the things `CLAUDE.md` calls mandatory, was unverified on two of three supported platforms.

`CLAUDE.md` also claimed *"all four run in CI on every OS"*. That was false. This makes it true, and names the workflow file so the next reader can check rather than trust.

## Why it matters right now

That gap is how three Windows-only path bugs shipped this week — none caught by CI:

- `Sys.which` never finds `claude.cmd` → the observer was invisible on Windows (#405)
- `Base.expanduser` is a no-op on Windows → `~` survived into `open` (#402)
- `python_bin_path()` returned `"python3"`, which Windows envs frequently lack (#406)

Each fix was deliberately written as **`iswin`-parameterised pure helpers** — `_agent_bin_candidates`, `_needs_cmd_shell`, `_agent_spawn_argv`, `_python_bin_candidates`, `expand_user` — specifically so a Windows runner could assert the Windows behaviour without a Windows machine. That design buys nothing while the suite holding those assertions doesn't run. Now it does.

## The change

Two steps, both tasks already existed (`pixi.toml`):

```yaml
- name: Instantiate Julia (package env)
  run: pixi run julia-instantiate
- name: Package tests
  run: pixi run test-pkg
```

`app/` needs instantiating in its own right — the existing step instantiates `api/`, which only path-*sources* Cecelia and leaves `app/`'s manifest untouched.

## What to watch on this run

This is a genuine experiment, not a formality. It's the first execution of 1828 tests on Windows and macOS, so a red job here is more likely to be a **pre-existing** platform issue than a regression from these steps:

- **Fixtures.** `test-pkg` is the only suite touching `test-data/`. Testsets gate on `have_fixture` → `@test_skip`, so a CI checkout without it should pass with skip warnings. If anything *fails* rather than skips, that gating is incomplete.
- **The parity testset**, newly un-skipped by #406, needs `anndata` importable in the pixi env on each runner.
- **Runtime**: ~90s locally, added to jobs already running 8–10 min.

If Windows or macOS surfaces unrelated failures, the options are to fix them or to scope this step to Linux first — either is better than the current state of not knowing. `fail-fast: false` is already set, so one OS failing still reports the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
