### PR TITLE
Quit says what it is about to kill

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -15,7 +15,7 @@ Last audited: 2026-07-16 (full six-area ground-truth read; against `main` @ c1ce
 
 ## Cross-cutting flows (one canonical path each — do not add a second)
 
-- **App shutdown / quit** — UI: sidebar footer + Settings only → `appControl.quit()` → `POST /api/app/shutdown` → `api_app_shutdown` → `_stop_children_for_exit()`. Two UI entry points, one store action, one endpoint. Do NOT add a third quit button. (Per-service stops — napari `/api/napari/close`, notebooks `/api/notebooks/shutdown` — are separate and legitimate.)
+- **App shutdown / quit** — UI: sidebar footer + Settings only → `appControl.quit()` → `POST /api/app/shutdown` → `api_app_shutdown` → `_stop_children_for_exit()`. Two UI entry points, one store action, one endpoint. Do NOT add a third quit button. (Per-service stops — napari `/api/napari/close`, notebooks `/api/notebooks/shutdown` — are separate and legitimate.) Both entry points warn when work is in flight via `frontend/src/utils/quitWarning.ts` (shutdown does NOT wait for running tasks), so keep the wording in that one module rather than per-site.
 - **App update** — `appControl.checkUpdate()`/`applyUpdate()` → `/api/update/check` + `/api/update/apply`. Header badge and Settings both read the one store; one handler each.
 - **Napari WebSocket (7655)** — one connector: `app/src/napari.jl` `send(v, msg)`; one bridge server: `napari/napari_bridge.py` `ws_server()`. Port constant `NAPARI_PORT` defined once in `napari.jl`.
 - **Julia ↔ Vue WebSocket (8080 `/ws`)** — one server handler: `api/src/server.jl` `handle_ws` → `sockets.jl` `handle_message`; one Vue client: `frontend/src/stores/ws.ts` (the only `new WebSocket` in the frontend). All outbound goes through `broadcast_ws`.

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -4,6 +4,8 @@ import { useProjectMetaStore } from '../stores/projectMeta'
 import { useSettingsStore } from '../stores/settings'
 import { useAppControlStore } from '../stores/appControl'
 import { useCustomModulesStore } from '../stores/customModules'
+import { runningTaskCount } from '../utils/runningTasks'
+import { quitConfirmTooltip } from '../utils/quitWarning'
 import ProjectPanel from './ProjectPanel.vue'
 import ConfirmButton from './ConfirmButton.vue'
 
@@ -15,6 +17,15 @@ const labLogBadgeStyle = computed(() =>
   : settings.labLogUnseenLevel === 'warn' ? { color: 'var(--cc-sev-warn)' }
   : {})
 const appCtl = useAppControlStore()
+// Quit says what it will kill: shutdown exits the backend without waiting for in-flight work, so a
+// long segmentation run would otherwise vanish on a click the user thought was harmless. The count is
+// read from the backend when the button is ARMED (not on hover) — one request per intent to quit.
+const quitTasks   = ref(0)
+const quitConfirm = computed(() => quitConfirmTooltip(quitTasks.value))
+async function armQuit(arm: () => void) {
+  arm()                                        // arm first: the confirm must appear immediately
+  quitTasks.value = await runningTaskCount()   // then fill in what it will cost
+}
 const customModules = useCustomModulesStore()
 const showPanel = ref(false)
 
@@ -236,13 +247,13 @@ function isNavDisabled(item: NavItem): boolean {
       </RouterLink>
       <div class="footer-ctl">
         <ConfirmButton @confirm="appCtl.quit()" v-slot="{ armed, arm, confirm, cancel }">
-          <button v-if="!armed" class="footer-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg danger" :disabled="appCtl.busy" @click="arm"
+          <button v-if="!armed" class="footer-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg danger" :disabled="appCtl.busy" @click="armQuit(arm)"
                   v-tooltip.right="'Quit Cecelia — stop napari, notebooks and the backend'">
             <i class="pi pi-power-off" />
           </button>
           <template v-else>
             <button class="footer-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg danger" @click="confirm"
-                    v-tooltip.right="'Confirm quit — stops napari, notebooks and the backend'"><i class="pi pi-check" /></button>
+                    v-tooltip.right="quitConfirm"><i class="pi pi-check" /></button>
             <button class="footer-btn cc-btn cc-btn-ghost cc-btn-icon cc-btn-lg" @click="cancel" v-tooltip.right="'Cancel'"><i class="pi pi-times" /></button>
           </template>
         </ConfirmButton>

--- a/frontend/src/components/ProjectPanel.vue
+++ b/frontend/src/components/ProjectPanel.vue
@@ -11,6 +11,7 @@ import CollapsibleSection from './CollapsibleSection.vue'
 import { useProjectMetaStore } from '../stores/projectMeta'
 import { useWsStore } from '../stores/ws'
 import { useTaskStore } from '../stores/tasks'
+import { runningTaskCount } from '../utils/runningTasks'
 
 const emit = defineEmits<{ (e: 'close'): void }>()
 
@@ -86,15 +87,9 @@ function onBrowserSelect(paths: string[]) {
 }
 
 // Warn before exporting while analysis tasks are in flight — packing a store that's being written can
-// capture a torn snapshot. GET /api/tasks is a live view of in-flight scheduler tasks (empty = idle).
+// capture a torn snapshot. The count comes from the shared `runningTaskCount` (utils/runningTasks.ts),
+// which quit uses too — same question, one asker.
 const exportWarn = ref<{ p: { uid: string; name: string }; count: number } | null>(null)
-async function runningTaskCount(): Promise<number> {
-  try {
-    const r = await fetch('/api/tasks')
-    if (r.ok) { const t = await r.json(); return Array.isArray(t) ? t.length : 0 }
-  } catch { /* treat as idle if the check fails */ }
-  return 0
-}
 async function exportProject(p: { uid: string; name: string }) {
   if (ioBusy.value) return
   const n = await runningTaskCount()

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -11,6 +11,8 @@ import { useAppControlStore } from '../stores/appControl'
 import { useCustomModulesStore } from '../stores/customModules'
 import { fetchStorageSummary, reclaimStorage, formatBytes, type StorageSummary } from '../utils/storage'
 import { useWsStore } from '../stores/ws'
+import { quitConfirmTooltip, quitConfirmLabel } from '../utils/quitWarning'
+import { runningTaskCount } from '../utils/runningTasks'
 import { useTaskStore } from '../stores/tasks'
 import CcToggle from '../components/CcToggle.vue'
 
@@ -278,6 +280,15 @@ async function appRestart() {
   await appCtl.restartBackend()
   svcMsg.value = appCtl.message
   pollServices()
+}
+// Quit reports what it will kill — shutdown exits the backend without waiting for in-flight work.
+// Same builders as the sidebar footer so the two entry points can't drift.
+const quitTasks   = ref(0)
+const quitConfirm = computed(() => quitConfirmTooltip(quitTasks.value))
+const quitLabel   = computed(() => quitConfirmLabel(quitTasks.value))
+async function armQuit(arm: () => void) {
+  arm()
+  quitTasks.value = await runningTaskCount()
 }
 async function quitApp() {
   await appCtl.quit()
@@ -555,13 +566,13 @@ async function switchWt(path: string) {
             <i :class="['pi', appCtl.busy ? 'pi-spin pi-cog' : 'pi-refresh']" /> Restart
           </button>
           <ConfirmButton @confirm="quitApp" v-slot="{ armed, arm, confirm, cancel }">
-            <button v-if="!armed" class="save-btn danger" :disabled="appCtl.busy" @click="arm"
+            <button v-if="!armed" class="save-btn danger" :disabled="appCtl.busy" @click="armQuit(arm)"
                     v-tooltip.top="'Stop napari, notebooks and the backend, then exit Cecelia'">
               <i class="pi pi-power-off" /> Quit
             </button>
             <template v-else>
               <button class="save-btn danger" @click="confirm"
-                      v-tooltip.top="'Confirm — stop napari, notebooks and the backend'"><i class="pi pi-power-off" /> Quit everything</button>
+                      v-tooltip.top="quitConfirm"><i class="pi pi-power-off" /> {{ quitLabel }}</button>
               <button class="save-btn ghost" @click="cancel">Cancel</button>
             </template>
           </ConfirmButton>

--- a/frontend/src/utils/quitWarning.test.ts
+++ b/frontend/src/utils/quitWarning.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { quitTaskPhrase, quitConfirmTooltip, quitConfirmLabel } from './quitWarning'
+
+describe('quitTaskPhrase', () => {
+  it('is empty when idle, so the common case gains no noise', () => {
+    expect(quitTaskPhrase(0)).toBe('')
+    expect(quitTaskPhrase(-1)).toBe('')
+  })
+
+  it('singularises one task', () => {
+    expect(quitTaskPhrase(1)).toBe('1 task running')
+    expect(quitTaskPhrase(2)).toBe('2 tasks running')
+  })
+})
+
+describe('quit tooltips', () => {
+  it('keep the plain description when nothing is running', () => {
+    expect(quitConfirmTooltip(0)).toBe('Confirm quit — stops napari, notebooks and the backend')
+    expect(quitConfirmLabel(0)).toBe('Quit everything')
+  })
+
+  it('say what will be lost when work is in flight', () => {
+    expect(quitConfirmTooltip(1)).toBe('Confirm quit — kills 1 task running')
+    expect(quitConfirmTooltip(3)).toContain('3 tasks running')
+  })
+
+  it('put the count in the button label where there is room for text', () => {
+    expect(quitConfirmLabel(0)).toBe('Quit everything')
+    expect(quitConfirmLabel(1)).toBe('Quit — kills 1 task')
+    expect(quitConfirmLabel(4)).toBe('Quit — kills 4 tasks')
+  })
+
+  // UI copy budget (docs/UI.md): a phrase, not a sentence. Guard against it growing into prose.
+  it('stay short', () => {
+    for (const n of [0, 1, 12]) {
+      expect(quitConfirmTooltip(n).split(' ').length).toBeLessThanOrEqual(11)
+      expect(quitConfirmLabel(n).split(' ').length).toBeLessThanOrEqual(11)
+    }
+  })
+})

--- a/frontend/src/utils/quitWarning.ts
+++ b/frontend/src/utils/quitWarning.ts
@@ -1,0 +1,35 @@
+// Quit tells you what it's about to kill.
+//
+// `POST /api/app/shutdown` stops the children and then `exit(0)`s the backend ~0.3s later — it does
+// NOT wait for in-flight work. So quitting during a 40-minute cellpose run silently throws that run
+// away, and the two-click ConfirmButton alone doesn't help: the user is confirming "quit", not
+// "abandon 2 running tasks", because nothing told them tasks were running.
+//
+// Pure string builders so they're testable without mounting the SFC (frontend test scope = src/utils
+// only — see docs/DEV.md). Both quit entry points (sidebar footer, Settings) read these, so the
+// wording stays identical in the two places; see INVENTORY.md → app shutdown/quit. The COUNT comes
+// from `runningTasks.ts` (the backend), not the local task store, which reads 0 after a page reload.
+//
+// Only the ARMED state reports the count. The idle control keeps its plain description: the count is
+// fetched when you arm, so putting it on the idle tooltip too would show a stale number after a cancel.
+
+/** `2 tasks running` / `1 task running` / `''` when idle. The shared fragment, not a full sentence. */
+export function quitTaskPhrase(count: number): string {
+  if (count <= 0) return ''
+  return `${count} task${count === 1 ? '' : 's'} running`
+}
+
+/** Tooltip for the armed Quit control — the last thing seen before the work is dropped. */
+export function quitConfirmTooltip(count: number): string {
+  const phrase = quitTaskPhrase(count)
+  return phrase ? `Confirm quit — kills ${phrase}`
+                : 'Confirm quit — stops napari, notebooks and the backend'
+}
+
+/**
+ * Label for the armed Quit *button* where there's room for text (Settings). The sidebar footer is
+ * icon-only, so there it lives in the tooltip instead — same numbers, one source.
+ */
+export function quitConfirmLabel(count: number): string {
+  return count > 0 ? `Quit — kills ${count} task${count === 1 ? '' : 's'}` : 'Quit everything'
+}

--- a/frontend/src/utils/runningTasks.test.ts
+++ b/frontend/src/utils/runningTasks.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { runningTaskCount } from './runningTasks'
+
+const okJson = (body: unknown) =>
+  vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(body) })
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('runningTaskCount', () => {
+  it('counts the in-flight tasks the backend reports', async () => {
+    vi.stubGlobal('fetch', okJson([{ id: 'a' }, { id: 'b' }, { id: 'c' }]))
+    expect(await runningTaskCount()).toBe(3)
+  })
+
+  it('is 0 when the scheduler is idle', async () => {
+    vi.stubGlobal('fetch', okJson([]))
+    expect(await runningTaskCount()).toBe(0)
+  })
+
+  it('asks the backend, not the local task store — the store is empty after a reload', async () => {
+    const f = okJson([{ id: 'a' }])
+    vi.stubGlobal('fetch', f)
+    await runningTaskCount()
+    expect(f).toHaveBeenCalledWith('/api/tasks')
+  })
+
+  // Fails OPEN: the count gates a warning, so a transient error must not block quit/export.
+  it('reports 0 on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve([]) }))
+    expect(await runningTaskCount()).toBe(0)
+  })
+
+  it('reports 0 when the request throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    expect(await runningTaskCount()).toBe(0)
+  })
+
+  it('reports 0 when the payload is not an array', async () => {
+    vi.stubGlobal('fetch', okJson({ error: 'nope' }))
+    expect(await runningTaskCount()).toBe(0)
+  })
+})

--- a/frontend/src/utils/runningTasks.ts
+++ b/frontend/src/utils/runningTasks.ts
@@ -1,0 +1,31 @@
+// How many scheduler tasks are in flight, from the BACKEND — the one place that asks.
+//
+// `GET /api/tasks` is the authoritative live view of the scheduler's task registry. The frontend
+// `tasks` store is NOT a substitute: it's built from WS events received by *this* tab, so after a
+// page reload (or a tab opened mid-run) it reports 0 while work is still running — exactly the case
+// where a destructive action needs the count.
+//
+// Used before anything that would corrupt or discard in-flight work:
+//   - project export — packing a store that's being written captures a torn snapshot
+//   - quit — shutdown exits the backend without waiting for running tasks
+//
+// This was inline in ProjectPanel.vue (export only). Kept as one shared helper so a second caller
+// can't drift, and so it's testable outside an SFC (see docs/DEV.md → frontend test scope).
+
+/**
+ * Count of in-flight scheduler tasks, or `0` if the check fails.
+ *
+ * Failing OPEN (0 = idle) is deliberate: the count gates a *warning*, not the action itself, so a
+ * transient fetch error must not block a user from quitting or exporting. The cost of a missed
+ * warning is lower than the cost of an unusable button.
+ */
+export async function runningTaskCount(): Promise<number> {
+  try {
+    const r = await fetch('/api/tasks')
+    if (r.ok) {
+      const t = await r.json()
+      return Array.isArray(t) ? t.length : 0
+    }
+  } catch { /* treat as idle if the check fails */ }
+  return 0
+}


### PR DESCRIPTION
Follow-up to #420, from the same release audit. That PR removed the *unrecoverable* failure (a killed write truncating `ccid.json`); this one addresses the other half of the same trigger — the Quit button kills work without saying so.

## The problem

`POST /api/app/shutdown` stops the children and `exit(0)`s the backend ~0.3s later. It does **not** wait for in-flight work. So quitting during a 40-minute cellpose run silently throws that run away, and the two-click `ConfirmButton` doesn't help: the user is confirming "quit", not "abandon 2 running tasks", because nothing told them tasks were running.

## The change

The **armed** Quit reports the cost — `Quit — kills 2 tasks` in Settings, where there's room for a label; a tooltip on the icon-only sidebar footer. Both entry points read the same builders (`utils/quitWarning.ts`), so the wording can't drift between them.

The count is fetched **on arm** — one request per intent to quit, not per hover — and only the armed state shows it. Putting it on the idle tooltip too would leave a stale number sitting there after a cancel.

## Two corrections the codebase made to the first attempt

**The count has to come from the backend.** I first read it from the frontend `tasks` store — which is built from WS events received by *this tab*, so after a page reload it reports 0 while work is still running. That's precisely the case the warning exists for. `ProjectPanel.vue` already did this correctly for project export (packing a store mid-write captures a torn snapshot) by asking `GET /api/tasks`. Also confirmed that endpoint is a true in-flight view rather than history: `_deregister_task!` drops each record on completion, so the registry only ever holds queued + running.

**And that meant a second variant of an existing helper.** `runningTaskCount` was inline and unexported in `ProjectPanel.vue`. It's now `utils/runningTasks.ts`, shared by export and both quit sites, with the tests it couldn't have had while it lived inside an SFC. It **fails open** (0 on any error): the count gates a warning, not the action, so a transient fetch failure must never leave someone unable to quit.

`vue-tsc` earned its keep here too — it caught a wrong store name (`useTasksStore` vs `useTaskStore`) and a duplicate import, both of which would have thrown inside `setup` and surfaced as the misleading `Maximum recursive updates` error rather than as the actual problem.

## Verification

`vue-tsc -b` clean, `npm run build` clean, 628 frontend tests (616 → 628, +12 across the two new util modules). `test-pkg` 2423 passing, re-run after rebasing onto merged `main`.

## Reservations

- **It warns; it does not block.** The backend still exits without checking, so a direct `POST /api/app/shutdown` bypasses this entirely. Refusing unless `force` would be airtight, but it changes the endpoint contract — not a pre-release move.
- **Asymmetric surfacing.** Settings gets the count in the button label; the icon-only sidebar footer can only put it in a tooltip, so a fast double-click there sees nothing.
- **Async ordering.** Arm happens first so the confirm never lags, then the count fills in — a user who confirms before the fetch resolves sees the plain label. Sub-millisecond against a local server, but real.
- Behaviour change for `ProjectPanel`'s export warning: same logic, now via the shared helper. Its own count semantics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
