### PR TITLE
fix(ngff): carry the time scale into the NGFF metadata and napari

### DIFF
--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -138,8 +138,16 @@ class NapariState:
                 self._im_scale = [s for i, s in enumerate(full_scale)
                                   if i != self._channel_axis]
         if self._im_scale is not None:
+            # Per-axis units, not one unit repeated. The time axis is seconds, the spatial axes
+            # micrometres; labelling them all with the pixel unit renders a correct frame
+            # interval as "10 um". Prefer the NGFF `axes[].unit` written at import and fall back
+            # to the OME pixel unit for stores written before that existed.
             unit = ome_xml_utils.read_pixel_unit(path)
-            self._im_units = tuple(unit for _ in self._im_scale)
+            ngff_units = zarr_utils.read_axis_units(path) or {}
+            self._im_units = tuple(
+                ngff_units.get(ax.lower()) or unit
+                for i, ax in enumerate(self._axes) if i != self._channel_axis
+            )
 
         # Delegate the actual layer creation to the SHARED generic helper (cecelia.utils.napari_utils,
         # which coastal mirrors): per-channel colormaps, additive blending, contrast-from-sample and the

--- a/python/cecelia/tests/test_zarr_store.py
+++ b/python/cecelia/tests/test_zarr_store.py
@@ -244,6 +244,30 @@ class MultiscalesMetadataTest(unittest.TestCase):
         self.assertNotIn('axes', ms[0])
         self.assertEqual(ms[0]['datasets'], [{'path': '0'}, {'path': '1'}])
 
+    def test_axes_carry_ngff_type_and_unit(self):
+        """Without `type`/`unit` a reader gets a bare number and cannot tell seconds from
+        micrometres — napari then labels the time axis with the spatial unit."""
+        ms = zu.multiscales_metadata(
+            ['T', 'C', 'Z', 'Y', 'X'], 1,
+            scale_for_axis={'T': 10.0, 'C': 1.0, 'Z': 5.0, 'Y': 0.5, 'X': 0.5},
+            unit_for_axis={'T': 's', 'Z': 'um', 'Y': 'um', 'X': 'um'})
+        axes = ms[0]['axes']
+        self.assertEqual([a['type'] for a in axes],
+                         ['time', 'channel', 'space', 'space', 'space'])
+        # abbreviations map to the UDUNITS names napari expects; channel takes no unit
+        self.assertEqual(axes[0]['unit'], 'second')
+        self.assertEqual(axes[2]['unit'], 'micrometer')
+        self.assertNotIn('unit', axes[1])
+        # the frame interval reaches the transform rather than defaulting to 1.0
+        self.assertEqual(ms[0]['datasets'][0]['coordinateTransformations'][0]['scale'][0], 10.0)
+
+    def test_axis_entry_builder_is_shared_with_set_ngff_axes(self):
+        """One builder decides an axis entry's shape, so a migrated store and a freshly
+        written one describe their axes identically (cecelia rule: no duplicated logic)."""
+        self.assertEqual(zu.ngff_axis_entry('t', 's'),
+                         {'name': 't', 'type': 'time', 'unit': 'second'})
+        self.assertEqual(zu.ngff_axis_entry('c'), {'name': 'c', 'type': 'channel'})
+
 
 def _write_store(path, value, nscales=2, shape=(2, 8, 6)):
     """Write a small complete 2-level store filled with `value`; return the level-0 array."""

--- a/python/cecelia/utils/dim_utils.py
+++ b/python/cecelia/utils/dim_utils.py
@@ -142,6 +142,16 @@ class DimUtils:
       axis_unit = self.omexml.images[0].pixels.physical_size_z_unit.value
     return axis_unit.replace('µ', 'u') if axis_unit is not None else default
 
+  def im_time_increment(self, default = None):
+    """Frame interval from the OME metadata (``Pixels.TimeIncrement``), or default."""
+    return self.omexml.images[0].pixels.time_increment if self.is_timeseries() else default
+
+  def im_time_increment_unit(self, default = 's'):
+    """Unit for `im_time_increment` — OME's ``TimeIncrementUnit``, e.g. 's'."""
+    unit = self.omexml.images[0].pixels.time_increment_unit
+    unit = getattr(unit, 'value', unit)
+    return unit if unit is not None else default
+
   def im_scale(self, dims = list(), as_dict = False, upper = True):
     size_x = self.omexml.images[0].pixels.physical_size_x
     size_y = self.omexml.images[0].pixels.physical_size_y
@@ -153,6 +163,13 @@ class DimUtils:
 
     if self.is_3D():
       im_scale[self.dim_idx('Z')] = size_z
+
+    # T carries a physical scale too (the frame interval). Without this the axis keeps the
+    # 1.0 from ones_like, which propagates all the way to the NGFF coordinateTransformations
+    # written at import — and napari then shows frame indices instead of elapsed time, even
+    # though TimeIncrement was read from the file and is sitting in the image metadata.
+    if self.is_timeseries():
+      im_scale[self.dim_idx('T')] = self.im_time_increment()
 
     im_scale = [x if x is not None else 1 for x in im_scale]
 

