### PR TITLE
Fix stale 'running' tasks in the task console (and the scheduler hazard behind it)

### DIFF
--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -118,6 +118,14 @@ function api_logs_recent()
 end
 
 # ── Chain event → WS bridge ───────────────────────────────────────────────────
+# `taskId` is the scheduler task the node ran as — the task console correlates it with its
+# `GET /api/tasks` row to attribute the node's real outcome (a chain run emits no `task:status`
+# frames, so without it a finished node can only be reported as "outcome unseen"). Read with
+# `_ev_task_id` rather than `p.task_id`: a hand-fired event from the REPL/tests may omit the field,
+# and a node with no task id yet (skipped before submission, set-scope) carries `nothing` — both
+# must degrade to "" and never take the bridge down.
+_ev_task_id(p)::String = something(get(p, :task_id, ""), "")
+
 
 subscribe_chain_events!("node:queued", function(p)
     broadcast_ws(Dict{String,Any}(
@@ -129,6 +137,7 @@ subscribe_chain_events!("node:queued", function(p)
         "nodeId"     => p.node_id,
         "fn"         => p.fn,
         "params"     => p.params,
+        "taskId"     => _ev_task_id(p),
     ))
 end)
 
@@ -142,6 +151,7 @@ subscribe_chain_events!("node:running", function(p)
         "nodeId"     => p.node_id,
         "fn"         => p.fn,
         "params"     => p.params,
+        "taskId"     => _ev_task_id(p),
     ))
 end)
 
@@ -156,6 +166,7 @@ subscribe_chain_events!("node:done", function(p)
         "fn"         => p.fn,
         "params"     => p.params,
         "result"     => p.result,
+        "taskId"     => _ev_task_id(p),
     ))
 end)
 
@@ -169,6 +180,7 @@ subscribe_chain_events!("node:failed", function(p)
         "nodeId"     => p.node_id,
         "fn"         => p.fn,
         "status"     => p.status,
+        "taskId"     => _ev_task_id(p),
     ))
 end)
 

--- a/api/task_console.jl
+++ b/api/task_console.jl
@@ -54,6 +54,12 @@ mutable struct TaskView
     progress::Float64      # -1 = unknown / not reported yet
     last_log::String
     updated::DateTime
+    # Reconciliation state (see refresh_snapshot!). `in_snapshot` marks a task the /api/tasks
+    # snapshot has listed at least once — i.e. a real SCHEDULER task, so its absence from a later
+    # snapshot is meaningful. WS-only producers (jobs, batch movies) never appear in the snapshot
+    # and must never be pruned by it. `misses` counts consecutive snapshots it went missing from.
+    in_snapshot::Bool
+    misses::Int
 end
 
 const TASKS      = Dict{String,TaskView}()   # taskId => view — ACTIVE tasks only (finished ones drop out)
@@ -65,7 +71,10 @@ const MAX_LOGS   = 500
 # Finished tasks are collapsed to a COUNT, not kept as rows — the console answers "what's running now
 # and how many are done", not "show all 50". TALLY holds cumulative terminal outcomes; SEEN_TERM stops
 # a task being re-counted / re-added (by a late WS event or the snapshot poll) once it has finished.
-const TALLY      = Dict{String,Int}("done" => 0, "failed" => 0, "cancelled" => 0)
+# "ended" = finished, outcome unseen: the task left the scheduler snapshot but its terminal
+# task:status frame never arrived (WS telemetry is lossy by design — see broadcast_ws). Counted
+# separately rather than guessed as done/failed, so the console never claims an outcome it didn't see.
+const TALLY      = Dict{String,Int}("done" => 0, "failed" => 0, "cancelled" => 0, "ended" => 0)
 const SEEN_TERM  = Set{String}()
 
 # Live resource-pool occupancy (polled from GET /api/pools): per pool, its configured concurrency
@@ -90,7 +99,7 @@ trunc_s(s::AbstractString, n::Int) = length(s) <= n ? String(s) : String(first(s
 # Get-or-create a task view, so a WS event for a not-yet-snapshotted task still shows up.
 function _task!(id::AbstractString)
     get!(TASKS, String(id)) do
-        TaskView(String(id), "", "", "", "", "queued", -1.0, "", Dates.now())
+        TaskView(String(id), "", "", "", "", "queued", -1.0, "", Dates.now(), false, 0)
     end
 end
 
@@ -120,13 +129,28 @@ function _note_terminal!(id::AbstractString, status::AbstractString)
 end
 
 # ── HTTP snapshot (fills in fun_name / image / pool for in-flight tasks) ─────────
+# The snapshot is AUTHORITATIVE and complete: /api/tasks returns the scheduler's whole in-flight set
+# under its lock, and a task is deregistered the moment it finishes. So reconciliation runs BOTH ways —
+# rows are added/updated from the snapshot AND retired when they vanish from it. The retire half is what
+# makes WS telemetry genuinely lossy-safe: frames are dropped by design for a slow client (per-client
+# drop-on-full queue in server.jl) and lost outright on a half-open socket, and without this a missed
+# terminal frame stranded the row as "running" forever — the scheduler idle, the console still listing it.
+#
+# Only tasks the snapshot has ALREADY listed (`in_snapshot`) are eligible: jobs and batch movies are
+# WS-only producers that never appear there, and pruning them would delete every row they own.
+# Two consecutive misses are required so a task registered between the poll and its first WS frame
+# is never retired on a one-poll race.
+const SNAPSHOT_MISSES_TO_RETIRE = 2
+
 function refresh_snapshot!()
     try
         r = HTTP.get("$HTTP_BASE/api/tasks"; connect_timeout=2, readtimeout=3, retry=false)
         rows = JSON3.read(String(r.body))
         lock(LOCK) do
+            present = Set{String}()
             for row in rows
                 id = String(row.id)
+                push!(present, id)
                 id in SEEN_TERM && continue                 # already finished + counted — don't resurrect
                 status = String(get(row, :status, ""))
                 if status in TERMINAL                       # finished before we saw it live → just count it
@@ -139,6 +163,17 @@ function refresh_snapshot!()
                 t.pool_name    = String(get(row, :pool_name, t.pool_name))
                 t.chain_run_id = String(get(row, :chain_run_id, t.chain_run_id))
                 isempty(status) || (t.status = status)
+                t.in_snapshot  = true
+                t.misses       = 0
+            end
+            # retire what the scheduler no longer knows about (outcome unseen — tallied as "ended")
+            for (id, t) in collect(TASKS)
+                (t.in_snapshot && !(id in present)) || continue
+                t.misses += 1
+                t.misses >= SNAPSHOT_MISSES_TO_RETIRE || continue
+                _note_terminal!(id, "ended")
+                push_event!("status", string(col(BOLD, short(id)), " ", col(GREY, "ended"),
+                            col(DIM, " (outcome unseen — dropped frame)")); colour = GREY)
             end
         end
         return true
@@ -231,7 +266,7 @@ function handle_ws(raw::AbstractString)
         end
         # ping/pong and anything else are ignored.
     end
-    STREAM_MODE || render()
+    STREAM_MODE || render_throttled()
 end
 
 # ── Dashboard render (in-place redraw) ───────────────────────────────────────────
@@ -275,6 +310,7 @@ function render()
           col(DIM, " · "), col(GREEN, "$(TALLY["done"]) done"),
           col(DIM, " · "), col(RED, "$(TALLY["failed"]) failed"),
           TALLY["cancelled"] > 0 ? string(col(DIM, " · "), col(MAGENTA, "$(TALLY["cancelled"]) cancelled")) : "",
+          TALLY["ended"] > 0 ? string(col(DIM, " · "), col(GREY, "$(TALLY["ended"]) ended")) : "",
           "\n")
 
     # pools panel — configured concurrency limit vs slots in use now (+ any queued) for each pool.
@@ -324,6 +360,19 @@ function render()
 
     print(String(take!(io)))
     flush(stdout)
+    _last_render[] = Dates.now()
+end
+
+# A full-screen repaint per WS frame made the receive loop the bottleneck at task-log volume — and a
+# slow reader is exactly what makes the server drop THIS client's frames (per-client drop-on-full queue
+# in server.jl), so the console helped cause the loss it then couldn't recover from. Coalesce repaints;
+# the 2s snapshot loop always repaints, so a skipped frame is at most 2s behind.
+const RENDER_MIN_INTERVAL = Millisecond(100)
+const _last_render        = Ref(Dates.now() - Second(10))
+
+function render_throttled()
+    Dates.now() - _last_render[] < RENDER_MIN_INTERVAL && return
+    render()
 end
 
 function show_waiting(reason::AbstractString)
@@ -360,7 +409,16 @@ function run_console()
                     try sleep(2); refresh_snapshot!(); STREAM_MODE || refresh_pools!(); STREAM_MODE || render() catch end
                 end
                 @async while connected[]
-                    try sleep(20); HTTP.WebSockets.send(ws, "{\"type\":\"ping\"}") catch end
+                    try
+                        sleep(20); HTTP.WebSockets.send(ws, "{\"type\":\"ping\"}")
+                    catch
+                        # A failed keepalive means the socket is dead or half-open. Swallowing it left
+                        # the reader blocked in `for msg in ws` forever — HTTP polling kept refreshing
+                        # rows while no WS frame ever arrived again, so nothing ever reached a terminal
+                        # status. Tear it down instead: the outer loop reconnects, clears and reseeds.
+                        connected[] = false
+                        try; close(ws); catch; end
+                    end
                 end
                 for msg in ws
                     handle_ws(msg isa AbstractString ? msg : String(msg))

--- a/api/task_console.jl
+++ b/api/task_console.jl
@@ -141,40 +141,47 @@ end
 # is never retired on a one-poll race.
 const SNAPSHOT_MISSES_TO_RETIRE = 2
 
+# Pure half — takes already-parsed rows, touches no socket, so `api/test/runtests.jl` can drive it
+# with synthetic snapshots (that's the only automated coverage this script can have: it's run by path,
+# never imported, so the entrypoint at the bottom is guarded to keep `include`ing it side-effect-free).
+function _reconcile_snapshot!(rows)
+    lock(LOCK) do
+        present = Set{String}()
+        for row in rows
+            id = String(row.id)
+            push!(present, id)
+            id in SEEN_TERM && continue                 # already finished + counted — don't resurrect
+            status = String(get(row, :status, ""))
+            if status in TERMINAL                       # finished before we saw it live → just count it
+                _note_terminal!(id, status)
+                continue
+            end
+            t = _task!(id)
+            t.fun_name     = String(get(row, :fun_name, t.fun_name))
+            t.image_uid    = String(get(row, :image_uid, t.image_uid))
+            t.pool_name    = String(get(row, :pool_name, t.pool_name))
+            t.chain_run_id = String(get(row, :chain_run_id, t.chain_run_id))
+            isempty(status) || (t.status = status)
+            t.in_snapshot  = true
+            t.misses       = 0
+        end
+        # retire what the scheduler no longer knows about (outcome unseen — tallied as "ended")
+        for (id, t) in collect(TASKS)
+            (t.in_snapshot && !(id in present)) || continue
+            t.misses += 1
+            t.misses >= SNAPSHOT_MISSES_TO_RETIRE || continue
+            _note_terminal!(id, "ended")
+            push_event!("status", string(col(BOLD, short(id)), " ", col(GREY, "ended"),
+                        col(DIM, " (outcome unseen — dropped frame)")); colour = GREY)
+        end
+    end
+    nothing
+end
+
 function refresh_snapshot!()
     try
         r = HTTP.get("$HTTP_BASE/api/tasks"; connect_timeout=2, readtimeout=3, retry=false)
-        rows = JSON3.read(String(r.body))
-        lock(LOCK) do
-            present = Set{String}()
-            for row in rows
-                id = String(row.id)
-                push!(present, id)
-                id in SEEN_TERM && continue                 # already finished + counted — don't resurrect
-                status = String(get(row, :status, ""))
-                if status in TERMINAL                       # finished before we saw it live → just count it
-                    _note_terminal!(id, status)
-                    continue
-                end
-                t = _task!(id)
-                t.fun_name     = String(get(row, :fun_name, t.fun_name))
-                t.image_uid    = String(get(row, :image_uid, t.image_uid))
-                t.pool_name    = String(get(row, :pool_name, t.pool_name))
-                t.chain_run_id = String(get(row, :chain_run_id, t.chain_run_id))
-                isempty(status) || (t.status = status)
-                t.in_snapshot  = true
-                t.misses       = 0
-            end
-            # retire what the scheduler no longer knows about (outcome unseen — tallied as "ended")
-            for (id, t) in collect(TASKS)
-                (t.in_snapshot && !(id in present)) || continue
-                t.misses += 1
-                t.misses >= SNAPSHOT_MISSES_TO_RETIRE || continue
-                _note_terminal!(id, "ended")
-                push_event!("status", string(col(BOLD, short(id)), " ", col(GREY, "ended"),
-                            col(DIM, " (outcome unseen — dropped frame)")); colour = GREY)
-            end
-        end
+        _reconcile_snapshot!(JSON3.read(String(r.body)))
         return true
     catch
         return false   # server not up yet / transient — the caller shows connection state
@@ -433,9 +440,13 @@ function run_console()
     end
 end
 
-try
-    run_console()
-catch e
-    e isa InterruptException || rethrow()
-    println("\n", col(DIM, "task console stopped."))
+# Entrypoint — only when run as a script (`pixi run console`). Guarded so the test suite can
+# `include` this file to drive `_reconcile_snapshot!` without opening a socket or a dashboard.
+if abspath(PROGRAM_FILE) == @__FILE__
+    try
+        run_console()
+    catch e
+        e isa InterruptException || rethrow()
+        println("\n", col(DIM, "task console stopped."))
+    end
 end

--- a/api/task_console.jl
+++ b/api/task_console.jl
@@ -120,9 +120,23 @@ function push_log!(id::AbstractString, line::AbstractString)
 end
 
 # A task's first terminal sighting: bump its outcome tally and drop the row (kept only as a count).
+#
+# One exception to "first sighting wins": a task retired as `ended` (finished, outcome unseen) whose
+# real outcome shows up LATER — a chain node's terminal frame delayed past the retire window, or any
+# frame that arrived after the snapshot had already dropped the row. Moving the count is strictly
+# better than keeping a number we know to be wrong, and it can't double-count: the id leaves
+# ENDED_IDS as it's corrected, and every other repeat sighting still returns early.
+const ENDED_IDS = Set{String}()   # ids currently counted as "ended" — correctable, unlike a real outcome
+
 function _note_terminal!(id::AbstractString, status::AbstractString)
-    id in SEEN_TERM && return
-    push!(SEEN_TERM, id)
+    if id in SEEN_TERM
+        (id in ENDED_IDS && status != "ended" && haskey(TALLY, status)) || return
+        TALLY["ended"] -= 1                       # …and fall through to count the real outcome
+        delete!(ENDED_IDS, String(id))
+    else
+        push!(SEEN_TERM, String(id))
+        status == "ended" && push!(ENDED_IDS, String(id))
+    end
     haskey(TALLY, status) && (TALLY[status] += 1)
     delete!(TASKS, id)
 end
@@ -261,6 +275,16 @@ function handle_ws(raw::AbstractString)
                         colour = status_colour(node == "done" ? "done" :
                                                node == "failed" ? "failed" :
                                                node == "running" ? "running" : "queued"))
