### PR TITLE
fix(ome): write OME-XML into staged stores instead of silently skipping

### DIFF
--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -259,8 +259,9 @@ class NapariState:
             ov.visible = False
             return
         t_idx = axes.index("t")
-        from cecelia.utils import ome_xml_utils
-        interval = ome_xml_utils.read_time_increment(path)   # seconds per frame, or None
+        # NGFF time-axis scale first, OME-XML fallback — one resolver, so the overlay works
+        # for stores that carry only one of the two (see zarr_utils.read_time_increment).
+        interval = zarr_utils.read_time_increment(path)      # seconds per frame, or None
         def _update(event=None):
             try:
                 step = self._viewer.dims.current_step

--- a/python/cecelia/tests/test_image_readers.py
+++ b/python/cecelia/tests/test_image_readers.py
@@ -7,7 +7,7 @@ the analysis pipeline and coastal. This is their first unit coverage — it pins
   - series_base: structural bioformats2raw-series-wrapper detection (nested `0/` vs flat root),
   - read_axes / read_scale: NGFF axes + coordinateTransformations, with the OME-XML scale fallback,
   - open_as_zarr: a read-only multiscale open on both layouts,
-  - ome_xml_utils.load_ome_xml + read_pixel_unit / read_scale_from_ome_xml / read_time_increment.
+  - ox.load_ome_xml + read_pixel_unit / read_scale_from_ome_xml / read_time_increment.
 
 Part of the Python (analysis-env) suite — run with `pixi run test-py`.
 """
@@ -178,3 +178,71 @@ class ImageJMetadataTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class OmeXmlStagedWriteTest(unittest.TestCase):
+    """OME-XML must survive being written into a STAGED store.
+
+    Regression: `zarr_utils.staged_store` writes to `<store>.ome.zarr.partial` and renames on
+    success, but the OME writers gated on `os.path.splitext(path)[1] == '.zarr'` — so every
+    write into a staging path silently did nothing. Because `save_meta_in_zarr` created the
+    `OME/` directory first, the result was an empty `OME/` dir, no error, and a task log
+    reporting success; the sidecar (pixel sizes, channel names, TimeIncrement) was simply gone
+    from every imported/corrected store.
+    """
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.d, ignore_errors=True)
+
+    def _store(self, name):
+        """A minimal zarr-looking store directory."""
+        p = os.path.join(self.d, name)
+        os.makedirs(p, exist_ok=True)
+        with open(os.path.join(p, ".zgroup"), "w") as f:
+            f.write('{"zarr_format": 2}')
+        return p
+
+    def test_writes_into_a_staging_path(self):
+        staged = self._store("img.ome.zarr" + zu.STAGING_SUFFIX)
+        ox.save_meta_in_zarr(staged, omexml=ox.from_xml(_OME_XML))
+        self.assertTrue(os.path.exists(os.path.join(staged, "OME", "METADATA.ome.xml")),
+                        "OME-XML was skipped because the staging path does not end in .zarr")
+
+    def test_survives_the_rename_onto_the_final_path(self):
+        """End to end through staged_store — the shape the import task actually uses."""
+        final = os.path.join(self.d, "img.ome.zarr")
+        with zu.staged_store(final) as staging:
+            os.makedirs(staging, exist_ok=True)
+            with open(os.path.join(staging, ".zgroup"), "w") as f:
+                f.write('{"zarr_format": 2}')
+            ox.save_meta_in_zarr(staging, omexml=ox.from_xml(_OME_XML))
+        self.assertTrue(os.path.exists(os.path.join(final, "OME", "METADATA.ome.xml")))
+        # and it round-trips: the value the timestamp overlay reads
+        self.assertEqual(ox.read_time_increment(final), 30.0)
+
+    def test_change_pixel_type_also_works_on_a_staging_path(self):
+        """The same guard was copy-pasted here, so it no-opped too."""
+        staged = self._store("img.ome.zarr" + zu.STAGING_SUFFIX)
+        ox.save_meta_in_zarr(staged, omexml=ox.from_xml(_OME_XML))
+        ox.change_pixel_type(staged, "uint8")
+        self.assertEqual(ox.parse_meta(staged).images[0].pixels.type.value, "uint8")
+
+    def test_a_tiff_is_still_not_a_zarr_store(self):
+        """Non-store callers must keep no-opping rather than growing an OME/ dir."""
+        tiff = os.path.join(self.d, "plain.tiff")
+        with open(tiff, "w") as f:
+            f.write("not a store")
+        self.assertFalse(ox.is_zarr_store(tiff))
+        ox.write_ome_xml(tiff, _OME_XML)
+        self.assertFalse(os.path.exists(os.path.join(tiff, "OME")))
+
+    def test_a_skipped_write_leaves_no_empty_ome_dir(self):
+        """An empty OME/ reads as 'half written'; a skip must leave nothing behind."""
+        plain = os.path.join(self.d, "notastore.txt")
+        with open(plain, "w") as f:
+            f.write("x")
+        ox.save_meta_in_zarr(plain, omexml=ox.from_xml(_OME_XML))
+        self.assertFalse(os.path.exists(os.path.join(plain, "OME")))

--- a/python/cecelia/utils/ome_xml_utils.py
+++ b/python/cecelia/utils/ome_xml_utils.py
@@ -12,6 +12,32 @@ from functools import lru_cache
 import tifffile
 from ome_types import from_xml, from_tiff, to_xml
 
+
+# Markers that identify a zarr store on disk, in either zarr format.
+_ZARR_MARKERS = ('.zgroup', '.zattrs', 'zarr.json')
+
+
+def is_zarr_store(im_path):
+  """True when `im_path` is a zarr store DIRECTORY — including a staged one.
+
+  Decided by STRUCTURE, not by file extension, matching how zarr_utils identifies stores
+  (`series_base`, `_has_multiscales`). The writers below used to test
+  `os.path.splitext(path)[1] == '.zarr'` — three copies of it — which silently skipped every
+  write into a staging path: `zarr_utils.staged_store` writes to `<store>.ome.zarr.partial`
+  and renames on success, so while the store is being written the extension is `.partial`.
+  The result was an OME directory containing no METADATA.ome.xml, no error raised, and a task
+  log reporting success; every store written that way lost its OME-XML sidecar.
+
+  A TIFF is a file, not a directory, so those callers keep no-opping as before.
+  """
+  if not os.path.isdir(im_path):
+    return False
+  if any(os.path.exists(os.path.join(im_path, m)) for m in _ZARR_MARKERS):
+    return True
+  # a store directory that exists but has no group metadata written into it yet
+  return '.zarr' in os.path.basename(im_path)
+
+
 """
 save (changed) OME XML from previous image into zarr structure
 """
@@ -57,13 +83,9 @@ def save_meta_in_zarr(
       if i == 'X':
         omexml.images[0].pixels.size_x = x
   
-  # save OME XML in zarr directory
-  # create directory
-  ome_dir = os.path.join(store_path, 'OME')
-  if os.path.exists(ome_dir) is False:
-    os.mkdir(ome_dir)
-  
-  # write back
+  # save OME XML in zarr directory. write_ome_xml creates OME/ itself, and only when it
+  # actually writes — creating it here too meant a skipped write left an empty OME directory,
+  # which reads as "half written" rather than "not written".
   write_ome_xml(store_path, omexml)
   
 """
