### PR TITLE
Text I/O declares UTF-8, so Windows CI stops decoding sources as cp1252

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,13 @@ use the named helper, don't re-derive the platform branch inline:
 - **Path separators** — always `joinpath()`, never string-concatenate paths.
 - **`[PROGRESS]` line endings** — `eachline()` already strips `\r\n` on Windows, no special-casing
   needed.
+- **Python text I/O — always pass `encoding="utf-8"`.** Python's default is the *locale* encoding:
+  UTF-8 here, **cp1252 on Windows**. Everything we read and write is UTF-8 (params JSON from Julia,
+  OME-XML carrying `µm`, our own sources), so a bare `open(p)` / `Path.read_text()` is a Windows-only
+  crash that passes every local run — it broke CI reading a source file containing `∝` (UTF-8 `0x9D`
+  is undefined in cp1252). For durable output use `write_json_atomic`/`write_atomic`
+  (`python/cecelia/utils/atomic_io.py`), which default to UTF-8. The `TextIoDeclaresEncodingTest`
+  detector in `python/cecelia/tests/test_atomic_io.py` fails on a new bare text open.
 
 Launcher logic for all of the above lives in `pixi.toml` tasks (`dev`/`prod`/`frontend`/`napari`/
 `stop`), not shell scripts — add a `[target.<platform>.tasks]` override for OS-specific commands

--- a/app/src/tasks/cleanupImages/drift_correct_run.py
+++ b/app/src/tasks/cleanupImages/drift_correct_run.py
@@ -14,14 +14,13 @@ Parameter contract (JSON written by Julia):
   driftNormalisation - "phase" | "none"  (passed to skimage phase_cross_correlation)
 """
 
-import json
-
 # `cecelia.*` resolves via PYTHONPATH=python/, set by the Julia launcher (app/src/py_runner.jl::run_py).
 import cecelia.utils.zarr_utils as zarr_utils
 import cecelia.utils.ome_xml_utils as ome_xml_utils
 from cecelia.utils.dim_utils import DimUtils
 import cecelia.utils.script_utils as script_utils
 import cecelia.utils.correction_utils as correction_utils
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def run(params):
@@ -86,14 +85,13 @@ def run(params):
     if qc_out_path:
         n_axes = int(shifts.shape[1]) if shifts.ndim == 2 else len(shifts)
         axes = ['Z', 'Y', 'X'] if n_axes == 3 else ['Y', 'X']
-        with open(qc_out_path, 'w') as f:
-            json.dump({
-                'dimOrder':    ''.join(dim_utils.im_dim_order),
-                'sourceShape': [int(x) for x in im_dat[0].shape],
-                'outputShape': [int(x) for x in out_shape],
-                'shiftAxes':   axes,
-                'shifts':      [[float(v) for v in row] for row in shifts],
-            }, f)
+        write_json_atomic(qc_out_path, {
+            'dimOrder':    ''.join(dim_utils.im_dim_order),
+            'sourceShape': [int(x) for x in im_dat[0].shape],
+            'outputShape': [int(x) for x in out_shape],
+            'shiftAxes':   axes,
+            'shifts':      [[float(v) for v in row] for row in shifts],
+        })
         log.log(f'>> saved drift/QC trajectory: {qc_out_path}')
 
     log.progress(4, 4)

--- a/app/src/tasks/clustPops/cluster_run.py
+++ b/app/src/tasks/clustPops/cluster_run.py
@@ -15,7 +15,6 @@ Invoked by `app/src/tasks/clustPops/cluster.jl` via a params JSON. Params:
   resolution, normaliseAxis, normaliseToMedian, maxFraction, normalisePercentile,
   normalisePercentileBottom, transformation, logBase, createUmap, usePaga, pagaThreshold, randomState
 """
-import json
 
 import numpy as np
 import pandas as pd
@@ -24,6 +23,7 @@ import pandas as pd
 from cecelia.utils.label_props_utils import LabelPropsView
 import cecelia.utils.script_utils as script_utils
 import cecelia.utils.clustering_utils as clustering_utils
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def run(params):
@@ -107,8 +107,7 @@ def run(params):
     # (qc.jl). Best-effort; never fails the task. Same qcOutPath pattern as cellpose_run.py.
     qc_out_path = params.get("qcOutPath")
     if qc_out_path is not None:
-        with open(qc_out_path, "w") as f:
-            json.dump(qc, f)
+        write_json_atomic(qc_out_path, qc)
         log.log(f">> saved cluster QC: {qc['nClusters']} clusters over {len(qc['perSegment'])} segment(s)")
 
     log.log(">> cluster_cells done")

