### PR TITLE
Run the CI suites as three parallel jobs per OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,18 @@ on:
   pull_request:
   workflow_dispatch:
 
+# `actions: write` is what lets `julia-actions/cache` PRUNE its old entries. Without it the delete
+# step fails ("Failed to delete N existing caches on ref …") and every run's depot caches simply
+# accumulate: the key carries the run id, so nothing is ever overwritten. With two Julia jobs × 3
+# OSes that is ~600 MB per run against a 10 GB repo cap the pixi caches already fill to ~6.4 GB —
+# it reached the cap the first day. At the cap GitHub evicts least-recently-used, which lands on the
+# depot caches (pixi's are touched by every job and stay warm) and silently restores the ~200 s
+# precompile #430 removed. `contents: read` is spelled out because naming any permission drops the
+# rest to none.
+permissions:
+  contents: read
+  actions: write
+
 defaults:
   run:
     shell: bash   # Git Bash on the Windows runner → `&`, curl, seq, sleep work everywhere

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,28 @@ name: CI
 # Deliberately heavy (installs the real analysis env incl. torch cu124 on Linux/Windows), so the
 # Pixi env is cached on pixi.lock (per platform). fail-fast is off so one OS failing still reports
 # the others. Runs on pushes/PRs to main and on demand.
+#
+# ── THREE JOBS PER OS, NOT ONE ────────────────────────────────────────────────────────────────
+# The work after setup used to run in series — package tests, API tests, Python tests, frontend
+# build, server health — so wall-clock was their SUM even though nothing depended on anything else.
+# Jobs run concurrently (the OS matrix already proved that), so splitting turns the sum into the
+# max. On Windows, the slowest runner: ~12.3 min → the length of the package suite alone.
+#
+# The split is by WHAT EACH JOB NEEDS TO INSTALL, not by tidiness — every job repeats ~110s of
+# setup, so more jobs is not automatically faster:
+#
+#   julia   — pixi + Julia + depot cache.  The package suite (the long pole, ~324s on Windows).
+#   server  — pixi + Julia + Node.         Everything that needs the api env or a built frontend.
+#   python  — pixi ONLY.                   Python + MCP suites; no Julia, so no depot cache either.
+#
+# Keeping `python` Julia-free is deliberate and load-bearing for the cache budget: `julia-actions/cache`
+# keys on the job name, so every Julia-using job adds one ~100 MB depot cache PER RUN per OS. Two
+# Julia jobs × 3 OSes = 6/run; adding a third would be 9/run against a 10 GB repo cap that the pixi
+# caches already fill to ~6.4 GB. Evictions there land on the depot caches (pixi's are touched every
+# run and survive), which would silently bring back the 200s precompile that #430 removed.
+#
+# All four test categories still run on every OS — that requirement is unchanged, they are just
+# distributed across jobs rather than stacked in one.
 
 # `pull_request` is deliberately NOT filtered to `[main]`. With that filter a STACKED pr — one whose
 # base is another feature branch — matched no trigger and got **zero checks**, which reads as
@@ -32,28 +54,38 @@ defaults:
     shell: bash   # Git Bash on the Windows runner → `&`, curl, seq, sleep work everywhere
 
 jobs:
-  smoke:
-    name: ${{ matrix.os }} — install → build → server health
+  # ── Julia package tests ───────────────────────────────────────────────────────────────────────
+  # app/test/runtests.jl — the data model, ccid.json round-trip, versioned fields, task dispatch,
+  # param validation, the gating engine, config/path resolution. The longest single step in CI, so
+  # it gets a job to itself and defines the critical path.
+  #
+  # This suite used to run nowhere but a dev machine, which is how Windows-only path bugs shipped:
+  # `Sys.which` never finding `claude.cmd`, `Base.expanduser` being a no-op on Windows, `python3` not
+  # existing there. Those fixes are asserted by `iswin`-parameterised helpers precisely so a Windows
+  # runner can check them — it has to run here for that to mean anything. Fixture-dependent testsets
+  # self-skip (`have_fixture`), so a CI checkout without test-data/ still passes.
+  julia:
+    name: ${{ matrix.os }} — Julia package tests
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         # macos-latest is arm64 (M-series) — the exact osx-arm64 target the workspace builds for.
         #
-        # `cpu_target` is what makes the depot cache below reusable. Julia compiles package images to
+        # `cpu_target` is what makes the depot cache reusable. Julia compiles package images to
         # NATIVE code and validates them against the running CPU, and GitHub's x86 runner pools are
         # heterogeneous — a cache built on a Zen 3 machine is rejected wholesale on the next runner
         # ("Unable to find compatible target in cached code image. Target 0 (znver3): Rejecting this
         # target due to use of runtime-disabled features"), so Windows re-precompiled all 166 deps on
         # every run despite a healthy 261 MB cache hit. A multiversioned target emits a portable