--- a/python/cecelia/utils/zarr_utils.py
+++ b/python/cecelia/utils/zarr_utils.py
@@ -187,11 +187,33 @@ def read_axes(path):
     return [ax["name"] for ax in axes] if axes else None
 
 
+def read_axis_units(path):
+    """NGFF ``axes[].unit`` keyed by axis name (e.g. ``{'t': 'second', 'x': 'micrometer'}``), or
+    None. Axes without a unit are omitted, so a caller can fall back per axis."""
+    ms = read_multiscales_meta(path)
+    axes = ms.get("axes", [])
+    units = {ax["name"]: ax["unit"] for ax in axes if ax.get("unit")}
+    return units or None
+
+
 # NGFF axis-type by name; unit-abbreviation → NGFF (UDUNITS) name napari/read_ome_metadata expect.
 _NGFF_AXIS_TYPE = {'t': 'time', 'c': 'channel', 'z': 'space', 'y': 'space', 'x': 'space'}
 _NGFF_UNIT = {'µm': 'micrometer', 'um': 'micrometer', 'nm': 'nanometer', 'mm': 'millimeter',
               's': 'second', 'ms': 'millisecond', 'min': 'minute',
               'micrometer': 'micrometer', 'second': 'second'}
+
+
+def ngff_axis_entry(name, unit=None):
+    """One NGFF ``axes`` entry: ``name`` + ``type`` (+ ``unit``, mapped to its UDUNITS name).
+
+    The single place that decides an axis entry's shape, shared by the writer that creates a store
+    (`multiscales_metadata`) and the one that annotates an existing store (`set_ngff_axes`), so a
+    migrated store and a freshly written one describe their axes identically."""
+    nm = str(name).lower()
+    entry = {"name": nm, "type": _NGFF_AXIS_TYPE.get(nm, "space")}
+    if unit:
+        entry["unit"] = _NGFF_UNIT.get(unit, unit)
+    return entry
 
 
 def set_ngff_axes(path, axis_names, scale=None, units=None, channels=None):
@@ -225,12 +247,7 @@ def set_ngff_axes(path, axis_names, scale=None, units=None, channels=None):
     except Exception:
         return False
 
-    axes = []
-    for nm in axis_names:
-        ax = {"name": nm, "type": _NGFF_AXIS_TYPE.get(nm, "space")}
-        u = (units or {}).get(nm)
-        u and ax.update(unit=_NGFF_UNIT.get(u, u))
-        axes.append(ax)
+    axes = [ngff_axis_entry(nm, (units or {}).get(nm)) for nm in axis_names]
 
     new_datasets = []
     for lvl, d in enumerate(datasets):
