### PR TITLE
Stop a cancelled task's trailing logs resurrecting it as a zombie queued row

### DIFF
--- a/api/task_console.jl
+++ b/api/task_console.jl
@@ -56,7 +56,9 @@ mutable struct TaskView
     # Reconciliation state (see refresh_snapshot!). `in_snapshot` marks a task the /api/tasks
     # snapshot has listed at least once — i.e. a real SCHEDULER task, so its absence from a later
     # snapshot is meaningful. WS-only producers (jobs, batch movies) never appear in the snapshot
-    # and must never be pruned by it. `misses` counts consecutive snapshots it went missing from.
+    # and must never be pruned by it — they identify themselves with fun + pool on their status
+    # frames, which is also what tells them apart from an unattributed row (`_unattributed`, which
+    # IS prunable). `misses` counts consecutive snapshots it went missing from.
     in_snapshot::Bool
     misses::Int
 end
@@ -155,6 +157,18 @@ end
 # is never retired on a one-poll race.
 const SNAPSHOT_MISSES_TO_RETIRE = 2
 
+# …with ONE addition: an UNATTRIBUTED row is eligible too. Every `task:status` frame in the codebase
+# carries `fun` (and non-scheduler producers also carry `pool`), so a row with neither has only ever
+# seen `task:log` / `task:progress` frames — it has no identity, and nothing to display but its id.
+# Left ineligible it is immortal: absent from the scheduler (so no snapshot can set `in_snapshot`) yet
+# never retired, it sits in the table as "queued / waiting" forever while every pool reads idle.
+# It cannot be a live job or batch movie — those announce themselves with fun + pool — and it cannot
+# be a live scheduler task, because that would be IN the snapshot and so never miss a poll.
+# Dropped silently rather than tallied: we never saw what it was, so "ended" would be a claim about a
+# task we can't even name. Nor is it added to SEEN_TERM — if frames keep coming the row simply comes
+# back and is dropped again, which is self-correcting; SEEN_TERM would suppress it permanently.
+_unattributed(t::TaskView) = isempty(t.fun_name) && isempty(t.pool_name)
+
 # Pure half — takes already-parsed rows, touches no socket, so `api/test/runtests.jl` can drive it
 # with synthetic snapshots (that's the only automated coverage this script can have: it's run by path,
 # never imported, so the entrypoint at the bottom is guarded to keep `include`ing it side-effect-free).
@@ -179,14 +193,22 @@ function _reconcile_snapshot!(rows)
             t.in_snapshot  = true
             t.misses       = 0
         end
-        # retire what the scheduler no longer knows about (outcome unseen — tallied as "ended")
+        # retire what the scheduler no longer knows about: a task it once listed is tallied as "ended"
+        # (finished, outcome unseen); an unattributed row is dropped without a tally (see above).
         for (id, t) in collect(TASKS)
-            (t.in_snapshot && !(id in present)) || continue
+            ((t.in_snapshot || _unattributed(t)) && !(id in present)) || continue
             t.misses += 1
             t.misses >= SNAPSHOT_MISSES_TO_RETIRE || continue
-            _note_terminal!(id, "ended")
-            push_event!("status", string(col(BOLD, short(id)), " ", col(GREY, "ended"),
-                        col(DIM, " (outcome unseen — dropped frame)")); colour = GREY)
+            if t.in_snapshot
+                _note_terminal!(id, "ended")
+                push_event!("status", string(col(BOLD, short(id)), " ", col(GREY, "ended"),
+                            col(DIM, " (outcome unseen — dropped frame)")); colour = GREY)
+            else
+                delete!(TASKS, id)
+                push_event!("status", string(col(BOLD, short(id)), " ", col(GREY, "dropped"),
+                            col(DIM, " (unattributed — logs only, never in the scheduler)"));
+                            colour = GREY)
+            end
         end
     end
     nothing
@@ -258,7 +280,17 @@ function handle_ws(raw::AbstractString)
         elseif type == "task:log"
             id = String(get(msg, :taskId, "")); isempty(id) && return
             line = String(get(msg, :line, ""))
-            t = _task!(id); t.last_log = line; t.updated = Dates.now()
+            # Always SHOW the line — but never let it (re)create a row for a task that has already
+            # finished. Post-mortem log frames are normal: cancel_task! kills the subprocess and the
+            # terminal frame goes out at once, then the process reader flushes whatever was still in
+            # the pipe. A log frame carries no fun / pool / status, so `_task!` minted a blank row
+            # stuck at the default "queued" — and nothing could ever retire it: the scheduler had
+            # already deregistered the task, so it never came back in a snapshot to set `in_snapshot`.
+            # That was the zombie queued row (six of them after seven cancels, every pool idle).
+            id in SEEN_TERM || let t = _task!(id)
+                t.last_log = line
+                t.updated  = Dates.now()
+            end
             push_log!(id, line)
 
         elseif type == "task:result"

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -1466,6 +1466,58 @@ end
     @test C.TASKS["t3"].misses == 0
     reconcile([])
     @test haskey(C.TASKS, "t3")                           # would have been retired if it hadn't reset