@@ -133,7 +155,7 @@ TODO this only works on OME-ZARR for now
 """
 def write_ome_xml(im_path, omexml):
   # flip dimension order in pixels and adjust sizes
-  if os.path.splitext(im_path)[1] == ".zarr":
+  if is_zarr_store(im_path):
     ome_path = os.path.join(im_path, 'OME')
     
     if os.path.exists(ome_path) is False:
@@ -159,7 +181,7 @@ TODO this only works on OME-ZARR for now
 """
 def change_pixel_type(im_path, pixel_type = 'uint16'):
   # flip dimension order in pixels and adjust sizes
-  if os.path.splitext(im_path)[1] == ".zarr":
+  if is_zarr_store(im_path):
     omexml = parse_meta(im_path)
     
     omexml.images[0].pixels.type = pixel_type
@@ -174,7 +196,7 @@ TODO this only works on OME-ZARR for now
 """
 def switch_dim_order(im_path, dim_order = 'XYZCT'):
   # flip dimension order in pixels and adjust sizes
-  if os.path.splitext(im_path)[1] == '.zarr':
+  if is_zarr_store(im_path):
     omexml = parse_meta(im_path)
     
     # get previous order
@@ -322,15 +344,9 @@ def read_time_increment(path):
 Parse metadata from zarr file
 """
 def parse_meta(im_path):
-  omexml = None
-  
-  # get extension
-  im_ext = os.path.splitext(im_path)[1]
-  
-  # open zarr
-  if im_ext == ".zarr":
-    omexml = parse_meta_from_zarr(im_path)
-  else:
-    omexml = parse_meta_from_tiff(im_path)
-    
-  return omexml
+  # Structural, not by extension — same reason as the writers (see is_zarr_store). Dispatching
+  # on ".zarr" sent a staged store (`<store>.ome.zarr.partial`) down the TIFF branch, where
+  # ome_types raises trying to read a directory as a TIFF.
+  if is_zarr_store(im_path):
+    return parse_meta_from_zarr(im_path)
+  return parse_meta_from_tiff(im_path)

--- a/python/cecelia/utils/zarr_utils.py
+++ b/python/cecelia/utils/zarr_utils.py
@@ -187,6 +187,30 @@ def read_axes(path):
     return [ax["name"] for ax in axes] if axes else None
 
 
