### PR TITLE
Cache the Julia depot, with a CPU target that makes the cache portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,29 @@ jobs:
       fail-fast: false
       matrix:
         # macos-latest is arm64 (M-series) — the exact osx-arm64 target the workspace builds for.
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        #
+        # `cpu_target` is what makes the depot cache below reusable. Julia compiles package images to
+        # NATIVE code and validates them against the running CPU, and GitHub's x86 runner pools are
+        # heterogeneous — a cache built on a Zen 3 machine is rejected wholesale on the next runner
+        # ("Unable to find compatible target in cached code image. Target 0 (znver3): Rejecting this
+        # target due to use of runtime-disabled features"), so Windows re-precompiled all 166 deps on
+        # every run despite a healthy 261 MB cache hit. A multiversioned target emits a portable
+        # baseline alongside the fast paths, which is how official Julia binaries ship.
+        #
+        # macOS keeps `native`: that fleet is uniform Apple Silicon and already gets cache hits, so
+        # there is nothing to buy and multiversioning would only cost image size.
+        #
+        # NOTE: this env var participates in the cache key (include-matrix), so changing it starts a
+        # fresh cache rather than silently restoring images built for the old target.
+        include:
+          - os: ubuntu-latest
+            cpu_target: "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+          - os: windows-latest
+            cpu_target: "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+          - os: macos-latest
+            cpu_target: "native"
+    env:
+      JULIA_CPU_TARGET: ${{ matrix.cpu_target }}
     steps:
       - uses: actions/checkout@v5
 
@@ -61,6 +83,25 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24
+
+      # Cache the Julia depot — above all its `compiled/` precompilation cache, which is the single
+      # biggest cost in this workflow. Uncached, every run re-precompiled the whole graph from
+      # scratch and threw it away: "166 dependencies successfully precompiled in 243 seconds" on
+      # Windows (181s on Linux), plus another ~60s for the package env — ~5 of the Windows job's
+      # 17.6 minutes, on every run, forever.
+      #
+      # The key is workflow+job+matrix+OS, NOT a manifest hash, so it restores the most recent cache
+      # for this job and re-saves an updated one each run. A manifest change therefore costs one
+      # partial re-precompile rather than a full cold miss. Julia validates cache entries itself,
+      # so a stale entry can only cost time, never correctness.
+      #
+      # BUDGET: GitHub caps a repo at 10 GB and evicts least-recently-used. The three pixi caches
+      # already sit at ~9 GB, so these depots WILL push past the cap and something gets evicted.
+      # If the pixi caches start missing (watch `Install Pixi + Python env` — 30-75s warm), the knob
+      # is `cache-artifacts: false`: artifact downloads are only ~25s of the step, while `compiled/`
+      # is the ~300s that matters. Check with `gh cache list`.
+      - name: Cache Julia depot
+        uses: julia-actions/cache@v3
 
       # Instantiate the *server* project (api → pulls Cecelia from ../app). This precompiles
       # everything the server loads (incl. PythonCall/CondaPkg on first use — see TODO #00056).


### PR DESCRIPTION
## Why

Nothing Julia was cached, so every CI run re-precompiled the entire dependency graph and threw it
away — ~5 of the Windows job's 17.6 minutes, and Windows is the critical path.

## Caching alone did not work, which is the interesting half

The depot restored fine on Windows (`du` after the restore: **261 MB of `compiled/`**) and Julia
rejected all of it:

```
Rejecting cache file ...\compiled\v1.12\Combinatorics\AwRuT_nmcDc.ji
  Reasons = "Unable to find compatible target in cached code image.
             Target 0 (znver3): Rejecting this target due to use of runtime-disabled features"
```

Package images are **native code validated against the running CPU**, and GitHub's x86 runner pools
are heterogeneous — the cache was built on a Zen 3 machine and the next runner wasn't one. Linux and
macOS only *appeared* to work because they happened to land on compatible hardware (macOS genuinely
is uniform Apple Silicon).

`JULIA_CPU_TARGET` emits a portable baseline alongside the fast paths, which is how official Julia
binaries ship. The rejections stop. macOS stays `native` — nothing to buy, and multiversioning would
only cost image size.

## Measured (warm)

| | before | after | instantiate |
|---|---|---|---|
| **windows** | **17.6 min** | **12.2 min** | 268s + 71s → **4s + 9s** |
| ubuntu | 12.8 min | 9.6 min | 189s + 59s → 3s + 6s |
| macOS | 12.2 min | 7.0 min | 189s + 65s → 2s + 6s |

**On `Package tests`, read nothing into the numbers.** That step measured 313s / 231s / 320s on
Windows across three runs without changing — ±40% runner variance. So: no evidence multiversioned
code costs runtime here, and equally none that it helps. The instantiate saving is the part outside
the noise band, and it is what the ~5 min comes from.

## Notes

- The target is a **matrix key**, so it participates in the cache key: changing it starts a fresh
  cache rather than silently restoring images built for the previous target.
- Cache budget: the Julia depots are ~95 MiB each (I had expected GB and said so — wrong by an order
  of magnitude). Repo usage went 9.09 → 9.18 GB of the 10 GB cap; no pixi cache was evicted.
- `delete-old-caches` logs `Failed to delete 1 existing caches on ref refs/pull/...` — the prune step
  wants a write-scoped token, so old caches will age out by LRU instead of being pruned.

## Reservations

- The 12.2 min figure inherits the `Package tests` variance above; realistically 11–14 min.
- Cold precompilation is *slower* with a multiversioned target (Windows 268s → 277s), so the first
  run after any cache-key change pays slightly more than it used to.
- Not addressed: `Package tests` (~230-320s) is now the dominant Windows cost and is real work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)