@@ -418,7 +435,8 @@ def create_zarr_from_ndarray(im_array, dim_utils, reference_zarr=None, im_chunks
     return new_zarr, im_chunks
 
 
-def multiscales_metadata(axes, nscales, scale_for_axis=None, keyword='datasets'):
+def multiscales_metadata(axes, nscales, scale_for_axis=None, keyword='datasets',
+                         unit_for_axis=None):
     """Build the NGFF ``multiscales`` attr value (a 1-element list) shared by every multiscale
     writer — the image writer (`create_multiscales`) and the label writer
     (`segmentation_utils._write_labels_zarr`). One place that decides the datasets/axes/scale
@@ -429,6 +447,8 @@ def multiscales_metadata(axes, nscales, scale_for_axis=None, keyword='datasets')
     ``scale_for_axis``: maps an axis letter → base physical scale (missing → 1.0). None → omit
     ``coordinateTransformations``. XY axes are downsampled by ``2**level``; all other axes keep
     the base scale.
+    ``unit_for_axis``: maps an axis letter → unit string for the NGFF ``axes`` entry (e.g.
+    ``{'T': 's', 'Z': 'um'}``). Missing/None → the axis gets ``type`` but no ``unit``.
     ``keyword``: the datasets key (``'datasets'``)."""
     axes = list(axes or [])
     datasets = []
@@ -442,8 +462,12 @@ def multiscales_metadata(axes, nscales, scale_for_axis=None, keyword='datasets')
         datasets.append(entry)
     ms_entry = {keyword: datasets}
     if axes:
-        ms_entry['axes'] = [{'name': ax.lower()} for ax in axes]
+        # `type` (and `unit` where known) per the NGFF axes spec. Without them a reader gets a
+        # bare number and cannot tell seconds from micrometres — napari then labels every axis
+        # with the spatial unit, so a correct time scale would still render as "10 um".
+        ms_entry['axes'] = [ngff_axis_entry(ax, (unit_for_axis or {}).get(ax)) for ax in axes]
     return [ms_entry]
+
 
 
 def create_multiscales(im_array, filepath, dim_utils=None, im_chunks=None,
@@ -471,14 +495,22 @@ def create_multiscales(im_array, filepath, dim_utils=None, im_chunks=None,
     else:
         axes = list(dim_utils.im_dim_order) if (dim_utils is not None and dim_utils.im_dim_order) else []
     scale_for_axis = None
+    unit_for_axis = None
     if axes and dim_utils is not None:
         # Map by axis NAME off dim_utils' OWN order — never zip against the (possibly overridden)
         # `axes` list positionally, or a store that dropped an axis inherits its neighbours' scales.
         src = {ax: (float(s) if s is not None else 1.0)
                for ax, s in zip(dim_utils.im_dim_order, dim_utils.im_scale())}
         scale_for_axis = {ax: src.get(ax, 1.0) for ax in axes}
+        # Units alongside the scale, so a reader can tell 10 seconds from 10 micrometres.
+        # Spatial units come from the existing per-axis accessor (not one unit assumed for all);
+        # T uses the OME TimeIncrementUnit.
+        unit_for_axis = {ax.upper(): u for ax, u in dim_utils.im_physical_units().items()}
+        if dim_utils.is_timeseries():
+            unit_for_axis['T'] = dim_utils.im_time_increment_unit()
     multiscales_zarr.attrs['multiscales'] = multiscales_metadata(
-        axes, nscales, scale_for_axis=scale_for_axis, keyword=keyword)
+        axes, nscales, scale_for_axis=scale_for_axis, keyword=keyword,
+        unit_for_axis=unit_for_axis)
 
     if isinstance(im_array, dask.array.core.Array):
         # Write into the group so the sub-array inherits zarr v2 format. Chunk PER PLANE — NOT with the


### PR DESCRIPTION
## Symptom

napari shows `t = 0, 1, 2, …` instead of elapsed time, even though the frame interval was read
from the file at import and is sitting in each image's metadata (`TimeIncrement: 10`,
`TimeIncrementUnit: second`).

## Cause

`DimUtils.im_scale()` sets X, Y and Z — and never T:

```python
im_scale = list(np.ones_like(self.im_dim))
im_scale[self.dim_idx('X')] = size_x
im_scale[self.dim_idx('Y')] = size_y
if self.is_3D():
    im_scale[self.dim_idx('Z')] = size_z
# T keeps the 1.0 from ones_like
```

Everything downstream then propagates that 1.0 faithfully, which is why nothing looks broken:

```
ccid.json  TimeIncrement: 10 second          ✔ present
  → dim_utils.im_scale()                     ✘ t = 1.0
  → create_multiscales() scale_for_axis      (zarr_utils.py)
  → .zattrs  scale: [1.0, 1.0, 5.0, .497, .497]
  → napari_bridge → zarr_utils.read_scale()  → 1.0
  → napari renders frame indices
```

`ome_types` exposes `Pixels.time_increment` / `time_increment_unit`, so the value was always
reachable — just never read.

## Fix

- **`dim_utils`** — `im_scale()` sets T from the OME `TimeIncrement`, via new
  `im_time_increment()` / `im_time_increment_unit()` accessors mirroring the existing
  `im_physical_size()` / `im_physical_unit()` pair.
- **`zarr_utils`** — NGFF axes now carry `type` and `unit` beside the scale. Without them a reader
  gets a bare number and cannot tell seconds from micrometres. `multiscales_metadata` takes
  `unit_for_axis`; `create_multiscales` fills it from `im_physical_units()` plus the time unit.
  New `read_axis_units()` mirrors `read_axes()` / `read_scale()`.
- **`napari_bridge`** — per-axis units instead of one spatial unit repeated, which would otherwise
  render a correct interval as `10 um`.

**No duplicated logic:** the axis-entry shape is built by one helper, `ngff_axis_entry`, shared by
the writer that creates a store (`multiscales_metadata`) and the one that annotates an existing
store (`set_ngff_axes`) — so a migrated store and a freshly written one describe their axes
identically. My first cut carried a second private copy of that logic plus a hard-coded spatial
unit; both are gone.

## Tests

**252 pass** (250 + 2). The new cases assert axes carry NGFF `type`/`unit` with abbreviations
mapped to the UDUNITS names napari expects (`s` → `second`, `um` → `micrometer`), that the frame
interval reaches the transform rather than defaulting to 1.0, and that both writers go through the
shared builder.

## Existing stores

A code fix only helps future imports, so the nine images in set `jHMfOI` ("Tcell types") were
backfilled with `set_ngff_axes` — the sanctioned structural writer for an already-materialised
store, not hand-edited JSON. Metadata only, no pixels touched, idempotent:

```
t: 1.0 -> 10 second   ×9      spatial -> micrometer
```

Verified after: `read_scale` → `[10.0, 1.0, 5.0, 0.497, 0.497]`,
`read_axis_units` → `{'t': 'second', 'z': 'micrometer', 'y': 'micrometer', 'x': 'micrometer'}`.

## Reservations

- **Not driven in a browser.** I verified what a reader gets back from the metadata, but did not
  open napari and look at the slider — which is the actual claim.
- **The bridge change is the riskiest line**: `_axes` and `_im_scale` are built in separate
  branches and the new comprehension iterates `_axes`. The enclosing `if self._im_scale is not
  None` should cover the mismatch case, but it is a shipped component I did not re-verify
  end-to-end.
- Only `ccidImage.ome.zarr` existed in that set — no corrected or label stores yet. Anything
  written before this lands still needs the backfill.