### PR TITLE
feat(zarr): a valid box — which part of a store is data, not padding

### DIFF
--- a/app/src/tasks/cleanupImages/drift_correct_run.py
+++ b/app/src/tasks/cleanupImages/drift_correct_run.py
@@ -83,6 +83,15 @@ def run(params):
         # disagree. See zarr_utils.write_calibration.
         zarr_utils.write_calibration(staging, dim_utils)
 
+        # Which part of the expanded canvas is data. Drift drops each frame into a ZEROED canvas at
+        # its own offset, so most of this store is padding (8 z-planes in a 22-plane canvas on the
+        # worst movie here). Recorded on the STORE so any consumer asks one question —
+        # `read_valid_box` — instead of knowing drift produced it and re-deriving the geometry. The
+        # numbers come from the same call that placed the pixels.
+        zarr_utils.write_valid_box(
+            staging, dim_utils.spatial_axis(),
+            correction_utils.drift_frame_origins(im_dat[0].shape, dim_utils, shifts))
+
     # Persist the APPLIED drift so it's inspectable and drives QC (the Julia task reads this, computes
     # findings, and writes the qc/ sidecar). shifts is [T, ndim] per-frame deltas; axes are Z,Y,X (3D)
     # or Y,X (2D). See docs/todo/QC_PLAN.md.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,7 +143,51 @@ emit **advisory** findings about the output it produced.
 - **First producer:** `cleanupImages.driftCorrect` — persists the applied per-frame drift and flags a
   large inter-frame jump (`drift.jump`) or abnormal XY canvas growth (`drift.canvas_expansion`).
 
+(Where the data *is*, as opposed to how good it is, is not a QC concern — see
+*Valid box* below.)
+
 Full design + phased plan: [`docs/todo/QC_PLAN.md`](todo/QC_PLAN.md).
+
+---
+
+## Valid box — which part of a store is data
+
+A task may write a canvas larger than its data. Drift correction expands the canvas to hold the
+whole trajectory and drops each frame into a **zeroed** canvas at that frame's own offset, so the
+rest is padding — 38–64% on real movies here, one going from 8 z-planes to 22. NGFF has no way to
+say where the data is, so without this a consumer either treats padding as background (it will skew
+any background estimate, and it borders real signal) or pays to process it.
+
+**One question, one answer, on the store.** `zarr_utils.write_valid_box` / `read_valid_box`, under a
+namespaced `cecelia` attr next to the pixels:
+
+```python
+box = zarr_utils.read_valid_box(path)                  # None  → the whole store is valid
+box = zarr_utils.read_valid_box(path, timepoint=t)     # {'Z': (5, 13), 'Y': …, 'X': …}
+box = zarr_utils.read_valid_box(path, level=1)         # rescaled to that pyramid level
+```
+
+Design points, each of which was a candidate mistake:
+
+- **On the store, not in the producer's QC sidecar.** QC is advisory and task-scoped; a consumer
+  would have to know *which* task padded and where its JSON lives. This is a property of the data,
+  so it travels with a copy or an export.
+- **`None` means "all valid",** which is every store that never padded. That is what lets a
+  consumer have one code path instead of special-casing drift output.
+- **The producer passes the numbers it placed the pixels with** — for drift,
+  `correction_utils.drift_frame_slices`, the call the writer itself uses. Not a second derivation
+  that can disagree. (Same discipline as *Calibration — three copies, one stamp* in `CLAUDE.md`.)
+- **Level-0 coordinates,** rescaled on read by the same `DOWNSAMPLED_AXES` rule the NGFF scale uses;
+  start floors and stop ceils so a level never crops real data.
+- **Only drift correction writes one today.** Deliberately not a plugin framework: the generality
+  that pays is on the *read* side, where every consumer benefits, not the write side, where there
+  is one producer.
+
+**Two traps.** The box is per timepoint, and each frame sits at its own offset *because* the
+correction aligned them in the shared canvas — cropping each frame to its own box puts them back out
+of register. Crop to a common region or not at all. And the intersection across all timepoints can
+be **empty**, which is not hypothetical: it is true for 4 of the 9 movies in `kSUFux`, where the
+z-drift exceeded the 8-plane stack depth.
 
 ---
 