+def read_time_increment(path):
+    """Seconds per frame for a store: the NGFF time-axis scale first, falling back to the
+    OME-XML ``TimeIncrement``. None when neither is available or there is no time axis.
+
+    Mirrors `read_scale`, which prefers NGFF and falls back to OME-XML — one resolver, so a
+    caller does not have to know which of the two sources a given store happens to carry.
+    `ome_xml_utils.read_time_increment` remains the raw OME-XML reader underneath.
+
+    Only a time axis in seconds is taken from NGFF; any other unit falls through to OME-XML
+    rather than being silently misinterpreted as seconds."""
+    axes = read_axes(path)
+    scale = read_scale(path)
+    if axes and scale is not None and len(axes) == len(scale):
+        low = [a.lower() for a in axes]
+        if 't' in low:
+            unit = (read_axis_units(path) or {}).get('t')
+            if unit in (None, 'second', 's'):
+                t_scale = scale[low.index('t')]
+                if t_scale and float(t_scale) > 0:
+                    return float(t_scale)
+    from cecelia.utils import ome_xml_utils     # lazy: see read_scale
+    return ome_xml_utils.read_time_increment(path)
+
+
 def read_axis_units(path):
     """NGFF ``axes[].unit`` keyed by axis name (e.g. ``{'t': 'second', 'x': 'micrometer'}``), or
     None. Axes without a unit are omitted, so a caller can fall back per axis."""


### PR DESCRIPTION
## Symptom

An imported image's store has an **empty `OME/` directory** — no `METADATA.ome.xml`, no error, and
a task log reporting success. Downstream, anything reading the sidecar gets nothing; the visible
tell was napari's timestamp overlay showing `t = 0, 1, 2 …` instead of elapsed time, because
`ome_xml_utils.read_time_increment()` returns `None`.

## Cause

`staged_store` (`59837eb`, merged this morning) writes a store to `<name>.ome.zarr.partial` and
renames it onto the final path on success. Four functions in `ome_xml_utils` decided *"is this a
zarr store?"* by extension:

```python
if os.path.splitext(im_path)[1] == ".zarr":     # ".partial" ≠ ".zarr"
```

So every OME-XML write into a staging path silently did nothing. `save_meta_in_zarr` had already
created `OME/` unconditionally, which is why the result looks half-written rather than skipped.

**All five store-writing tasks are affected**, not just the one that surfaced it — `importImages`
(8-bit rescale), `cleanupImages` drift / AF / cellpose correct, and `editImages` crop all call
`save_meta_in_zarr` inside a staged block. They have been losing the entire sidecar: pixel sizes,
channel names, `SignificantBits`, `TimeIncrement`.

## Fix

One structural predicate replacing four copies of the extension test:

```python
def is_zarr_store(im_path):   # a directory carrying .zgroup / .zattrs / zarr.json
```

Structure, not suffix — matching how `zarr_utils` already identifies stores (`series_base` checks
the attr, not the `.ome.zarr` name). The duplication is exactly why this had four symptoms from one
root cause. A TIFF is a file, so those callers keep no-opping.

**`parse_meta` was the fourth copy and the nastiest**: it sent a staging path down the TIFF branch,
where `ome_types` raises trying to read a directory. Invisible only because the broken writer guard
returned early first — fixing the writers exposed it, and the new test caught it.

**`save_meta_in_zarr` no longer pre-creates `OME/`.** `write_ome_xml` creates it itself, only when
it actually writes, so a skip leaves nothing behind instead of an empty directory.

**`STAGING_SUFFIX` deliberately stays a trailing `.partial`.** Moving it to `.partial.zarr` would
have fixed this class of bug generally, but `store_sweep.py:81` matches stores with
`d.endswith('.zarr')` — killed-run debris would then look like a real store, which is worse than the
bug being fixed.

## Also: one resolver for the frame interval

`zarr_utils.read_time_increment()` — NGFF time-axis scale first, OME-XML fallback — mirroring
`read_scale`'s existing "NGFF first, fall back to OME-XML" pattern, with the napari overlay pointed
at it. The overlay was the last consumer reading geometry from OME-XML while the bridge read
scale/axes/units from NGFF; with one resolver a store carrying *either* source shows elapsed time.
Only a seconds-unit time axis is taken from NGFF, so another unit falls through rather than being
misread as seconds.

Verified against the nine already-imported images in set `jHMfOI`, which have no OME-XML at all:

```
r0hufV: OME=None  resolver=10.0  ->  overlay at t=7 shows "0:01:10"
```

## Tests

**257 pass** (252 + 5). The new cases write through a real `staged_store` block and assert the XML
survives the rename and round-trips `TimeIncrement`; that `change_pixel_type` works on a staging
path; that a TIFF is still not a store; and that a skipped write leaves no empty `OME/` dir.

## Reservations

- **Not driven in napari.** I verified the resolver returns 10.0 and the overlay string formats to
  `0:01:10`, but did not watch the overlay itself.
- **Already-imported stores keep the rest of their loss.** The timestamp now works via NGFF, but
  channel names, `SignificantBits` and plane timings are gone from anything imported since this
  morning. Only a re-import restores them — the 16-bit transient is deleted.
- **`is_zarr_store` is slightly looser than the test it replaces**: a `*.zarr*` directory with no
  group metadata yet now counts (intentional, for a store mid-creation), on a shared helper.