### PR TITLE
feat(import): fixed absolute window for the 16→8-bit rescale

### DIFF
--- a/app/src/tasks/importImages/omezarr.jl
+++ b/app/src/tasks/importImages/omezarr.jl
@@ -581,6 +581,12 @@ function _run_task(task::ImportOmezarr, img::CciaImage, params::Dict{String,Any}
     convert_8bit = Bool(get(params, "convertTo8bit", false))
     low_pct      = Float64(get(params, "rescaleLowPercentile", 0.0))
     high_pct     = Float64(get(params, "rescaleHighPercentile", 100.0))
+    # An absolute window in RAW units, shared by every channel and every image. When set it
+    # overrides the percentiles — the only way to get one intensity space across a set, which
+    # anything comparing channels or pooling movies needs. See intensity_utils.channel_ranges.
+    fixed_min    = Float64(get(params, "rescaleFixedMin", 0.0))
+    fixed_max    = Float64(get(params, "rescaleFixedMax", 0.0))
+    fixed_window = fixed_max > fixed_min
 
     # When converting, bioformats2raw writes a single-level transient (the pyramid is rebuilt on the
     # 8-bit output); otherwise it writes the final pyramid directly.
@@ -622,7 +628,9 @@ function _run_task(task::ImportOmezarr, img::CciaImage, params::Dict{String,Any}
     on_log("[INFO] Output:  $zarr_out")
     on_log("[INFO] Pyramid: $pyramid_scale levels")
     stage_local  && on_log("[INFO] Staged source locally (network-source speedup).")
-    convert_8bit && on_log("[INFO] Convert to 8-bit: window low=$(low_pct)% high=$(high_pct)%")
+    convert_8bit && on_log(fixed_window ?
+        "[INFO] Convert to 8-bit: FIXED window [$(fixed_min), $(fixed_max)] (shared by all channels)" :
+        "[INFO] Convert to 8-bit: window low=$(low_pct)% high=$(high_pct)%")
 
     out_pipe = Pipe()
     proc = run(pipeline(`$bf2raw --resolutions $bf2raw_res $eff_src $bf2raw_out`;
@@ -674,6 +682,8 @@ function _run_task(task::ImportOmezarr, img::CciaImage, params::Dict{String,Any}
                nscales        = pyramid_scale,
                lowPercentile  = low_pct,
                highPercentile = high_pct,
+               fixedMin       = fixed_min,
+               fixedMax       = fixed_max,
                resultPath     = result_file),
             run_dir; on_log = on_log, on_progress = on_progress, on_process = on_process)
         # drop the 16-bit scratch regardless of outcome — it's transient (never keep it locally)
@@ -688,8 +698,11 @@ function _run_task(task::ImportOmezarr, img::CciaImage, params::Dict{String,Any}
                 res   = JSON3.read(read(result_file, String))
                 chans = get(res, :channels, nothing)
                 if !isnothing(chans)
+                    # Record which window was actually applied, so the mapping stays invertible
+                    # (v/255*(vmax-vmin)+vmin) whichever mode produced it.
                     zarr_meta["rescale8bit"] = Dict{String,Any}(
                         "low" => low_pct, "high" => high_pct,
+                        "fixed" => fixed_window,
                         "channels" => [Dict{String,Any}(String(k) => v for (k, v) in ch) for ch in chans],
                     )
                     on_log("[INFO] 8-bit rescale complete ($(length(chans)) channel(s)).")

--- a/app/src/tasks/importImages/omezarr.json
+++ b/app/src/tasks/importImages/omezarr.json
@@ -57,6 +57,26 @@
           "tip": "Top of the 8-bit intensity window (100 = true maximum)"
         },
         {
+          "key": "rescaleFixedMin",
+          "label": "8-bit fixed window min",
+          "type": "float",
+          "min": 0,
+          "max": 65535,
+          "default": 0,
+          "step": 1,
+          "tip": "Bottom of a fixed raw-value window shared by every channel and image"
+        },
+        {
+          "key": "rescaleFixedMax",
+          "label": "8-bit fixed window max",
+          "type": "float",
+          "min": 0,
+          "max": 65535,
+          "default": 0,
+          "step": 1,
+          "tip": "Top of the fixed window; 0 = off, use the percentiles instead"
+        },
+        {
           "key": "chunkSizeX",
           "label": "Chunk size X",
           "type": "int",

--- a/app/src/tasks/importImages/rescale_to_8bit_run.py
+++ b/app/src/tasks/importImages/rescale_to_8bit_run.py
@@ -35,6 +35,11 @@ def run(params):
     nscales     = int(params.get('nscales', 1))
     low_pct     = float(params.get('lowPercentile', 0.0))
     high_pct    = float(params.get('highPercentile', 100.0))
+    # An absolute window, in RAW units, shared by every channel and every image. Overrides the
+    # percentiles when set (fixedMax > fixedMin). See intensity_utils.channel_ranges.
+    fixed_min   = float(params.get('fixedMin', 0.0))
+    fixed_max   = float(params.get('fixedMax', 0.0))
+    fixed       = (fixed_min, fixed_max) if fixed_max > fixed_min else None
     result_path = params['resultPath']
 
     log.progress(0, 4)
@@ -49,10 +54,14 @@ def run(params):
     log.log(f'>> image dims: {dim_utils.im_dim_order} {dim_utils.im_dim} (channel axis={c_idx})')
 
     log.progress(1, 4)
-    log.log(f'>> compute per-channel intensity window over the stack '
-            f'(low={low_pct}%, high={high_pct}%)')
+    log.log('>> compute intensity window over the stack ' + (
+        f'(FIXED [{fixed_min:.0f}, {fixed_max:.0f}], shared by all channels)' if fixed
+        else f'(per channel, low={low_pct}%, high={high_pct}%)'))
+    # Histograms are computed either way — with a fixed window they no longer choose it, but
+    # clip_stats still reports how much of each channel it actually clips, which is the number
+    # that tells you whether the window was set sensibly.
     hists  = intensity_utils.channel_histograms(level0, c_idx)
-    ranges = [intensity_utils.range_from_hist(h, low_pct, high_pct) for h in hists]
+    ranges = intensity_utils.channel_ranges(hists, low_pct, high_pct, fixed=fixed)
 
     channels = []
     for i, (h, (vmin, vmax)) in enumerate(zip(hists, ranges)):

--- a/python/cecelia/tests/test_intensity_utils.py
+++ b/python/cecelia/tests/test_intensity_utils.py
@@ -41,6 +41,32 @@ class TestIntensityUtils(unittest.TestCase):
         _, vmax = iu.range_from_hist(hists[0], 0.0, 50.0)
         self.assertEqual(vmax, 20.0)
 
+    def test_channel_ranges_percentile_matches_the_per_channel_default(self):
+        hists = iu.channel_histograms(self.arr, self.caxis)
+        self.assertEqual(iu.channel_ranges(hists, 0.0, 100.0),
+                         [iu.range_from_hist(h, 0.0, 100.0) for h in hists])
+
+    def test_channel_ranges_fixed_is_the_same_window_for_every_channel(self):
+        """The point of the fixed window: two channels with very different content still get the
+        SAME map, so their values stay comparable. The percentile default does the opposite — here
+        it gives ch0 a span of 50 and ch1 a span of 0, i.e. a ~infinitely different gain."""
+        hists = iu.channel_histograms(self.arr, self.caxis)
+        self.assertEqual(iu.channel_ranges(hists, fixed=(20, 120)), [(20.0, 120.0), (20.0, 120.0)])
+
+        out = iu.rescale_stack_to_uint8(self.arr, self.caxis, iu.channel_ranges(hists, fixed=(0, 100)))
+        # one shared map [0,100] -> [0,255]: ch1's flat 100 now reads 255, not 0, and ch0's 50
+        # reads half of it — the ratio between the channels survives.
+        np.testing.assert_array_equal(out[1], np.full((2, 3), 255, np.uint8))
+        self.assertEqual(int(out[0][1, 2]), 127)
+
+    def test_fixed_window_clip_stats_still_report_what_was_clipped(self):
+        """A fixed window can clip, unlike the true-min/max default — so the QC numbers are the
+        thing that tells you whether it was set sensibly. They must stay meaningful."""
+        hists = iu.channel_histograms(self.arr, self.caxis)
+        s = iu.clip_stats(hists[0], 0.0, 25.0)        # ch0 spans 0..50, so half the values clip
+        self.assertGreater(s['clipHighFrac'], 0.0)
+        self.assertEqual(s['trueMax'], 50)
+
     def test_rescale_golden(self):
         hists = iu.channel_histograms(self.arr, self.caxis)
         ranges = [iu.range_from_hist(h, 0.0, 100.0) for h in hists]

--- a/python/cecelia/utils/intensity_utils.py
+++ b/python/cecelia/utils/intensity_utils.py
@@ -92,6 +92,28 @@ def range_from_hist(hist, lo_pct=0.0, hi_pct=100.0):
     return float(vmin), float(vmax)
 
 
+def channel_ranges(hists, lo_pct=0.0, hi_pct=100.0, fixed=None):
+    """One ``(vmin, vmax)`` window per channel — the single place that decides how the 8-bit
+    rescale window is chosen.
+
+    ``fixed=(lo, hi)`` uses that SAME window for every channel and, being absolute, for every image.
+    Otherwise each channel gets its own percentile window (``range_from_hist``).
+
+    A per-channel percentile window is the right default for viewing — it gives each channel the
+    full 8-bit range. It is the wrong one whenever intensities have to be compared *between*
+    channels or *between* images, because it applies a different gain to each. Confetti is exactly
+    that case: identity is the ratio across channels, and pooling movies needs one intensity space.
+    Measured on the nine `kSUFux` movies, the per-channel percentile window left the same channel
+    with a 3x different gain across images, and 3.5x between channels within one image, while
+    pinning the top of the window to a saturated 12-bit pixel so the real signal used only ~15% of
+    the range.
+    """
+    if fixed is not None:
+        lo, hi = float(fixed[0]), float(fixed[1])
+        return [(lo, hi)] * len(hists)
+    return [range_from_hist(h, lo_pct, hi_pct) for h in hists]
+
+
 def clip_stats(hist, vmin, vmax):
     """
     QC stats for a channel's rescale, from its histogram + chosen window. Pure/JSON-friendly.


### PR DESCRIPTION
The 8-bit rescale picks its window **per channel, from that channel's own percentiles**. That's right for viewing — every channel gets the full range — and wrong whenever intensities must be compared *between* channels or *between* images.

Confetti is exactly that case: identity is the ratio across channels, and the nine `kSUFux` movies are meant to be pooled.

## What the per-channel window did to that set

```
uid        CH2 span  CH3 span  CH4 span
Or1L8a         1143      4023      4027
PsD5Xc         3344      4023      4017
mkh3Tu         1120      4015      4020

CH2: 1120 -> 3344 = 3.0x gain spread across the nine images
```

- **3.0× different gain for the same channel across images** — CH2's true max varies while CH3/CH4 always saturate.
- **3.5× different gain between channels within one image.** A pixel equally bright in CH2 and CH3 read `47` vs `14`.
- **~15% of the 8-bit range used**, because `high = 100%` pins the top to a saturated 12-bit pixel (4095), not the real signal ceiling. CH3 had **58 of 256** grey levels present.

## The change

`rescaleFixedMin` / `rescaleFixedMax` — an absolute window in raw units, shared by every channel and, being absolute, every image. Set both (`max > min`) to override the percentiles; default `0/0` leaves today's behaviour untouched.

`intensity_utils.channel_ranges` is now the single place that decides the window — the runner no longer maps `range_from_hist` itself, so there's one place to look for "how was this window chosen".

Histograms are still computed either way. With a fixed window they no longer *choose* it, but `clip_stats` still reports how much each channel clips — which is the number that tells you whether the window was set sensibly.

The applied window is recorded in ccid meta as before, plus a `fixed` flag, so `v/255*(vmax-vmin)+vmin` stays invertible whichever mode produced it.

## Verified headless on real data

`run_tasks("kSUFux", ...)` with `[0, 1500]`:

```
                NEW (fixed)         OLD (per-channel percentile)
CH3   p99.9=100  levels=241         p99.9=14  levels= 58
CH4   p99.9=114  levels=245         p99.9=11  levels=102
background p50 = 18-22              background p50 = 2-4
windows: all four = (0, 1500)       four different ranges
```

`clipHigh` came out at 0.002% (CH3) / 0.009% (CH4) — matching the 0.007% predicted from the raw distributions.

Choosing `min = 0` rather than the tempting `80` was deliberate: the noise floor sits at raw 84–94, so a min of 80 clips the bottom of the background distribution and biases every background estimate. Min 0 keeps the camera offset and measured *better* background→cell contrast anyway (101 vs 85 grey levels).

## What this is not

**A fixed window is not a better default.** It can't adapt, so it's only right where the acquisition gain is stable. On this set the backgrounds agree to within 29% across two acquisition dates, which is what made it safe:

```
uid        bg lands  cell p95  cell px clipped
Or1L8a          5.9       126           0.42%
RbC99T          5.8        71           1.91%
mkh3Tu          5.6        90           0.11%
background spread 5.2-6.7 (1.29x) -> same gain, one window fits
```

Had those disagreed 3×, percentiles would be the safer choice. The clip stats are how you check it for any other set.

## Tests

2519 Julia · 280 Python. New coverage: `channel_ranges` percentile mode matches the old per-channel default exactly; fixed mode gives every channel the same map (and the ratio between two channels survives, where the percentile default gives them ~infinitely different gain); clip stats stay meaningful under a window that actually clips — unlike the true-min/max default, which never does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)