--- a/python/cecelia/tests/test_drift_geometry.py
+++ b/python/cecelia/tests/test_drift_geometry.py
@@ -1,0 +1,156 @@
+"""Drift-correction geometry: where each timepoint lands in the expanded canvas.
+
+`drift_correct_im` writes every frame into a ZEROED canvas at a per-frame offset, so the canvas is
+mostly padding — 38–64% on the movies this was written for, one of which went from 8 z-planes to 22.
+`drift_frame_slices` is that placement as a pure function, so a consumer can skip the padding
+without re-deriving the geometry or reading a voxel, and — the point — WITHOUT a second
+implementation that can disagree with the writer.
+
+Two things are pinned here:
+  1. the refactor is bit-identical to the inline loop it replaced (verbatim oracle below), and
+  2. the slices really are the data box — everything outside them is zero.
+
+Part of the Python (analysis-env) suite — run with `pixi run test-py`.
+"""
+import unittest
+
+import numpy as np
+
+import cecelia.utils.correction_utils as cu
+import cecelia.utils.zarr_utils as zarr_utils
+
+
+def _drift_correct_im_ORIGINAL(input_array, dim_utils, shifts, timepoints=None):
+    """The placement loop EXACTLY as it stood before `drift_frame_slices` was extracted
+    (commit b1ecf13, correction_utils.py:226-268), kept verbatim as the oracle. Do not tidy it —
+    its value is being untouched. Only the parts the refactor could affect are retained."""
+    if timepoints is None:
+        timepoints = range(dim_utils.dim_val('T'))
+    drift_im_shape_round, first_im_pos = cu.drift_correct_shape(input_array, dim_utils, shifts)
+    result = np.zeros(drift_im_shape_round, dtype=input_array.dtype)
+    tp_shape = list(drift_im_shape_round)
+    tp_shape[dim_utils.dim_idx('T')] = 1
+    tp_shape = tuple(tp_shape)
+    slices = list(first_im_pos)
+
+    for i in timepoints:
+        if i > 0:
+            new_slices = []
+            for j, y in enumerate(slices):
+                new_slices.append(slice(y.start + shifts[i - 1, j], y.stop + shifts[i - 1, j], 1))
+            slices = new_slices
+
+        new_slices = [slice(None)] * len(drift_im_shape_round)
+        im_slices = [slice(None)] * len(drift_im_shape_round)
+        for j, y in enumerate(dim_utils.spatial_axis()):
+            new_slices[dim_utils.dim_idx(y)] = slice(
+                round(slices[j].start), round(slices[j].stop), 1)
+        im_slices[dim_utils.dim_idx('T')] = slice(i, i + 1, 1)
+        new_slices = tuple(new_slices)
+        im_slices = tuple(im_slices)
+
+        src = zarr_utils.fortify(input_array[im_slices])
+        new_image = np.zeros(tp_shape, dtype=result.dtype)
+        if new_image[new_slices].shape != src.shape:
+            dif_dim = [x - y for x, y in zip(new_image[new_slices].shape, src.shape)]
+            adj = list(new_slices)
+            for j, y in enumerate(dif_dim):
+                if y > 0:
+                    adj[j] = slice(adj[j].start + y, adj[j].stop, 1)
+                elif y < 0:
+                    if adj[j].start - y >= 0:
+                        adj[j] = slice(adj[j].start + y, adj[j].stop, 1)
+                    elif adj[j].stop + y < result.shape[j]:
+                        adj[j] = slice(adj[j].start, adj[j].stop + y, 1)
+            new_slices = tuple(adj)
+        new_image[new_slices] = src
+        result[im_slices] = new_image
+    return result
+
+
+_OME = """<?xml version="1.0" encoding="UTF-8"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06">
+  <Image ID="Image:0" Name="d"><Pixels ID="Pixels:0" DimensionOrder="XYZCT" Type="uint8"
+    SizeT="{t}" SizeC="1" SizeZ="{z}" SizeY="{y}" SizeX="{x}"
+    PhysicalSizeX="0.5" PhysicalSizeXUnit="µm" PhysicalSizeY="0.5" PhysicalSizeYUnit="µm"
+    PhysicalSizeZ="2.0" PhysicalSizeZUnit="µm">
+    <Channel ID="Channel:0:0" SamplesPerPixel="1"/><MetadataOnly/></Pixels></Image></OME>"""
+
+
+def _fixture(shape=(6, 1, 4, 12, 10), seed=0):
+    """(array, dim_utils) for a [T,C,Z,Y,X] movie of noise — noise, so any mis-placement by even
+    one pixel shows up as a value mismatch rather than blending into a smooth gradient."""
+    import ome_types
+    from cecelia.utils.dim_utils import DimUtils
+    t, c, z, y, x = shape
+    du = DimUtils(ome_types.from_xml(_OME.format(t=t, z=z, y=y, x=x)), use_channel_axis=True)
+    du.calc_image_dimensions(shape)
+    arr = np.random.default_rng(seed).integers(1, 255, size=shape, dtype=np.uint8)  # no 0s: 0 = pad
+    return arr, du
+
+
+# Drift patterns chosen to hit the branches: a steady creep (the real-data case, which accumulates
+# past the stack depth), sign changes, sub-pixel rounding, and a shift big enough to push a frame
+# against the canvas edge and trigger the clamp.
+_PATTERNS = {
+    'steady creep':   lambda n: np.tile([0.4, 0.3, 0.2], (n, 1)),
+    'sign changes':   lambda n: np.array([[(-1) ** i * 0.6, 0.5, -0.4] for i in range(n)]),
+    'sub-pixel':      lambda n: np.tile([0.5, 0.5, 0.5], (n, 1)),
+    'mixed + zero':   lambda n: np.array([[0.0, 1.2, -0.7] if i % 2 else [0.9, 0.0, 0.3]
+                                          for i in range(n)]),
+    'large':          lambda n: np.tile([1.5, 2.0, -1.5], (n, 1)),
+}
+
+
+class DriftFrameSlicesTest(unittest.TestCase):
+    def test_refactor_is_bit_identical_to_the_original_loop(self):
+        for name, make in _PATTERNS.items():
+            with self.subTest(pattern=name):
+                arr, du = _fixture()
+                shifts = make(du.dim_val('T') - 1)
+                got = cu.drift_correct_im(arr, du, 0, shifts=shifts)
+                want = _drift_correct_im_ORIGINAL(arr, du, shifts)
+                self.assertEqual(got.shape, want.shape)
+                self.assertTrue(np.array_equal(got, want),
+                                f"{name}: placement changed ({int((got != want).sum())} voxels)")
+
+    def test_slices_are_exactly_the_non_zero_box(self):
+        """The contract a consumer relies on: outside these slices the canvas is untouched zero,
+        inside it is the source frame. The fixture has no 0 values, so this is unambiguous."""
+        for name, make in _PATTERNS.items():
+            with self.subTest(pattern=name):
+                arr, du = _fixture()
+                shifts = make(du.dim_val('T') - 1)
+                out = cu.drift_correct_im(arr, du, 0, shifts=shifts)
+                boxes = cu.drift_frame_slices(arr, du, shifts)
+                t_idx = du.dim_idx('T')
+                for t in range(du.dim_val('T')):
+                    frame = out[(slice(None),) * t_idx + (t,)]
+                    inside = np.zeros(frame.shape, dtype=bool)
+                    sl = list(boxes[t])
+                    sl.pop(t_idx)                       # the frame has no T axis
+                    inside[tuple(sl)] = True
+                    self.assertTrue(np.all(frame[~inside] == 0),
+                                    f"{name} t={t}: non-zero data OUTSIDE the reported box")
+                    self.assertTrue(np.all(frame[inside] != 0),
+                                    f"{name} t={t}: padding INSIDE the reported box")
+
+    def test_origins_need_no_array_only_a_shape(self):
+        """Replayable from a QC sidecar: same answer from the plain shape as from the array, so a
+        consumer never has to open the store to know where the padding is."""
+        arr, du = _fixture()
+        shifts = _PATTERNS['steady creep'](du.dim_val('T') - 1)
+        self.assertEqual(cu.drift_frame_slices(arr, du, shifts),
+                         cu.drift_frame_slices(arr.shape, du, shifts))
+        org = cu.drift_frame_origins(arr.shape, du, shifts)
+        self.assertEqual(sorted(org), list(range(du.dim_val('T'))))
+        self.assertEqual(sorted(org[0]), ['X', 'Y', 'Z'])
+        # steady positive creep => the Z origin only ever advances
+        z0 = [org[t]['Z'][0] for t in range(du.dim_val('T'))]
+        self.assertEqual(z0, sorted(z0))
+        # and the box is the source depth, so a consumer reading it skips real padding
+        self.assertEqual(org[0]['Z'][1] - org[0]['Z'][0], arr.shape[du.dim_idx('Z')])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/cecelia/tests/test_valid_box.py
+++ b/python/cecelia/tests/test_valid_box.py
@@ -1,0 +1,95 @@
+"""The valid box: which part of a store is data, and which is padding a task added.
+
+Lives on the STORE (namespaced `cecelia` attr), not in the producing task's QC sidecar, so a
+consumer asks one question regardless of which task made the store — and gets None, meaning "all of
+it", for the stores that never padded. That None case is most of them, and it is what lets a
+consumer have one code path.
+
+Part of the Python (analysis-env) suite — run with `pixi run test-py`.
+"""
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+import zarr
+
+import cecelia.utils.zarr_utils as zu
+
+
+def _store(path, shape=(2, 1, 8, 16, 12), nscales=2):
+    g = zarr.open_group(path, mode="w", zarr_format=2)
+    g.attrs["multiscales"] = zu.multiscales_metadata(
+        ["T", "C", "Z", "Y", "X"], nscales, scale_for_axis={"Z": 2.0, "Y": 0.5, "X": 0.5})
+    for lvl in range(nscales):
+        s = list(shape)
+        s[3] //= 2 ** lvl
+        s[4] //= 2 ** lvl
+        g.create_array(str(lvl), data=np.zeros(s, dtype=np.uint8), chunks=tuple(s))
+    return path
+
+
+class ValidBoxTest(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.d, True)
+
+    def test_a_store_with_no_padding_reports_none(self):
+        """The default, and the reason a consumer needs no knowledge of the producer."""
+        p = _store(os.path.join(self.d, "plain.ome.zarr"))
+        self.assertIsNone(zu.read_valid_box(p))
+        self.assertIsNone(zu.read_valid_box(os.path.join(self.d, "does-not-exist")))
+
+    def test_static_box_roundtrips(self):
+        p = _store(os.path.join(self.d, "static.ome.zarr"))
+        zu.write_valid_box(p, ["Z", "Y", "X"], {"Z": (1, 5), "Y": (2, 14), "X": (0, 12)})
+        self.assertEqual(zu.read_valid_box(p), {"Z": (1, 5), "Y": (2, 14), "X": (0, 12)})
+
+    def test_per_timepoint_box_and_its_union(self):
+        p = _store(os.path.join(self.d, "moving.ome.zarr"))
+        boxes = {0: {"Z": (0, 4), "Y": (0, 10), "X": (0, 12)},
+                 1: {"Z": (3, 7), "Y": (2, 12), "X": (0, 12)}}
+        zu.write_valid_box(p, ["Z", "Y", "X"], boxes)
+        self.assertEqual(zu.read_valid_box(p, timepoint=0)["Z"], (0, 4))
+        self.assertEqual(zu.read_valid_box(p, timepoint=1)["Z"], (3, 7))
+        # no timepoint → the union, i.e. the smallest region containing every frame's data
+        self.assertEqual(zu.read_valid_box(p)["Z"], (0, 7))
+        self.assertEqual(zu.read_valid_box(p)["Y"], (0, 12))
+
+    def test_level_rescales_xy_only_and_never_crops(self):
+        """Level-n coordinates must not lose a pixel of real data, so start floors and stop ceils.
+        XY halve per level; Z does not — the same rule the NGFF scale uses (DOWNSAMPLED_AXES),
+        because a box and a scale expressed in level-0 pixels have to agree about what a level is."""
+        p = _store(os.path.join(self.d, "lvl.ome.zarr"))
+        zu.write_valid_box(p, ["Z", "Y", "X"], {"Z": (1, 5), "Y": (3, 11), "X": (1, 12)})
+        self.assertEqual(zu.read_valid_box(p, level=1),
+                         {"Z": (1, 5),            # Z is not downsampled
+                          "Y": (1, 6),            # 3//2=1, ceil(11/2)=6  → contains [3,11)
+                          "X": (0, 6)})           # 1//2=0, ceil(12/2)=6
+        self.assertIn("Y", zu.read_valid_box(p, level=0))
+
+    def test_writing_does_not_disturb_the_ngff_metadata(self):
+        """It is a sibling attr, not an edit to `multiscales` — a store stays readable by anything
+        that has never heard of it."""
+        p = _store(os.path.join(self.d, "keep.ome.zarr"))
+        before = zarr.open_group(p, mode="r").attrs["multiscales"]
+        zu.write_valid_box(p, ["Z"], {"Z": (2, 6)})
+        g = zarr.open_group(p, mode="r")
+        self.assertEqual(g.attrs["multiscales"], before)
+        self.assertEqual(zu.read_axes(p), ["t", "c", "z", "y", "x"])
+        self.assertIsNotNone(zu.read_scale(p))
+
+    def test_nested_series_layout(self):
+        """Both on-disk layouts, via series_base — a bioformats2raw store must work too."""
+        p = os.path.join(self.d, "nested.ome.zarr")
+        root = zarr.open_group(p, mode="w", zarr_format=2)
+        s = root.create_group("0")
+        s.attrs["multiscales"] = zu.multiscales_metadata(["T", "C", "Z", "Y", "X"], 1)
+        s.create_array("0", data=np.zeros((2, 1, 8, 16, 12), dtype=np.uint8), chunks=(2, 1, 8, 16, 12))
+        zu.write_valid_box(p, ["Z"], {"Z": (1, 7)})
+        self.assertEqual(zu.read_valid_box(p), {"Z": (1, 7)})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/cecelia/utils/correction_utils.py
+++ b/python/cecelia/utils/correction_utils.py
@@ -72,8 +72,14 @@ def shifts_summary(shifts, cumulative=True, is_3D=True):
     return {'max': max_shifts, 'min': min_shifts, 'sum': max_shifts + min_shifts}
 
 