-        # baseline alongside the fast paths, which is how official Julia binaries ship.
+        # baseline alongside the fast paths, which is how official Julia binaries ship. macOS keeps
+        # `native`: that fleet is uniform Apple Silicon and already gets cache hits.
         #
-        # macOS keeps `native`: that fleet is uniform Apple Silicon and already gets cache hits, so
-        # there is nothing to buy and multiversioning would only cost image size.
-        #
-        # NOTE: this env var participates in the cache key (include-matrix), so changing it starts a
-        # fresh cache rather than silently restoring images built for the old target.
+        # NOTE: this participates in the cache key (include-matrix), so changing it starts a fresh
+        # cache rather than silently restoring images built for the old target. Repeated in the
+        # `server` job below — GitHub has no matrix reuse without a reusable workflow, and inlining
+        # the value as an expression would drop it from the cache key.
         include:
           - os: ubuntu-latest
             cpu_target: "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
@@ -66,7 +98,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Installs Pixi and materialises the default environment from pixi.lock (cached per platform).
       - name: Install Pixi + Python env
         uses: prefix-dev/setup-pixi@v0
         with:
@@ -79,27 +110,58 @@ jobs:
         with:
           version: '1.12'
 
+      # Caches the Julia depot, above all its `compiled/` precompilation cache. Uncached, every run
+      # re-precompiled the whole graph and threw it away (~5 min on Windows). See the cpu_target note
+      # above for why caching alone was not enough.
+      - name: Cache Julia depot
+        uses: julia-actions/cache@v3
+
+      - name: Instantiate Julia (package env)
+        run: pixi run julia-instantiate
+
+      - name: Package tests
+        run: pixi run test-pkg
+
+  # ── API tests + frontend + the server actually booting ────────────────────────────────────────
+  # Everything that needs the *server* env (api/, which path-sources Cecelia from app/) or a built
+  # frontend. Grouped because they share that instantiate and the Node install.
+  server:
+    name: ${{ matrix.os }} — API + frontend + server health
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cpu_target: "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+          - os: windows-latest
+            cpu_target: "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+          - os: macos-latest
+            cpu_target: "native"
+    env:
+      JULIA_CPU_TARGET: ${{ matrix.cpu_target }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Pixi + Python env
+        uses: prefix-dev/setup-pixi@v0
+        with:
+          pixi-version: v0.71.1
+          cache: true
+
+      - name: Install Julia
+        uses: julia-actions/setup-julia@v3
+        with:
+          version: '1.12'
+
       - name: Install Node
         uses: actions/setup-node@v5
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
-      # Cache the Julia depot — above all its `compiled/` precompilation cache, which is the single
-      # biggest cost in this workflow. Uncached, every run re-precompiled the whole graph from
-      # scratch and threw it away: "166 dependencies successfully precompiled in 243 seconds" on
-      # Windows (181s on Linux), plus another ~60s for the package env — ~5 of the Windows job's
-      # 17.6 minutes, on every run, forever.
-      #
-      # The key is workflow+job+matrix+OS, NOT a manifest hash, so it restores the most recent cache
-      # for this job and re-saves an updated one each run. A manifest change therefore costs one
-      # partial re-precompile rather than a full cold miss. Julia validates cache entries itself,
-      # so a stale entry can only cost time, never correctness.
-      #
-      # BUDGET: GitHub caps a repo at 10 GB and evicts least-recently-used. The three pixi caches
-      # already sit at ~9 GB, so these depots WILL push past the cap and something gets evicted.
-      # If the pixi caches start missing (watch `Install Pixi + Python env` — 30-75s warm), the knob
-      # is `cache-artifacts: false`: artifact downloads are only ~25s of the step, while `compiled/`
-      # is the ~300s that matters. Check with `gh cache list`.
       - name: Cache Julia depot
         uses: julia-actions/cache@v3
 
@@ -108,35 +170,10 @@ jobs:
       - name: Instantiate Julia (server env)
         run: julia --project=api -e 'using Pkg; Pkg.instantiate()'
 
-      # Julia PACKAGE tests (app/test/runtests.jl) — the data model, ccid.json round-trip, versioned
-      # fields, task dispatch, param validation, the gating engine, config/path resolution. Needs app/
-      # instantiated in its own right (the step above instantiates api/, which only path-SOURCES
-      # Cecelia). This is the largest suite and used to run nowhere but a dev machine, which is how
-      # Windows-only path bugs shipped: `Sys.which` never finding `claude.cmd`, `Base.expanduser`
-      # being a no-op on Windows, `python3` not existing there. Those fixes are asserted by
-      # `iswin`-parameterised helpers precisely so a Windows runner can check them — it has to run here
-      # for that to mean anything. Fixture-dependent testsets self-skip (`have_fixture`), so a CI
-      # checkout without test-data/ still passes.
-      - name: Instantiate Julia (package env)
-        run: pixi run julia-instantiate
-
-      - name: Package tests
-        run: pixi run test-pkg
-
       # API-layer unit tests: load the handlers with CECELIA_NO_SERVE (no socket) and exercise them
       # directly. Fixture-free, so it runs on every OS in the matrix.
       - name: API tests
         run: pixi run test-api
-
-      # Python analysis-env tests (unittest-discovered python/cecelia/tests/*) — e.g. the zarr writer
-      # regression. Runs in the Pixi env (needs numpy/dask/zarr); fixture-free.
-      - name: Python tests
-        run: pixi run test-py
-
-      # MCP observer client tests (mcp/tests/*) — allow-list + URL/body building, HTTP mocked. Stdlib
-      # only; no server needed.
-      - name: MCP tests
-        run: pixi run test-mcp
 
       - name: Build frontend
         working-directory: frontend
@@ -176,3 +213,33 @@ jobs:
           echo "== / (server-served frontend) =="
           curl -fsS -o /dev/null -w "%{http_code} %{content_type}\n" http://localhost:8080/
           pixi run stop || true
+
+  # ── Python + MCP ──────────────────────────────────────────────────────────────────────────────
+  # Needs the Pixi env and NOTHING else — no Julia, and therefore no Julia depot cache (see the
+  # budget note at the top). The cheapest job by a wide margin.
+  python:
+    name: ${{ matrix.os }} — Python + MCP tests
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Pixi + Python env
+        uses: prefix-dev/setup-pixi@v0
+        with:
+          pixi-version: v0.71.1
+          cache: true
+
+      # Python analysis-env tests (unittest-discovered python/cecelia/tests/*) — e.g. the zarr writer
+      # regression and the UTF-8 text-I/O detector. Runs in the Pixi env; fixture-free.
+      - name: Python tests
+        run: pixi run test-py
+
+      # MCP observer client tests (mcp/tests/*) — allow-list + URL/body building, HTTP mocked. Stdlib
+      # only; no server needed.
+      - name: MCP tests
+        run: pixi run test-mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,15 @@ jobs:
       - name: Cache Julia depot
         uses: julia-actions/cache@v3
 
+      # `julia-instantiate` runs `Pkg.resolve()`, which needs the General registry and does NOT
+      # install one — it errors with "no registries have been installed". In the old single job this
+      # was invisible: the server-env `Pkg.instantiate()` ran first and bootstrapped the registry as
+      # a side effect. This job doesn't do that, so on a cold depot (a new cache key, an eviction)
+      # resolve had nothing to resolve against. Explicit and idempotent — a no-op once the depot
+      # cache restores registries — rather than relying on step order in another job.
+      - name: Ensure the General registry
+        run: julia -e 'using Pkg; isempty(Pkg.Registry.reachable_registries()) && Pkg.Registry.add("General")'
+
       - name: Instantiate Julia (package env)
         run: pixi run julia-instantiate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -470,9 +470,11 @@ Revise reloads function bodies on save. Struct/macro changes still need a restar
 
 ## Testing
 
-**Four test categories — one per layer. All four run in CI on every OS (one step per category in
-`.github/workflows/ci.yml` — keep it that way; the package suite was missing for a long time, which is
-how three Windows-only path bugs shipped), and each has a `pixi run` task that runs the whole suite.
+**Four test categories — one per layer. All four run in CI on every OS — keep it that way; the
+package suite was missing for a long time, which is how three Windows-only path bugs shipped. They
+are spread across three parallel jobs in `.github/workflows/ci.yml` (`julia` / `server` / `python`),
+split by what each needs installed, so wall-clock is the longest job rather than the sum; a new suite
+goes in the job that already has its toolchain. Each has a `pixi run` task that runs the whole suite.
 Write AND run the matching category in the same change as the code:**
 
 | You changed… | Write/run | Command |

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -103,15 +103,30 @@ git push -u origin feat/<short-slug>
 
 ## CI
 
-Every push/PR runs `.github/workflows/ci.yml` (smoke: fresh checkout → `pixi install` →
-`julia … instantiate` → **package tests** → API tests → **Python tests** → MCP tests → frontend build →
-**frontend tests (Vitest)** → server serves `/api/health` + the frontend). It runs the
-**full chain as a matrix on Linux, Windows and macOS-arm64** (`fail-fast: false`), so a
+Every push/PR runs `.github/workflows/ci.yml` — a smoke test from a fresh checkout, as **three
+parallel jobs per OS**, split by what each needs installed:
+
+| job | installs | runs |
+|---|---|---|
+| `julia` | pixi + Julia + depot cache | **package tests** (the long pole) |
+| `server` | pixi + Julia + Node | API tests → frontend build → **frontend tests (Vitest)** → server serves `/api/health` + the frontend |
+| `python` | pixi only | **Python tests** → MCP tests |
+
+Jobs run concurrently, so wall-clock is the longest job, not the sum. It runs as a
+**matrix on Linux, Windows and macOS-arm64** (`fail-fast: false`), so a
 platform-specific install/build/boot failure is caught in CI rather than by a tester — e.g. a PyPI
 dep with no macOS wheel falling back to a source build (TODO #00062). The repo is public, so
 GitHub-hosted runners are free on all OSes (no minute metering — the multipliers only bill private
 repos). All steps run under `bash` (Git Bash on the Windows runner). Keep it green before requesting
 a merge. See `docs/SHIPPING.md` for the release pipeline.
+
+**Adding a job is not free — it costs cache budget.** The Pixi env and the Julia depot are both
+cached and share GitHub's **10 GB per-repo budget**, which the three pixi caches alone fill to
+~6.4 GB. `julia-actions/cache` keys on the job name, so every *Julia-using* job adds one ~100 MB
+depot cache per run per OS (today: 2 jobs × 3 OSes = 6). Over-splitting evicts the depot caches
+before pixi's — pixi's are touched by every job and survive — which silently restores the ~200 s
+precompile that #430 removed. Keep suites that need no Julia in the `python` job, and read the
+budget note at the top of `ci.yml` before adding a cache or a fourth job.
 
 > **A PR with no checks is not a passing PR.** `pull_request` is intentionally left **unfiltered** so
 > a *stacked* PR — one whose base is another feature branch, not `main` — still runs. It used to be


### PR DESCRIPTION
Everything after setup ran in series — package tests, API tests, Python tests, frontend build, server
health — so wall-clock was their **sum**, although nothing depended on anything else. Jobs run
concurrently (the OS matrix already proved that), so the sum becomes the max.

## The split is by what each job must install

Every job repeats ~110s of setup, so more jobs is not automatically faster:

| job | installs | runs | ~ |
|---|---|---|---|
| `julia` | pixi + Julia + depot cache | package tests | 434s |
| `server` | pixi + Julia + Node | API tests, frontend build + tests, server health | 344s |
| `python` | **pixi only** | Python + MCP tests | 104s |

Windows wall-clock **12.3 → ~7 min**, and the package suite alone becomes the entire critical path —
no further split helps without splitting that suite.

## Why `python` has no Julia

Load-bearing, not cosmetic. `julia-actions/cache` keys on the **job name**, so every Julia-using job
adds a ~100 MB depot cache **per run, per OS**:

| | depot caches/run | ~size/run |
|---|---|---|
| before | 3 | 300 MB |
| this PR (2 Julia jobs) | 6 | 600 MB |
| if `python` also used Julia | 9 | 900 MB |

The cap is 10 GB and the three pixi caches already fill ~6.4 GB. Evictions land on the **depot**
caches, because pixi's are touched by every job and stay warm — which would silently restore the
~200s precompile #430 just removed. That is the failure mode to watch after merging.

Also adds `cache: npm` to setup-node, which was uncached.

## Docs

`CLAUDE.md` and `docs/DEV.md` both asserted the old one-job shape ("one step per category … keep it
that way"). Updated to describe the jobs, with the rule that a new suite goes in the job that already
has its toolchain.

Also **restores a note I lost**: the cache-budget paragraph was in the original #430 commit, and I
dropped it while rebuilding that branch to strip a diagnostic — what merged was `ci.yml` only. It is
back here, expanded with the per-job cost.

## Reservations

- **Only CI can verify this.** The YAML parses and the job/step structure is confirmed, but the
  speedup is a prediction.
- **The cache-budget effect is the real risk** and I am predicting eviction behaviour, not measuring
  it. If `Install Pixi` stops being ~60s warm, this is net negative — check `gh cache list` after a
  few runs.
- **`cache: npm` is untested here.** If the lockfile path is wrong, setup-node warns rather than
  fails, so it would silently do nothing.
- **~110s setup is extrapolated** from the old single job; three jobs pulling caches simultaneously
  may contend.
- **~7 min inherits `Package tests` variance** (231–324s observed on Windows), so realistically 6–8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
