### PR TITLE
Make the test suites hermetic, and run CI on stacked PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Line endings: normalise to LF in the repo AND on checkout, on every platform.
+#
+# Without `eol=lf`, git hands a Windows checkout CRLF. That is not cosmetic — it broke the
+# `docs/REPL.md` golden test the first time the package suite ran on Windows: the test compares the
+# committed file against a section regenerated from live docstrings, which is emitted with LF, so every
+# line mismatched for a reason unrelated to the docstring drift it exists to catch. Any future
+# golden/snapshot test would hit the same wall. Julia, Node and Python all read LF fine on Windows.
+* text=auto eol=lf
+
+# Binary — never line-ending-convert or diff these. `text=auto` already detects them, but being
+# explicit means a corrupt fixture can't be blamed on heuristics.
+*.png   binary
+*.h5ad  binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,15 @@ name: CI
 # Pixi env is cached on pixi.lock (per platform). fail-fast is off so one OS failing still reports
 # the others. Runs on pushes/PRs to main and on demand.
 
+# `pull_request` is deliberately NOT filtered to `[main]`. With that filter a STACKED pr — one whose
+# base is another feature branch — matched no trigger and got **zero checks**, which reads as
+# green-by-absence rather than as "not run": nothing on the pr says the suite never ran. That is how
+# #409 (the pr that ADDS the package tests to CI) was reviewed with no CI at all. Pushes stay filtered
+# to main so a plain branch push doesn't double-run alongside its own pr.
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 defaults:

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -5,6 +5,22 @@
 # Run: `julia --project=api api/test/runtests.jl`  (or `pixi run test-api`).
 ENV["CECELIA_NO_SERVE"] = "1"
 
+# HERMETIC BY DEFAULT — same guard as `app/test/runtests.jl`, and here it fixes a real leak, not just
+# CI. Testsets redirect `dirs["projects"]` to a temp dir individually and restore it in a `finally`;
+# anything that forgets, or any `create_project!` on a path between one restore and the next redirect,
+# writes into the DEVELOPER'S REAL projects dir and shows up in their project list. (Dominik has been
+# seeing these: `apiqc-7602` was still sitting there, from a testset since renamed.) Pointing config at
+# a throwaway dir for the whole run makes the whole class impossible instead of per-testset diligence.
+#
+# Set `CECELIA_DEV_DIR` yourself to run against a specific config. Julia deletes both temp dirs at exit.
+# Paths go in TOML *literal* strings (single quotes) so Windows backslashes are not escapes.
+if !haskey(ENV, "CECELIA_DEV_DIR")
+    let cfg = mktempdir(), proj = mktempdir()
+        write(joinpath(cfg, "custom.toml"), "[dirs]\nprojects = '" * proj * "'\n")
+        ENV["CECELIA_DEV_DIR"] = cfg
+    end
+end
+
 using Test
 include(joinpath(@__DIR__, "..", "src", "server.jl"))   # defines handlers + shared state; does not start
 using JSON3