+def _as_shape(array_or_shape):
+    """Accept either an array or a plain shape tuple. Lets the geometry helpers below be used
+    post-hoc — from a QC sidecar, say — without opening the store they describe."""
+    return tuple(getattr(array_or_shape, 'shape', array_or_shape))
+
+
 def correction_im_shape(image_array, dim_utils, shifts_sum):
-    new_shape = list(image_array.shape)
+    new_shape = list(_as_shape(image_array))
     if dim_utils.is_3D():
         new_shape[dim_utils.dim_idx('Z')] += abs(shifts_sum['sum'][0])
         new_shape[dim_utils.dim_idx('Y')] += abs(shifts_sum['sum'][1])
@@ -113,6 +119,80 @@ def drift_correct_shape(input_array, dim_utils, shifts):
     return drift_im_shape_round, first_im_pos
 
 
+def drift_frame_slices(input_array, dim_utils, shifts, timepoints=None):
+    """Where each timepoint's pixels LAND in the expanded canvas: ``{t: tuple(slice per axis)}``.
+
+    Drift correction writes every frame into a ZEROED canvas at a per-frame offset, so these
+    slices are also the answer to "which part of a corrected store is data and which is padding".
+    That matters because the expansion is not small — a 30-minute 8-plane movie here came out
+    22 planes deep, i.e. 64% zeros — and a downstream consumer that does not know the box pays
+    for all of it.
+
+    Pure shape arithmetic; touches no pixels, so it can be replayed later from nothing but the
+    source shape and the shifts a run recorded. `drift_correct_im` places its frames with this,
+    and the QC sidecar persists its output — one implementation, so the padding a consumer skips
+    is exactly the padding the writer left.
+
+    ``input_array`` may be an array or a plain shape tuple. ``timepoints`` must start at 0 and be
+    consecutive: the offset ACCUMULATES across frames (``shifts`` are per-frame deltas), so a
+    subset would silently mis-place everything after the first gap — the same constraint the
+    writer's loop has always had.
+    """
+    shifts = np.asarray(shifts)
+    canvas_shape, first_im_pos = drift_correct_shape(input_array, dim_utils, shifts)
+    src_shape = list(_as_shape(input_array))
+    src_shape[dim_utils.dim_idx('T')] = 1
+    tp_shape = list(canvas_shape)
+    tp_shape[dim_utils.dim_idx('T')] = 1
+    if timepoints is None:
+        timepoints = range(dim_utils.dim_val('T'))
+
+    out = {}
+    slices = list(first_im_pos)
+    for i in timepoints:
+        if i > 0:
+            slices = [slice(y.start + shifts[i - 1, j], y.stop + shifts[i - 1, j], 1)
+                      for j, y in enumerate(slices)]
+
+        new_slices = [slice(None)] * len(canvas_shape)
+        for j, y in enumerate(dim_utils.spatial_axis()):
+            new_slices[dim_utils.dim_idx(y)] = slice(
+                round(slices[j].start), round(slices[j].stop), 1)
+
+        # Clamp exactly as the writer does: rounding can leave the destination window a pixel off
+        # the source, and a frame at the very start/end of the drift can run past the canvas edge.
+        # `slice.indices` is what numpy itself applies, so this measures the real destination size.
+        dest = [len(range(*sl.indices(tp_shape[k]))) for k, sl in enumerate(new_slices)]
+        if dest != src_shape:
+            adj = list(new_slices)
+            for j, y in enumerate([d - s for d, s in zip(dest, src_shape)]):
+                if y > 0:
+                    adj[j] = slice(adj[j].start + y, adj[j].stop, 1)
+                elif y < 0:
+                    if adj[j].start - y >= 0:
+                        adj[j] = slice(adj[j].start + y, adj[j].stop, 1)
+                    elif adj[j].stop + y < canvas_shape[j]:
+                        adj[j] = slice(adj[j].start, adj[j].stop + y, 1)
+            new_slices = adj
+        out[i] = tuple(new_slices)
+    return out
+
+
+def drift_frame_origins(input_array, dim_utils, shifts, timepoints=None):
+    """`drift_frame_slices` reduced to what a consumer usually wants: per timepoint, the
+    ``{axis: [start, stop]}`` of the occupied box on each SPATIAL axis, as plain ints.
+
+    JSON-friendly, so a run can record it (see the drift QC sidecar) and anything reading that
+    store later — coastal, a viewer — can skip the padding without re-deriving the geometry or
+    reading a single voxel."""
+    axes = list(dim_utils.spatial_axis())
+    return {
+        t: {ax: [int(sl[dim_utils.dim_idx(ax)].start), int(sl[dim_utils.dim_idx(ax)].stop)]
+            for ax in axes}
+        for t, sl in drift_frame_slices(input_array, dim_utils, shifts, timepoints).items()
+    }
+
+
 def drift_correct_im(
         input_array, dim_utils, phase_shift_channel,
         timepoints=None, drift_corrected_path=None,
@@ -127,7 +207,7 @@ def drift_correct_im(
             upsample_factor=upsample_factor,
         )
 
-    drift_im_shape_round, first_im_pos = drift_correct_shape(input_array, dim_utils, shifts)
+    drift_im_shape_round, _ = drift_correct_shape(input_array, dim_utils, shifts)
 
     # The writer owns byte order (zarr_utils.native_dtype): when `out` is a pre-created native store
     # we match it; the out=None numpy path returns source-order and create_multiscales makes it native.
@@ -143,28 +223,15 @@ def drift_correct_im(
     tp_shape[dim_utils.dim_idx('T')] = 1
     tp_shape = tuple(tp_shape)
 
-    slices = list(first_im_pos)
+    # Where each frame lands. Shape arithmetic only, so it is computed up front and shared with
+    # every other consumer of this store (the QC sidecar records it) instead of living inline here
+    # — see drift_frame_slices.
+    frame_slices = drift_frame_slices(input_array, dim_utils, shifts, timepoints)
 
     for i in timepoints:
-        if i > 0:
-            new_slices = []
-            for j, y in enumerate(slices):
-                new_slices.append(slice(
-                    y.start + shifts[i - 1, j],
-                    y.stop + shifts[i - 1, j],
-                    1,
-                ))
-            slices = new_slices
-
-        new_slices = [slice(None)] * len(drift_im_shape_round)
+        new_slices = frame_slices[i]
         im_slices = [slice(None)] * len(drift_im_shape_round)
-
-        for j, y in enumerate(dim_utils.spatial_axis()):
-            new_slices[dim_utils.dim_idx(y)] = slice(
-                round(slices[j].start), round(slices[j].stop), 1)
-
         im_slices[dim_utils.dim_idx('T')] = slice(i, i + 1, 1)
-        new_slices = tuple(new_slices)
         im_slices = tuple(im_slices)
 
         if i % 10 == 0:
@@ -172,20 +239,6 @@ def drift_correct_im(
 
         src = zarr_utils.fortify(input_array[im_slices])
         new_image = np.zeros(tp_shape, dtype=result_dtype)
-
-        if new_image[new_slices].shape != src.shape:
-            dif_dim = [x - y for x, y in zip(new_image[new_slices].shape, src.shape)]
-            adj = list(new_slices)
-            for j, y in enumerate(dif_dim):
-                if y > 0:
-                    adj[j] = slice(adj[j].start + y, adj[j].stop, 1)
-                elif y < 0:
-                    if adj[j].start - y >= 0:
-                        adj[j] = slice(adj[j].start + y, adj[j].stop, 1)
-                    elif adj[j].stop + y < result.shape[j]:
-                        adj[j] = slice(adj[j].start, adj[j].stop + y, 1)
-            new_slices = tuple(adj)
-
         new_image[new_slices] = src
         result[im_slices] = new_image
 

--- a/python/cecelia/utils/zarr_utils.py
+++ b/python/cecelia/utils/zarr_utils.py
@@ -462,6 +462,95 @@ def create_zarr_from_ndarray(im_array, dim_utils, reference_zarr=None, im_chunks
     return new_zarr, im_chunks
 
 
+# The axes a pyramid level halves. Shared, because anything expressed in level-0 pixels has to be
+# rescaled by the SAME rule to stay meaningful at level n — the NGFF scale (`multiscales_metadata`)
+# and the valid box (`read_valid_box`) must not each decide this for themselves.
+DOWNSAMPLED_AXES = ('X', 'Y')
+
+# ── Valid box: which part of a store is data, and which is padding ────────────────────────────
+# A task may write a canvas bigger than its data — drift correction expands to hold the whole
+# trajectory and drops each frame into a ZEROED canvas at its own offset, which on real movies
+# leaves 38–64% padding (one went from 8 z-planes to 22). Nothing in NGFF says where the data is,
+# so a consumer either reads the padding as if it were background, or hunts down whichever task
+# produced the store and re-derives its geometry.
+#
+# So it lives on the STORE, namespaced under `cecelia`, next to the pixels it describes: any
+# consumer asks `read_valid_box(path)` and gets None — meaning "all of it" — for the stores that
+# have no padding. One code path, no knowledge of the producer, and it survives a copy or export
+# in a way a QC sidecar under `1/{uid}/qc/` does not.
+#
+# Coordinates are LEVEL-0 pixels in STORE axis order; `read_valid_box(path, level=n)` rescales.
+CECELIA_ATTR = 'cecelia'
+
+
+def write_valid_box(path, axes, boxes):
+    """Record which region of ``path`` holds data. ``axes`` are the axis letters the box is given
+    on (a subset — unlisted axes are wholly valid). ``boxes`` is either one ``{axis: (start, stop)}``
+    for a static region, or ``{timepoint: {axis: (start, stop)}}`` when it moves per frame.
+
+    Level-0 pixel coordinates. Writing this is the producer's job and it should pass the SAME
+    numbers it placed the pixels with — for drift that is `correction_utils.drift_frame_slices`,
+    the call the writer itself uses, so the region a consumer skips is the region the writer left
+    empty rather than a second opinion about it."""
+    axes = [str(a).upper() for a in axes]
+    per_t = bool(boxes) and not isinstance(next(iter(boxes.values())), (list, tuple)) \
+        and all(isinstance(k, (int, np.integer)) for k in boxes)
+
+    def _one(b):
+        return [[int(b[a][0]), int(b[a][1])] for a in axes]
+
+    entry = {'axes': axes, 'perTimepoint': per_t}
+    if per_t:
+        entry['boxes'] = [_one(boxes[t]) for t in sorted(boxes)]
+    else:
+        entry['boxes'] = [_one(boxes)]
+
+    g = zarr.open_group(series_base(path), mode='a')
+    ns = dict(g.attrs.get(CECELIA_ATTR, {}))
+    ns['validBox'] = entry
+    g.attrs[CECELIA_ATTR] = ns
+    return True
+
+
+def read_valid_box(path, level=0, timepoint=None):
+    """The data region of a store as ``{axis: (start, stop)}``, or **None when the whole store is
+    valid** — which is the common case, so a consumer can treat None as "no special handling".
+
+    ``level`` rescales from the stored level-0 coordinates using the same downsampling rule as the
+    NGFF scale (`DOWNSAMPLED_AXES`): start floors, stop ceils, so the box never crops real data.
+    ``timepoint`` picks one frame of a per-frame box; omitted, a per-frame box returns the UNION
+    over all frames — the smallest region containing every frame's data.
+
+    A per-frame box is not a crop. Each frame sits at its own offset *because* the correction
+    aligned them in the shared canvas; cropping each to its own box would put them back out of
+    register. Crop to a common region or not at all. Note that the intersection across frames can
+    be empty when the drift exceeds the stack depth, which is real on this data."""
+    try:
+        g = zarr.open_group(series_base(path), mode='r')
+        entry = (g.attrs.get(CECELIA_ATTR) or {}).get('validBox')
+    except Exception:
+        return None
+    if not entry or not entry.get('boxes'):
+        return None
+
+    axes = [str(a).upper() for a in entry['axes']]
+    boxes = entry['boxes']
+    if entry.get('perTimepoint') and timepoint is not None:
+        sel = boxes[int(timepoint)]
+    elif entry.get('perTimepoint'):
+        sel = [[min(b[i][0] for b in boxes), max(b[i][1] for b in boxes)] for i in range(len(axes))]
+    else:
+        sel = boxes[0]
+
+    out = {}
+    for ax, (lo, hi) in zip(axes, sel):
+        if level and ax in DOWNSAMPLED_AXES:
+            f = 2 ** int(level)
+            lo, hi = lo // f, -(-hi // f)        # floor / ceil — never crop real data
+        out[ax] = (int(lo), int(hi))
+    return out
+
+
 def multiscales_metadata(axes, nscales, scale_for_axis=None, keyword='datasets',
                          unit_for_axis=None):
     """Build the NGFF ``multiscales`` attr value (a 1-element list) shared by every multiscale
@@ -483,7 +572,7 @@ def multiscales_metadata(axes, nscales, scale_for_axis=None, keyword='datasets',
         entry = {'path': str(lvl)}
         if axes and scale_for_axis is not None:
             entry['coordinateTransformations'] = [{'type': 'scale', 'scale': [
-                float(scale_for_axis.get(ax, 1.0)) * (2 ** lvl if ax in ('X', 'Y') else 1.0)
+                float(scale_for_axis.get(ax, 1.0)) * (2 ** lvl if ax in DOWNSAMPLED_AXES else 1.0)
                 for ax in axes
             ]}]
         datasets.append(entry)


### PR DESCRIPTION
Two commits. The second is the mechanism; the first is the refactor that makes it honest.

## The problem

Drift correction expands the canvas to hold the whole trajectory and drops each frame into a **zeroed** canvas at that frame's own offset. On the nine movies in `kSUFux`, **38–64% of every corrected store is zeros** — the worst went from 8 z-planes to 22.

NGFF has no way to say where the data is. So a consumer either treats padding as background (it borders real signal, and will drag any background estimate down) or goes hunting for whichever task produced the store and re-derives its geometry.

## 1. `refactor(drift)` — one placement, not two

`drift_correct_im` computed each frame's destination inline, including a non-obvious edge-clamp fixup. Anyone wanting the data box had to re-implement it. `drift_frame_slices` is that placement as a pure function, and **the writer now places its frames with it** — so there is one implementation, not a copy that can drift.

Pure shape arithmetic, so it replays from just the source shape and the recorded shifts, without opening the store.

**Why you can trust it's behaviour-preserving:** the test keeps the pre-refactor loop *verbatim* as an oracle and asserts bit-identical output across five drift patterns — steady creep, sign changes, sub-pixel rounding, mixed, and shifts large enough to hit the clamp. The fixture is random noise with no zeros, so a one-pixel misplacement fails rather than blending in.

I carried the clamp over character-for-character. It's asymmetric between the positive and negative mismatch cases and I haven't tried to justify it; the oracle is what makes leaving it alone safe.

## 2. `feat(zarr)` — the valid box

```python
read_valid_box(path)                # None -> whole store is valid
read_valid_box(path, timepoint=t)   # {'Z': (5, 13), 'Y': ..., 'X': ...}
read_valid_box(path, level=1)       # rescaled to that pyramid level
```

- **On the store**, namespaced `cecelia` attr — not the producer's QC sidecar. QC is advisory and task-scoped; this is a property of the data and travels with a copy or export. *An earlier draft put it in the drift QC file. Wrong home.*
- **`None` = all valid**, which is every store that never padded. That's what lets a consumer keep one code path.
- **The producer passes the numbers it placed the pixels with.** Not a second derivation.
- **Level-0 coordinates**, rescaled by the same `DOWNSAMPLED_AXES` rule the NGFF scale uses — extracted rather than duplicated, so a box and a scale can't disagree about what a level is. Start floors, stop ceils; a level never crops real data.

**Deliberately not a producer framework.** I surveyed first: AF correction widens the *channel* axis, crop shrinks, 8-bit import and cellpose correct preserve shape. Drift is the only task that pads. A plugin mechanism for one writer would be speculative generality — the generality that pays is on the read side.

## Two traps, both documented

The box is **per timepoint**, and each frame sits at its own offset *because* the correction aligned them in the shared canvas. Cropping each frame to its own box puts them back out of register.

And the intersection across all timepoints can be **empty** — true for `PsD5Xc`, `RbC99T`, `i0FSPZ`, `mkh3Tu`, where z-drift exceeded the 8-plane stack depth. So "crop to the common region" is not a usable strategy in general; the box is for masking statistics and skipping known-empty work, not for cropping.

## Verified on real data

The nine existing corrected stores were backfilled from their recorded shifts, and I checked the reconstruction against the actual pixels rather than trusting the arithmetic:

```
Or1L8a   t=  0  predicted Z=[0, 8]    actual non-zero Z=[0, 8]     match
         t= 90  predicted Z=[2, 10]   actual non-zero Z=[2, 10]    match
         t=179  predicted Z=[5, 13]   actual non-zero Z=[5, 13]    match
```

## Tests

2513 Julia · 286 Python. New: `test_drift_geometry.py` (oracle equivalence, box-is-the-data in both directions, shape-only replay) and `test_valid_box.py` (None default, static, per-timepoint + union, level rescaling, NGFF metadata untouched, both store layouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)