### PR TITLE
refactor(notebooks): one implementation of the sysimage stamp, with a detector

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -105,7 +105,7 @@ Last audited: 2026-07-16 (full six-area ground-truth read; against `main` @ c1ce
 - **gating_api.jl**: population manager + gating engine routes; **owns the shared helpers** (`_gating_image`/`_resolve_vn`/`_gerr`/`_live_map`) reused by tracking/plotting/napari (include-order coupled — `gating_api.jl` first).
 - **plotting_api.jl**: summary-canvas routes (thin wrappers over `plot_summary_data`).
 - **tracking_api.jl**: `/api/tracking/motion-dims` preflight.
-- **notebooks_api.jl**: Pluto engine lifecycle (:7660) + registry/snapshot CRUD + sysimage build.
+- **notebooks_api.jl**: Pluto engine lifecycle (:7660) + registry/snapshot CRUD + sysimage build. **The sysimage stamp — freshness AND which recipe built the image — has ONE implementation: `pluto/sysimage_stamp.jl`**, which this file `include`s by path (it is deliberately dependency-free so an env that can't depend on the pluto project can still load it). Don't re-derive `deps.so`/`.stamp` paths, the Manifest fingerprint, or the stamp readers here or anywhere else — that copy existed, was "kept in sync" by hand, and drifted the moment a field was added.
 - **app_api.jl**: `_stop_children_for_exit`, `/api/app/shutdown|restart`, dev worktree-switch.
 - **storage_api.jl**: `/api/storage/summary` (walked disk/reclaimable scan) + `/api/storage/reclaim` — thin adapters over `storage.jl`.
 - **repl_api.jl / update_api.jl / setup_api.jl**: diagnostics + gated REPL; self-update; first-launch wizard.

--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -124,39 +124,25 @@ end
 # The freshly-built image is picked up by launch.jl on the NEXT server launch — we don't restart a
 # running server out from under an open session. Mirrors the server lifecycle above (one tracked proc,
 # atexit cleanup). See docs/NOTEBOOKS.md and TODO #00070.
-_sysimage_path()  = joinpath(_pluto_root(), "deps.so")
-_sysimage_stamp() = _sysimage_path() * ".stamp"
-# Fingerprint of the resolved pluto deps — mirrors pluto/sysimage_stamp.jl (`hash(Manifest.toml)`), so
-# a package update that re-resolves the Manifest invalidates the stamp.
-_manifest_hash() = (m = joinpath(_pluto_root(), "Manifest.toml"); isfile(m) ? string(hash(read(m, String))) : "")
+# The stamp format has ONE implementation — pluto/sysimage_stamp.jl — and this file uses it rather
+# than keeping a parallel copy (paths, Manifest fingerprint and both stamp readers used to be
+# duplicated here, "kept trivially in sync" by hand). It is deliberately dependency-free so it can be
+# included by path from an env that does not depend on the pluto project.
+let helper = joinpath(_pluto_root(), "sysimage_stamp.jl")
+    # Loaded at server START, so a missing file takes the whole API down, not just notebooks. Say why.
+    isfile(helper) || error("pluto/sysimage_stamp.jl not found at $helper — the notebook sysimage " *
+                            "stamp helpers live there and the API server needs them at load. " *
+                            "A partial checkout/install?")
+    include(helper)
+end
+
+# Zero-arg conveniences: this server always means THE pluto env, so bind the dir once.
+_sysimage_path()  = _sysimage_file(_pluto_root())
+_sysimage_stamp() = _sysimage_stamp(_pluto_root())
+_manifest_hash()  = _manifest_fingerprint(_pluto_root())
 
 const _nb_build_proc  = Ref{Union{Base.Process,Nothing}}(nothing)
 const _nb_build_error = Ref{Union{String,Nothing}}(nothing)
-
-# Does the on-disk stamp match this Julia + the current Manifest? (Same two fields the build writes.)
-function _stamp_matches(stamp::Union{String,Nothing}, julia::AbstractString, manifest::AbstractString)::Bool
-    stamp === nothing && return false
-    try
-        d = JSON3.read(stamp)
-        String(get(d, :julia, "")) == julia && String(get(d, :manifest, "")) == manifest
-    catch
-        false
-    end
-end
-
-# Which recipe built the on-disk image: "deps", "full", or "unknown" (no stamp, unreadable, or a
-# stamp written before the field existed). Reads one more field out of the JSON `_stamp_matches`
-# already parses. Mirrors `sysimage_variant` in pluto/sysimage_stamp.jl — the same hand-sync noted
-# above; folding the two together is tracked separately.
-function _stamp_variant(stamp::Union{String,Nothing})::String
-    stamp === nothing && return "unknown"
-    try
-        v = String(get(JSON3.read(stamp), :variant, ""))
-        v in ("deps", "full") ? v : "unknown"
-    catch
-        "unknown"
-    end
-end
 
 # Pure classifier (testable, no IO): given whether deps.so exists, its stamp contents (or nothing),
 # whether a build is running, whether the last build errored, and the current Julia + Manifest hash →
@@ -165,7 +151,7 @@ end
 function _classify_sysimage(exists::Bool, stamp::Union{String,Nothing}, building::Bool, errored::Bool,
                             julia::AbstractString, manifest::AbstractString)::String
     if exists
-        _stamp_matches(stamp, julia, manifest) && return "ready"
+        stamp_matches(stamp, julia, manifest) && return "ready"
         return building ? "building" : "stale"
     end
     building && return "building"
@@ -197,7 +183,7 @@ function _ensure_sysimage_build!()::String
         # pre-variant stamp → deps, which is the safe default and what a first run has always built.
         pluto_root   = _pluto_root()
         onstamp      = isfile(_sysimage_stamp()) ? read(_sysimage_stamp(), String) : nothing
-        script_name  = _stamp_variant(onstamp) == "full" ? "build_sysimage_full.jl" : "build_sysimage.jl"
+        script_name  = stamp_variant(onstamp) == "full" ? "build_sysimage_full.jl" : "build_sysimage.jl"
         build_script = joinpath(pluto_root, script_name)
         isfile(build_script) || error("pluto/$script_name not found at $build_script")
         _pluto_env_ready() || error("The notebook environment is not set up. $_SETUP_HINT")

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -483,7 +483,7 @@ end
     # this Julia + Manifest (no build running in tests).
     onstamp = isfile(_sysimage_stamp()) ? read(_sysimage_stamp(), String) : nothing
     @test (_sysimage_status() == "ready") ==
-          (isfile(_sysimage_path()) && _stamp_matches(onstamp, string(VERSION), _manifest_hash()))
+          (isfile(_sysimage_path()) && stamp_matches(onstamp, string(VERSION), _manifest_hash()))
 end
 
 @testset "API: image geometry (axis mapping + version resolution)" begin
@@ -2089,7 +2089,9 @@ end
     # Revise can hot-reload it while -full bakes Cecelia in. Without a variant they are identical on
     # disk, so a -full build on a dev machine silently froze Cecelia in notebook workers while
     # launch.jl still logged "deps sysimage". These are the pure halves of that fix.
-    include(joinpath(@__DIR__, "..", "..", "pluto", "sysimage_stamp.jl"))
+    # No include needed: notebooks_api.jl (loaded via server.jl above) now includes the shared
+    # pluto/sysimage_stamp.jl itself, so these functions are already in scope. That IS the fix —
+    # if this testset ever needs its own include again, the duplication has come back.
 
     d = mktempdir()
     write(joinpath(d, "Manifest.toml"), "dummy")
@@ -2116,26 +2118,66 @@ end
     @test sysimage_variant(d) == "unknown"
     @test !sysimage_fresh(d)
 
-    # The stamp is read by TWO hand-synced implementations (pluto/sysimage_stamp.jl writes it,
-    # api/src/notebooks_api.jl's _stamp_matches reads it). A field added on one side must not break
-    # the other — that divergence is the standing risk this file's classifier tests sit next to.
+    # Writer and readers are now ONE implementation (pluto/sysimage_stamp.jl, included by the API
+    # server rather than copied). These pin the round trip end to end: what the builder writes is
+    # what the classifier and the rebuild path read back.
     full = "{\"julia\":\"1.11\",\"manifest\":\"abc\",\"variant\":\"full\"}"
     @test _classify_sysimage(true, full, false, false, "1.11", "abc") == "ready"
     @test _classify_sysimage(true, full, false, false, "1.10", "abc") == "stale"
 
     # The API reads the variant to rebuild LIKE FOR LIKE. Getting "unknown" wrong in the unreadable /
     # pre-variant / absent cases is what would silently downgrade a release's full image to deps.
-    @test _stamp_variant(full) == "full"
-    @test _stamp_variant("{\"julia\":\"1.11\",\"manifest\":\"abc\",\"variant\":\"deps\"}") == "deps"
-    @test _stamp_variant("{\"julia\":\"1.11\",\"manifest\":\"abc\"}") == "unknown"   # pre-variant stamp
-    @test _stamp_variant("{\"variant\":\"bogus\"}") == "unknown"                     # unrecognised
-    @test _stamp_variant("not json at all")         == "unknown"
-    @test _stamp_variant(nothing)                   == "unknown"                     # absent → first run
+    @test stamp_variant(full) == "full"
+    @test stamp_variant("{\"julia\":\"1.11\",\"manifest\":\"abc\",\"variant\":\"deps\"}") == "deps"
+    @test stamp_variant("{\"julia\":\"1.11\",\"manifest\":\"abc\"}") == "unknown"   # pre-variant stamp
+    @test stamp_variant("{\"variant\":\"bogus\"}") == "unknown"                     # unrecognised
+    @test stamp_variant("not json at all")         == "unknown"
+    @test stamp_variant(nothing)                   == "unknown"                     # absent → first run
 
-    # …and the two readers must agree on the same bytes, since they are hand-synced across envs.
+    # Round trip through the real writer: what a build stamps is what the readers report.
     for v in ("deps", "full")
-        d2 = mktempdir(); write(joinpath(d2, "Manifest.toml"), "x"); touch(joinpath(d2, "deps.so"))
+        d2 = mktempdir(); write(joinpath(d2, "Manifest.toml"), "x"); touch(_sysimage_file(d2))
         write_sysimage_stamp(d2, v)
-        @test _stamp_variant(read(joinpath(d2, "deps.so.stamp"), String)) == sysimage_variant(d2) == v
+        @test stamp_variant(read_sysimage_stamp(d2)) == sysimage_variant(d2) == v
     end
+end
+
+@testset "the sysimage stamp format has exactly one implementation" begin
+    # REPLACES a "both readers agree" assertion that went vacuous the moment they became the same
+    # function. The live risk is no longer drift between two copies — it is someone re-deriving the
+    # format a third time, which is exactly how the copy this consolidation deleted came to exist
+    # (with a comment noting the two were "kept trivially in sync"). So detect that instead.
+    canonical = normpath(joinpath(@__DIR__, "..", "..", "pluto", "sysimage_stamp.jl"))
+    @test isfile(canonical)
+
+    roots = [normpath(joinpath(@__DIR__, "..", "src")),
+             normpath(joinpath(@__DIR__, "..", "..", "app", "src")),
+             normpath(joinpath(@__DIR__, "..", "..", "pluto"))]
+
+    # Knowledge belonging to the canonical file alone: the artefact filenames, the stamp's JSON field
+    # spellings, and the Manifest fingerprint. Anything else deriving these is a second source of
+    # truth, whether or not it happens to agree today.
+    banned = [("image/stamp filename", r"\"deps\.so"),
+              ("stamp field literal",  r"\\\"(julia|manifest|variant)\\\""),
+              ("manifest fingerprint", r"hash\(read\(.*Manifest\.toml")]
+
+    offenders, scanned = String[], 0
+    for root in roots, (dir, _, files) in walkdir(root), f in files
+        endswith(f, ".jl") || continue
+        path = joinpath(dir, f)
+        normpath(path) == canonical && continue
+        scanned += 1
+        for (i, line) in enumerate(eachline(path))
+            startswith(strip(line), "#") && continue        # prose may name them freely
+            for (what, re) in banned
+                occursin(re, line) && push!(offenders, "$(basename(path))#$i — $what: $(strip(line))")
+            end
+        end
+    end
+
+    @test isempty(offenders)
+    isempty(offenders) || @info "sysimage stamp format re-derived outside pluto/sysimage_stamp.jl — use its helpers (_sysimage_file / _sysimage_stamp / _manifest_fingerprint / stamp_matches / stamp_variant)" offenders
+
+    # Anti-vacuity: a walk over nothing reports a clean bill of health, so pin that we really looked.
+    @test scanned > 100
 end

--- a/pluto/build_sysimage.jl
+++ b/pluto/build_sysimage.jl
@@ -15,8 +15,8 @@ include(joinpath(@__DIR__, "sysimage_stamp.jl"))
 
 create_sysimage(
     ["CairoMakie", "AlgebraOfGraphics", "DataFrames", "HDF5", "HTTP"];
-    sysimage_path = joinpath(@__DIR__, "deps.so"),
+    sysimage_path = _sysimage_file(@__DIR__),
     precompile_execution_file = joinpath(@__DIR__, "precompile_workload.jl"),
 )
 write_sysimage_stamp(@__DIR__, "deps")   # Julia + Manifest (staleness) + which recipe built it
-@info "sysimage built" path = joinpath(@__DIR__, "deps.so")
+@info "sysimage built" path = _sysimage_file(@__DIR__)

--- a/pluto/build_sysimage_full.jl
+++ b/pluto/build_sysimage_full.jl
@@ -14,8 +14,8 @@ include(joinpath(@__DIR__, "sysimage_stamp.jl"))
 
 create_sysimage(
     ["CairoMakie", "AlgebraOfGraphics", "DataFrames", "HDF5", "HTTP", "CSV", "Cecelia", "CeceliaNb"];
-    sysimage_path = joinpath(@__DIR__, "deps.so"),
+    sysimage_path = _sysimage_file(@__DIR__),
     precompile_execution_file = joinpath(@__DIR__, "precompile_workload_full.jl"),
 )
 write_sysimage_stamp(@__DIR__, "full")   # "full" so launch.jl can say Cecelia is baked in (frozen)
-@info "full sysimage built" path = joinpath(@__DIR__, "deps.so")
+@info "full sysimage built" path = _sysimage_file(@__DIR__)

--- a/pluto/launch.jl
+++ b/pluto/launch.jl
@@ -32,7 +32,7 @@ launch_browser = get(ENV, "CECELIA_PLUTO_BROWSER", "true") == "true"
 # workers reject it. So we use it only when its stamp matches (sysimage_stamp.jl); otherwise fall back
 # to a plain session (slow first plot) and let the app rebuild it. Never hand workers a stale image.
 include(joinpath(@__DIR__, "sysimage_stamp.jl"))
-sysimg = joinpath(@__DIR__, "deps.so")
+sysimg = _sysimage_file(@__DIR__)
 compiler = if sysimage_fresh(@__DIR__)
     # Say WHICH image, not just that there is one. Both recipes write this same path, and a `full`
     # image has Cecelia baked in at BUILD time — so app/src edits never reach notebook workers, not

--- a/pluto/sysimage_stamp.jl
+++ b/pluto/sysimage_stamp.jl
@@ -23,9 +23,12 @@
 # NB this is about the image being frozen, NOT about Revise: nothing in the notebook path loads
 # Revise at all (it lives in the global default env and only api/dev.jl uses it, for the API server).
 #
-# The API server mirrors the julia+manifest classification in api/src/notebooks_api.jl
-# (_classify_sysimage) — kept trivially in sync; if you change THOSE fields, change both. It ignores
-# unknown fields, so adding `variant` here does not affect it.
+# THIS FILE IS THE SINGLE IMPLEMENTATION. api/src/notebooks_api.jl used to carry a parallel copy of
+# all of it — its own path/fingerprint helpers plus its own JSON-parsing stamp readers — with a
+# comment admitting they were "kept trivially in sync". They were not one edit away from diverging;
+# they were one *forgotten* edit away. The API server now `include`s this file and calls these
+# functions, which is why they stay dependency-free (no JSON3): an env that cannot take a dependency
+# must still be able to load it by path.
 
 _sysimage_file(dir)  = joinpath(dir, "deps.so")
 _sysimage_stamp(dir) = joinpath(dir, "deps.so.stamp")
@@ -41,30 +44,41 @@ function write_sysimage_stamp(dir, variant::AbstractString = "deps")
     end
 end
 
-# Which recipe built the on-disk image: "deps", "full", or "unknown" (no stamp, unreadable, or a
-# stamp written before `variant` existed). "unknown" is NOT an error — it must not affect freshness,
-# only what we report — so an image from an older build keeps working and is simply described
-# honestly rather than mislabelled "deps".
-function sysimage_variant(dir)::String
-    isfile(_sysimage_stamp(dir)) || return "unknown"
-    try
-        s = read(_sysimage_stamp(dir), String)
-        occursin("\"variant\":\"full\"", s) ? "full" :
-        occursin("\"variant\":\"deps\"", s) ? "deps" : "unknown"
-    catch
-        "unknown"
-    end
+# ── Pure predicates over the stamp CONTENTS ──────────────────────────────────
+# THE single implementation, shared by both callers: the Pluto launcher (which has a directory) and
+# the API server (which has already read the bytes). Deliberately string-matching rather than JSON
+# parsing, so this file stays dependency-free and any env can `include` it by path — which is what
+# lets the API server use it instead of keeping a second copy.
+
+"""Does the stamp match this Julia + Manifest? `nothing` (no stamp) is never a match."""
+function stamp_matches(stamp::Union{String,Nothing}, julia::AbstractString, manifest::AbstractString)::Bool
+    stamp === nothing && return false
+    occursin("\"julia\":\"$(julia)\"", stamp) && occursin("\"manifest\":\"$(manifest)\"", stamp)
 end
+
+"""
+Which recipe built the image: "deps", "full", or "unknown" (no stamp, unreadable, or written before
+`variant` existed). "unknown" is NOT an error — it must not affect freshness, only what we report —
+so an older image keeps working and is described honestly rather than mislabelled "deps".
+"""
+function stamp_variant(stamp::Union{String,Nothing})::String
+    stamp === nothing && return "unknown"
+    occursin("\"variant\":\"full\"", stamp) ? "full" :
+    occursin("\"variant\":\"deps\"", stamp) ? "deps" : "unknown"
+end
+
+# ── Thin IO wrappers over the predicates above ───────────────────────────────
+
+"""Stamp contents for `dir`, or `nothing` if absent/unreadable."""
+function read_sysimage_stamp(dir)::Union{String,Nothing}
+    isfile(_sysimage_stamp(dir)) || return nothing
+    try read(_sysimage_stamp(dir), String) catch; nothing end
+end
+
+sysimage_variant(dir)::String = stamp_variant(read_sysimage_stamp(dir))
 
 # Fresh = the image exists AND its stamp matches this Julia + the current Manifest. A missing stamp
 # (e.g. an image from before stamping existed) counts as NOT fresh, so it gets rebuilt once and stamped.
-function sysimage_fresh(dir)::Bool
-    (isfile(_sysimage_file(dir)) && isfile(_sysimage_stamp(dir))) || return false
-    try
-        s = read(_sysimage_stamp(dir), String)
-        occursin("\"julia\":\"$(VERSION)\"", s) &&
-            occursin("\"manifest\":\"$(_manifest_fingerprint(dir))\"", s)
-    catch
-        false
-    end
-end
+sysimage_fresh(dir)::Bool =
+    isfile(_sysimage_file(dir)) &&
+    stamp_matches(read_sysimage_stamp(dir), string(VERSION), _manifest_fingerprint(dir))


### PR DESCRIPTION
## The duplication

`api/src/notebooks_api.jl` carried a parallel copy of essentially **all** of `pluto/sysimage_stamp.jl`:

| `pluto/sysimage_stamp.jl` | `api/src/notebooks_api.jl` | |
|---|---|---|
| `_sysimage_file(dir)` | `_sysimage_path()` | same path logic |
| `_sysimage_stamp(dir)` | `_sysimage_stamp()` | same name, different arity |
| `_manifest_fingerprint(dir)` | `_manifest_hash()` | **identical body** |
| `sysimage_fresh(dir)` | `_stamp_matches(...)` | same two-field check |
| `sysimage_variant(dir)` | `_stamp_variant(...)` | added by #441 |

…under a comment stating the two were *"kept trivially in sync"*. They were not one edit from diverging — they were one **forgotten** edit from it, and #441 made it five duplicated functions instead of four.

The shared file is deliberately dependency-free (hand-written JSON, no JSON3) **precisely so** an env that cannot depend on the pluto project can `include` it by path. Nothing was stopping the API server from doing that except a name/arity clash.

## What changed

- The pure predicates move into the shared file — `stamp_matches(stamp, julia, manifest)` and `stamp_variant(stamp)` — with `sysimage_fresh` / `sysimage_variant` as thin IO wrappers. The launcher (which has a directory) and the API server (which has already read the bytes) now call the same code.
- `notebooks_api.jl` includes the shared file and deletes its copies. Its remaining zero-arg helpers are one-line bindings to `_pluto_root()`, not reimplementations.
- **The image path was duplicated too** — five sites built `joinpath(@__DIR__, "deps.so")` by hand *in files that already included the helper defining `_sysimage_file(dir)`*. Now routed through it.

## The vacuous test, replaced

#441 added a "both readers agree on the same bytes" assertion as a drift guard. Consolidation makes that **tautological** — they are now the same function, so it cannot fail.

Replaced with a detector, matching the house pattern (`no hand-rolled state writes`, `no_bare_write_h5ad`, `store staging convention`): no file under `api/src`, `app/src` or `pluto/` may re-derive the artefact filenames, the stamp's JSON field spellings, or the `hash(read(Manifest.toml))` fingerprint. Comment lines are exempt so prose can name them freely.

**Verified to fire** by planting an offender:

```
Evaluated: isempty(["storage_api.jl#42 — image/stamp filename:
                    _bad_stamp_path() = joinpath(_pluto_root(), \"deps.so.stamp\")"])
```

It also carries an anti-vacuity assertion (`scanned > 100`) — a walk over zero files would otherwise report a clean bill of health, which is a failure mode this repo has hit before.

And removing the testset's *own* `include` of the shared file, while it still passes, is what proves the consolidation is load-bearing rather than cosmetic.

```
API: notebooks sysimage status                            12/12
sysimage stamp records which recipe built the image       20/20
the sysimage stamp format has exactly one implementation   3/3
```

Net −79/+121 with the detector; the production code itself shrinks.

## Reservations

- **`stamp_matches` changed from JSON parsing to substring matching** — the shared file must stay dependency-free. Identical for anything the writer produces; a hand-edited or corrupt stamp could classify differently. Six cases tested.
- **The detector is lexical, not semantic.** It catches literal filenames, field spellings and the fingerprint idiom, but someone assembling the path from pieces would slip through. It raises the cost of duplicating; it does not make it impossible.
- **New load-time coupling**: the API server `include`s a `pluto/` file at startup, so a partial install breaks the whole server rather than just notebooks. Guarded with an explicit `isfile` check and a clear message, and genuinely exercised — `test-api` loads `server.jl`, so this path runs in CI on all three OSes.
- Not driven through a live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