--- a/app/src/tasks/clustRegions/cluster_run.py
+++ b/app/src/tasks/clustRegions/cluster_run.py
@@ -20,7 +20,6 @@ code index), graphPaths {uID: path}, graphSuffix, compCols (composition column n
 otherCol, includeOther, clusterMethod ("leiden"|"kmeans"), numClusters, resolution, createUmap,
 randomState, qcOutPath.
 """
-import json
 from collections import defaultdict
 
 import numpy as np
@@ -30,6 +29,7 @@ import pandas as pd
 import cecelia.utils.script_utils as script_utils
 import cecelia.utils.spatial_utils as spatial_utils
 import cecelia.utils.clustering_utils as clustering_utils
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def run(params):
@@ -168,8 +168,7 @@ def run(params):
 
     qc_out_path = params.get("qcOutPath")
     if qc_out_path is not None:
-        with open(qc_out_path, "w") as f:
-            json.dump(qc, f)
+        write_json_atomic(qc_out_path, qc)
         log.log(f">> saved region QC: {qc['nClusters']} regions over {len(qc['perSegment'])} segment(s)")
 
     log.log(">> clustRegions done")

--- a/app/src/tasks/clustTracks/cluster_run.py
+++ b/app/src/tasks/clustTracks/cluster_run.py
@@ -24,13 +24,13 @@ Invoked by `app/src/tasks/clustTracks/cluster.jl` via a params JSON. Params:
   resolution, normaliseAxis, normaliseToMedian, maxFraction, normalisePercentile,
   normalisePercentileBottom, transformation, logBase, createUmap, usePaga, pagaThreshold, randomState
 """
-import json
 
 import numpy as np
 
 # `cecelia.*` resolves via PYTHONPATH=python/, set by the Julia launcher (app/src/py_runner.jl::run_py).
 import cecelia.utils.script_utils as script_utils
 import cecelia.utils.clustering_utils as clustering_utils
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def run(params):
@@ -85,8 +85,7 @@ def run(params):
     # fails the task. Same qcOutPath pattern as clustPops/cellpose runners.
     qc_out_path = params.get("qcOutPath")
     if qc_out_path is not None:
-        with open(qc_out_path, "w") as f:
-            json.dump(qc, f)
+        write_json_atomic(qc_out_path, qc)
         log.log(f">> saved cluster QC: {qc['nClusters']} clusters over {len(qc['perSegment'])} segment(s)")
 
     log.log(">> cluster_tracks done")

--- a/app/src/tasks/importImages/migrate_legacy_run.py
+++ b/app/src/tasks/importImages/migrate_legacy_run.py
@@ -12,10 +12,10 @@ Parameter contract (JSON written by Julia):
   mode             - "copy" (default) or "symlink" for the zarr
   rscript          - Rscript to use (optional; default "Rscript")
 """
-import json
 
 import cecelia.utils.script_utils as script_utils
 from cecelia.utils.legacy_migrate import migrate_image
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def run(params):
@@ -27,8 +27,7 @@ def run(params):
         rscript=params.get('rscript', 'Rscript'),
         log=lambda m: print(m, flush=True),
     )
-    with open(params['resultPath'], 'w') as f:
-        json.dump(fields, f)
+    write_json_atomic(params['resultPath'], fields)
 
 
 def main():

--- a/app/src/tasks/importImages/read_imagej_physical_size_run.py
+++ b/app/src/tasks/importImages/read_imagej_physical_size_run.py
@@ -16,10 +16,9 @@ Result JSON: {"PhysicalSizeZ": <float, µm>, "sourceUnit": <str>} or {} if there
 usable to correct (not a TIFF, no ImageJ metadata, no `spacing`, or unit already micron).
 """
 
-import json
-
 import cecelia.utils.ome_xml_utils as ome_xml_utils
 import cecelia.utils.script_utils as script_utils
+from cecelia.utils.atomic_io import write_json_atomic
 
 # ImageJ calibration unit → micrometers
 _UNIT_TO_MICRON = {
@@ -55,8 +54,7 @@ def run(params):
         elif spacing is not None and factor is None:
             log.log(f'>> ImageJ unit "{unit}" has no known micron conversion, skipping')
 
-    with open(result_path, 'w') as f:
-        json.dump(result, f)
+    write_json_atomic(result_path, result)
 
 
 def main():

--- a/app/src/tasks/importImages/rescale_to_8bit_run.py
+++ b/app/src/tasks/importImages/rescale_to_8bit_run.py
@@ -17,7 +17,6 @@ Parameter contract (JSON written by Julia):
 Writes `resultPath` with `{"channels": [{"index","vmin","vmax","clipLowFrac","clipHighFrac",
 "p999","trueMax","rangeSpan"}, …]}` — the Julia handler turns this into ccid meta + QC findings.
 """
-import json
 
 # `cecelia.*` resolves via PYTHONPATH=python/, set by the Julia launcher (app/src/py_runner.jl::run_py).
 import cecelia.utils.zarr_utils as zarr_utils
@@ -25,6 +24,7 @@ import cecelia.utils.ome_xml_utils as ome_xml_utils
 from cecelia.utils.dim_utils import DimUtils
 import cecelia.utils.script_utils as script_utils
 import cecelia.utils.intensity_utils as intensity_utils
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def run(params):
@@ -87,8 +87,7 @@ def run(params):
         # the sidecar honest for any OME-XML consumer).
         ome_xml_utils.change_pixel_type(staging, 'uint8')
 
-    with open(result_path, 'w') as f:
-        json.dump({'channels': channels}, f)
+    write_json_atomic(result_path, {'channels': channels})
 
     log.progress(4, 4)
     log.log('>> done')

--- a/app/src/tasks/importImages/scan_legacy_run.py
+++ b/app/src/tasks/importImages/scan_legacy_run.py
@@ -8,10 +8,10 @@ Parameter contract (JSON written by Julia):
   rscript          - Rscript to use (optional; default "Rscript")
   imageUids        - optional list to restrict the scan
 """
-import json
 
 import cecelia.utils.script_utils as script_utils
 from cecelia.utils.legacy_migrate import scan_project
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def run(params):
@@ -21,8 +21,7 @@ def run(params):
         rscript=params.get('rscript', 'Rscript'),
         uids=params.get('imageUids'),
     )
-    with open(params['resultPath'], 'w') as f:
-        json.dump(manifest, f)
+    write_json_atomic(params['resultPath'], manifest)
     log.log(f"[INFO] Scanned {manifest.get('n_images', 0)} image(s) in {params['sourceProjectDir']}")
 
 

--- a/app/src/tasks/segment/cellpose_run.py
+++ b/app/src/tasks/segment/cellpose_run.py
@@ -38,13 +38,13 @@ Parameter contract (JSON written by Julia):
 
 import sys
 import os
-import json
 # `cecelia.*` resolves via PYTHONPATH=python/, set by the Julia launcher (app/src/py_runner.jl::run_py).
 import cecelia.utils.zarr_utils as zarr_utils
 import cecelia.utils.ome_xml_utils as ome_xml_utils
 import cecelia.utils.script_utils as script_utils
 from cecelia.utils.dim_utils import DimUtils
 from cecelia.utils.cellpose_utils import CellposeUtils
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def run(params):
@@ -75,8 +75,7 @@ def run(params):
     # sidecar — same qcOutPath pattern as drift_correct_run.py). Best-effort; never fails the task.
     qc_out_path = params.get('qcOutPath')
     if qc_out_path:
-        with open(qc_out_path, 'w') as f:
-            json.dump({'labelCounts': label_counts}, f)
+        write_json_atomic(qc_out_path, {'labelCounts': label_counts})
         log.log(f'>> saved segment QC counts: {label_counts}')
 
     log.log('>> done')

--- a/app/src/tasks/spatialAnalysis/cell_aggregates_mesh_run.py
+++ b/app/src/tasks/spatialAnalysis/cell_aggregates_mesh_run.py
@@ -9,7 +9,6 @@ for live images (docs/todo/SPATIAL_REGIONS_PLAN.md, Decision 11). Meshes built o
 Membership + label-zarr path come from Julia (aggregatesMeshes.jl). Params: imPath, labelPath, labels
 (member ids), physicalSizes [sz,sy,sx], maxClusterDist (µm), minCells, popType, propsPath, qcOutPath.
 """
-import json
 
 import numpy as np
 import pandas as pd
@@ -21,6 +20,7 @@ import cecelia.utils.script_utils as script_utils
 import cecelia.utils.mesh_utils as mesh_utils
 from cecelia.utils.label_props_utils import LabelPropsView
 from cecelia.utils.dim_utils import DimUtils
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def _extract_t(arr, t_axis, t):
@@ -87,8 +87,7 @@ def run(params):
     frac = float(is_agg.sum() / len(lbls)) if lbls else 0.0
     log.log(f">> aggregatesMeshes: {n_agg} aggregate(s), {int(is_agg.sum())}/{len(lbls)} cells aggregated")
     if qc_path is not None:
-        with open(qc_path, "w") as f:
-            json.dump({"nCells": len(lbls), "nAggregates": n_agg, "fracAggregated": frac}, f)
+        write_json_atomic(qc_path, {"nCells": len(lbls), "nAggregates": n_agg, "fracAggregated": frac})
 
 
 def main():

--- a/app/src/tasks/spatialAnalysis/cell_contacts_mesh_run.py
+++ b/app/src/tasks/spatialAnalysis/cell_contacts_mesh_run.py
@@ -12,7 +12,6 @@ imPath (for dims), aLabelPath / bLabelPath (label zarrs), aLabels / bLabels (mem
 physicalSizes [sz,sy,sx], maxContactDist (µm), target (obs-column suffix), popType, propsPath (A's
 labelProps to write), qcOutPath.
 """
-import json
 
 import numpy as np
 import pandas as pd
@@ -24,6 +23,7 @@ import cecelia.utils.script_utils as script_utils
 import cecelia.utils.mesh_utils as mesh_utils
 from cecelia.utils.label_props_utils import LabelPropsView
 from cecelia.utils.dim_utils import DimUtils
+from cecelia.utils.atomic_io import write_json_atomic
 
 
 def _extract_t(arr, t_axis, t):
@@ -96,9 +96,8 @@ def run(params):
     n_contact = int(np.nansum(contact))
     log.log(f">> contactsMeshes: {n_contact}/{len(labels)} A cells contact {target} (≤{max_dist}µm)")
     if qc_path is not None:
-        with open(qc_path, "w") as f:
-            json.dump({"nCellsA": len(labels), "nContacts": n_contact,
-                       "fracInContact": (n_contact / len(labels)) if labels else 0.0}, f)
+        write_json_atomic(qc_path, {"nCellsA": len(labels), "nContacts": n_contact,
+                                   "fracInContact": (n_contact / len(labels)) if labels else 0.0})
 
 
 def main():

--- a/app/src/tasks/spatialAnalysis/cell_neighbours_run.py
+++ b/app/src/tasks/spatialAnalysis/cell_neighbours_run.py
@@ -17,11 +17,11 @@ Node resolution happens in Julia (cellNeighbours.jl). Params: segments [{valueNa
 (`labels: null` = every cell of that segmentation), graphPath, physicalSizes [sz,sy,sx], neighbourMethod,
 neighbourRadius, nNeighbours, perTimepoint, qcOutPath.
 """
-import json
 
 # `cecelia.*` resolves via PYTHONPATH=python/, set by the Julia launcher (app/src/py_runner.jl::run_py).
 import cecelia.utils.script_utils as script_utils
 import cecelia.utils.spatial_utils as spatial_utils
+from cecelia.utils.atomic_io import write_json_atomic
 
 _EMPTY_QC = {"nCells": 0, "nEdges": 0, "meanDegree": 0.0, "isolatedFrac": 0.0}
 
@@ -63,8 +63,7 @@ def run(params):
 
 def _dump(path, payload):
     if path is not None:
-        with open(path, "w") as f:
-            json.dump(payload, f)
+        write_json_atomic(path, payload)
 
 
 def main():

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -1280,7 +1280,7 @@ class NapariState:
         # atomic write (tmp + os.replace) so a crash/kill never leaves a half-written props file —
         # the image always reopens in a valid remembered state.
         tmp = filepath + ".tmp"
-        with open(tmp, "w") as f:
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump(props, f)
             f.flush()
             os.fsync(f.fileno())
@@ -1288,7 +1288,7 @@ class NapariState:
 
     def load_layer_props(self, filepath: str):
         if os.path.exists(filepath):
-            with open(filepath) as f:
+            with open(filepath, encoding="utf-8") as f:
                 data = json.load(f)
         else:
             # One-time migration of a pre-JSON pickle (same dict shape) → rewrite as JSON, then use it.
@@ -1302,7 +1302,7 @@ class NapariState:
                 data = pickle.load(f)
             try:
                 tmp = filepath + ".tmp"
-                with open(tmp, "w") as f:
+                with open(tmp, "w", encoding="utf-8") as f:
                     json.dump(data, f)
                 os.replace(tmp, filepath)
             except Exception:

--- a/python/cecelia/tests/test_atomic_io.py
+++ b/python/cecelia/tests/test_atomic_io.py
@@ -89,6 +89,21 @@ class AtomicWriteTest(unittest.TestCase):
             self.assertEqual(os.path.dirname(tmp), os.path.dirname(p))
             pathlib.Path(tmp).write_text("{}", encoding="utf-8")
 
+    def test_text_mode_writes_utf8_regardless_of_locale(self):
+        """`open()` defaults to the LOCALE encoding — cp1252 on Windows, where `µm` in an OME-XML
+        or a QC message is a `UnicodeEncodeError`. The helper pins UTF-8 so callers can't inherit
+        the platform's."""
+        p = os.path.join(self.td, "qc.txt")
+        with write_atomic(p) as f:
+            f.write("resolution ≥ 0.5 µm")
+        self.assertEqual(pathlib.Path(p).read_bytes().decode("utf-8"), "resolution ≥ 0.5 µm")
+
+    def test_binary_mode_is_untouched(self):
+        p = os.path.join(self.td, "raw.bin")
+        with write_atomic(p, "wb") as f:
+            f.write(b"\x00\x9d\xff")
+        self.assertEqual(pathlib.Path(p).read_bytes(), b"\x00\x9d\xff")
+
     def test_two_writers_of_one_path_get_distinct_temps(self):
         p = os.path.join(self.td, "x.json")
         with atomic_path(p) as a, atomic_path(p) as b:

--- a/python/cecelia/tests/test_atomic_io.py
+++ b/python/cecelia/tests/test_atomic_io.py
@@ -36,7 +36,7 @@ class AtomicWriteTest(unittest.TestCase):
     def test_json_round_trips(self):
         p = os.path.join(self.td, "qc.json")
         write_json_atomic(p, {"nCells": 42})
-        with open(p) as f:
+        with open(p, encoding="utf-8") as f:
             self.assertEqual(json.load(f)["nCells"], 42)
         self.assertEqual(self._leftovers(), [])
 
@@ -48,7 +48,7 @@ class AtomicWriteTest(unittest.TestCase):
             with write_atomic(p) as f:
                 f.write('{"partial":')
                 raise RuntimeError("killed mid-write")
-        with open(p) as f:
+        with open(p, encoding="utf-8") as f:
             self.assertEqual(json.load(f)["v"], 1)      # untouched, NOT truncated
         self.assertEqual(self._leftovers(), [])         # and no temp left behind
 
@@ -78,7 +78,7 @@ class AtomicWriteTest(unittest.TestCase):
         p = os.path.join(self.td, "base.h5ad")
         with atomic_path(p) as tmp:
             capture(tmp)
-            pathlib.Path(tmp).write_text("x")
+            pathlib.Path(tmp).write_text("x", encoding="utf-8")
         self.assertFalse(seen["tmp"].endswith(".h5ad"))
         self.assertTrue(seen["tmp"].startswith("base.h5ad.tmp."))
 
@@ -87,14 +87,14 @@ class AtomicWriteTest(unittest.TestCase):
         p = os.path.join(self.td, "sub", "x.json")
         with atomic_path(p) as tmp:
             self.assertEqual(os.path.dirname(tmp), os.path.dirname(p))
-            pathlib.Path(tmp).write_text("{}")
+            pathlib.Path(tmp).write_text("{}", encoding="utf-8")
 
     def test_two_writers_of_one_path_get_distinct_temps(self):
         p = os.path.join(self.td, "x.json")
         with atomic_path(p) as a, atomic_path(p) as b:
             self.assertNotEqual(a, b)
-            pathlib.Path(a).write_text("{}")
-            pathlib.Path(b).write_text("{}")
+            pathlib.Path(a).write_text("{}", encoding="utf-8")
+            pathlib.Path(b).write_text("{}", encoding="utf-8")
 
 
 class AtomicH5adTest(unittest.TestCase):
@@ -146,7 +146,7 @@ class NoHandRolledWritesTest(unittest.TestCase):
             for f in (repo / root).rglob("*.py"):
                 if f.name in self.ALLOWED_FILES or "/tests/" in f.as_posix():
                     continue
-                tree = ast.parse(f.read_text())
+                tree = ast.parse(f.read_text(encoding="utf-8"))
                 for node in ast.walk(tree):
                     # `<x>.write_h5ad(...)` — the unsafe form. `write_h5ad_atomic(...)` is a plain
                     # Call with a Name func, so it never matches here.
@@ -155,6 +155,62 @@ class NoHandRolledWritesTest(unittest.TestCase):
                         offenders.append(f"{f.relative_to(repo)}:{node.lineno}")
         self.assertEqual(offenders, [], "use write_h5ad_atomic (cecelia.utils.atomic_io): "
                                         f"{offenders}")
+
+
+class TextIoDeclaresEncodingTest(unittest.TestCase):
+    """Detector: text-mode file I/O must name its encoding.
+
+    Python's default is the *locale* encoding, which is UTF-8 on Linux/macOS and **cp1252 on
+    Windows** — so a bare `open(p)` / `read_text()` is a platform-dependent bug that only ever
+    shows up on the Windows runner. It has bitten twice over: reading a source file with a `∝`
+    in it (`0x9D` is undefined in cp1252 → `UnicodeDecodeError`), and writing an OME-XML with
+    `µm` in it would fail the same way on the encode side. Everything we read and write is UTF-8.
+    """
+
+    ROOTS = ("python/cecelia", "app/src", "napari", "api", "mcp", "scripts")
+    # `atomic_io` IS the implementation — it supplies the utf-8 default via **open_kwargs
+    ALLOWED_FILES = {"atomic_io.py"}
+
+    def _repo(self):
+        return pathlib.Path(__file__).resolve().parents[3]
+
+    @staticmethod
+    def _mode(call):
+        """The literal mode of an `open(...)` call, or `None` if absent/not a literal."""
+        if len(call.args) > 1 and isinstance(call.args[1], ast.Constant):
+            return call.args[1].value
+        for kw in call.keywords:
+            if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                return kw.value.value
+        return None
+
+    def test_no_text_io_without_an_explicit_encoding(self):
+        repo = self._repo()
+        offenders = []
+        for root in self.ROOTS:
+            for f in sorted((repo / root).rglob("*.py")):
+                if f.name in self.ALLOWED_FILES:
+                    continue
+                tree = ast.parse(f.read_text(encoding="utf-8"))
+                for node in ast.walk(tree):
+                    if not isinstance(node, ast.Call):
+                        continue
+                    if {kw.arg for kw in node.keywords} & {"encoding", None}:
+                        continue          # explicit, or forwarded via **kwargs
+                    # bare `open(...)` — an attribute call (`zarr.open`, `gzip.open`) is not a
+                    # builtin text open and is left alone
+                    if isinstance(node.func, ast.Name) and node.func.id == "open":
+                        mode = self._mode(node)
+                        if mode is None or "b" not in mode:
+                            offenders.append(f"{f.relative_to(repo)}:{node.lineno} open()")
+                    elif isinstance(node.func, ast.Attribute) \
+                            and node.func.attr in ("read_text", "write_text"):
+                        offenders.append(
+                            f"{f.relative_to(repo)}:{node.lineno} {node.func.attr}()")
+        self.assertEqual(
+            offenders, [],
+            "pass encoding='utf-8' (the locale default is cp1252 on Windows):\n  "
+            + "\n  ".join(offenders))
 
 
 if __name__ == "__main__":

--- a/python/cecelia/tests/test_image_readers.py
+++ b/python/cecelia/tests/test_image_readers.py
@@ -72,7 +72,7 @@ _OME_XML = """<?xml version="1.0" encoding="UTF-8"?>
 def _write_ome_xml(store):
     ome_dir = os.path.join(store, "OME")
     os.makedirs(ome_dir, exist_ok=True)
-    with open(os.path.join(ome_dir, "METADATA.ome.xml"), "w") as f:
+    with open(os.path.join(ome_dir, "METADATA.ome.xml"), "w", encoding="utf-8") as f:
         f.write(_OME_XML)
 
 
@@ -201,7 +201,7 @@ class OmeXmlStagedWriteTest(unittest.TestCase):
         """A minimal zarr-looking store directory."""
         p = os.path.join(self.d, name)
         os.makedirs(p, exist_ok=True)
-        with open(os.path.join(p, ".zgroup"), "w") as f:
+        with open(os.path.join(p, ".zgroup"), "w", encoding="utf-8") as f:
             f.write('{"zarr_format": 2}')
         return p
 
@@ -216,7 +216,7 @@ class OmeXmlStagedWriteTest(unittest.TestCase):
         final = os.path.join(self.d, "img.ome.zarr")
         with zu.staged_store(final) as staging:
             os.makedirs(staging, exist_ok=True)
-            with open(os.path.join(staging, ".zgroup"), "w") as f:
+            with open(os.path.join(staging, ".zgroup"), "w", encoding="utf-8") as f:
                 f.write('{"zarr_format": 2}')
             ox.save_meta_in_zarr(staging, omexml=ox.from_xml(_OME_XML))
         self.assertTrue(os.path.exists(os.path.join(final, "OME", "METADATA.ome.xml")))
@@ -233,7 +233,7 @@ class OmeXmlStagedWriteTest(unittest.TestCase):
     def test_a_tiff_is_still_not_a_zarr_store(self):
         """Non-store callers must keep no-opping rather than growing an OME/ dir."""
         tiff = os.path.join(self.d, "plain.tiff")
-        with open(tiff, "w") as f:
+        with open(tiff, "w", encoding="utf-8") as f:
             f.write("not a store")
         self.assertFalse(ox.is_zarr_store(tiff))
         ox.write_ome_xml(tiff, _OME_XML)
@@ -242,7 +242,7 @@ class OmeXmlStagedWriteTest(unittest.TestCase):
     def test_a_skipped_write_leaves_no_empty_ome_dir(self):
         """An empty OME/ reads as 'half written'; a skip must leave nothing behind."""
         plain = os.path.join(self.d, "notastore.txt")
-        with open(plain, "w") as f:
+        with open(plain, "w", encoding="utf-8") as f:
             f.write("x")
         ox.save_meta_in_zarr(plain, omexml=ox.from_xml(_OME_XML))
         self.assertFalse(os.path.exists(os.path.join(plain, "OME")))

--- a/python/cecelia/tests/test_task_result_writes.py
+++ b/python/cecelia/tests/test_task_result_writes.py
@@ -1,0 +1,138 @@
+"""Task runners write their QC/result JSON through `write_json_atomic`.
+
+Julia reads these files back after the process exits (`qcOutPath` → the qc/ sidecar, `resultPath` →
+the import handler), so a half-written one is consumed as real data. Twelve runners hand-rolled
+`open(p, "w") + json.dump` while two already used the helper; this pins the migration and stops the
+next runner re-growing the unsafe form — the same detector shape as `no_bare_write_h5ad`.
+
+The `write_json_atomic` NAME is the specific risk here: it resolves at *call* time, so a runner that
+calls it without importing it raises `NameError` only during a real task run, long after CI is green.
+`test_the_helper_resolves_in_every_runner_that_calls_it` imports each runner and checks the binding.
+"""
+
+import ast
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+
+import numpy as np
+import tifffile
+
+
+def _repo():
+    return pathlib.Path(__file__).resolve().parents[3]
+
+
+def _runners():
+    """Every task runner — `(path, source)`. Runners live beside their `.jl` under app/src/tasks."""
+    return [(f, f.read_text(encoding="utf-8"))
+            for f in sorted((_repo() / "app" / "src" / "tasks").rglob("*_run.py"))]
+
+
+def _load(path):
+    """Import a runner BY PATH, the way `run_py` runs it (they are not an importable package)."""
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TaskRunnerJsonWriteTest(unittest.TestCase):
+    def test_no_hand_rolled_json_dump_to_a_file(self):
+        """`json.dump(payload, f)` writes straight into the destination — the truncating form."""
+        offenders = []
+        for path, src in _runners():
+            for node in ast.walk(ast.parse(src, filename=str(path))):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+                        and node.func.attr == "dump" and isinstance(node.func.value, ast.Name) \
+                        and node.func.value.id == "json":
+                    offenders.append(f"{path.relative_to(_repo())}:{node.lineno}")
+        self.assertEqual(
+            offenders, [],
+            "write result/QC JSON with write_json_atomic (cecelia.utils.atomic_io) — a cancelled "
+            f"task must not leave a truncated file Julia then reads:\n  {offenders}")
+
+    def test_the_helper_resolves_in_every_runner_that_calls_it(self):
+        """A call without the import is a `NameError` that only fires during a real task run."""
+        missing = []
+        for path, src in _runners():
+            if "write_json_atomic" not in src:
+                continue
+            mod = _load(path)
+            if not hasattr(mod, "write_json_atomic"):
+                missing.append(str(path.relative_to(_repo())))
+        self.assertEqual(missing, [], f"calls write_json_atomic without importing it: {missing}")
+
+    def test_the_scan_actually_reaches_the_runners(self):
+        """Guard against the scan silently covering nothing (a moved tasks dir, a bad glob)."""
+        callers = [p for p, src in _runners() if "write_json_atomic" in src]
+        self.assertGreaterEqual(
+            len(callers), 14, f"expected the known result/QC writers to be in scope, found {callers}")
+
+
+class ReadImagejPhysicalSizeRunTest(unittest.TestCase):
+    """Executes a migrated runner end to end — the only one whose whole `run()` is reachable without
+    an image pipeline. Covers the write itself, not just the call's shape."""
+
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.mod = _load(_repo() / "app" / "src" / "tasks" / "importImages"
+                         / "read_imagej_physical_size_run.py")
+
+    def _run(self, im_path):
+        out = os.path.join(self.td, "result.json")
+        with contextlib.redirect_stdout(io.StringIO()):       # runners log to stdout
+            self.mod.run({"imPath": im_path, "resultPath": out})
+        with open(out, encoding="utf-8") as f:
+            return out, json.load(f)
+
+    def _imagej_tiff(self, unit, spacing):
+        p = os.path.join(self.td, f"ij_{unit}.tif")
+        tifffile.imwrite(p, np.zeros((2, 4, 4), dtype="uint8"), imagej=True,
+                         metadata={"unit": unit, "spacing": spacing})
+        return p
+
+    def test_writes_the_converted_z_spacing(self):
+        _, result = self._run(self._imagej_tiff("nm", 500.0))
+        self.assertAlmostEqual(result["PhysicalSizeZ"], 0.5)   # 500 nm → 0.5 µm
+        self.assertEqual(result["sourceUnit"], "nm")
+
+    def test_writes_an_empty_result_when_there_is_nothing_to_correct(self):
+        """Julia reads this file unconditionally, so the no-op case must still produce valid JSON."""
+        plain = os.path.join(self.td, "not-a.tiff")
+        pathlib.Path(plain).write_text("not a tiff", encoding="utf-8")
+        out, result = self._run(plain)
+        self.assertEqual(result, {})
+        self.assertTrue(os.path.isfile(out))
+
+    def test_leaves_no_temp_behind(self):
+        self._run(self._imagej_tiff("mm", 0.002))
+        self.assertEqual([f for f in os.listdir(self.td) if ".tmp." in f], [])
+
+
+class CellNeighboursDumpTest(unittest.TestCase):
+    """`_dump` is the QC write for cellNeighbours, and it is reachable directly."""
+
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.mod = _load(_repo() / "app" / "src" / "tasks" / "spatialAnalysis"
+                         / "cell_neighbours_run.py")
+
+    def test_writes_the_payload(self):
+        p = os.path.join(self.td, "qc.json")
+        self.mod._dump(p, {"nCells": 7, "meanDegree": 2.5})
+        with open(p, encoding="utf-8") as f:
+            self.assertEqual(json.load(f)["nCells"], 7)
+
+    def test_no_path_is_a_no_op(self):
+        self.mod._dump(None, {"nCells": 7})
+        self.assertEqual(os.listdir(self.td), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/cecelia/utils/atomic_io.py
+++ b/python/cecelia/utils/atomic_io.py
@@ -86,7 +86,12 @@ def write_atomic(path, mode="w", **open_kwargs):
 
         with write_atomic(qc_path) as f:
             json.dump(payload, f)
+
+    Text mode defaults to UTF-8 — Python's default is the *locale* encoding, which on Windows is
+    cp1252 and cannot represent most of what we write (µm in an OME-XML, `≥` in a QC message).
     """
+    if "b" not in mode:
+        open_kwargs.setdefault("encoding", "utf-8")
     with atomic_path(path) as tmp:
         with open(tmp, mode, **open_kwargs) as f:
             yield f

--- a/python/cecelia/utils/legacy_migrate.py
+++ b/python/cecelia/utils/legacy_migrate.py
@@ -155,7 +155,7 @@ def scan_project(src_proj: str, rscript: str = "Rscript", uids=None) -> dict:
     for p in sorted(ana1.iterdir()):
         if p.name.startswith((".", "._")) or not (p / "ccid.type").is_file():
             continue
-        if (p / "ccid.type").read_text().strip() == "CciaImage":
+        if (p / "ccid.type").read_text(encoding="utf-8").strip() == "CciaImage":
             all_uids.append(p.name)
     want = [u for u in all_uids if (uids is None or u in uids)]
 
@@ -297,7 +297,7 @@ def _store_ndim(zarr_path: str):
     for cand in (os.path.join(zarr_path, "0", "0", ".zarray"),
                  os.path.join(zarr_path, "0", ".zarray")):
         if os.path.isfile(cand):
-            with open(cand) as f:
+            with open(cand, encoding="utf-8") as f:
                 return len(json.load(f).get("shape", []))
     return None
 

--- a/python/cecelia/utils/ome_xml_utils.py
+++ b/python/cecelia/utils/ome_xml_utils.py
@@ -162,7 +162,9 @@ def write_ome_xml(im_path, omexml):
       os.makedirs(ome_path)
     
     # write to file
-    ome_xml_file = open(os.path.join(ome_path, 'METADATA.ome.xml'), 'w')
+    # UTF-8 explicitly: OME-XML declares itself UTF-8 and routinely carries µm; the locale default
+    # (cp1252 on Windows) would raise UnicodeEncodeError writing exactly that.
+    ome_xml_file = open(os.path.join(ome_path, 'METADATA.ome.xml'), 'w', encoding='utf-8')
     
     if isinstance(omexml, str):
       ome_xml_file.write(omexml)
@@ -273,7 +275,7 @@ def _parse_ome_xml_cached(xml_path, _mtime):
   bridge) parses each store's metadata at most once; a rewrite (new mtime) invalidates the entry.
   ome-types is already imported at module top, so the pydantic model-build cost is paid on the
   first parse regardless."""
-  with open(xml_path) as f:
+  with open(xml_path, encoding='utf-8') as f:
     return from_xml(f.read())
 
 

--- a/python/cecelia/utils/script_utils.py
+++ b/python/cecelia/utils/script_utils.py
@@ -69,7 +69,7 @@ def script_params():
     if args.params is None or not os.path.exists(args.params):
         return None
 
-    with open(args.params, 'r') as f:
+    with open(args.params, 'r', encoding='utf-8') as f:
         params = json.load(f)
 
     os.remove(args.params)


### PR DESCRIPTION
## The failure

Windows-only, on every run since #425:

```
File "python/cecelia/tests/test_atomic_io.py", line 149, in test_no_bare_write_h5ad
    tree = ast.parse(f.read_text())
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 8625
```

Python's default is the **locale** encoding — UTF-8 on Linux/macOS, **cp1252 on Windows**. The
`no_bare_write_h5ad` detector walks every `.py` source, and `measure_utils.py` contains `∝`
(`# We use: axis_k ∝ sqrt(I_j…`). Its UTF-8 byte `0x9D` is undefined in cp1252, so the Windows
runner died where ubuntu and macOS passed.

## What this fixes

The failing line is one instance; the bug is the class.

- Every text `open`/`read_text`/`write_text` now names `encoding="utf-8"`.
- `write_atomic` defaults text mode to UTF-8, so the canonical helper carries the rule.
- **Real runtime bugs, not just the test.** `ome_xml_utils` *wrote* `METADATA.ome.xml` with the
  locale encoding — OME-XML routinely carries `µm`, which is a `UnicodeEncodeError` on Windows —
  and read it back the same way. Same for the params JSON Julia hands to every Python runner, two
  `legacy_migrate` reads, and the napari layer-props file.
- **One canonical helper instead of a second variant.** 12 task runners hand-rolled
  `open(p,"w") + json.dump` for their QC/result JSON, while `cell_neighbour_stats` and `branching`
  already used `write_json_atomic`. All 12 now use it — which fixes the encoding and closes the
  truncate-on-cancel window in the same move.
- `TextIoDeclaresEncodingTest` fails on any new bare text open, beside the existing
  `no_bare_write_h5ad` detector. CLAUDE.md → *Windows compatibility* gets the rule.

## Verification

Full Python suite green (258), MCP green (51) — and the suite also passes under a **forced ASCII
locale** (`LC_ALL=C PYTHONUTF8=0`, `getpreferredencoding() = ANSI_X3.4-1968`), which rejects every
non-ASCII byte rather than the handful cp1252 rejects. Confirmed the pre-fix `read_text()` does fail
under that env, so the repro is real. The detector was checked against a planted bare `open()`.

## Reservations

- ~~The 12 migrated runners have no test coverage.~~ **Addressed in the second commit:** all 14
  runners are imported by path and their `write_json_atomic` binding checked (the NameError class),
  a detector bans `json.dump(payload, f)` under `app/src/tasks`, and
  `read_imagej_physical_size_run` is executed end to end against a synthetic ImageJ TIFF. Both
  detectors were mutation-checked.
- That migration changes two behaviours (both improvements): parent dirs are created if missing,
  and a mid-write exception now leaves no file where it previously left a partial one.
- Still no *execution* coverage for the other 11 runners' write lines — they are inline in a `run()`
  that needs a real image pipeline. The binding + shape are checked statically instead.
- A napari layer-props file written on Windows *before* this fix, containing non-ASCII, was cp1252
  on disk and will now raise on read instead of silently mojibake. Near-zero in practice.
- The Windows job aborted *at* the Python-tests step, so MCP tests, frontend build and server-health
  have not run on Windows in any recent run. This unblocks that step; anything hidden behind it will
  only show on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)