### PR TITLE
fix(notebooks): record which recipe built the sysimage, and rebuild like for like

### DIFF
--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -144,6 +144,20 @@ function _stamp_matches(stamp::Union{String,Nothing}, julia::AbstractString, man
     end
 end
 
+# Which recipe built the on-disk image: "deps", "full", or "unknown" (no stamp, unreadable, or a
+# stamp written before the field existed). Reads one more field out of the JSON `_stamp_matches`
+# already parses. Mirrors `sysimage_variant` in pluto/sysimage_stamp.jl — the same hand-sync noted
+# above; folding the two together is tracked separately.
+function _stamp_variant(stamp::Union{String,Nothing})::String
+    stamp === nothing && return "unknown"
+    try
+        v = String(get(JSON3.read(stamp), :variant, ""))
+        v in ("deps", "full") ? v : "unknown"
+    catch
+        "unknown"
+    end
+end
+
 # Pure classifier (testable, no IO): given whether deps.so exists, its stamp contents (or nothing),
 # whether a build is running, whether the last build errored, and the current Julia + Manifest hash →
 # one of: "ready" (fresh image), "stale" (image exists but built for a different Julia/package set —
@@ -176,9 +190,16 @@ function _ensure_sysimage_build!()::String
         p = _nb_build_proc[]
         (p !== nothing && process_running(p)) && return "building"
 
+        # Rebuild LIKE FOR LIKE. This always built the deps recipe, so a release shipping a FULL image
+        # (Cecelia + CeceliaNb baked in) would silently downgrade to deps the first time it went stale
+        # and the user pressed Rebuild: plots stay fast, but the first `pop_df` is slow again, with no
+        # error to explain it. The stamp now records which recipe was there, so match it. Absent or
+        # pre-variant stamp → deps, which is the safe default and what a first run has always built.
         pluto_root   = _pluto_root()
-        build_script = joinpath(pluto_root, "build_sysimage.jl")
-        isfile(build_script) || error("pluto/build_sysimage.jl not found at $build_script")
+        onstamp      = isfile(_sysimage_stamp()) ? read(_sysimage_stamp(), String) : nothing
+        script_name  = _stamp_variant(onstamp) == "full" ? "build_sysimage_full.jl" : "build_sysimage.jl"
+        build_script = joinpath(pluto_root, script_name)
+        isfile(build_script) || error("pluto/$script_name not found at $build_script")
         _pluto_env_ready() || error("The notebook environment is not set up. $_SETUP_HINT")
 
         julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -2079,3 +2079,63 @@ end
     isempty(missing_exports) ||
         @info "not exported from Cecelia but called unqualified in api/src" missing_exports
 end
+
+# ── Notebook sysimage: which recipe built the image ───────────────────────────────
+# Deliberately at the END of this file rather than beside the `API: notebooks sysimage status`
+# testset it belongs with: #437 inserts ~104 lines at line 486, exactly there, and a flat testset
+# suite does not care about order. Move it back up once that has landed.
+@testset "sysimage stamp records which recipe built the image" begin
+    # Both builders write the SAME pluto/deps.so by design, but the deps-only one EXCLUDES Cecelia so
+    # Revise can hot-reload it while -full bakes Cecelia in. Without a variant they are identical on
+    # disk, so a -full build on a dev machine silently froze Cecelia in notebook workers while
+    # launch.jl still logged "deps sysimage". These are the pure halves of that fix.
+    include(joinpath(@__DIR__, "..", "..", "pluto", "sysimage_stamp.jl"))
+
+    d = mktempdir()
+    write(joinpath(d, "Manifest.toml"), "dummy")
+    touch(joinpath(d, "deps.so"))
+
+    write_sysimage_stamp(d, "deps")
+    @test sysimage_variant(d) == "deps"
+    @test sysimage_fresh(d)
+    write_sysimage_stamp(d, "full")
+    @test sysimage_variant(d) == "full"
+    @test sysimage_fresh(d)                        # variant must not affect staleness
+    write_sysimage_stamp(d)                        # default is the safe one
+    @test sysimage_variant(d) == "deps"
+    @test_throws ArgumentError write_sysimage_stamp(d, "bogus")
+
+    # An image stamped BEFORE `variant` existed must keep working — reported honestly as unknown
+    # rather than mislabelled "deps", and crucially still FRESH (no forced ~10 min rebuild).
+    write(joinpath(d, "deps.so.stamp"),
+          "{\"julia\":\"$(VERSION)\",\"manifest\":\"$(string(hash("dummy")))\"}")
+    @test sysimage_variant(d) == "unknown"
+    @test sysimage_fresh(d)
+
+    rm(joinpath(d, "deps.so.stamp"))
+    @test sysimage_variant(d) == "unknown"
+    @test !sysimage_fresh(d)
+
+    # The stamp is read by TWO hand-synced implementations (pluto/sysimage_stamp.jl writes it,
+    # api/src/notebooks_api.jl's _stamp_matches reads it). A field added on one side must not break
+    # the other — that divergence is the standing risk this file's classifier tests sit next to.
+    full = "{\"julia\":\"1.11\",\"manifest\":\"abc\",\"variant\":\"full\"}"
+    @test _classify_sysimage(true, full, false, false, "1.11", "abc") == "ready"
+    @test _classify_sysimage(true, full, false, false, "1.10", "abc") == "stale"
+
+    # The API reads the variant to rebuild LIKE FOR LIKE. Getting "unknown" wrong in the unreadable /
+    # pre-variant / absent cases is what would silently downgrade a release's full image to deps.
+    @test _stamp_variant(full) == "full"
+    @test _stamp_variant("{\"julia\":\"1.11\",\"manifest\":\"abc\",\"variant\":\"deps\"}") == "deps"
+    @test _stamp_variant("{\"julia\":\"1.11\",\"manifest\":\"abc\"}") == "unknown"   # pre-variant stamp
+    @test _stamp_variant("{\"variant\":\"bogus\"}") == "unknown"                     # unrecognised
+    @test _stamp_variant("not json at all")         == "unknown"
+    @test _stamp_variant(nothing)                   == "unknown"                     # absent → first run
+
+    # …and the two readers must agree on the same bytes, since they are hand-synced across envs.
+    for v in ("deps", "full")
+        d2 = mktempdir(); write(joinpath(d2, "Manifest.toml"), "x"); touch(joinpath(d2, "deps.so"))
+        write_sysimage_stamp(d2, v)
+        @test _stamp_variant(read(joinpath(d2, "deps.so.stamp"), String)) == sysimage_variant(d2) == v
+    end
+end

--- a/docs/NOTEBOOKS.md
+++ b/docs/NOTEBOOKS.md
@@ -24,7 +24,7 @@ pluto/                       ← the notebook ENGINE (its own Julia env; path-so
   launch.jl                  ← starts Pluto (:7660), wires the sysimage + CECELIA_PLUTO_ENV
   build_sysimage.jl          ← deps-only sysimage (dev)      → pluto/deps.so (git-ignored)
   build_sysimage_full.jl     ← full sysimage (release)       → pluto/deps.so
-  sysimage_stamp.jl          ← writes/checks deps.so.stamp (Julia+Manifest) for update-staleness
+  sysimage_stamp.jl          ← writes/checks deps.so.stamp (Julia+Manifest+variant); staleness + which recipe
   notebook_template.jl       ← starter copied by "Add notebook"
   CeceliaNb/                 ← small notebook-side helper package (aggregation + AoG plot shortcuts)
 notebooks/                   ← shipped EXAMPLE notebooks (UID-free, versioned with the code)
@@ -209,11 +209,11 @@ line (`_NB_DESC_MAX`).
 
 Makie compiles plotting code on first use (~20 s cold). A PackageCompiler sysimage bakes that in
 (measured cold-start 32 s → 7.6 s). Built to `pluto/deps.so` (git-ignored, ~1.4 GB, ~10 min):
-`notebooks-sysimage` (dev, deps only — excludes Cecelia so Revise still hot-reloads it) /
+`notebooks-sysimage` (dev, deps only — excludes Cecelia so workers load it from source and see edits) /
 `notebooks-sysimage-full` (release, bakes Cecelia + CeceliaNb in). Both run the same
 `create_sysimage`; the **only** difference is the package list — the `-full` build adds `CSV`,
 `Cecelia`, and `CeceliaNb`, so a release image also skips the first-`pop_df` compile, at the cost of
-being frozen (no Revise). `launch.jl` picks up `deps.so` and passes it to notebook workers; without
+being frozen at build time. `launch.jl` picks up `deps.so` and passes it to notebook workers; without
 it, notebooks still work, just slow-first-plot.
 
 **Built from a button, not by hand.** An end user never runs the `pixi` task. The Notebooks page shows
@@ -225,13 +225,27 @@ stray click); `pixi run notebooks-sysimage` remains the manual/dev path.
 
 **Update-safe (the stamp).** A sysimage is native code tied to the exact Julia version + baked package
 versions, so it can't be shipped prebuilt as one universal artifact, and after an update the on-disk
-image goes **stale**. Each build writes a sidecar `deps.so.stamp` (`{julia, hash(Manifest.toml)}`, see
-`pluto/sysimage_stamp.jl`). Freshness = both fields match the current Julia + Manifest. `launch.jl`
+image goes **stale**. Each build writes a sidecar `deps.so.stamp` (`{julia, hash(Manifest.toml), variant}`,
+see `pluto/sysimage_stamp.jl`). Freshness = the first two fields match the current Julia + Manifest —
+`variant` never affects staleness. `launch.jl`
 ignores a stale image (falls back to slow-first-plot rather than handing workers an incompatible one),
 and the status endpoint reports `stale` so the page shows a **Rebuild** button — same flow as first-run.
 `_classify_sysimage` (in `notebooks_api.jl`) is the pure, tested classifier: `ready` / `stale` /
 `building` / `error` / `absent`. Release packaging (ship a prebuilt image per platform vs. build on
 first run): see `docs/SHIPPING.md` and TODO #00070.
+
+**Which recipe built it (`variant`).** Both builds write the same `deps.so`, but the deps-only one
+excludes `Cecelia` so workers load it from source, while `-full` bakes it in. That made them
+indistinguishable on disk: running `notebooks-sysimage-full` on a dev machine silently handed workers
+a **frozen `Cecelia`** — `app/src` edits stopped reaching notebooks — while `launch.jl` still logged
+"deps sysimage". The stamp now records `"deps"` or `"full"`, and `launch.jl` says which it loaded,
+warning on `full` that app/src edits won't reach workers. A stamp written before this field reads as
+`unknown` and stays **fresh** (no forced ~10 min rebuild).
+
+**Rebuild is like-for-like.** `_ensure_sysimage_build!` used to always run `build_sysimage.jl`, so a
+release shipping a `full` image would silently drop to deps the first time it went stale and the user
+pressed *Rebuild* — plots still fast, but the first `pop_df` slow again, with nothing to explain it.
+It now picks the recipe matching the stamped variant; `unknown`/absent → deps (the first-run default).
 
 ## API surface (`api/src/notebooks_api.jl`)
 

--- a/pluto/build_sysimage.jl
+++ b/pluto/build_sysimage.jl
@@ -3,7 +3,8 @@
 #   pixi run notebooks-sysimage
 #
 # Deps-only (Locked #6): bakes the stable heavy stack — Makie/CairoMakie + AoG + DataFrames + HDF5 +
-# HTTP — but NOT Cecelia, so Revise still hot-reloads Cecelia in dev. For RELEASE, a full sysimage
+# HTTP — but NOT Cecelia, so workers load Cecelia from source and pick up app/src edits. For RELEASE,
+# a full sysimage
 # (Cecelia included) is built in the packaging flow (docs/SHIPPING.md).
 #
 # Cost (Phase 0, Linux): ~10 min to build, ~1.4 GB on disk. One-time. deps.so is git-ignored.
@@ -17,5 +18,5 @@ create_sysimage(
     sysimage_path = joinpath(@__DIR__, "deps.so"),
     precompile_execution_file = joinpath(@__DIR__, "precompile_workload.jl"),
 )
-write_sysimage_stamp(@__DIR__)   # record Julia + Manifest versions so a later update can detect staleness
+write_sysimage_stamp(@__DIR__, "deps")   # Julia + Manifest (staleness) + which recipe built it
 @info "sysimage built" path = joinpath(@__DIR__, "deps.so")

--- a/pluto/build_sysimage_full.jl
+++ b/pluto/build_sysimage_full.jl
@@ -3,9 +3,10 @@
 #
 #   pixi run notebooks-sysimage-full
 #
-# Difference from the deps-only build (build_sysimage.jl): that one deliberately EXCLUDES Cecelia so
-# Revise can hot-reload it in dev. This one bakes Cecelia + CeceliaNb in too — correct for a release
-# where the code is frozen. Wire this into the packaging flow (docs/SHIPPING.md); output is git-ignored.
+# Difference from the deps-only build (build_sysimage.jl): that one deliberately EXCLUDES Cecelia, so
+# workers load it from source and see app/src edits. This one bakes Cecelia + CeceliaNb in too, which
+# FREEZES them at build time — correct for a release, and wrong for dev (the stamp records which, so
+# launch.jl can warn). Wire this into the packaging flow (docs/SHIPPING.md); output is git-ignored.
 import Pkg
 Pkg.activate(@__DIR__)
 using PackageCompiler
@@ -16,5 +17,5 @@ create_sysimage(
     sysimage_path = joinpath(@__DIR__, "deps.so"),
     precompile_execution_file = joinpath(@__DIR__, "precompile_workload_full.jl"),
 )
-write_sysimage_stamp(@__DIR__)   # record Julia + Manifest versions so a later update can detect staleness
+write_sysimage_stamp(@__DIR__, "full")   # "full" so launch.jl can say Cecelia is baked in (frozen)
 @info "full sysimage built" path = joinpath(@__DIR__, "deps.so")

--- a/pluto/launch.jl
+++ b/pluto/launch.jl
@@ -34,7 +34,18 @@ launch_browser = get(ENV, "CECELIA_PLUTO_BROWSER", "true") == "true"
 include(joinpath(@__DIR__, "sysimage_stamp.jl"))
 sysimg = joinpath(@__DIR__, "deps.so")
 compiler = if sysimage_fresh(@__DIR__)
-    @info "Pluto workers will use the deps sysimage (fast first plot)" sysimg
+    # Say WHICH image, not just that there is one. Both recipes write this same path, and a `full`
+    # image has Cecelia baked in at BUILD time — so app/src edits never reach notebook workers, not
+    # even a freshly spawned one, until the image is rebuilt. Correct for a release, wrong for dev,
+    # and it used to be invisible: this line always claimed "deps". (Measured: with a full image a
+    # brand-new session returns the build-time definition while the source on disk says otherwise,
+    # and `pathof(Cecelia)` still points at the source, so nothing gives it away.)
+    variant = sysimage_variant(@__DIR__)
+    if variant == "full"
+        @warn "Pluto workers will use the FULL sysimage — Cecelia is baked in at build time, so changes to app/src will NOT reach notebooks (not even in a fresh worker) until it is rebuilt. Correct for a release; in dev rebuild deps-only with: pixi run notebooks-sysimage" sysimg
+    else
+        @info "Pluto workers will use the $(variant == "deps" ? "deps" : "(unstamped)") sysimage (fast first plot)" sysimg variant
+    end
     Pluto.Configuration.CompilerOptions(sysimage = sysimg)
 else
     isfile(sysimg) ?

--- a/pluto/sysimage_stamp.jl
+++ b/pluto/sysimage_stamp.jl
@@ -5,20 +5,54 @@
 # would make Pluto's workers reject it outright, not merely run slow. So we write a sidecar
 # `deps.so.stamp` at build time and check it before use (launch.jl) and to decide when to rebuild.
 #
-# Stamp format (hand-written JSON — no dep in the pluto env): {"julia":"<VERSION>","manifest":"<hash>"}
+# Stamp format (hand-written JSON — no dep in the pluto env):
+#   {"julia":"<VERSION>","manifest":"<hash>","variant":"deps"|"full"}
 # where <hash> fingerprints pluto/Manifest.toml (the resolved dep versions).
 #
-# The API server mirrors this same two-field classification in api/src/notebooks_api.jl
-# (_classify_sysimage) — kept trivially in sync; if you change the fields, change both.
+# WHY `variant` EXISTS. Both builders write the SAME pluto/deps.so — that is deliberate (one path,
+# two recipes; see docs/NOTEBOOKS.md), so launch.jl picks up whichever was built. But the deps-only
+# build EXCLUDES Cecelia, so workers load it from source and pick up edits, while the -full build
+# bakes Cecelia into the image at build time. Without recording which recipe produced the image the
+# two are indistinguishable on disk: a `pixi run notebooks-sysimage-full` on a dev machine silently
+# hands notebook workers a FROZEN Cecelia and edits to app/src stop reaching notebooks, with nothing
+# to say so. (Verified against real 1.4 GB images: under `full`, a brand-new session returns the
+# build-time definition while the source says otherwise — and `pathof(Cecelia)` still points at the
+# source, so inspection does not reveal it.) The stamp records the recipe so launch.jl can report
+# which image it is actually using instead of always claiming "deps".
+#
+# NB this is about the image being frozen, NOT about Revise: nothing in the notebook path loads
+# Revise at all (it lives in the global default env and only api/dev.jl uses it, for the API server).
+#
+# The API server mirrors the julia+manifest classification in api/src/notebooks_api.jl
+# (_classify_sysimage) — kept trivially in sync; if you change THOSE fields, change both. It ignores
+# unknown fields, so adding `variant` here does not affect it.
 
 _sysimage_file(dir)  = joinpath(dir, "deps.so")
 _sysimage_stamp(dir) = joinpath(dir, "deps.so.stamp")
 _manifest_fingerprint(dir) = (m = joinpath(dir, "Manifest.toml"); isfile(m) ? string(hash(read(m, String))) : "")
 
 # Write the stamp next to a freshly-built deps.so. Call right after create_sysimage.
-function write_sysimage_stamp(dir)
+# `variant` is "deps" (Cecelia loaded from source, edits apply) or "full" (Cecelia baked in, frozen).
+function write_sysimage_stamp(dir, variant::AbstractString = "deps")
+    variant in ("deps", "full") || throw(ArgumentError("variant must be \"deps\" or \"full\", got $(repr(variant))"))
     open(_sysimage_stamp(dir), "w") do io
-        print(io, "{\"julia\":\"", VERSION, "\",\"manifest\":\"", _manifest_fingerprint(dir), "\"}")
+        print(io, "{\"julia\":\"", VERSION, "\",\"manifest\":\"", _manifest_fingerprint(dir),
+                  "\",\"variant\":\"", variant, "\"}")
+    end
+end
+
+# Which recipe built the on-disk image: "deps", "full", or "unknown" (no stamp, unreadable, or a
+# stamp written before `variant` existed). "unknown" is NOT an error — it must not affect freshness,
+# only what we report — so an image from an older build keeps working and is simply described
+# honestly rather than mislabelled "deps".
+function sysimage_variant(dir)::String
+    isfile(_sysimage_stamp(dir)) || return "unknown"
+    try
+        s = read(_sysimage_stamp(dir), String)
+        occursin("\"variant\":\"full\"", s) ? "full" :
+        occursin("\"variant\":\"deps\"", s) ? "deps" : "unknown"
+    catch
+        "unknown"
     end
 end
 


### PR DESCRIPTION
## The bug

`build_sysimage.jl` and `build_sysimage_full.jl` both write **the same** `pluto/deps.so`. That is deliberate — one path, two recipes — but the deps-only build **excludes** `Cecelia` (so workers load it from source) while `-full` **bakes it in**. Nothing recorded which recipe produced the image, so on disk they were indistinguishable.

Run `pixi run notebooks-sysimage-full` on a dev machine and notebook workers silently get a **frozen `Cecelia`**: edits to `app/src` stop reaching notebooks, with no error — while `launch.jl` cheerfully logs *"Pluto workers will use the deps sysimage"*.

The UI auto-build always ran the deps recipe, so this only fires via the manual `-full` task — which sits right next to the normal one in `pixi.toml` with no guard.

## Verified, not reasoned

Built both images for real (deps 460s, full 497s, 1.4 GB each) and probed a function in `app/src`:

| image | source on disk | fresh session reads | |
|---|---|---|---|
| deps | `BEFORE` | `BEFORE` | |
| deps, after editing source | `AFTER` | **`AFTER`** | edits apply |
| full, baked at `AFTER` | `AFTER` | `AFTER` | |
| full, after editing source | **`FINAL`** | **`AFTER`** | frozen |

`pathof(Cecelia)` returns the **source path** under both, so inspection cannot tell them apart — which is exactly why the stamp has to say.

Also validated against the real pre-existing image on this machine (built Jul 8, before the field): reads as `unknown` and stays **fresh**, so nobody is forced into a ~10 min rebuild.

## What changed

- Stamp gains `"variant":"deps"|"full"`; `sysimage_variant()` reads it. Freshness is unaffected — `variant` never contributes to staleness.
- `launch.jl` reports the image it actually loaded, and **warns** on `full` that `app/src` changes will not reach notebooks until rebuilt.
- **Rebuild is now like-for-like.** `_ensure_sysimage_build!` always ran the deps recipe, so a release shipping a full image would silently drop to deps the first time it went stale and the user pressed *Rebuild* — plots still fast, first `pop_df` slow again, no error. It now matches the stamped variant; `unknown`/absent → deps, which is what a first run has always built.

## A pre-existing claim corrected

The deps-only split was documented as existing *"so Revise still hot-reloads Cecelia"*. That is not what happens: `Revise` is in **no** project env (only the global default), and the only loader in the repo is `api/dev.jl`, for the API server. **Notebook workers never load Revise.** The real mechanism is that a baked module is frozen at build time. Corrected in `launch.jl`, `sysimage_stamp.jl`, both builders and `docs/NOTEBOOKS.md`.

## Reservations

- **Tested with plain Julia sessions under each image, not Malt-spawned Pluto workers.** The mechanism is the same (a baked module wins), but the notebook path itself is inferred.
- **The like-for-like rebuild was never driven end-to-end** — `_stamp_variant` is unit-tested across all six cases, but *Rebuild* was never pressed with a full image present.
- `launch.jl`'s branch has no automated test (that file boots Pluto); verified by parse-check and by simulating the branch.
- `_stamp_variant` is a **fourth** site that knows the stamp format, alongside `sysimage_stamp.jl`, `_stamp_matches` and `_manifest_hash`. There is now a test asserting both readers agree on the same bytes, which turns silent drift into a failing test — a guard, not a fix.
- The new testset is appended at the **end** of `api/test/runtests.jl` rather than beside the other sysimage tests, to avoid colliding with #437's insertion at line 486. A comment says to move it back.

Unrelated but worth knowing: the sysimage on this machine is currently **stale** (Julia matches; `pluto/Manifest.toml` changed since Jul 8), so notebooks are on the slow-first-plot path until *Rebuild*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
