### PR TITLE
ci: attribute the server-boot wait instead of leaving it silent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,13 +220,27 @@ jobs:
       - name: Start server and verify health + frontend serving
         run: |
           set -uo pipefail
-          pixi run prod > server.log 2>&1 &
+          t0=$(date +%s)
+          # Stamp each line as it arrives. The server's own logger prints no timestamp, so plain
+          # redirection records WHAT it logged but not WHEN — useless for splitting the boot.
+          ( pixi run prod 2>&1 | while IFS= read -r line; do
+              printf '%s %s\n' "$(date +%H:%M:%S)" "$line"
+            done ) > server.log &
           # Wait up to ~5 min for the API (first request JIT-compiles the handler; slower on
           # Windows/macOS runners than the warm Linux one).
-          for i in $(seq 1 150); do
+          for i in $(seq 1 300); do
             curl -fsS http://localhost:8080/api/health >/dev/null 2>&1 && break
-            sleep 2
+            sleep 1
           done
+          # ATTRIBUTION, not decoration. This poll loop is the single slowest step in the job, and it
+          # is silent — so a slow boot arrives as one opaque number with no way to tell Julia
+          # startup/load/compile apart from first-request JIT. `server.log` carries the timestamped
+          # "CeceliaAPI starting" line, which splits exactly that, so print it on SUCCESS too (it was
+          # already dumped on failure). Same lesson as #430: measure where the time goes before
+          # trying to move it.
+          echo "== boot =="
+          echo "wall to first healthy response: $(( $(date +%s) - t0 ))s"
+          cat server.log
           echo "== /api/health =="
           curl -fsS http://localhost:8080/api/health \
             || { echo "server never became healthy"; cat server.log; exit 1; }


### PR DESCRIPTION
## Why

After #438 the `julia` job is no longer the critical path — the `server` job is, and its slowest step by a wide margin is the server-boot wait:

| step | ubuntu | windows | macos |
|---|---|---|---|
| **Start server + verify health** | **72s** | **85s** | **67s** |
| API tests | 56s | 68s | 52s |
| Install Pixi + Python env | 36s | 61s | 34s |
| Build frontend | 18s | 35s | 18s |
| Frontend tests | 7s | 11s | 7s |

(For the record: I assumed the frontend build was the cost. It isn't — it's 18–35s.)

That top step is a **black box**. The poll loop prints nothing and `server.log` is dumped only on failure, so a green run gives one opaque number. On run 30613469432 the log shows the step opening at `07:39:51` and health responding at `07:41:03` — 72s with nothing in between.

There's no way to tell from that whether the time is Julia startup + loading `Cecelia`/HTTP + compiling `api/src`, or the first request JIT-compiling the handler stack. Loading `server.jl` locally (with `CECELIA_NO_SERVE`, no socket) is only ~5s, so the number isn't explained by what's currently visible. And `api/` is deliberately **not a package**, so none of it precompiles — which is exactly why the split matters before choosing a fix.

## What

- Print elapsed wall time to the first healthy response.
- `cat server.log` on success too (it was already dumped on failure). The `CeceliaAPI starting` line splits the wait into "process up and listening" vs "first request served".
- **Stamp each log line as it arrives.** The server wraps the default `ConsoleLogger`, which prints no timestamp, so plain redirection would record *what* it logged but not *when*.
- Poll every 1s instead of 2s — same ~5 min ceiling, half the granularity error.

## No speedup

This PR makes CI marginally *slower* (a few log lines). It's the measurement that has to exist before anything in that step is worth moving — the same lesson as #430, where the depot cache reported "restored" while silently recompiling, and the fix only became findable once the time was attributable.

## Reservations

- **The timestamping pipeline is unverified on the Windows/macOS runners.** Plain bash, works in a local dry run, but Git Bash is where shell constructs bite. Worst case the log is empty or unstamped — the boot and both health assertions are unchanged, so the step still passes or fails on the same conditions.
- Diagnostic-only. If the numbers come back saying the boot is irreducible Julia compile with `api/` unable to precompile, the honest outcome is to stop optimising CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