+
+    # an UNATTRIBUTED row (no fun, no pool — only ever log/progress frames) is prunable even though
+    # the snapshot never listed it: nothing else could ever remove it, so it sat there forever.
+    reset_console!()
+    C._task!("ghost")                        # blank fun + pool, default status "queued"
+    reconcile([])                            # miss 1
+    @test haskey(C.TASKS, "ghost")
+    reconcile([])                            # miss 2 → dropped
+    @test !haskey(C.TASKS, "ghost")
+    @test sum(values(C.TALLY)) == 0                       # no outcome claimed for a task we can't name
+    @test !("ghost" in C.SEEN_TERM)                       # …and not suppressed, so a real task returns
+end
+
+# ── Task console: post-mortem log frames must not resurrect a finished task ────
+# The zombie-queued-row regression. Cancelling a running task broadcasts the terminal `task:status`
+# at once (cancel_task! → on_status_change), then the killed subprocess's reader flushes whatever was
+# still in its pipe as `task:log` frames. Those carry no fun / pool / status, so each one minted a
+# fresh blank row stuck at the default "queued" — and the snapshot could never retire it, because the
+# scheduler had already deregistered the task. Six cancels, six immortal "queued / waiting" rows with
+# every pool reading idle and GET /api/tasks returning [].
+@testset "API: task console ignores post-mortem log frames" begin
+    C = TaskConsoleUT
+    row(id; status="running") = (; id=id, status=status, fun_name="spatialAnalysis.aggregatesMeshes",
+                                  pool_name="cpu", image_uid="EaMaVq", chain_run_id="")
+    feed(frame) = redirect_stdout(devnull) do; C.handle_ws(JSON3.write(frame)) end
+    recon(rows)  = redirect_stdout(devnull) do; C._reconcile_snapshot!(rows) end
+    reset_console!() = (empty!(C.TASKS); empty!(C.SEEN_TERM); empty!(C.EVENTS); empty!(C.LOGS);
+                        empty!(C.ENDED_IDS); for k in keys(C.TALLY); C.TALLY[k] = 0; end)
+
+    reset_console!()
+    recon([row("k1")])
+    feed((; type="task:status", taskId="k1", status="cancelled", imageUid="EaMaVq",
+           fun="spatialAnalysis.aggregatesMeshes"))
+    @test !haskey(C.TASKS, "k1") && C.TALLY["cancelled"] == 1
+
+    # the dying subprocess's remaining stdout arrives AFTER the terminal frame
+    nlogs = length(C.LOGS)
+    feed((; type="task:log", taskId="k1", line=">> t74: 13 meshes, 0 aggregate(s)"))
+    feed((; type="task:log", taskId="k1", line="[QC] mesh aggregates: 31, 18% of cells."))
+    @test !haskey(C.TASKS, "k1")                          # ← used to reappear as a blank "queued" row
+    @test length(C.LOGS) == nlogs + 2                     # still SHOWN, just not resurrected as a row
+    @test C.TALLY["cancelled"] == 1                        # and not re-counted
+
+    # a progress frame after the fact is likewise ignored (this half was already guarded — pin it)
+    feed((; type="task:progress", taskId="k1", progress=0.9))
+    @test !haskey(C.TASKS, "k1")
+
+    # the row STAYS while the task is alive — a log frame for a live task is the normal case
+    reset_console!()
+    recon([row("k2")])
+    feed((; type="task:log", taskId="k2", line=">> t01: 4 meshes"))
+    @test haskey(C.TASKS, "k2") && C.TASKS["k2"].last_log == ">> t01: 4 meshes"
 end
 
 # ── Task console: a chain node's real outcome ─────────────────────────────────