+            # A chain run emits NO task:status frames (handle_chain_run passes no on_status_change), so
+            # a chain node's row would otherwise only ever leave the table via the snapshot-retire path —
+            # i.e. always "ended / outcome unseen", never done or failed. `taskId` on the chain event is
+            # the correlation handle: attribute the node's real outcome to its task row here. Terminal
+            # events only; `:queued`/`:running` already come from the snapshot poll.
+            tid = let t = get(msg, :taskId, nothing); t isa AbstractString ? String(t) : "" end
+            if !isempty(tid) && node in ("done", "failed")
+                # node:failed carries which of failed/skipped/cancelled it was
+                _note_terminal!(tid, node == "done" ? "done" : String(get(msg, :status, "failed")))
+            end
 
         elseif startswith(type, "chain:run:") || type == "chain:log"
             detail = type == "chain:log" ? String(get(msg, :line, "")) :
@@ -406,6 +430,7 @@ function run_console()
                 # tasks from the previous server session would linger forever (we only ever add rows).
                 lock(LOCK) do
                     empty!(TASKS); empty!(EVENTS); empty!(LOGS); empty!(SEEN_TERM); empty!(POOLS)
+                    empty!(ENDED_IDS)
                     for k in keys(TALLY); TALLY[k] = 0; end
                 end
                 # seed the snapshot, then keep it fresh + keep the socket alive

--- a/api/task_console.jl
+++ b/api/task_console.jl
@@ -40,8 +40,7 @@ function status_colour(s::AbstractString)
     s == "cancelled" ? MAGENTA : GREY
 end
 
-const ACTIVE   = ("queued", "running")
-const TERMINAL = ("done", "failed", "cancelled")
+const TERMINAL = ("done", "failed", "cancelled")   # everything else is active (queued / running)
 
 # ── State ───────────────────────────────────────────────────────────────────────
 mutable struct TaskView

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -1363,3 +1363,65 @@ end
     bad = JSON3.read(JSON3.write(Dict("allBranchLabels" => "nope")))
     @test _parse_all_branch_labels(bad) == Dict{String,Vector{String}}()
 end
+
+# ── Task console: snapshot reconciliation (the stale-"running"-row regression) ──
+# `api/task_console.jl` is run by path (`pixi run console`), never imported, so this is the only
+# automated coverage it can have: its entrypoint is guarded by `PROGRAM_FILE`, and the reconciliation
+# half is split out as the socket-free `_reconcile_snapshot!(rows)` we drive with synthetic snapshots.
+# Wrapped in a module because the script defines top-level consts (TASKS, LOCK, TALLY, …).
+#
+# The bug this pins: the console only ever ADDED rows from GET /api/tasks, and dropped one solely on a
+# terminal task:status frame — which is lossy by design (per-client drop-on-full queue in server.jl,
+# and nothing at all on a half-open socket). One missed frame stranded the row as "running" forever:
+# six tasks listed as running while every pool read idle and the scheduler held none.
+module TaskConsoleUT
+    include(joinpath(@__DIR__, "..", "task_console.jl"))
+end
+
+@testset "API: task console reconciles snapshot removals" begin
+    C = TaskConsoleUT
+    row(id; status="running", fun="segment.branching", pool="cpu", img="EaMaVq") =
+        (; id=id, status=status, fun_name=fun, pool_name=pool, image_uid=img, chain_run_id="")
+    reset_console!() = (empty!(C.TASKS); empty!(C.SEEN_TERM); empty!(C.EVENTS);
+                        for k in keys(C.TALLY); C.TALLY[k] = 0; end)
+
+    # a scheduler task appears, then vanishes with NO terminal frame ever delivered
+    reset_console!()
+    C._reconcile_snapshot!([row("t1")])
+    @test haskey(C.TASKS, "t1") && C.TASKS["t1"].status == "running"
+    @test C.TASKS["t1"].in_snapshot                       # eligible for retiring
+    C._reconcile_snapshot!([])                            # miss 1 — not yet (poll/registration race)
+    @test haskey(C.TASKS, "t1")
+    C._reconcile_snapshot!([])                            # miss 2 — retire
+    @test !haskey(C.TASKS, "t1")                          # ← the row used to live here forever
+    @test C.TALLY["ended"] == 1                           # counted, and NOT guessed as done/failed
+    @test C.TALLY["done"] == 0 && C.TALLY["failed"] == 0
+
+    # a retired task must not be resurrected by a later snapshot (SEEN_TERM)
+    C._reconcile_snapshot!([row("t1")])
+    @test !haskey(C.TASKS, "t1") && C.TALLY["ended"] == 1
+
+    # a WS-only producer (job / batch movie) never appears in the snapshot → never retired by it
+    reset_console!()
+    t = C._task!("job1"); t.fun_name = "project.export"; t.pool_name = "job"; t.status = "running"
+    for _ in 1:5
+        C._reconcile_snapshot!([])
+    end
+    @test haskey(C.TASKS, "job1") && C.TALLY["ended"] == 0
+
+    # a terminal status seen IN the snapshot is counted for real, not as "ended"
+    reset_console!()
+    C._reconcile_snapshot!([row("t2")])
+    C._reconcile_snapshot!([row("t2"; status="failed")])
+    @test !haskey(C.TASKS, "t2")
+    @test C.TALLY["failed"] == 1 && C.TALLY["ended"] == 0
+
+    # a task still listed keeps its row and its miss counter resets (no drift toward retirement)
+    reset_console!()
+    C._reconcile_snapshot!([row("t3")])
+    C._reconcile_snapshot!([])                            # one miss
+    C._reconcile_snapshot!([row("t3")])                   # back in the snapshot → counter cleared
+    @test C.TASKS["t3"].misses == 0
+    C._reconcile_snapshot!([])
+    @test haskey(C.TASKS, "t3")                           # would have been retired if it hadn't reset
+end

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -1382,46 +1382,142 @@ end
     C = TaskConsoleUT
     row(id; status="running", fun="segment.branching", pool="cpu", img="EaMaVq") =
         (; id=id, status=status, fun_name=fun, pool_name=pool, image_uid=img, chain_run_id="")