--- a/app/src/config.jl
+++ b/app/src/config.jl
@@ -41,10 +41,17 @@ go through. `homedir()` is correct on Windows (it honours `USERPROFILE`).
 """
 function expand_user(path::AbstractString)::String
     s = String(path)
-    s == "~"            && return homedir()
-    startswith(s, "~/")  && return joinpath(homedir(), s[3:end])
+    s == "~" && return homedir()
     # Windows users may type either separator
-    Sys.iswindows() && startswith(s, "~\\") && return joinpath(homedir(), s[3:end])
+    if startswith(s, "~/") || (Sys.iswindows() && startswith(s, "~\\"))
+        # Split the remainder into components rather than pasting it on, so the result is a canonical
+        # path: `joinpath(homedir(), "foo/bar")` on Windows yields `C:\Users\x\foo/bar` — mixed
+        # separators, which Windows tolerates but which makes every path comparison unreliable.
+        # Only treat `\` as a separator ON Windows; on Unix it is a legal filename character.
+        seps = Sys.iswindows() ? ('/', '\\') : ('/',)
+        parts = split(s[3:end], seps; keepempty = false)
+        return isempty(parts) ? homedir() : joinpath(homedir(), parts...)
+    end
     s
 end
 

--- a/app/src/project_io.jl
+++ b/app/src/project_io.jl
@@ -132,11 +132,21 @@ end
 _tar_available()::Bool = Sys.which("tar") !== nothing
 
 # Run one `tar` (pack or unpack) as a tracked subprocess, so cancel_job! can kill it. Returns clean exit.
-function _run_tar(cmd::Cmd, task_id::AbstractString)::Bool
-    proc = run(pipeline(cmd; stdout = devnull, stderr = devnull); wait = false)
+# `on_err` receives tar's own stderr when it fails. Previously both streams went to `devnull`, so a
+# failed pack reported only "[ERROR] Export failed." with no cause — which is exactly the position we
+# were in when export turned out to be broken on Windows and the log said nothing about why. Success
+# stays silent (tar is chatty and the caller logs its own progress).
+function _run_tar(cmd::Cmd, task_id::AbstractString; on_err::Function = _ -> nothing)::Bool
+    err  = IOBuffer()
+    proc = run(pipeline(cmd; stdout = devnull, stderr = err); wait = false)
     track_job!(task_id, proc)
     wait(proc)
-    proc.exitcode == 0 && proc.termsignal == 0   # termsignal too: libuv reports 0 exitcode on kill
+    ok = proc.exitcode == 0 && proc.termsignal == 0   # termsignal too: libuv reports 0 exitcode on kill
+    if !ok
+        msg = strip(String(take!(err)))
+        isempty(msg) || on_err(msg)
+    end
+    ok
 end
 
 # Pack/unpack a set of units in parallel, bounded by `concurrency`, reporting progress + honouring
@@ -211,7 +221,8 @@ function export_project(proj_uid::AbstractString;
         status = _parallel_stores(stores, task_id, concurrency, on_log, on_progress) do (sdir, srel, sname)
             out_tar = joinpath(tmp, srel, sname * PACKED_STORE_EXT)
             mkpath(dirname(out_tar))
-            ok = _run_tar(`tar -cf $out_tar -C $(dirname(sdir)) $(basename(sdir))`, task_id)
+            ok = _run_tar(`tar -cf $out_tar -C $(dirname(sdir)) $(basename(sdir))`, task_id;
+                          on_err = m -> on_log("  [ERROR] tar pack $(joinpath(srel, sname)): $m"))
             ok && on_log("  packed $(joinpath(srel, sname))")
             ok
         end
@@ -311,7 +322,8 @@ function import_project(bundle::AbstractString;
             if !isfile(tar_path)
                 on_log("  !! missing packed store: $rel"); return false
             end
-            ok = _run_tar(`tar -xf $tar_path -C $(dirname(tar_path))`, task_id)
+            ok = _run_tar(`tar -xf $tar_path -C $(dirname(tar_path))`, task_id;
+                          on_err = m -> on_log("  [ERROR] tar unpack $(basename(tar_path)): $m"))
             ok && (rm(tar_path; force = true); on_log("  unpacked $(rel[1:end-length(PACKED_STORE_EXT)])"))
             ok
         end

--- a/app/src/project_io.jl
+++ b/app/src/project_io.jl
@@ -136,6 +136,22 @@ _tar_available()::Bool = Sys.which("tar") !== nothing
 # failed pack reported only "[ERROR] Export failed." with no cause — which is exactly the position we
 # were in when export turned out to be broken on Windows and the log said nothing about why. Success
 # stays silent (tar is chatty and the caller logs its own progress).
+# Tar command builders — PURE, so the one property that matters can be asserted on any host: the
+# `-f` argument is a BARE FILENAME and the process cwd carries the directory.
+#
+# Why that property: GNU tar reads an archive path as `host:path` when a colon appears before any
+# separator, and tries to open a REMOTE archive. Every Windows absolute path starts `D:\...`, so
+# `-f D:\a\...\x.tar` becomes a connection attempt to host `D` — while a unix absolute path can
+# never trigger it (the leading `/` precedes the colon), which is why this only ever failed on Windows
+# and cannot be reproduced on Linux. `-C` is NOT parsed that way, so it stays absolute.
+#
+# Windows' own System32\tar.exe is bsdtar and doesn't do remote at all; but under `shell: bash` —
+# CI, and any Git Bash — `tar` resolves to Git-for-Windows' GNU tar.
+_tar_pack_cmd(out_tar::AbstractString, sdir::AbstractString)::Cmd =
+    Cmd(`tar -cf $(basename(out_tar)) -C $(dirname(sdir)) $(basename(sdir))`; dir = dirname(out_tar))
+_tar_unpack_cmd(tar_path::AbstractString)::Cmd =
+    Cmd(`tar -xf $(basename(tar_path))`; dir = dirname(tar_path))   # extracts into the cwd
+
 function _run_tar(cmd::Cmd, task_id::AbstractString; on_err::Function = _ -> nothing)::Bool
     err  = IOBuffer()
     proc = run(pipeline(cmd; stdout = devnull, stderr = err); wait = false)
@@ -221,7 +237,7 @@ function export_project(proj_uid::AbstractString;
         status = _parallel_stores(stores, task_id, concurrency, on_log, on_progress) do (sdir, srel, sname)
             out_tar = joinpath(tmp, srel, sname * PACKED_STORE_EXT)
             mkpath(dirname(out_tar))
-            ok = _run_tar(`tar -cf $out_tar -C $(dirname(sdir)) $(basename(sdir))`, task_id;
+            ok = _run_tar(_tar_pack_cmd(out_tar, sdir), task_id;
                           on_err = m -> on_log("  [ERROR] tar pack $(joinpath(srel, sname)): $m"))
             ok && on_log("  packed $(joinpath(srel, sname))")
             ok
@@ -322,7 +338,7 @@ function import_project(bundle::AbstractString;
             if !isfile(tar_path)
                 on_log("  !! missing packed store: $rel"); return false
             end
-            ok = _run_tar(`tar -xf $tar_path -C $(dirname(tar_path))`, task_id;
+            ok = _run_tar(_tar_unpack_cmd(tar_path), task_id;
                           on_err = m -> on_log("  [ERROR] tar unpack $(basename(tar_path)): $m"))
             ok && (rm(tar_path; force = true); on_log("  unpacked $(rel[1:end-length(PACKED_STORE_EXT)])"))
             ok

--- a/app/src/utils.jl
+++ b/app/src/utils.jl
@@ -9,7 +9,12 @@ gen_uid(n::Int=UID_LENGTH) = String(rand(UID_CHARS, n))
 
 function _dir_bytes(path::String)::Int
     if Sys.isunix()
-        try; parse(Int, split(readchomp(`du -sb $path`))[1]); catch; 0; end
+        # `du -sk` (KiB), NOT `-sb`: `-b` is a GNU coreutils extension that BSD/macOS `du` does not
+        # have, so on macOS the command failed, the `catch` swallowed it, and this returned **0 for
+        # every directory** — storage reclaim silently reported nothing to free. `-k` is in POSIX and
+        # works on both. It reports disk BLOCKS rather than apparent size (so slightly larger than
+        # `-sb` on Linux), which is the more honest number for "how much space would I get back".
+        try; parse(Int, split(readchomp(`du -sk $path`))[1]) * 1024; catch; 0; end
     else
         try
             total = 0

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -6,7 +6,22 @@ import DataFrames: DataFrame, nrow   # only the symbols the tests construct/meas
 
 # ── Smoke tests — no API, no WebSocket, no Vue ────────────────────────────────
 # Run from the app/ directory:  julia --project test/runtests.jl
-# Requires CECELIA_DEV_DIR to point at a config with a valid projects_dir.
+
+# HERMETIC BY DEFAULT: unless `CECELIA_DEV_DIR` is already set, point config at a throwaway dir with a
+# throwaway projects dir. The suite CREATES projects, and with no `custom.toml` anywhere `projects_dir()`
+# is the shipped placeholder `/path/to/projects` — so `create_project!` did `mkdir("/path")` and ~30
+# testsets errored with EACCES/EROFS. That is invisible on a dev machine (a real `.env` → `custom.toml`
+# makes it pass) and is why the suite could not run in CI at all.
+#
+# Set `CECELIA_DEV_DIR` yourself to run against a specific config instead. Julia deletes both temp dirs
+# at exit. Paths go in TOML *literal* strings (single quotes) so Windows backslashes are not escapes.
+if !haskey(ENV, "CECELIA_DEV_DIR")
+    let cfg = mktempdir(), proj = mktempdir()
+        write(joinpath(cfg, "custom.toml"), "[dirs]\nprojects = '" * proj * "'\n")
+        ENV["CECELIA_DEV_DIR"] = cfg
+        @info "Tests: hermetic config" config_dir=cfg projects_dir=proj
+    end
+end
 
 init_cecelia!()
 

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -6340,6 +6340,39 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         end
     end
 
+    # The tar invocation must never hand a Windows drive letter to `-f`. GNU tar reads an archive
+    # path as `host:path` when a colon precedes any separator, so `-f D:\a\...\x.tar` becomes a
+    # connection attempt to host `D` and the pack silently produces nothing — which is how `.ccbundle`
+    # export (the backup mechanism) came to be broken on Windows while every unix path was fine: a unix
+    # absolute path can NEVER trigger it, because the leading `/` comes before the colon.
+    #
+    # That asymmetry is exactly why this needs a PROPERTY test rather than a behaviour test. Running
+    # tar here would pass on unix no matter what the code does — a test that cannot fail. So assert the
+    # shape of the command instead: `-f` takes a bare filename, the directory rides on the cwd. Both
+    # assertions fail against the old absolute-`-f` form on every platform.
+    @testset "tar commands keep drive letters out of -f" begin
+        pack = Cecelia._tar_pack_cmd(joinpath("D:", "a", "out", "store.zarr.tar"),
+                                     joinpath("D:", "proj", "0", "img", "store.zarr"))
+        # the flag is the combined `-cf`, so the archive is the token after it
+        fidx = findfirst(==("-cf"), pack.exec)
+        @test fidx !== nothing
+        farg = pack.exec[fidx + 1]
+        @test farg == "store.zarr.tar"                      # bare filename…
+        @test !occursin(':', farg)                          # …so no drive letter can reach tar
+        @test !occursin('/', farg) && !occursin('\\', farg)
+        @test pack.dir == joinpath("D:", "a", "out")        # the directory rides on the cwd instead
+        # -C is NOT subject to the host:path parse, so it stays absolute
+        cidx = findfirst(==("-C"), pack.exec)
+        @test cidx !== nothing && pack.exec[cidx + 1] == joinpath("D:", "proj", "0", "img")
+        @test pack.exec[end] == "store.zarr"                # the member, relative to -C
+
+        unpack = Cecelia._tar_unpack_cmd(joinpath("D:", "a", "bundle", "0", "img", "store.zarr.tar"))
+        uidx = findfirst(==("-xf"), unpack.exec)
+        @test uidx !== nothing && unpack.exec[uidx + 1] == "store.zarr.tar"
+        @test !occursin(':', unpack.exec[uidx + 1])
+        @test unpack.dir == joinpath("D:", "a", "bundle", "0", "img")
+    end
+
     # ── Every directory whose params a USER actually sees ─────────────────────────────────────────
     #
     # All three copy testsets below walk THIS list. They each used to hardcode `src/tasks`, which

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -4024,7 +4024,10 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
     @testset "branch pop_type wiring" begin
         # POP_MAP_SUFFIX resolves the gating file suffix.
         @test Cecelia.POP_MAP_SUFFIX["branch"] == BRANCH_PROPS_SUFFIX
-        @test endswith(gating_path("/tmp", "stroma"; pop_type="branch"), "gating/stroma__branch.json")
+        # build the expected tail with joinpath — a literal "gating/..." fails on Windows, where the
+        # path is "\\gating\\stroma__branch.json" (the product is fine; the assertion wasn't portable)
+        @test endswith(gating_path("/tmp", "stroma"; pop_type="branch"),
+                       joinpath("gating", "stroma__branch.json"))
 
         # ACCEPT_TOKENS + validators.
         @test "branch" in Cecelia.ACCEPT_TOKENS

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -163,7 +163,15 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         # Windows accepts either separator after the tilde
         if Sys.iswindows()
             @test expand_user("~\\foo") == joinpath(homedir(), "foo")
+            @test expand_user("~\\foo\\bar") == joinpath(homedir(), "foo", "bar")
+            # The result must be a CANONICAL path — no mixed separators. Pasting the remainder on
+            # verbatim gave `C:\Users\x\foo/bar`, which Windows tolerates but which makes every path
+            # comparison unreliable (and this is what CI caught first time it ran on Windows).
+            @test !occursin('/', expand_user("~/foo/bar"))
         end
+        # collapsing a doubled separator is fine; losing a component is not
+        @test expand_user("~//foo") == joinpath(homedir(), "foo")
+        @test splitpath(expand_user("~/a/b/c"))[end-2:end] == ["a", "b", "c"]
     end
 
     # ── ensure_config_dir: safe to WRITE into ────────────────────────────────────
@@ -664,7 +672,12 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         p = Cecelia.repl_doc_path()
         if isfile(p)
             committed = read(p, String)
-            @test committed == Cecelia.render_repl_doc(committed)
+            # Compare line-ending agnostically: this is a CONTENT drift-guard, not a byte-exactness
+            # check. On Windows git checks the file out with CRLF while `repl_api_section()` emits LF,
+            # so the splice mismatched on every line and the test failed for a reason that has nothing
+            # to do with docstring drift.
+            _lf(s) = replace(s, "\r\n" => "\n")
+            @test _lf(committed) == _lf(Cecelia.render_repl_doc(committed))
             @test occursin(Cecelia.REPL_DOC_BEGIN, committed)
         else
             @test_skip "docs/REPL.md not found at $p"

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -104,14 +104,22 @@ git push -u origin feat/<short-slug>
 ## CI
 
 Every push/PR runs `.github/workflows/ci.yml` (smoke: fresh checkout → `pixi install` →
-`julia … instantiate` → API tests → **Python tests** → frontend build → **frontend tests (Vitest)** → server serves
-`/api/health` + the frontend). It runs the
+`julia … instantiate` → **package tests** → API tests → **Python tests** → MCP tests → frontend build →
+**frontend tests (Vitest)** → server serves `/api/health` + the frontend). It runs the
 **full chain as a matrix on Linux, Windows and macOS-arm64** (`fail-fast: false`), so a
 platform-specific install/build/boot failure is caught in CI rather than by a tester — e.g. a PyPI
 dep with no macOS wheel falling back to a source build (TODO #00062). The repo is public, so
 GitHub-hosted runners are free on all OSes (no minute metering — the multipliers only bill private
 repos). All steps run under `bash` (Git Bash on the Windows runner). Keep it green before requesting
 a merge. See `docs/SHIPPING.md` for the release pipeline.
+
+> **A PR with no checks is not a passing PR.** `pull_request` is intentionally left **unfiltered** so
+> a *stacked* PR — one whose base is another feature branch, not `main` — still runs. It used to be
+> filtered to `[main]`, and a stacked PR then matched no trigger and showed **zero checks**, which reads
+> as green-by-absence: nothing on the page says the suite never ran. That is how #409 — the PR that
+> added the package tests to CI — got reviewed with no CI. If you ever see a PR with no checks, that is
+> the bug; `gh pr checks <n>` saying *"no checks reported"* is the tell. (`push` stays filtered to
+> `main` so a branch push doesn't double-run alongside its own PR.)
 
 > **Frontend typecheck — use `vue-tsc -b`, never `vue-tsc --noEmit`.** The frontend uses TS **project
 > references**, and `vue-tsc --noEmit` on the root config **silently skips the `.vue` files** (exits 0


### PR DESCRIPTION
**Main is red — this fixes it.** Two CI-integrity fixes; the second is the one that restores green.

## 1. Make the test suites hermetic (fixes the red)

Adding `test-pkg` to CI (#409) turned main red on all three OSes. `create_project!` resolves `projects_dir()`, and with no `custom.toml` anywhere that is the shipped placeholder `/path/to/projects` — so it called `mkdir("/path")` and ~30 testsets errored:

```
IOError: mkdir("/path"; mode=0o777): permission denied (EACCES)     # linux/windows
IOError: mkdir("/path"; mode=0o777): read-only file system (EROFS)  # macos
```

Nothing platform-specific — the suite simply cannot run without a configured projects dir, which is invisible on a dev machine because `.env` → `custom.toml` supplies one. #409 didn't catch it because, being stacked, it got no CI (see fix 2).

Both suites now provision a throwaway config + projects dir unless `CECELIA_DEV_DIR` is already set.

**For `api/test/runtests.jl` this fixes a live leak, not just CI.** Testsets redirect `dirs["projects"]` to a temp dir one at a time and restore it in a `finally`. Any testset that forgets — or any `create_project!` between one restore and the next redirect — writes into the developer's **real** projects dir and shows up in their project list. Dominik has been seeing exactly that; `apiqc-7602` was still sitting in his, left by a testset since renamed. A whole-run throwaway config makes the class impossible instead of relying on per-testset diligence.

This is also what `CLAUDE.md`'s fixture rule already asked for — *"tests must not depend on the dev projects dir — it can be deleted"* — honoured for fixtures, but not for the projects the suites create themselves.

Verified by reproducing CI's condition locally, with `.env` moved aside so no config exists at all:

| | result |
|---|---|
| `test-pkg` | **1841 pass / 0 fail** |
| `test-api` | clean, observer 13/13 |
| real projects dir | unchanged, 4 entries before and after |

## 2. Run CI on stacked PRs

`pull_request` was filtered to `branches: [main]`, so a **stacked** PR matched no trigger and got **zero checks**. That doesn't read as *"not run"* — it reads as green-by-absence: nothing on the page says the suite never ran.

That is how #409 was reviewed. The PR whose entire purpose was to add the package tests to CI ran no CI, and shipped a break that all three OSes would have caught. The one PR where a missing run mattered most was the one that silently didn't get it.

```diff
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  pull_request:
   workflow_dispatch:
```

`push` stays filtered to `main` so a branch push doesn't double-run alongside its own PR.

`DEV.md`'s CI description had also drifted — it omitted the **package** and **MCP** steps — and now records the tell, since this failure mode is invisible by construction:

> **A PR with no checks is not a passing PR.** If you ever see a PR with no checks, that is the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