--- a/docs/API.md
+++ b/docs/API.md
@@ -175,9 +175,19 @@ retires rows that vanish from it** (2 consecutive misses; tallied `ended` — "f
 `task:status` frame — dropped for a slow client, or never delivered on a half-open socket — otherwise
 strands the row as `running` forever, so the console lists tasks the scheduler has long since finished
 while every pool reads idle. Rows for WS-only producers (jobs, batch movies) never appear in the
-snapshot and are exempt from retiring. The reconciliation half is split out as the socket-free
-`_reconcile_snapshot!(rows)` and pinned by the *API: task console reconciles snapshot removals*
-testset (the script's entrypoint is `PROGRAM_FILE`-guarded so the suite can `include` it).
+snapshot and are exempt from retiring — they identify themselves with `fun` + `pool` on their status
+frames. That identity is also the console's other retire rule: a row with **neither** (`_unattributed`)
+has only ever seen `task:log`/`task:progress` frames, so it can't be live work and is dropped by the
+snapshot too — silently, since we never saw what it was. Without that rule such a row is immortal:
+absent from the scheduler, so no snapshot can ever mark it eligible. That was the **zombie queued row**
+— `task:log` used to get-or-*create* its row unconditionally, and a cancelled task's killed subprocess
+flushes its remaining stdout *after* the terminal frame, so each trailing line minted a fresh blank row
+stuck at the default `queued` (six cancels → six phantom rows, `GET /api/tasks` returning `[]`). Log
+frames now honour `SEEN_TERM` like status/progress do: still shown in the logs pane, never resurrecting
+a row. The reconciliation half is split out as the socket-free
+`_reconcile_snapshot!(rows)` and pinned by the *API: task console reconciles snapshot removals* and
+*ignores post-mortem log frames* testsets (the script's entrypoint is `PROGRAM_FILE`-guarded so the
+suite can `include` it).
 **Chain nodes** report their outcome through a different door: a chain run emits no `task:status`
 frames, so the console attributes one from the `taskId` on the terminal `chain:node:done`/`failed`
 frame (see `docs/SCHEDULER.md` → *Event bus*). A row already retired as `ended` is *corrected* if its


### PR DESCRIPTION
## The symptom

`pixi run console` accumulated phantom rows after cancelling tasks — blank FUNCTION/IMAGE/POOL, stuck at `queued / waiting`, while every pool read idle:

```
0 running · 6 queued · 14 done · 0 failed · 7 cancelled
pools  cpu 0/4   gpu 0/1   io 0/1   network 0/1

TASK     FUNCTION                  IMAGE     POOL      STATUS     PROGRESS
KZRwk7   …                                             queued     waiting
MA4qbi   …                                             queued     waiting
…
```

Verified against the live server at the time: `GET /api/tasks` → `[]`, `GET /api/pools` → `queued: 0` on all four. The scheduler held nothing; the rows existed only in the console's own state.

## Cause

`cancel_task!` broadcasts the terminal `task:status` frame **immediately** (deliberate — a cancel should reflect at once, not only when a worker later dequeues and skips the job), and only then does the killed subprocess's reader flush whatever was still sitting in its pipe as `task:log` frames.

`handle_ws` guarded `task:status` and `task:progress` with `SEEN_TERM`, but not `task:log` — it called the get-or-**create** `_task!` unconditionally. A log frame carries no `fun`, `pool` or `status`, so each trailing line minted a fresh `TaskView` with the struct defaults: blank columns, status `queued`.

And then nothing could remove it. The snapshot-retire path only prunes rows with `in_snapshot`, which this row can never earn — the scheduler deregistered the task the moment it finished, so it never appears in `/api/tasks` again (and while it briefly did, reconcile skips `SEEN_TERM` ids before setting the flag). Immortal.

## Fix — two layers

- **Root cause:** `task:log` now honours `SEEN_TERM` like the other frames. The line is still shown in the logs pane; it just no longer resurrects a row.
- **Backstop:** an *unattributed* row — no `fun` **and** no `pool` — is now prunable by the snapshot even without `in_snapshot`. Every `ws_status` call site in the codebase carries `fun`, and the WS-only producers (jobs, batch movies) also carry `pool`, so a row with neither has only ever seen log/progress frames and cannot be live work. Dropped silently rather than tallied as `ended` (claiming an outcome for a task we can't even name would be worse), and not added to `SEEN_TERM`, so if it turns out real it simply comes back.

The backstop also closes the second route to the same symptom: a short task whose terminal frame was dropped by the per-client drop-on-full queue and which finished between two 2s polls, so it was never snapshotted at all.

The GUI Task Manager was never affected — `tasks.ts` `appendLog` is find-only.

## Tests

`pixi run test-api`, all green:

- new `API: task console ignores post-mortem log frames` (6) — cancel → trailing log frames → row stays gone, lines still shown, tally not re-counted; late progress likewise ignored; a log frame for a *live* task still updates its row.
- `API: task console reconciles snapshot removals` 13 → 16 — the unattributed-row prune: dropped after 2 misses, no tally claimed, not suppressed via `SEEN_TERM`.
- `API: task console attributes chain-node outcomes` 14, unchanged.

## Reservations

- The attribution is read from the code paths, not from a captured frame trace. The row shape matches exactly and `task:log` was the only unguarded creator, so I'm confident — but "six zombies from seven cancels" is reasoning, not a log.
- The backstop can flicker: if post-mortem logs keep arriving for an id that never reached `SEEN_TERM`, the row reappears per log frame and is dropped ~4s later, each drop writing an activity line. Bounded and self-correcting, but visible churn.
- Deliberate trade-off: a genuinely live WS-only producer whose only `running` frame was dropped, but which keeps logging, now loses its row while still working. Before it stayed — blank and mislabelled `queued`. Chose "no immortal zombies" over "never lose a live row"; easy to invert.

Docs: `docs/API.md` task-console paragraph updated with both retire rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