-    reset_console!() = (empty!(C.TASKS); empty!(C.SEEN_TERM); empty!(C.EVENTS);
+    reset_console!() = (empty!(C.TASKS); empty!(C.SEEN_TERM); empty!(C.EVENTS); empty!(C.ENDED_IDS);
                         for k in keys(C.TALLY); C.TALLY[k] = 0; end)
+    # retiring pushes an activity line, which STREAM_MODE prints — keep it out of the test output
+    reconcile(rows) = redirect_stdout(devnull) do; C._reconcile_snapshot!(rows) end
 
     # a scheduler task appears, then vanishes with NO terminal frame ever delivered
     reset_console!()
-    C._reconcile_snapshot!([row("t1")])
+    reconcile([row("t1")])
     @test haskey(C.TASKS, "t1") && C.TASKS["t1"].status == "running"
     @test C.TASKS["t1"].in_snapshot                       # eligible for retiring
-    C._reconcile_snapshot!([])                            # miss 1 — not yet (poll/registration race)
+    reconcile([])                            # miss 1 — not yet (poll/registration race)
     @test haskey(C.TASKS, "t1")
-    C._reconcile_snapshot!([])                            # miss 2 — retire
+    reconcile([])                            # miss 2 — retire
     @test !haskey(C.TASKS, "t1")                          # ← the row used to live here forever
     @test C.TALLY["ended"] == 1                           # counted, and NOT guessed as done/failed
     @test C.TALLY["done"] == 0 && C.TALLY["failed"] == 0
 
     # a retired task must not be resurrected by a later snapshot (SEEN_TERM)
-    C._reconcile_snapshot!([row("t1")])
+    reconcile([row("t1")])
     @test !haskey(C.TASKS, "t1") && C.TALLY["ended"] == 1
 
     # a WS-only producer (job / batch movie) never appears in the snapshot → never retired by it
     reset_console!()
     t = C._task!("job1"); t.fun_name = "project.export"; t.pool_name = "job"; t.status = "running"
     for _ in 1:5
-        C._reconcile_snapshot!([])
+        reconcile([])
     end
     @test haskey(C.TASKS, "job1") && C.TALLY["ended"] == 0
 
     # a terminal status seen IN the snapshot is counted for real, not as "ended"
     reset_console!()
-    C._reconcile_snapshot!([row("t2")])
-    C._reconcile_snapshot!([row("t2"; status="failed")])
+    reconcile([row("t2")])
+    reconcile([row("t2"; status="failed")])
     @test !haskey(C.TASKS, "t2")
     @test C.TALLY["failed"] == 1 && C.TALLY["ended"] == 0
 
     # a task still listed keeps its row and its miss counter resets (no drift toward retirement)
     reset_console!()
-    C._reconcile_snapshot!([row("t3")])
-    C._reconcile_snapshot!([])                            # one miss
-    C._reconcile_snapshot!([row("t3")])                   # back in the snapshot → counter cleared
+    reconcile([row("t3")])
+    reconcile([])                            # one miss
+    reconcile([row("t3")])                   # back in the snapshot → counter cleared
     @test C.TASKS["t3"].misses == 0
-    C._reconcile_snapshot!([])
+    reconcile([])
     @test haskey(C.TASKS, "t3")                           # would have been retired if it hadn't reset
+end
+
+# ── Task console: a chain node's real outcome ─────────────────────────────────
+# A chain run emits NO `task:status` frames (`handle_chain_run` passes no `on_status_change`), so a
+# chain node's row can only leave the table via the snapshot-retire path — i.e. always
+# "ended / outcome unseen", never done or failed. The `taskId` now carried on every `chain:node:*`
+# frame is the correlation handle; these pin that the console uses it, and that a frame WITHOUT one
+# (skipped before submission, set-scope node, hand-fired REPL event → JSON `null`) is harmless.
+@testset "API: task console attributes chain-node outcomes" begin
+    C = TaskConsoleUT
+    row(id; status="running") = (; id=id, status=status, fun_name="segment.branching",
+                                  pool_name="cpu", image_uid="EaMaVq", chain_run_id="run1")
+    feed(frame) = redirect_stdout(devnull) do        # STREAM_MODE prints; keep test output clean
+        C.handle_ws(JSON3.write(frame))
+    end
+    reset_console!() = (empty!(C.TASKS); empty!(C.SEEN_TERM); empty!(C.EVENTS); empty!(C.ENDED_IDS);
+                        for k in keys(C.TALLY); C.TALLY[k] = 0; end)
+    recon(rows) = redirect_stdout(devnull) do; C._reconcile_snapshot!(rows) end
+
+    # node finishes → counted as DONE (not "ended"), row dropped at once
+    reset_console!()
+    recon([row("c1")])
+    feed((; type="chain:node:done", runId="run1", chainName="ch", projectUid="p",
+           imageUid="EaMaVq", nodeId="n1", fn="segment.branching", taskId="c1"))
+    @test !haskey(C.TASKS, "c1")
+    @test C.TALLY["done"] == 1 && C.TALLY["ended"] == 0
+    # …and the snapshot's retire path must not then double-count it as ended
+    recon([]); recon([])
+    @test C.TALLY["ended"] == 0 && C.TALLY["done"] == 1
+
+    # node:failed carries WHICH terminal it was — cancelled must not be counted as failed
+    reset_console!()
+    recon([row("c2")])
+    feed((; type="chain:node:failed", runId="run1", imageUid="EaMaVq", nodeId="n1",
+           fn="segment.branching", status="cancelled", taskId="c2"))
+    @test C.TALLY["cancelled"] == 1 && C.TALLY["failed"] == 0
+    reset_console!()
+    recon([row("c3")])
+    feed((; type="chain:node:failed", runId="run1", imageUid="EaMaVq", nodeId="n1",
+           fn="segment.branching", status="failed", taskId="c3"))
+    @test C.TALLY["failed"] == 1
+
+    # taskId absent / JSON null (skipped node, set-scope node, hand-fired event) → no crash, no tally,
+    # and the row is left for the snapshot to retire as before
+    reset_console!()
+    recon([row("c4")])
+    feed((; type="chain:node:done", runId="run1", imageUid="EaMaVq", nodeId="n1", fn="f"))
+    feed((; type="chain:node:done", runId="run1", imageUid="EaMaVq", nodeId="n1", fn="f",
+           taskId=nothing))
+    feed((; type="chain:node:failed", runId="run1", imageUid="EaMaVq", nodeId="n2", fn="f",
+           status="skipped", taskId=""))
+    @test haskey(C.TASKS, "c4")                       # untouched — nothing to correlate
+    @test sum(values(C.TALLY)) == 0
+    recon([]); recon([])
+    @test !haskey(C.TASKS, "c4") && C.TALLY["ended"] == 1   # falls back to the retire path
+
+    # a LATE terminal frame corrects an `ended` tally rather than leaving a number we know is wrong
+    # (chain frame delayed past the 2-poll retire window). It must move the count, not add one.
+    reset_console!()
+    recon([row("c6")]); recon([]); recon([])
+    @test C.TALLY["ended"] == 1
+    feed((; type="chain:node:done", runId="run1", imageUid="EaMaVq", nodeId="n1", fn="f", taskId="c6"))
+    @test C.TALLY["ended"] == 0 && C.TALLY["done"] == 1        # moved, not added
+    # …and a further repeat of that frame changes nothing (no double count)
+    feed((; type="chain:node:done", runId="run1", imageUid="EaMaVq", nodeId="n1", fn="f", taskId="c6"))
+    @test C.TALLY["done"] == 1 && sum(values(C.TALLY)) == 1
+    # a real outcome is NOT correctable by a later, different one — first sighting wins
+    reset_console!()
+    recon([row("c7")])
+    feed((; type="chain:node:done", runId="run1", imageUid="EaMaVq", nodeId="n1", fn="f", taskId="c7"))
+    feed((; type="chain:node:failed", runId="run1", imageUid="EaMaVq", nodeId="n1", fn="f",
+           status="failed", taskId="c7"))
+    @test C.TALLY["done"] == 1 && C.TALLY["failed"] == 0
+
+    # a terminal chain frame for a task the console never saw still counts + blocks resurrection
+    reset_console!()
+    feed((; type="chain:node:done", runId="run1", imageUid="EaMaVq", nodeId="n1", fn="f", taskId="c5"))
+    @test C.TALLY["done"] == 1
+    recon([row("c5")])
+    @test !haskey(C.TASKS, "c5") && C.TALLY["done"] == 1
+end
+
+# ── Chain event → WS bridge: taskId degradation ───────────────────────────────
+# The bridge reads `task_id` through `_ev_task_id`, not `p.task_id`, because two real payloads lack a
+# usable one: a node with no task id yet (skipped before submission, set-scope/incremental nodes that
+# bypass `run_task`) carries `nothing`, and a hand-fired REPL/test event may omit the field entirely.
+# Either must degrade to "" — a bridge handler that throws would take down chain telemetry for every
+# connected client.
+@testset "API: chain bridge taskId degradation" begin
+    @test _ev_task_id((; task_id = "abc123")) == "abc123"
+    @test _ev_task_id((; task_id = nothing))  == ""       # node had no task id yet
+    @test _ev_task_id((; run_id  = "r1"))     == ""       # field absent (hand-fired event)
+    @test _ev_task_id(NamedTuple())            == ""
+    @test _ev_task_id((; task_id = "x")) isa String
 end

--- a/app/src/tasks/chain.jl
+++ b/app/src/tasks/chain.jl
@@ -5,13 +5,13 @@ import SHA
 # Two distinct artifacts:
 #
 #   ChainTemplate  — reusable, no images baked in. Lives at
-#                    <project>/chains/<name>.json. Editing a template never
+#                    <project>/settings/chains/<name>.json. Editing a template never
 #                    retroactively changes a completed run.
 #
 #   ChainRun       — created when a template is applied to a set of images.
 #                    Stores a FROZEN COPY of the template at run time (not a
 #                    pointer to the template file). Per-image per-node state
-#                    is persisted to <project>/chains/runs/<run_id>/run.json
+#                    is persisted to <project>/settings/chains/runs/<run_id>/run.json
 #                    after every node completion.
 
 # ── Template ──────────────────────────────────────────────────────────────────
@@ -71,7 +71,7 @@ ChainTemplate(name, nodes, edges) = ChainTemplate(name, nodes, edges, String[])
 # ── Run record ────────────────────────────────────────────────────────────────
 
 mutable struct ImageNodeState
-    status::Symbol                          # :pending | :running | :done | :failed | :cancelled | :skipped
+    status::Symbol                          # :pending | :queued | :running | :done | :failed | :cancelled | :skipped
     task_id::Union{String,Nothing}
     result::Union{Dict{String,Any},Nothing}
     params_hash::Union{String,Nothing}      # sha256 of effective params — set on :done, used for resume skip
@@ -88,10 +88,10 @@ mutable struct ChainRun
     template_hash::String                   # sha256 hex — pointer to cache entry on disk
     image_states::Dict{String,Dict{String,ImageNodeState}}  # uid => node_id => state
     created_at::Float64
-    _dir::String                            # <project>/chains/runs/<run_id>/
+    _dir::String                            # <project>/settings/chains/runs/<run_id>/
     _lock::ReentrantLock                    # guards image_states + disk writes
-    _barriers::Dict{String,Channel{Nothing}} # node_id => arrive channel (Step 3)
-    _barriers_done::Dict{String,Channel{Nothing}} # node_id => done channel (Step 3)
+    _barriers::Dict{String,Channel{Nothing}}      # node_id => arrive channel (set-scope barrier)
+    _barriers_done::Dict{String,Channel{Nothing}} # node_id => done channel   (set-scope barrier)
 end
 # NOTE: resource-pool concurrency is NOT a per-run concern. Every node runs via
 # `run_task`, which routes through the global scheduler pools (`_POOLS` in
@@ -148,7 +148,7 @@ function _edge_from_dict(d)::ChainEdge
 end
 
 """
-Load a chain template from `<project>/chains/<name>.json`.
+Load a chain template from `<project>/settings/chains/<name>.json`.
 """
 function load_chain_template(proj::CciaProject, name::String)::ChainTemplate
     path = _template_path(proj, name)
@@ -163,7 +163,7 @@ function load_chain_template(proj::CciaProject, name::String)::ChainTemplate
 end
 
 """
-Write a chain template to `<project>/chains/<name>.json`.
+Write a chain template to `<project>/settings/chains/<name>.json`.
 Creates the chains/ directory if needed.
 """
 function save_chain_template!(proj::CciaProject, t::ChainTemplate)::ChainTemplate
@@ -182,7 +182,7 @@ function save_chain_template!(proj::CciaProject, t::ChainTemplate)::ChainTemplat
 end
 
 # ── Template content cache ─────────────────────────────────────────────────────
-# Templates are stored once under chains/.cache/<sha256>.json.
+# Templates are stored once under settings/chains/.cache/<sha256>.json.
 # Run records reference the hash — editing a template after a run has started
 # produces a new hash, leaving the old cache entry (and run records) untouched.
 
@@ -989,7 +989,7 @@ scheduler.jl, sized from config.toml `[pools]`) — `run_chain` takes no pool ar
 A pool with limit 1 (e.g. `gpu`) serialises that node's work across the whole process.
 
 ## Fresh run
-Template is loaded from `<project>/chains/<name>.json` and `chain` must be given.
+Template is loaded from `<project>/settings/chains/<name>.json` and `chain` must be given.
 A frozen copy is stored in the run record — editing the template after the run
 has started does not change what that run is understood to have done.
 

--- a/app/src/tasks/chain.jl
+++ b/app/src/tasks/chain.jl
@@ -273,13 +273,21 @@ function _update_node_state!(run::ChainRun, image_uid::String, node_id::String;
                               result      = nothing,
                               params_hash = nothing)
     captured_result = Ref{Any}(nothing)
+    # The scheduler task id this node ran as, captured under the lock alongside the result. It goes out
+    # on every event so a consumer can correlate a node with its `TaskRecord` / `GET /api/tasks` row —
+    # the task console needs it to attribute a chain node's real outcome (chain runs emit no
+    # `task:status` frames, so without this a finished node can only be reported as "outcome unseen").
+    # "" when the node has no task id yet (skipped/cancelled before submission, set-scope/incremental
+    # nodes that bypass `run_task`): consumers must treat it as "no correlation available", never assume.
+    captured_task_id = Ref("")
     lock(run._lock) do
         st = run.image_states[image_uid][node_id]
         st.status = status
         isnothing(task_id)     || (st.task_id     = task_id)
         isnothing(result)      || (st.result      = result)
         isnothing(params_hash) || (st.params_hash = params_hash)
-        captured_result[] = st.result
+        captured_result[]  = st.result
+        captured_task_id[] = something(st.task_id, "")
         _save_run!(run)
     end
     # Fire events outside the lock — handlers must not re-enter run._lock
@@ -292,6 +300,7 @@ function _update_node_state!(run::ChainRun, image_uid::String, node_id::String;
             node_id     = node_id,
             fn          = fn,
             params      = node_params,
+            task_id     = captured_task_id[],
         ))
     elseif status == :running
         _fire_chain_event!("node:running", (
@@ -302,6 +311,7 @@ function _update_node_state!(run::ChainRun, image_uid::String, node_id::String;
             node_id     = node_id,
             fn          = fn,
             params      = node_params,
+            task_id     = captured_task_id[],
         ))
     elseif status == :done
         _fire_chain_event!("node:done", (
@@ -313,6 +323,7 @@ function _update_node_state!(run::ChainRun, image_uid::String, node_id::String;
             fn          = fn,
             params      = node_params,
             result      = captured_result[],
+            task_id     = captured_task_id[],
         ))
     elseif status ∈ (:failed, :skipped, :cancelled)
         _fire_chain_event!("node:failed", (
@@ -323,6 +334,7 @@ function _update_node_state!(run::ChainRun, image_uid::String, node_id::String;
             node_id     = node_id,
             fn          = fn,
             status      = string(status),
+            task_id     = captured_task_id[],
         ))
     end
 end

--- a/app/src/tasks/scheduler.jl
+++ b/app/src/tasks/scheduler.jl
@@ -135,11 +135,25 @@ function _start_pool!(name::String, limit::Int)
     pool  = ResourcePool(name, limit, queue, 0, Threads.Condition())
     _POOLS[name] = pool
     # dispatcher: pull a job, wait for a free slot, run it on its own task (freeing the slot after).
+    # Both `try`s below are backstops for the same failure mode: an exception in a `Threads.@spawn` is
+    # SILENT (nobody fetches these tasks), so an unguarded throw either strands a submitter forever
+    # (job task) or kills the dispatcher and wedges the whole pool at `:queued` (dispatcher task).
     Threads.@spawn begin
         for job in pool.queue
-            _acquire_slot!(pool)
+            try
+                _acquire_slot!(pool)
+            catch e
+                # Never let the loop die — one job's failure must not stop the pool consuming the rest.
+                @error "Pool dispatcher could not acquire a slot — job dropped" pool = pool.name exception = (e, catch_backtrace())
+                try; put!(job.done, nothing); catch; end   # release the blocked submitter
+                continue
+            end
             Threads.@spawn try
                 _execute_job!(job)
+            catch e
+                # Unreachable while _execute_job! keeps its contract (it always posts) — logged rather
+                # than swallowed so a future regression surfaces as an error, not a hung task.
+                @error "Job task died" pool = pool.name task_id = job.id exception = (e, catch_backtrace())
             finally
                 _release_slot!(pool)
             end
@@ -298,63 +312,93 @@ struct TaskJob
     imgs::Union{Nothing,Vector{CciaImage}}   # set-scope: run `_run_task` over all images at once; nothing = single-image
 end
 
+"""
+Run one job to completion and post its result to `job.done` — **exactly once, unconditionally**.
+
+That post is the job's only contract with its submitter: `run_task` is blocked in `take!(job.done)`
+and nothing else will ever wake it. The dispatcher's `Threads.@spawn` is fire-and-forget, so a throw
+escaping this function is *silent* — and costs a permanently blocked submitter plus a `TaskRecord`
+stranded at `:running` in `_TASKS`. That leak is invisible from the outside: the pool slot was already
+released by the dispatcher's `finally`, so pools read idle while `list_tasks()` (and the task console
+and the GUI) keep listing work that finished long ago. Hence the post lives in a `finally`, and the
+`catch` exists for a throw in the *error path itself* — the task's own errors are already handled
+inline below.
+"""
 function _execute_job!(job::TaskJob)
+    # `job.done` holds 1, so posting twice would block forever — post through this, never `put!`.
+    posted = Ref(false)
+    post!(result) = (posted[] || (posted[] = true; put!(job.done, result)))
+
     rec = lock(_TASKS_LOCK) do; get(_TASKS, job.id, nothing); end
     # Skip if cancelled while queued
     if isnothing(rec) || rec.status === :cancelled
-        put!(job.done, nothing)
+        post!(nothing)
         return
     end
-    _set_status!(rec, :running)
-    # invokelatest: workers are spawned once at pool init; user-supplied callbacks
-    # may be defined in a later world (e.g. in test files or interactive sessions).
-    # set-scope job runs _run_task over the whole image vector at once; else single image.
-    job_target = isnothing(job.imgs) ? job.img : job.imgs
-    result = try
-        _run_task(job.task, job_target,
-                  merge(job.params, Dict("_task_id" => job.id));
-                  on_log      = line -> Base.invokelatest(job.on_log, line),
-                  on_progress = (n, t) -> Base.invokelatest(job.on_progress, n, t),
-                  on_process  = proc -> begin
-                      @atomic rec.proc = proc
-                      # Race guard: if cancel arrived between :running and now, rec.proc
-                      # was nothing when cancel_task! ran, so the kill was skipped. Kill
-                      # here now that we hold the process handle.
-                      if is_cancelled(job.id)
-                          try; _kill_proc_tree(proc); catch; end
-                      end
-                      Base.invokelatest(job.on_process, proc)
-                  end)
-    catch e
-        bt = catch_backtrace()
-        @warn "Unhandled error in task" task_id = job.id exception = (e, bt)
-        # Also tee the crash into the per-image task log (job.on_log appends to
-        # {img._dir}/logs/{fun}.log). Without this, a Julia-side failure — e.g. one thrown before the
-        # Python subprocess even starts — leaves the task log ending mid-run with no error, invisible
-        # to `get_task_log` and to anyone debugging after the fact (the error only went to the console).
-        try
-            Base.invokelatest(job.on_log, "[ERROR] Task crashed: " * sprint(showerror, e, bt))
-        catch; end
-        nothing
-    end
-    final = is_cancelled(job.id) ? :cancelled : isnothing(result) ? :failed : :done
-    _set_status!(rec, final)
-    # append to each target image's run log — automatic run history for the image table AND the AI
-    # observer. Records BOTH :done and :failed (with status) so repeated failures are visible, not just
-    # successes; :cancelled is skipped (the user aborted — not an outcome worth logging). Never fail the
-    # task over a log write.
-    if final in (:done, :failed)
-        try
-            fn = _fun_name_from_task(job.task)
-            vn = string(get(job.params, "valueName", ""))
-            for tgt in (isnothing(job.imgs) ? [job.img] : job.imgs)
-                append_run_log!(tgt, fn, vn, string(final), job.params)
-            end
+    try
+        _set_status!(rec, :running)
+        # invokelatest: workers are spawned once at pool init; user-supplied callbacks
+        # may be defined in a later world (e.g. in test files or interactive sessions).
+        # set-scope job runs _run_task over the whole image vector at once; else single image.
+        job_target = isnothing(job.imgs) ? job.img : job.imgs
+        result = try
+            _run_task(job.task, job_target,
+                      merge(job.params, Dict("_task_id" => job.id));
+                      on_log      = line -> Base.invokelatest(job.on_log, line),
+                      on_progress = (n, t) -> Base.invokelatest(job.on_progress, n, t),
+                      on_process  = proc -> begin
+                          @atomic rec.proc = proc
+                          # Race guard: if cancel arrived between :running and now, rec.proc
+                          # was nothing when cancel_task! ran, so the kill was skipped. Kill
+                          # here now that we hold the process handle.
+                          if is_cancelled(job.id)
+                              try; _kill_proc_tree(proc); catch; end
+                          end
+                          Base.invokelatest(job.on_process, proc)
+                      end)
         catch e
-            @warn "run-log append failed" task_id = job.id exception = e
+            bt = catch_backtrace()
+            @warn "Unhandled error in task" task_id = job.id exception = (e, bt)
+            # Also tee the crash into the per-image task log (job.on_log appends to
+            # {img._dir}/logs/{fun}.log). Without this, a Julia-side failure — e.g. one thrown before the
+            # Python subprocess even starts — leaves the task log ending mid-run with no error, invisible
+            # to `get_task_log` and to anyone debugging after the fact (the error only went to the console).
+            try
+                Base.invokelatest(job.on_log, "[ERROR] Task crashed: " * sprint(showerror, e, bt))
+            catch; end
+            nothing
         end
+        final = is_cancelled(job.id) ? :cancelled : isnothing(result) ? :failed : :done
+        _set_status!(rec, final)
+        # append to each target image's run log — automatic run history for the image table AND the AI
+        # observer. Records BOTH :done and :failed (with status) so repeated failures are visible, not just
+        # successes; :cancelled is skipped (the user aborted — not an outcome worth logging). Never fail the
+        # task over a log write.
+        if final in (:done, :failed)
+            try
+                fn = _fun_name_from_task(job.task)
+                vn = string(get(job.params, "valueName", ""))
+                for tgt in (isnothing(job.imgs) ? [job.img] : job.imgs)
+                    append_run_log!(tgt, fn, vn, string(final), job.params)
+                end
+            catch e
+                @warn "run-log append failed" task_id = job.id exception = e
+            end
+        end
+        post!(result)
+    catch e
+        # The task's OWN failure is handled inline above, so reaching here means the error path itself
+        # threw (a logger that propagates, a callback in an unexpected place, anything added to this
+        # window later). Record it as failed — never leave the record at :running — and let the
+        # `finally` release the submitter. Logging is guarded because a throwing logger is one of the
+        # ways to get here in the first place.
+        try
+            @error "Scheduler job aborted" task_id = job.id exception = (e, catch_backtrace())
+        catch; end
+        try; _set_status!(rec, :failed); catch; end
+    finally
+        post!(nothing)   # no-op if the success path already posted
     end
-    put!(job.done, result)
 end
 
 # ── One path: run_task ─────────────────────────────────────────────────────────

--- a/app/src/tasks/testTasks/setTask.json
+++ b/app/src/tasks/testTasks/setTask.json
@@ -2,6 +2,7 @@
   "fun_name": "testTasks.setTask",
   "task": "setTask",
   "label": "Test set task",
+  "scope": "set",
   "resource_pool": "cpu",
   "params": [
     {

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -2727,7 +2727,8 @@ end
         save_chain_template!(proj, tpl)
 
         received = String[]
-        handler  = payload -> push!(received, payload.image_uid)
+        payloads = Any[]
+        handler  = payload -> (push!(received, payload.image_uid); push!(payloads, payload))
         subscribe_chain_events!("node:done", handler)
 
         run = run_chain(proj, [i.uid for i in imgs];
@@ -2737,6 +2738,17 @@ end
 
         # Both images fired node:done events
         @test Set(received) ⊇ Set(i.uid for i in imgs)
+
+        # …and every payload carries the scheduler `task_id` the node ran as, matching the state it
+        # was recorded under. This is the correlation handle the task console needs: a chain run emits
+        # no `task:status` frames, so without it a finished node can only be reported as "outcome
+        # unseen". Never `nothing` — absent ⇒ "" (see _update_node_state!).
+        for p in payloads
+            @test haskey(p, :task_id)
+            @test p.task_id isa String
+            @test p.task_id == run.image_states[p.image_uid][p.node_id].task_id
+            @test !isempty(p.task_id)                     # this node ran, so it has one
+        end
 
         # After unsubscribe, new events don't reach the handler
         n_before = length(received)

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -69,6 +69,27 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
                   on_log::Function = _ -> nothing, on_progress::Function = (_, _) -> nothing,
                   on_process::Function = _ -> nothing) = error("boom in _run_task (test)")
 
+# ── Fault injection: make the scheduler's OWN error path throw ────────────────────
+# `_execute_job!` must post to `job.done` no matter what, because `run_task` is blocked in `take!` and
+# a throw escaping into the dispatcher's `Threads.@spawn` is silent — the cost is a submitter blocked
+# forever and a TaskRecord stranded at `:running` (a task the scheduler keeps reporting as in-flight
+# long after it finished). A logger is just the injection handle: it puts the throw *inside* the
+# `catch` block, which is the one window the inline handling can't cover. `catch_exceptions = false`
+# is what makes `@warn` propagate instead of reporting; only the scheduler's crash message throws, so
+# Test's own output is untouched.
+using Logging
+struct _ThrowingLogger <: Logging.AbstractLogger
+    inner::Logging.AbstractLogger
+end
+Logging.min_enabled_level(l::_ThrowingLogger) = Logging.min_enabled_level(l.inner)
+Logging.shouldlog(l::_ThrowingLogger, level, _module, group, id) =
+    Logging.shouldlog(l.inner, level, _module, group, id)
+Logging.catch_exceptions(::_ThrowingLogger) = false
+function Logging.handle_message(l::_ThrowingLogger, level, message, _module, group, id, file, line; kwargs...)
+    occursin("Unhandled error in task", string(message)) && error("logger exploded (test)")
+    Logging.handle_message(l.inner, level, message, _module, group, id, file, line; kwargs...)
+end
+
 @testset "Cecelia package smoke tests" begin
 
     # ── Config ────────────────────────────────────────────────────────────────
@@ -1875,6 +1896,36 @@ Cecelia._run_task(::_CrashTask, ::CciaImage, ::Dict{String,Any};
         rlog = read_run_log(img)
         @test length(rlog) == 1
         @test String(rlog[end]["fun"]) == fun_name && String(rlog[end]["status"]) == "failed"
+        rm(proj.root; recursive=true)
+    end
+
+    # ── A job ALWAYS releases its submitter, even if the error path itself throws ──
+    # Regression: `_execute_job!` posted to `job.done` as its last statement, so any throw before that
+    # (here: the crash `@warn` itself failing) escaped into the dispatcher's fire-and-forget
+    # `Threads.@spawn` — silently. `run_task` then blocked in `take!(job.done)` FOREVER and never ran
+    # `_deregister_task!`, leaving the TaskRecord stranded at `:running`: `list_tasks()`, the GUI and
+    # the task console all keep listing a task that finished, while every pool correctly reads idle
+    # (the dispatcher's `finally` had released the slot). The post now lives in a `finally`.
+    @testset "Job posts its result even when the error path throws" begin
+        proj = create_project!(name="job-post-$(rand(1000:9999))")
+        img  = add_image!(add_set!(proj; name="s"); name="img")
+
+        tid = "jobpost$(rand(1000:9999))"
+        old = global_logger()
+        t = try
+            global_logger(_ThrowingLogger(old))
+            th = Threads.@spawn run_task(_CrashTask(), img, Dict{String,Any}(); task_id = tid)
+            timedwait(() -> istaskdone(th), 30.0)        # wait BEFORE restoring, so the throw is injected
+            th
+        finally
+            global_logger(old)                            # a failing @test must not log through it
+        end
+
+        @test istaskdone(t)                               # the whole point — this used to hang forever
+        # guarded: on a regression the task is still blocked, and a bare fetch would hang the SUITE
+        istaskdone(t) && @test fetch(t) === nothing       # aborted job → nil result, like any failure
+        # ...and the record is gone, not stranded at :running for the console/GUI to keep showing
+        @test !any(r -> r.id == tid, list_tasks())
         rm(proj.root; recursive=true)
     end
 

--- a/app/test/runtests.jl
+++ b/app/test/runtests.jl
@@ -1967,6 +1967,11 @@ end
         @test Cecelia._task_default_scope("behaviour.hmm")        == "set"
         @test Cecelia._task_default_scope("importImages.remove")  == "image"
         @test Cecelia._task_default_scope("nonexistent.task")     == "image"   # unknown fn → image
+        # EVERY set-scope task declares it in its own spec — including the mock, which used to rely on
+        # each chain node passing scope="set" (the one task that contradicted "the spec is the single
+        # source of truth", and it's the fixture the barrier tests are built on).
+        @test Cecelia._task_default_scope("testTasks.setTask")    == "set"
+        @test chain_node("testTasks.setTask").scope               == "set"
 
         # chain_node / ChainNode with no scope kwarg resolve from the spec …
         @test chain_node("clustTracks.cluster").scope == "set"

--- a/docs/API.md
+++ b/docs/API.md
@@ -174,7 +174,10 @@ retires rows that vanish from it** (2 consecutive misses; tallied `ended` — "f
 `task:status` frame — dropped for a slow client, or never delivered on a half-open socket — otherwise
 strands the row as `running` forever, so the console lists tasks the scheduler has long since finished
 while every pool reads idle. Rows for WS-only producers (jobs, batch movies) never appear in the
-snapshot and are exempt from retiring. `handle_task_run` forwards
+snapshot and are exempt from retiring. The reconciliation half is split out as the socket-free
+`_reconcile_snapshot!(rows)` and pinned by the *API: task console reconciles snapshot removals*
+testset (the script's entrypoint is `PROGRAM_FILE`-guarded so the suite can `include` it).
+`handle_task_run` forwards
 `queued`/`running` **and
 `cancelled`** from `on_status_change` immediately (cancel has no result to order before it), so
 cancelling a task — especially a still-**queued** one — reflects at once instead of only when a worker

--- a/docs/API.md
+++ b/docs/API.md
@@ -177,7 +177,11 @@ while every pool reads idle. Rows for WS-only producers (jobs, batch movies) nev
 snapshot and are exempt from retiring. The reconciliation half is split out as the socket-free
 `_reconcile_snapshot!(rows)` and pinned by the *API: task console reconciles snapshot removals*
 testset (the script's entrypoint is `PROGRAM_FILE`-guarded so the suite can `include` it).
-`handle_task_run` forwards
+**Chain nodes** report their outcome through a different door: a chain run emits no `task:status`
+frames, so the console attributes one from the `taskId` on the terminal `chain:node:done`/`failed`
+frame (see `docs/SCHEDULER.md` → *Event bus*). A row already retired as `ended` is *corrected* if its
+real outcome arrives late — moving the tally rather than keeping a number known to be wrong — which
+leaves `ended` meaning what it says: telemetry genuinely lost. `handle_task_run` forwards
 `queued`/`running` **and
 `cancelled`** from `on_status_change` immediately (cancel has no result to order before it), so
 cancelling a task — especially a still-**queued** one — reflects at once instead of only when a worker

--- a/docs/API.md
+++ b/docs/API.md
@@ -166,13 +166,22 @@ many worker threads, so writing sockets inline would let concurrent threads corr
 and let one slow/half-open client block a worker (which strands a pool slot → tasks stuck at `queued`).
 Workers must never block on WS I/O. The **per-client** queue (rather than one shared drainer) also
 means a single stuck client only ever loses *its own* frames — it can't head-of-line-block delivery to
-the other tabs or the console. WS telemetry is lossy-safe: the console reconciles the authoritative
-state from `GET /api/tasks`, so a dropped frame self-heals. `handle_task_run` forwards
+the other tabs or the console. WS telemetry is lossy-safe *because the console reconciles against
+`GET /api/tasks` in **both** directions* — that snapshot is the authoritative in-flight set (whole
+registry, under its lock, deregistered on completion), so the console adds/updates rows from it **and
+retires rows that vanish from it** (2 consecutive misses; tallied `ended` — "finished, outcome unseen"
+— rather than guessed as done/failed). Only add-and-update is not enough: a lost terminal
+`task:status` frame — dropped for a slow client, or never delivered on a half-open socket — otherwise
+strands the row as `running` forever, so the console lists tasks the scheduler has long since finished
+while every pool reads idle. Rows for WS-only producers (jobs, batch movies) never appear in the
+snapshot and are exempt from retiring. `handle_task_run` forwards
 `queued`/`running` **and
 `cancelled`** from `on_status_change` immediately (cancel has no result to order before it), so
 cancelling a task — especially a still-**queued** one — reflects at once instead of only when a worker
 later dequeues and skips it; `done`/`failed` are held until the result is sent. The console drops its
-whole view on reconnect (a localhost drop = server restart), so stale tasks don't linger.
+whole view on reconnect (a localhost drop = server restart), so stale tasks don't linger — and a failed
+20s keepalive now tears the socket down instead of being swallowed, so a half-open connection actually
+reaches that reconnect rather than leaving the reader blocked forever on a socket that never speaks again.
 
 ---
 

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -477,10 +477,21 @@ unsubscribe_chain_events!("node:done",  handler)
 
 | Event | Payload fields | Fired when |
 |-------|---------------|-----------|
-| `"node:queued"` | *base* = `run_id, chain_name, project_uid, image_uid, node_id, fn, params` | Node submitted to its pool, waiting for a free slot |
+| `"node:queued"` | *base* = `run_id, chain_name, project_uid, image_uid, node_id, fn, params, task_id` | Node submitted to its pool, waiting for a free slot |
 | `"node:running"` | *base* | The job acquired a slot and started (real start) |
 | `"node:done"` | *base* `+ result` | Node transitions to `:done` |
 | `"node:failed"` | *base* `− params + status` | Node transitions to `:failed`, `:skipped` or `:cancelled` (`status` carries which) |
+
+**`task_id` — the correlation handle.** The scheduler task the node ran as, captured under `run._lock`
+alongside the result. It matters because **a chain run emits no `task:status` frames at all**:
+`handle_chain_run` passes no `on_status_change`, by design — the GUI renders chain nodes from
+`chain:node:*` keyed by `runId::nodeId::imageUid`, and emitting parallel `task:status` frames would give
+every chain node a second row in the Task Manager. But chain nodes *are* registered in `_TASKS`, so they
+appear in `GET /api/tasks` and hence in the task console — which without `task_id` could only ever
+report them as "finished, outcome unseen". It is `""`, never `nothing`, when there is no task to
+correlate (skipped/cancelled before submission; set-scope and incremental nodes bypass `run_task`
+entirely) — consumers must treat that as "no correlation available". The bridge reads it through
+`_ev_task_id`, so a hand-fired REPL event that omits the field can't take chain telemetry down.
 
 **Why fired outside the lock**: handlers may need to read `run.image_states` or trigger further
 work. Re-entering `run._lock` from inside the lock would deadlock. The result is captured inside
@@ -500,7 +511,7 @@ run_chain(proj, uids; chain="my-chain")
 
 **API WebSocket bridge**: `api/src/server.jl` subscribes to **all four** events at startup and
 broadcasts each to every connected client, `chain:`-prefixed with camelCase keys:
-- `chain:node:queued`  — `{type, runId, chainName, projectUid, imageUid, nodeId, fn, params}`
+- `chain:node:queued`  — `{type, runId, chainName, projectUid, imageUid, nodeId, fn, params, taskId}`
 - `chain:node:running` — same shape
 - `chain:node:done`    — `{…, params, result}`
 - `chain:node:failed`  — `{…, status}` (which of failed/skipped/cancelled)

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -1,6 +1,7 @@
 # Chain Scheduler
 
-Design reference for `app/src/tasks/chain.jl` and `app/src/events.jl`.
+Design reference for `app/src/tasks/scheduler.jl` (pools, task records, `run_task`),
+`app/src/tasks/chain.jl` (the chain executor) and `app/src/events.jl` (the event bus).
 
 The scheduler exists to solve two problems the old R version had: (1) images were processed in
 lockstep batches — image 1 sat idle after finishing import instead of starting denoise immediately,
@@ -39,34 +40,29 @@ defined globally in `config.toml` `[pools]` (see Resource pools below).
 Internally spawns three kinds of concurrent tasks (`Threads.@spawn`):
 
 ```
-image_tasks  — one OS thread per image, walks all "image"-scope nodes in topo order
-set_tasks    — one OS thread per "set"-scope node, waits for all images then runs once
-incr_tasks   — one OS thread per "incremental"-scope node, event-driven debounced watcher
+image_tasks  — one task per image, walks all "image"-scope nodes in topo order
+set_tasks    — one task per "set"-scope node, waits for all images then runs once
+incr_tasks   — one task per "incremental"-scope node, event-driven debounced watcher
 ```
 
 All three kinds run concurrently. `run_chain` `fetch`es all of them before returning —
 it blocks the caller until the entire chain finishes.
 
-### Why OS threads (not async tasks)?
+### Why `Threads.@spawn` (not `@async`)?
 
-Chain nodes call `run_task`, which may block on a Python subprocess. Julia's async (`@async`)
-doesn't help for blocking I/O — it only helps for I/O that yields back to the scheduler.
-`Threads.@spawn` puts each image on a real OS thread so blocking one image never stalls others.
+Chain nodes call `run_task`, which may block on a Python subprocess. `@async` doesn't help for
+blocking I/O — it only helps I/O that yields back to the scheduler, so one blocked image would stall
+every other image sharing its thread. `Threads.@spawn` schedules each task across the thread pool,
+so a blocking node occupies one thread and the rest keep moving. (Tasks are multiplexed onto
+`--threads` OS threads — 50 images is 50 tasks, not 50 threads.)
 
 ---
 
 ## Resource pools
 
-There is **one** concurrency mechanism: the global scheduler worker pools. (An earlier design
-had a second, per-run `Base.Semaphore` layer on `ChainRun`; it was removed — it double-gated and
-was never wired from the API, which silently disabled it. Pools are now config-only.)
-
-### Scheduler worker pools (global, config-defined)
-
-`ResourcePool` structs in `_POOLS::Dict{String, ResourcePool}` in `scheduler.jl`. Each pool owns ONE
-persistent `Channel` of `TaskJob`s, ONE dispatcher task draining it, and a resizable budget of `limit`
-**slots** — concurrency is the slot budget, not a worker count (see *Slot-acquire model* below). A pool
-with `limit = 1` runs its jobs strictly one at a time — that is how `gpu` work is serialised.
+There is **one** concurrency mechanism: the global pools in `scheduler.jl`. (An earlier design added a
+second, per-run `Base.Semaphore` layer on `ChainRun`; it was removed — it double-gated, and was never
+wired from the API, which silently disabled it. Pools are config-only.)
 
 Pools are **global and persistent**, shared across every chain run and every module-page task —
 all execution goes through `run_task` → `_pool(name)` → the pool's queue. Defined in `config.toml`:
@@ -79,63 +75,55 @@ io      = 8    # local disk IO — bioformats2raw import/convert, crop
 network = 1    # remote/SMB reads — reserved for HPC/remote tasks (no tasks assigned yet)
 ```
 
-One pool per real bottleneck resource; the name says *what* it rations, not *how much*. Each
-limit is just a starting default — adjustable live (see *Live pool limits* below), so you can
-throttle whenever you want (e.g. drop `io` to 1 while importing over a slow SMB share) without
-editing config or restarting. `network` is defined but unused today; it exists so remote/HPC
-task runners have a lane to land in later.
+One pool per real bottleneck resource; the name says *what* it rations, not *how much*. Every limit is
+only a starting default — each is a live throttle (below), so you can drop `io` to 1 while importing
+over a slow SMB share without editing config or restarting. `network` is defined but unused today; it
+exists so remote/HPC task runners have a lane to land in later.
 
-`_pools_init!` reads `[pools]` at first use. `cpu` is guaranteed to exist (falls back to
-`tasks_concurrent_limit()` if absent). A node/task names its pool via the `resource_pool` field
-of its JSON spec (or, for a chain node, `ChainNode.resource_pool`).
+`_pools_init!` reads `[pools]` at first use; `cpu` always exists (falls back to
+`tasks_concurrent_limit()`). A task names its pool in the `resource_pool` field of its JSON spec, a
+chain node in `ChainNode.resource_pool`. **A missing pool warns once** and falls back to `cpu` — a GPU
+task silently landing in the wide cpu pool was the original "all GPU tasks run at once" bug.
 
-**Missing-pool fallback warns.** If a task requests a pool not in `[pools]`, `_pool` falls back to
-`cpu` and emits a one-time `@warn` (a GPU task silently landing in the wide cpu pool was
-the original "all GPU tasks run at once" bug). Add the pool to config to silence it.
+### Slot-acquire model — a resizable slot budget, not a worker count
 
-`resize_pool!(name, limit)` creates or resizes a pool at runtime (REPL/test path; e.g. tests
-register `slow_pool`/`par_pool` this way). `list_pools()` returns `[(; name, limit)]` for every
-initialized pool, exposed via `GET /api/pools` and shown in the pool dropdowns.
+Each pool (`ResourcePool` in `_POOLS`) owns **one** persistent `Channel` of `TaskJob`s, **one**
+dispatcher task draining it, a mutable `limit` (= max concurrent jobs), a live `in_flight` count, and a
+`Threads.Condition` guarding both counters. The dispatcher pulls a job, calls `_acquire_slot!` (blocks
+while `in_flight >= limit`), then runs it on its own spawned task, which releases the slot in a
+`finally`. A pool with `limit = 1` runs its jobs strictly one at a time — that is how `gpu` work is
+serialised.
 
-`pool_status()` returns `[(; name, limit, running, queued)]` — the same pools plus **live
-occupancy**: `running` = `in_flight` (slots currently executing) read from `_POOLS`, `queued` =
-tasks assigned to that pool sitting in `_TASKS` at status `:queued`. The two snapshots are taken
-under their own locks (`_POOLS_LOCK`, `_TASKS_LOCK`) and merged outside both — never nest them.
-This is what `GET /api/pools` actually serves; the `PoolThrottle` popover polls it (~1.5 s) to show
-a "running / limit" readout + bar under each slider. There is no `pool:*` WS event — occupancy is
-poll-only.
+Because a slot is claimed **at execution time** and checked against the *current* `limit`, a pool never
+runs more than `limit` jobs at once — including the instant after a throttle-down. So `resize_pool!`
+only sets `limit` and `notify`s, keeping the same queue and dispatcher (no queued job is ever orphaned):
 
-**Slot-acquire model — concurrency is a resizable slot budget, not a worker count.** Each pool has a
-fixed `queue`, a mutable `limit` (= max concurrent jobs), a live `in_flight` count, and a
-`Threads.Condition`. A single **dispatcher** task per pool pulls each job, calls `_acquire_slot!`
-(blocks while `in_flight >= limit`), then runs the job on its own task which `_release_slot!`s (and
-`notify`s) when done. `resize_pool!` just sets `limit` under the condition and `notify`s:
-- **grow** → the `notify` wakes the dispatcher if it was waiting for a slot; the queued backlog fans
-  out immediately up to the new `limit`;
-- **shrink** → in-flight jobs finish and release their slots; the dispatcher stays blocked in
-  `_acquire_slot!` until enough drain, then admits the next — so it settles to the new `limit`.
+- **grow** → the `notify` wakes a dispatcher waiting for a slot; the backlog fans out immediately.
+- **shrink** → running jobs are never interrupted; the dispatcher stays blocked in `_acquire_slot!`
+  until enough drain, so occupancy settles down to the new limit without ever oversubscribing.
 
-Because the slot is claimed **at execution time** and checked against the *current* `limit`, a pool
-never runs more than `limit` jobs at once — including the instant after a throttle-down (already-
-running jobs finish; no *new* one starts until `in_flight < limit`). This replaced an earlier design
-that swapped the queue on resize (which orphaned already-queued jobs onto the old workers at the old
-concurrency and could transiently oversubscribe).
+This replaced a design that swapped the queue on resize, which orphaned already-queued jobs onto the
+old workers at the old concurrency. `resize_pool!` also *creates* a pool if absent — the REPL/test path
+(tests register `slow_pool`/`par_pool` this way).
 
 ### Live pool limits (Task Manager throttle)
 
 Each pool's limit is a live throttle, not a fixed config value — the day-to-day control (the old R
-"concurrent tasks" slider, but one per resource). `set_pool_limit!(name, limit)` (`scheduler.jl`)
-does two things: `resize_pool!` to apply immediately, **and** persist the new limit to the user's
-`custom.toml` `[pools]` (merged, like `set_projects_dir!`) so it survives a restart. Clamped to
-`[1, POOL_LIMIT_MAX]`. Exposed as `POST /api/pools/set` `{name, limit}` (only already-configured
-pool names are accepted — no typo pools accumulating in `custom.toml`). The UI is the reusable
-`PoolThrottle.vue` component — a compact 2×2 slider grid (`cpu`/`gpu`, then `io`/`network`) shown
-in a `TeleportPopover` off the Task Manager toolbar (the sliders icon), not buried in Settings.
+"concurrent tasks" slider, but one per resource). `set_pool_limit!(name, limit)` = `resize_pool!` to
+apply immediately **plus** a merged write to the user's `custom.toml` `[pools]` (like
+`set_projects_dir!`) so it survives a restart. Clamped to `[1, POOL_LIMIT_MAX]`. Exposed as
+`POST /api/pools/set` `{name, limit}`, which rejects unknown pool names so typo pools can't accumulate
+in `custom.toml`. The UI is `PoolThrottle.vue` — a compact 2×2 slider grid (`cpu`/`gpu`, then
+`io`/`network`) in a `TeleportPopover` off the Task Manager toolbar (the sliders icon), not Settings.
 
-`resize_pool!` keeps the pool's one queue and dispatcher and only changes the slot budget, so no
-queued job is ever orphaned: a raise `notify`s the dispatcher and the backlog fans out immediately;
-a lower leaves it blocked in `_acquire_slot!` until enough in-flight jobs drain. Shrinking is safe —
-it never interrupts a running job, it just stops admitting new ones until the pool is under the limit.
+### Reporting occupancy
+
+`list_pools()` → `[(; name, limit)]` for every initialised pool (this feeds the pool dropdowns).
+`pool_status()` → the same plus **live occupancy**: `running` = `in_flight` (slots executing now),
+`queued` = tasks in `_TASKS` at `:queued` for that pool. The two snapshots are taken under their **own**
+locks (`_POOLS_LOCK`, `_TASKS_LOCK`) and merged outside both — never nest them. `GET /api/pools` serves
+`pool_status()`; the `PoolThrottle` popover polls it (~1.5 s) for the "running / limit" readout + bar
+under each slider. There is no `pool:*` WS event — occupancy is poll-only.
 
 ### Queue visibility — :queued vs :running
 
@@ -143,13 +131,13 @@ A node that is waiting for a pool slot and a node actively executing are **diffe
 the live view must distinguish them (a saturated GPU pool must not look like a hang).
 
 `_execute_image_chain!` marks the node `:queued` *before* calling `run_task`, then flips it to
-`:running` only when a pool worker actually picks the job up — driven by `run_task`'s
-`on_status_change` callback (the worker calls `_set_status!(rec, :running)` in `_execute_job!`).
+`:running` only when the job actually starts — driven by `run_task`'s `on_status_change` callback
+(`_execute_job!` calls `_set_status!(rec, :running)` once it holds a slot).
 So `startedAt` (and the live elapsed timer) counts from the real slot acquisition, not from when
 the image thread reached the node. With `gpu = 1` and three images, the live grid shows one
 `:running` and two `:queued`, and each task's elapsed reflects its own ~2 min, not 2/4/6 min.
 
-> **Pitfall (tests):** `node:running` now fires from the pool worker thread while `node:done`
+> **Pitfall (tests):** `node:running` fires from the job's own task while `node:done`
 > fires from the image thread, so a size-1 pool has a benign running/done handoff overlap (both
 > contend on `run._lock`). Assert serialisation by **wall-clock** (sum of durations), not by
 > counting concurrent `node:running`/`node:done` events. A size-N>1 pool is race-free because all
@@ -164,7 +152,8 @@ the image thread reached the node. With `gpu = 1` and three images, the live gri
 `_CANCELLED_CHAINS::Set{String}` — set of run IDs that have been cancelled.
 `_CANCELLED_CHAINS_LOCK::ReentrantLock` — guards all reads and writes to the set.
 
-Both live in `api/src/scheduler.jl`.
+Both live in `app/src/tasks/scheduler.jl` — in the **package**, not the API layer, so cancel works
+from the REPL and tests with no server running.
 
 ### Public API (exported from `Cecelia.jl`)
 
@@ -201,38 +190,35 @@ In `_run_set_scope_node!` the cancel check also runs before the barrier wait; if
 set-scope runner marks all pending images as `:cancelled` and signals the done channel to unblock
 waiting image threads (avoiding deadlock).
 
-**Race guard (start window):** if cancel arrives after a worker sets `:running` but before the
+**Race guard (start window):** if cancel arrives after the job sets `:running` but before the
 task's `on_process` callback records the subprocess handle, `cancel_task!` would find `rec.proc ==
 nothing` and skip the kill. `_execute_job!`'s `on_process` wrapper closes this: right after storing
 `rec.proc`, it re-checks `is_cancelled(job.id)` and kills immediately if so.
 
-### Limitation — set-scope / incremental subprocesses
+### Limitation — set-scope / incremental nodes *inside a chain*
 
-The per-image path is fully covered. Set-scope and incremental nodes call the multi-image
-`_run_task` directly with `on_process = _ -> nothing` and are **not** registered in `_TASKS`, so a
-chain cancel won't kill a subprocess they spawned mid-run (the between-node flag still stops
-not-yet-started ones). No real set-scope subprocess task exists yet (only mock/plot tasks); see
-TODO #00016 if one is added.
+The per-image path is fully covered. It's specifically the **chain's** set-scope and incremental
+runners (`_run_set_scope_node!`, `_run_incremental_node!`) that call the multi-image `_run_task`
+**directly** — with `on_process = _ -> nothing` and no `_TASKS` entry — so `cancel_chain_run!` can't
+reach a subprocess they spawned mid-run (the between-node flag still stops not-yet-started ones). A
+set-scope task launched from a **module page** is unaffected: `handle_task_run` goes through the
+registered `run_task(task, imgs, …)` overload, so it has a `TaskRecord` and cancels normally.
+
+Impact is currently nil — no real set-scope subprocess task exists (only mock/plot tasks). When the
+first one lands (e.g. HMM training), give the chain's multi-image path a `TaskRecord` + `chain_run_id`
+like the per-image path: **TODO #00020**.
 
 ---
 
 ## pool_name override in run_task
 
-`run_task` (both overloads in `scheduler.jl`) accepts an optional kwarg:
+Both `run_task` overloads take `pool_name::String = ""`; when non-empty it overrides the task spec's
+`resource_pool`, directing that one call to a specific pool. Two callers use it:
 
-```julia
-run_task(task_type, img, params; pool_name::String = "", ...)
-```
-
-When `pool_name` is non-empty, it overrides the pool name from the task spec's `resource_pool`
-field. This allows the caller to direct a task to a specific scheduler worker pool at call time.
-
-**From the WS handler**: `handle_task_run` in `sockets.jl` reads `poolName` from the WS message
-payload and passes it as `pool_name` to `run_task`. The frontend sends `poolName` in the
-`task:run` message, populated from the pool dropdown in `TaskRunner.vue`.
-
-**From chain nodes**: `_execute_image_chain!` passes `pool_name = node.resource_pool` so each
-node routes to the correct global pool even when the task spec's default differs.
+- **WS handler** — `handle_task_run` (`sockets.jl`) forwards `poolName` from the `task:run` message,
+  which the frontend populates from the pool dropdown in `TaskRunner.vue`.
+- **Chain nodes** — `_execute_image_chain!` passes `pool_name = node.resource_pool`, so a node routes
+  to its configured pool even when the task spec's default differs.
 
 ---
 
@@ -352,27 +338,23 @@ Editing a template after a run has started does not retroactively change what th
 > also migrate a legacy `<project>/chains/` on access. A round-trip test asserts the settings/ path.
 
 **Run record** (`<project>/settings/chains/runs/<run_id>/run.json`) — created when a template is
-applied to a set of images. Stores a **frozen copy** of the template via a SHA-256 content hash, not
-a pointer to the template file. The template content is cached once under
-`settings/chains/.cache/<hash>.json`.
-
-Run records store `template_hash` (not the template inline) to keep `run.json` compact.
-`load_chain_run` resolves the hash to the cached template.
+applied to a set of images. It stores a **frozen** `template_hash` (SHA-256 of the content), not the
+template inline and not a pointer to the template *file*: the content is cached once under
+`settings/chains/.cache/<hash>.json`, and `load_chain_run` resolves the hash back to it. So editing the
+template afterwards can't rewrite history, and `run.json` stays compact.
 
 ### Live QC row
 
-A task whose JSON spec declares `"qcPlot": "<plotDefId>"` (e.g. `segment.cellposeMeasure` /
-`segment.measureLabels` → `segmentation_qc`) gets an **automatic QC thumbnail** in the Live view — a
-band above the image grid, aligned to the producing column. QC is **not** a chain node: it's an
-always-available overlay tied to the producing node, toggled from the Live toolbar. Because a segment
-run may produce several segmentations, each QC column shows **one thumbnail per `value_name`** (B, T,
-…), stacked. The value_names are discovered from the canonical population picker
-(`/api/plots/populations?popType=labels`); each thumbnail (`ChainQcNode`) shows the aggregate cell
-count + a per-image sparkline (from `POST /api/plot_data`, `popType=labels` + `chartType=count`, one
-request per run image, debounced, re-run as images clear the stage — incremental fill). Clicking a
-thumbnail expands the full segment QC canvas (`SummaryCanvas module="segment"`). This reuses the
-canonical plot framework end-to-end (registry def + `SummaryCanvas` + `/api/plot_data`) — there is no
-bespoke QC route or panel. Distinct from user-dragged plot nodes (a separate, later mechanism).
+A task whose spec declares `"qcPlot": "<plotDefId>"` (`segment.cellposeMeasure` /
+`segment.measureLabels` → `segmentation_qc`) gets an automatic QC thumbnail in a band above the image
+grid, aligned to the producing column. QC is **not** a chain node — it's an overlay tied to the
+producing node, toggled from the Live toolbar. A segment run can produce several segmentations, so each
+column stacks **one thumbnail per `value_name`** (B, T, …), discovered from the canonical population
+picker (`/api/plots/populations?popType=labels`). Each `ChainQcNode` shows the aggregate cell count + a
+per-image sparkline (`POST /api/plot_data`, `popType=labels` + `chartType=count`; one debounced request
+per image, re-run as images clear the stage — incremental fill), and expands on click to the full
+`SummaryCanvas module="segment"`. All of it reuses the canonical plot framework — no bespoke QC route or
+panel. Distinct from user-dragged plot nodes (a separate, later mechanism).
 
 ### Loading past runs into the Live view
 
@@ -484,10 +466,10 @@ unsubscribe_chain_events!("node:done",  handler)
 
 | Event | Payload fields | Fired when |
 |-------|---------------|-----------|
-| `"node:queued"` | `run_id, project_uid, image_uid, node_id, fn, params` | Node submitted to its pool, waiting for a worker slot |
-| `"node:running"` | `run_id, project_uid, image_uid, node_id, fn, params` | A pool worker picked the job up (real start) |
-| `"node:done"` | `run_id, project_uid, image_uid, node_id, fn, params, result` | Node transitions to `:done` |
-| `"node:failed"` | `run_id, project_uid, image_uid, node_id, fn, status` | Node transitions to `:failed`, `:skipped`, or `:cancelled` (`status` carries which) |
+| `"node:queued"` | *base* = `run_id, chain_name, project_uid, image_uid, node_id, fn, params` | Node submitted to its pool, waiting for a free slot |
+| `"node:running"` | *base* | The job acquired a slot and started (real start) |
+| `"node:done"` | *base* `+ result` | Node transitions to `:done` |
+| `"node:failed"` | *base* `− params + status` | Node transitions to `:failed`, `:skipped` or `:cancelled` (`status` carries which) |
 
 **Why fired outside the lock**: handlers may need to read `run.image_states` or trigger further
 work. Re-entering `run._lock` from inside the lock would deadlock. The result is captured inside
@@ -505,10 +487,12 @@ run_chain(proj, uids; chain="my-chain")
 
 **Triggering a run from the UI**: `ws.ts` sends `{ type: "chain:run", projectUid, chain, imageUids }`. The handler in `sockets.jl` (`handle_chain_run`) calls `load_project(project_uid)` then `run_chain` in a `Threads.@spawn` so the WS thread is never blocked. On success it broadcasts `chain:run:done`; on error `chain:run:failed` (also surfaced in the log console).
 
-**API WebSocket bridge**: `api/src/server.jl` subscribes to all three events at startup and broadcasts them to all connected clients as:
-- `chain:node:running` — `{type, runId, projectUid, imageUid, nodeId, fn, params}`
-- `chain:node:done`    — `{type, runId, projectUid, imageUid, nodeId, fn, params, result}`
-- `chain:node:failed`  — `{type, runId, projectUid, imageUid, nodeId, fn, status}`
+**API WebSocket bridge**: `api/src/server.jl` subscribes to **all four** events at startup and
+broadcasts each to every connected client, `chain:`-prefixed with camelCase keys:
+- `chain:node:queued`  — `{type, runId, chainName, projectUid, imageUid, nodeId, fn, params}`
+- `chain:node:running` — same shape
+- `chain:node:done`    — `{…, params, result}`
+- `chain:node:failed`  — `{…, status}` (which of failed/skipped/cancelled)
 
 `ws.ts` routes these into `taskStore.addFromChainEvent`, which upserts a `TaskEntry` keyed by `runId::nodeId::imageUid`. The Live tab in `ChainModule.vue` renders these tasks as a VueFlow grid.
 
@@ -520,7 +504,7 @@ run_chain(proj, uids; chain="my-chain")
 :pending → :queued → :running → :done
                               → :failed
                               → :cancelled (cancel_chain_run! killed the subprocess mid-run)
-         → :queued → :cancelled (cancel flag seen before the pool worker picked it up)
+         → :queued → :cancelled (cancel flag seen before the job got a slot)
          → :skipped  (fault isolation: a DIRECT predecessor is :failed/:cancelled/:skipped)
 ```
 
@@ -533,8 +517,8 @@ its successor sees a skipped pred → also skipped). Topo order guarantees every
 is set before a node is evaluated. Incremental (plot) predecessors never gate. The predecessor map
 is built from `template_snapshot.edges` in `_execute_image_chain!`.
 
-`:queued` is the slot-wait state (job submitted to its pool, no worker free yet); `:running` is
-set when a pool worker actually starts the job — see Queue visibility above.
+`:queued` is the slot-wait state (submitted to its pool, no free slot yet); `:running` is set when the
+job acquires a slot and starts — see *Queue visibility* above.
 
 Transitions are written under `run._lock` and persisted to `run.json` after every change
 (`_save_run!` inside the lock). Events are fired outside the lock.
@@ -564,8 +548,8 @@ These are easy to break accidentally:
    the pool in `config.toml` instead. The slot is released in the dispatcher's `finally`, so it comes
    back even if the job dies.
 
-6. **Mark `:queued` before `run_task`, `:running` from the worker** — the node must not flip to
-   `:running` until a pool worker starts it (via `on_status_change`), or `startedAt`/elapsed and the
+6. **Mark `:queued` before `run_task`, `:running` from the job** — the node must not flip to
+   `:running` until the job actually starts (via `on_status_change`), or `startedAt`/elapsed and the
    "waiting vs running" distinction break (the 2/4/6-min bug).
 
 7. **`Threads.@spawn` not `@async`** — tasks call blocking Python subprocesses. `@async` would
@@ -573,17 +557,14 @@ These are easy to break accidentally:
    I/O in `_run_task` still works.
 
 8. **Every job posts to `job.done` exactly once — in a `finally`.** `run_task` is parked in
-   `take!(job.done)` and nothing else will ever wake it, and the dispatcher's `Threads.@spawn` is
-   fire-and-forget, so an exception escaping `_execute_job!` is **silent**. The cost is a submitter
-   blocked forever plus a `TaskRecord` stranded at `:running` (`_deregister_task!` never runs) — and it
-   looks like nothing is wrong, because the slot was already released: pools read idle while
-   `list_tasks()`, the GUI and the task console all keep listing a task that finished. So: anything
-   added between `_set_status!(rec, :running)` and the post is inside the guarded window, `post!`
-   replaces bare `put!` (the channel holds 1 — a second post would block), and the outer `catch` marks
-   the record `:failed` rather than leaving it `:running`. Both `Threads.@spawn`s in `_start_pool!` log
-   their exceptions for the same reason: a spawned task's error is otherwise lost, and a dispatcher that
-   dies wedges the whole pool at `:queued`. Pinned by the *"Job posts its result even when the error
-   path throws"* testset.
+   `take!(job.done)`, nothing else will ever wake it, and an exception in the dispatcher's
+   fire-and-forget `Threads.@spawn` is **silent**. So a throw escaping `_execute_job!` costs a submitter
+   blocked forever and a `TaskRecord` stranded at `:running` (`_deregister_task!` never runs) — while
+   looking fine, because the slot was already released: pools read idle as `list_tasks()`, the GUI and
+   the task console keep listing a finished task. Hence `post!` (never a bare `put!` — the channel holds
+   1) in a `finally`, and an outer `catch` that marks the record `:failed`. Both `Threads.@spawn`s in
+   `_start_pool!` log their exceptions for the same reason — and a dispatcher that dies wedges its whole
+   pool at `:queued`. Pinned by the *"Job posts its result even when the error path throws"* testset.
 
    > The console side of this pairs with it: WS task frames are lossy by design, so the task console
    > must reconcile `GET /api/tasks` in **both** directions — see `docs/API.md`. A row that is only ever
@@ -602,8 +583,8 @@ make_chain(proj, "my-pipeline", [
     chain_node("importImages.omezarr"),
     chain_node("cleanupImages.cellposeCorrect"; resource_pool="gpu",
                params=Dict("model" => "cyto2")),
-    chain_node("testTasks.setTask"; scope="set"),   # picnic node
-])
+    chain_node("testTasks.setTask"; scope="set"),   # picnic node — explicit, as this mock
+])                                                  # spec declares no scope of its own
 
 # Or build manually (identical result, more control over node IDs)
 n1 = ChainNode(; id="import",  fn="importImages.omezarr")
@@ -636,16 +617,16 @@ run = load_chain_run(proj, run_id)
 
 | File | Role |
 |------|------|
-| `app/src/tasks/chain.jl` | Chain data model, scheduler, executor, resume logic, `chain_node`/`make_chain` REPL helpers |
+| `app/src/tasks/scheduler.jl` | Resource pools + dispatchers, `TaskRecord`/`_TASKS`, `run_task`, cancel registry |
+| `app/src/tasks/chain.jl` | Chain data model, executor, barriers, resume logic, `chain_node`/`make_chain` REPL helpers |
 | `app/src/events.jl` | Package-level pub/sub event bus |
 | `app/src/tasks/testTasks/imageTask.jl` | Mock image-scope task (supports `waitMs` for timing tests) |
 | `app/src/tasks/testTasks/setTask.jl` | Mock set-scope task |
 | `app/src/tasks/testTasks/incrementalPlotTask.jl` | Mock incremental plot task |
-| `app/test/runtests.jl` | Verification tests (Steps 4–7) |
+| `app/test/runtests.jl` | Pool, chain-run, resume, barrier-policy and job-completion testsets |
 | `api/src/routes.jl` | `api_chains_list`, `api_chains_get`, `api_chains_save` — chain CRUD over HTTP |
 | `frontend/src/modules/ChainModule.vue` | Whiteboard page: Edit tab (palette, VueFlow canvas, node config) + Live tab (real-time task grid) |
 | `frontend/src/components/ChainTaskNode.vue` | Custom VueFlow node for image/incremental-scope tasks |
 | `frontend/src/components/ChainPicnicNode.vue` | Custom VueFlow node for set-scope tasks (visually distinct) |
 | `frontend/src/components/ChainLiveNode.vue` | Custom VueFlow node for live run display (status-colored header) |
-| `frontend/src/components/plots/IntensityHistogram.vue` | Plotly before/after intensity histogram; lazy-loads `plotly.js-dist-min` |
-| `frontend/src/plotly-dist-min.d.ts` | TS module shim re-exporting `plotly.js` types for `plotly.js-dist-min` |
+| `frontend/src/components/ChainQcNode.vue` | QC thumbnail in the Live view's QC band (see *Live QC row*) |

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -558,8 +558,8 @@ These are easy to break accidentally:
 
 5. **Concurrency lives in the global pool, not the chain** — there is no per-run semaphore. A node
    blocks inside `run_task` on its pool's worker queue. Don't reintroduce a chain-level gate; size
-   the pool in `config.toml` instead. Slots are freed when `_execute_job!` returns (no `finally`
-   release to forget).
+   the pool in `config.toml` instead. The slot is released in the dispatcher's `finally`, so it comes
+   back even if the job dies.
 
 6. **Mark `:queued` before `run_task`, `:running` from the worker** — the node must not flip to
    `:running` until a pool worker starts it (via `on_status_change`), or `startedAt`/elapsed and the
@@ -568,6 +568,23 @@ These are easy to break accidentally:
 7. **`Threads.@spawn` not `@async`** — tasks call blocking Python subprocesses. `@async` would
    starve other images on the same thread. If you change the execution model, verify that blocking
    I/O in `_run_task` still works.
+
+8. **Every job posts to `job.done` exactly once — in a `finally`.** `run_task` is parked in
+   `take!(job.done)` and nothing else will ever wake it, and the dispatcher's `Threads.@spawn` is
+   fire-and-forget, so an exception escaping `_execute_job!` is **silent**. The cost is a submitter
+   blocked forever plus a `TaskRecord` stranded at `:running` (`_deregister_task!` never runs) — and it
+   looks like nothing is wrong, because the slot was already released: pools read idle while
+   `list_tasks()`, the GUI and the task console all keep listing a task that finished. So: anything
+   added between `_set_status!(rec, :running)` and the post is inside the guarded window, `post!`
+   replaces bare `put!` (the channel holds 1 — a second post would block), and the outer `catch` marks
+   the record `:failed` rather than leaving it `:running`. Both `Threads.@spawn`s in `_start_pool!` log
+   their exceptions for the same reason: a spawned task's error is otherwise lost, and a dispatcher that
+   dies wedges the whole pool at `:queued`. Pinned by the *"Job posts its result even when the error
+   path throws"* testset.
+
+   > The console side of this pairs with it: WS task frames are lossy by design, so the task console
+   > must reconcile `GET /api/tasks` in **both** directions — see `docs/API.md`. A row that is only ever
+   > added produces the same false "still running" readout from the opposite direction.
 
 ---
 

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -63,8 +63,9 @@ was never wired from the API, which silently disabled it. Pools are now config-o
 
 ### Scheduler worker pools (global, config-defined)
 
-`ResourcePool` structs in `_POOLS::Dict{String, ResourcePool}` in `scheduler.jl`. Each pool owns
-exactly `limit` long-lived OS worker threads draining a shared `Channel` of `TaskJob`s. A pool
+`ResourcePool` structs in `_POOLS::Dict{String, ResourcePool}` in `scheduler.jl`. Each pool owns ONE
+persistent `Channel` of `TaskJob`s, ONE dispatcher task draining it, and a resizable budget of `limit`
+**slots** — concurrency is the slot budget, not a worker count (see *Slot-acquire model* below). A pool
 with `limit = 1` runs its jobs strictly one at a time — that is how `gpu` work is serialised.
 
 Pools are **global and persistent**, shared across every chain run and every module-page task —
@@ -131,8 +132,10 @@ pool names are accepted — no typo pools accumulating in `custom.toml`). The UI
 `PoolThrottle.vue` component — a compact 2×2 slider grid (`cpu`/`gpu`, then `io`/`network`) shown
 in a `TeleportPopover` off the Task Manager toolbar (the sliders icon), not buried in Settings.
 
-`resize_pool!` closes the old queue (in-flight + buffered jobs on the old workers still drain) and
-starts fresh workers at the new limit — so shrinking is safe, it just lets current jobs finish.
+`resize_pool!` keeps the pool's one queue and dispatcher and only changes the slot budget, so no
+queued job is ever orphaned: a raise `notify`s the dispatcher and the backlog fans out immediately;
+a lower leaves it blocked in `_acquire_slot!` until enough in-flight jobs drain. Shrinking is safe —
+it never interrupts a running job, it just stops admitting new ones until the pool is under the limit.
 
 ### Queue visibility — :queued vs :running
 
@@ -557,7 +560,7 @@ These are easy to break accidentally:
    Moving it before causes a deadlock that is non-obvious to debug.
 
 5. **Concurrency lives in the global pool, not the chain** — there is no per-run semaphore. A node
-   blocks inside `run_task` on its pool's worker queue. Don't reintroduce a chain-level gate; size
+   blocks inside `run_task` on its pool's queue. Don't reintroduce a chain-level gate; size
    the pool in `config.toml` instead. The slot is released in the dispatcher's `finally`, so it comes
    back even if the job dies.
 

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -50,11 +50,22 @@ it blocks the caller until the entire chain finishes.
 
 ### Why `Threads.@spawn` (not `@async`)?
 
-Chain nodes call `run_task`, which may block on a Python subprocess. `@async` doesn't help for
-blocking I/O — it only helps I/O that yields back to the scheduler, so one blocked image would stall
-every other image sharing its thread. `Threads.@spawn` schedules each task across the thread pool,
-so a blocking node occupies one thread and the rest keep moving. (Tasks are multiplexed onto
-`--threads` OS threads — 50 images is 50 tasks, not 50 threads.)
+A **Task** is a coroutine the Julia runtime schedules; a **thread** is an OS thread it runs *on*. Both
+macros create Tasks — the difference is placement. `@async` pins its Task to the *current* thread
+(concurrency, never parallelism); `Threads.@spawn` lets the scheduler place it on any thread in the
+pool. Tasks are multiplexed onto the `-t` count (`prod` and the backend `dev.jl` spawns both pass
+`-t auto`), so 50 images means 50 Tasks over ~N threads — **not** 50 threads.
+
+A Task only occupies a thread while it is *running*; every yield point hands the thread back. Waiting
+on a subprocess is a yield point — `run_py` reads `eachline(out_pipe)` then `wait(proc)`, both
+libuv-backed — so a node blocked on cellpose costs no thread at all, and its parallelism lives in the
+OS processes rather than in Julia. What *does* hold a thread hostage is work that never yields:
+pure-Julia compute loops and `ccall`s into C (notably HDF5, hence the `_with_h5` serialisation). Under
+`@async` those run on the one shared thread and stall every other image *and* the WS accept loop —
+that, not subprocess waiting, is the reason for `Threads.@spawn`.
+
+Hence two independent ceilings: a pool's slot `limit` (the one you tune) and the thread count, which
+only bites for Julia-side non-yielding work.
 
 ---
 
@@ -583,8 +594,8 @@ make_chain(proj, "my-pipeline", [
     chain_node("importImages.omezarr"),
     chain_node("cleanupImages.cellposeCorrect"; resource_pool="gpu",
                params=Dict("model" => "cyto2")),
-    chain_node("testTasks.setTask"; scope="set"),   # picnic node — explicit, as this mock
-])                                                  # spec declares no scope of its own
+    chain_node("testTasks.setTask"),                # picnic node — "set" comes from its spec
+])
 
 # Or build manually (identical result, more control over node IDs)
 n1 = ChainNode(; id="import",  fn="importImages.omezarr")


### PR DESCRIPTION
## The symptom

`pixi run console` listed six tasks as `running` — five `segment.branching` plus a
`clustRegions.cluster` — while every pool read idle:

```
6 running · 0 queued · 0 done · 0 failed
pools  cpu 0/4   gpu 0/1   io 0/1   network 0/1
```

The scheduler was clean the whole time (`GET /api/tasks` → `[]`). The display was wrong,
and the readout said how: **empty activity pane, no logs pane, 0 done / 0 failed** — the
console had received *zero* WS frames for those tasks. Everything on screen came from the
2 s HTTP poll.

## Fix 1 — the console only ever added rows (`api/task_console.jl`)

`refresh_snapshot!` merged `GET /api/tasks` rows in but never retired a row that
**vanished** from the snapshot. The only removal path was a terminal `task:status` frame
over WS — which is lossy *by design* (per-client drop-on-full queue in `broadcast_ws`, and
nothing at all on a half-open socket). Miss it once and the row is stranded at `running`
forever. `docs/API.md` already claimed the console "reconciles the authoritative state from
`GET /api/tasks`, so a dropped frame self-heals" — only half of that reconciliation existed.

- **Retire rows the snapshot no longer lists** (2 consecutive misses, so a registration/poll
  race can't retire a live task). Tallied `ended` = *finished, outcome unseen* — never guessed
  as done/failed. Rows for WS-only producers (jobs, batch movies) never appear in the snapshot
  and are exempt.
- **A failed 20 s keepalive tears the socket down** instead of being swallowed, so a half-open
  connection actually reaches the reconnect-and-clear path rather than leaving the reader
  blocked on a socket that never speaks again.
- **Coalesced repaints** (≤1/100 ms; the 2 s poll always repaints). A full redraw per WS
  message made the reader slow — which is exactly what makes the server drop *this* client's
  frames, so the console helped cause the loss it then couldn't recover from.

Verified against a throwaway fake API (real TTY dashboard, task disappears from the snapshot
with no terminal frame ever sent):

```
2 running · 0 queued · 0 done · 0 failed      →   1 running · … · 1 ended
k00002  project.export     job  running           k00002  project.export  job  running
k00001  segment.branching  cpu  running           (retired)
```

The WS-only `job` row survives; the scheduler row is retired.

## Fix 2 — the same false readout, reachable from the backend (`app/src/tasks/scheduler.jl`)

Tracing the above surfaced a real latent hazard that produces the symptom *for real*.
`_execute_job!` posted to `job.done` as its **last statement**. `run_task` is parked in
`take!(job.done)`, nothing else will ever wake it, and the dispatcher's `Threads.@spawn` is
fire-and-forget — so a throw before that post was **silent**: submitter blocked forever,
`_deregister_task!` never runs, `TaskRecord` stranded at `:running`. And nothing looks wrong,
because the slot was already released by the dispatcher's `finally`: pools read idle while
`list_tasks()`, the GUI and the console keep listing finished work.

- Post through a `post!` helper in a **`finally`** — exactly once (the channel holds 1, so a
  second post would block).
- Outer `catch` marks the record `:failed` rather than leaving it `:running`, with guarded
  logging (a throwing logger is one way to land there).
- Both `Threads.@spawn`s in `_start_pool!` log instead of swallowing, and a throw from
  `_acquire_slot!` no longer kills the dispatcher — that wedges the whole pool at `:queued`.

**Proven, not assumed.** New testset injects a throw into the scheduler's own crash `@warn`.
With the fix neutered: `submitter released: NO (blocked in take!) / record stranded: YES`.
With it: released, deregistered. The test is fail-safe — a regression fails the assertion
instead of hanging the suite.

## Tests

`pixi run test-pkg` **1858/1858 pass**; `pixi run test-api` green. Grepped for
`did not pass`/`Test Failed` rather than trusting the exit code.

## Docs

- `docs/API.md` — reconciliation is two-directional, and why add-only isn't enough.
- `docs/SCHEDULER.md` — new concurrency invariant #8 (a job posts exactly once, in a
  `finally`); invariant #5's stale "no `finally` release to forget" corrected.

## Known gaps

- A genuinely lost frame still reports `ended` rather than `done`/`failed` — but only if it is *never*
  delivered. A late one now corrects the tally (7th commit), and chain nodes are attributed from their
  `chain:node:*` frame, so `ended` is now a real signal that telemetry was lost rather than routine noise.
- The scheduler's outer `catch` is unreachable in today's code (every throw site in that window is
  already guarded inline) — it's a forward guard plus the "never leave the record `:running`"
  behaviour. Exercised only by the fault-injection test, which is the point of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Widened: the scheduler docs (commits 3-4)

`docs/SCHEDULER.md`'s Resource-pools section still described the pre-slot-acquire design and
**contradicted the "Slot-acquire model" paragraph ten lines below it**:

- *"each pool owns exactly `limit` long-lived OS worker threads draining a shared Channel"* → one
  persistent queue + one dispatcher + a resizable budget of `limit` **slots**. There are no
  per-slot worker threads; each job runs on its own spawned task.
- *"`resize_pool!` closes the old queue and starts fresh workers at the new limit"* → that
  queue-swapping design was replaced *precisely because* it orphaned already-queued jobs onto the
  old workers at the old concurrency. It now only changes the budget, same queue, same dispatcher.
- invariant #5 "its pool's worker queue" → "its pool's queue".

Plus the dead `ACTIVE` const in the console (unused since finished rows became a tally).


### SCHEDULER.md audit (4th commit)

Every claim checked against `scheduler.jl` / `chain.jl` / `events.jl` / `server.jl` / `routes.jl`.
Ten were **wrong**, not merely stale-sounding:

| Claim in the doc | Reality |
|---|---|
| `_CANCELLED_CHAINS` lives in `api/src/scheduler.jl` | It's in the **package** (`app/src/tasks/scheduler.jl`) — which is why cancel works from the REPL |
| API "subscribes to all three events" | Four. `chain:node:queued` was missing from the bridge list |
| Event payload rows | Every one omitted `chain_name` / `chainName` |
| Cancel limitation → TODO #00016 | #00016 is the per-image path, **done**; the open item is #00020 |
| "set-scope isn't cancellable" | True only *inside a chain*; a module-page set task uses the registered `run_task(task, imgs, …)` overload and cancels normally |
| File map: `IntensityHistogram.vue`, `plotly-dist-min.d.ts` | Deleted when Plotly was dropped. `scheduler.jl` and `ChainQcNode.vue` were missing |
| "Verification tests (Steps 4–7)" | Meaningless now — replaced with what the suite covers |
| Header credits chain.jl + events.jl | Most of the file documents `scheduler.jl` |
| "one OS thread per image" | `Threads.@spawn` multiplexes onto `--threads` OS threads — 50 images is 50 tasks, not 50 threads |
| "pool worker" (pre-slot-acquire model) | 8 more occurrences swept to slot/job language |

Compacted with no rationale dropped: the slot model was explained **three times** and `resize_pool!`
**four times** (now once each, other sections point at it), the run-record hash twice, and the
`pool_name` override took 17 lines for one kwarg. **651 → 632 lines**, with more facts in it.

Same audit caught stale **code comments** in `chain.jl`: six comments and docstrings — including the
user-facing `load_chain_template` / `save_chain_template!` / `run_chain` ones — still named the legacy
`<project>/chains/` dir that `_chains_dir` migrated to `<project>/settings/chains/`;
`ImageNodeState.status` didn't list `:queued`, which the chain does set; `_barriers` still carried
"(Step 3)" build-order labels.

### Scope + the task/thread story (5th commit)

Two loose ends the audit surfaced.

**`testTasks/setTask.json` declared no `"scope"`.** The one mock the barrier / picnic / resume tests
are built on became set-scope *only* because every chain node passed `scope="set"` — the single task
contradicting the documented rule that the spec is the source of truth. It now declares
`"scope": "set"`, resolving like `behaviour.hmm` / `clustTracks.cluster`. The explicit kwargs in the
tests pass the same value, so no set-scope testset changed. Asserted in *"Chain node scope inherits
from task spec"*; the doc's REPL example now demonstrates the inheritance rather than restating it.

**"Why `Threads.@spawn` (not `@async`)?" had the reason backwards.** It claimed `@async` "doesn't help
for blocking I/O" — but subprocess waiting is exactly what `@async` handles fine: `run_py`'s
`eachline(out_pipe)` + `wait(proc)` are libuv yield points, so a node blocked on cellpose holds **no
thread** and its parallelism is in the OS process, not in Julia. What actually needs `Threads.@spawn`
is work that never yields — pure-Julia compute and `ccall`s into C (notably HDF5, hence `_with_h5`) —
which under `@async` would stall every other image *and* the WS accept loop. The section now also
states that a Task is a coroutine multiplexed onto the `-t` threads (50 images = 50 Tasks, not 50
threads), and that this leaves two independent ceilings: the pool's slot `limit` and the thread count.

## Tests

`app/test/runtests.jl`: **1860/1860 pass**, verified in this worktree (grepping for `did not pass` /
`Test Failed`, not trusting the exit code). `pixi run test-api` green.


### Console coverage (6th commit)

The console was the one piece here with no automated coverage — run by path, never imported, and it
started the dashboard at load, so no test category could touch it. Now:

- the entrypoint is `PROGRAM_FILE`-guarded, so `include`ing the script is side-effect-free;
- the socket-free half is split out as `_reconcile_snapshot!(rows)`.

`api/test/runtests.jl` drives it with synthetic snapshots and pins five behaviours: retire after 2
misses tallied `ended`; no resurrection of a retired id; a WS-only producer survives indefinitely; a
terminal status seen *in* the snapshot is counted for real; and a reappearing task has its miss counter
cleared. **Verified the tests catch the regression** — reverting to add-only reconciliation fails 3
assertions — and the script still runs unchanged end-to-end against a fake API.


### Chain-node outcomes (7th commit)

Checking *why* `ended` appears turned up something bigger than the lossy-frame path: **a chain run emits
no `task:status` frames at all.** `handle_chain_run` passes no `on_status_change` — deliberately, since
the GUI renders chain nodes from `chain:node:*` keyed by `runId::nodeId::imageUid` and parallel
`task:status` frames would give every node a second Task Manager row. But chain nodes *are* registered in
`_TASKS`, so they appear in `GET /api/tasks` and in the console — which could then only ever retire them
as "ended / outcome unseen". `ended` would have fired on every chain node: noise, not signal.

Additive fix, **no frontend change** (`ws.ts` doesn't read the new key, so no duplicate rows):

- `chain.jl` — capture `st.task_id` under `run._lock` beside the result; put it on all four payloads.
  `""`, never `nothing`, when there's nothing to correlate (skipped/cancelled before submission;
  set-scope and incremental nodes bypass `run_task`).
- `server.jl` — bridge it as `taskId` through `_ev_task_id`, which degrades a missing field or a
  `nothing` to `""`; a throwing bridge handler would kill chain telemetry for every client.
- `task_console.jl` — a terminal `chain:node:*` frame with a taskId attributes the real outcome.
  `node:failed` carries *which* terminal it was, so a cancel isn't counted as a failure.

**The tally is now self-correcting.** The end-to-end check surfaced the edge case: a terminal frame
arriving after the 2-poll retire window found the row already counted `ended` and discarded the truth. A
real chain emits it milliseconds after deregistration, well inside the window — but a delayed one
shouldn't leave a wrong number. `_note_terminal!` moves an `ended` count to the real outcome (tracked in
`ENDED_IDS`, cleared on reconnect); every other repeat sighting still returns early, so nothing
double-counts and a real outcome is never overwritten by a later, different one.

Verified end-to-end against a fake API emitting a real chain frame over a real socket — the header goes
from `1 running · 1 ended` to `1 running · 1 done`.

**Totals: package 1868 pass, API suite green** (31 assertions across the three new testsets).
