### PR TITLE
feat(sets): a reference image, nominated by the user

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -884,6 +884,30 @@ function api_sets_create(body_bytes::Vector{UInt8})
     200, JSON3.write((; uid=s.uid, name))
 end
 
+# Nominate (or clear) the set's reference image — the one the user judges representative. Consumers
+# derive their own numbers from it; see model/set.jl. `imageUid` empty/absent clears.
+function api_sets_reference_set(body_bytes::Vector{UInt8})
+    body = try JSON3.read(String(body_bytes)) catch
+        return 400, JSON3.write((; error="Invalid JSON body"))
+    end
+    project_uid = String(get(body, :projectUid, ""))
+    set_uid     = String(get(body, :setUid, ""))
+    image_uid   = String(get(body, :imageUid, ""))
+    isempty(project_uid) && return 400, JSON3.write((; error="projectUid required"))
+    isempty(set_uid)     && return 400, JSON3.write((; error="setUid required"))
+
+    proj = load_project(project_uid)
+    idx  = findfirst(x -> x.uid == set_uid, proj._sets)
+    isnothing(idx) && return 404, JSON3.write((; error="Set not found: $set_uid"))
+    s = proj._sets[idx]
+    try
+        set_reference_image!(s, isempty(image_uid) ? nothing : image_uid)
+    catch e
+        return 400, JSON3.write((; error=sprint(showerror, e)))
+    end
+    200, JSON3.write((; ok=true, setUid=set_uid, referenceImage=reference_image_uid(s)))
+end
+
 function api_sets_delete(body_bytes::Vector{UInt8})
     body = try JSON3.read(String(body_bytes)) catch
         return 400, JSON3.write((; error="Invalid JSON body"))
@@ -1911,4 +1935,8 @@ function _image_payload(img::CciaImage)
     )
 end
 
-_set_payload(s::CciaSet) = (; uid=s.uid, name=s.name, images=[_image_payload(i) for i in s._images])
+# `referenceImage` — the set's nominated representative (model/set.jl). Sent with the set rather
+# than the image so the table can render exactly one star without scanning every image, and so an
+# unset reference is a plain `nothing` instead of nine images each claiming not to be it.
+_set_payload(s::CciaSet) = (; uid=s.uid, name=s.name, referenceImage=reference_image_uid(s),
+                              images=[_image_payload(i) for i in s._images])

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -370,6 +370,8 @@ function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
             api_projects_delete(body_bytes)
         elseif path == "/api/sets/create"
             api_sets_create(body_bytes)
+        elseif path == "/api/sets/reference"
+            api_sets_reference_set(body_bytes)
         elseif path == "/api/sets/delete"
             api_sets_delete(body_bytes)
         elseif path == "/api/images/register"

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -22,6 +22,7 @@ export save!
 export load_project, init_object
 export create_project!, add_image!, add_set!, images, image_by_uid, sets
 export delete_image!, delete_set!, move_image!
+export reference_image_uid, set_reference_image!
 export img_filepath, img_zero_dir, img_physical_sizes, physical_size_for_axis, image_included
 export img_axes, img_has_time
 export img_label_props_dir, img_label_props_path, img_track_props_path, img_value_names, img_has_value_name, resolve_value_name

--- a/app/src/model/set.jl
+++ b/app/src/model/set.jl
@@ -95,6 +95,53 @@ function image_by_uid(s::CciaSet; uid::AbstractString)::Union{CciaImage,Nothing}
     isnothing(idx) ? nothing : s._images[idx]
 end
 
+# ── Reference image ───────────────────────────────────────────────────────────────────────────────
+#
+# One image per set, nominated by the user as REPRESENTATIVE of the set. It is a property of the set,
+# deliberately not of any task: the first consumer is the 8-bit import (deriving one intensity window
+# for the whole set from the reference, so channels and images stay comparable), but "process this
+# set the way this image says" is a shape that recurs — a normalisation baseline, a gating template,
+# a parameter sweep's anchor. Any of those reads the same field instead of inventing its own.
+#
+# Why a nominated image rather than a derived value: the alternative is asking the user for a number
+# (`rescaleFixedMax = 1500`), which they can only get by eyeballing a histogram. Picking "this movie
+# looks typical" is a judgement they can actually make. The consuming task derives the number.
+#
+# Unset is the normal state and must stay usable — a consumer falls back to its per-image behaviour.
+
+const REFERENCE_IMAGE_KEY = "referenceImage"
+
+"""
+    reference_image_uid(s::CciaSet) -> Union{String,Nothing}
+
+The set's reference image uid, or `nothing` when none is set **or when the nominated image is no
+longer in the set** (deleted, moved) — a caller gets one answer for "there is no usable reference"
+rather than having to re-check membership itself.
+"""
+function reference_image_uid(s::CciaSet)::Union{String,Nothing}
+    uid = get(s.meta, REFERENCE_IMAGE_KEY, nothing)
+    uid isa AbstractString || return nothing
+    String(uid) in s.image_uids ? String(uid) : nothing
+end
+
+"""
+    set_reference_image!(s::CciaSet, uid) -> CciaSet
+
+Nominate `uid` as the set's reference, or clear it with `nothing`. Errors if the image is not in the
+set — a reference pointing outside it is a bug, not a state to persist.
+"""
+function set_reference_image!(s::CciaSet, uid::Union{AbstractString,Nothing})::CciaSet
+    if isnothing(uid) || isempty(uid)
+        delete!(s.meta, REFERENCE_IMAGE_KEY)
+    else
+        String(uid) in s.image_uids ||
+            error("set_reference_image!: $uid is not in set $(s.uid)")
+        s.meta[REFERENCE_IMAGE_KEY] = String(uid)
+    end
+    save!(s)
+    s
+end
+
 """
 Delete an image from the set: removes its data dir ({proj}/0/{uid}) and metadata
 dir ({proj}/1/{uid}) from disk, drops it from the set manifest, and persists the set.

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -630,6 +630,43 @@ end
     rm(proj.root; recursive=true)
 end
 
+# ── Reference image: a SET-level nomination, deliberately not a task param ────────────────────────
+# The user picks the image they judge representative; a consumer (first: the 8-bit import) derives
+# its numbers from it. The load-bearing property is that "no usable reference" is ONE answer — a
+# consumer must not have to re-check set membership after a delete or a move.
+@testset "reference image" begin
+    proj = create_project!(name = "ref-$(rand(1000:9999))")
+    s    = add_set!(proj; name = "set")
+    img1 = add_image!(s; name = "a")
+    img2 = add_image!(s; name = "b")
+
+    @test isnothing(reference_image_uid(s))                     # unset is the normal state
+
+    set_reference_image!(s, img1.uid)
+    @test reference_image_uid(s) == img1.uid
+    reloaded = load_project(proj.uid)
+    rs = reloaded._sets[1]
+    @test reference_image_uid(rs) == img1.uid                   # persisted through meta
+
+    set_reference_image!(s, img2.uid)                           # one per set — re-nominating moves it
+    @test reference_image_uid(s) == img2.uid
+
+    set_reference_image!(s, nothing)                            # and can be cleared
+    @test isnothing(reference_image_uid(s))
+    @test !haskey(s.meta, Cecelia.REFERENCE_IMAGE_KEY)          # cleared, not left as an empty string
+
+    # A reference pointing outside the set is a bug, not a state to persist.
+    @test_throws ErrorException set_reference_image!(s, "not-in-set")
+
+    # ...and one that LEAVES the set reads as unset rather than as a dangling uid, so every consumer
+    # gets the same answer without re-checking membership itself.
+    set_reference_image!(s, img1.uid)
+    delete_image!(s, img1.uid)
+    @test isnothing(reference_image_uid(s))
+
+    rm(proj.root; recursive=true)
+end
+
 @testset "move_image! (manifest-only, no data moved)" begin
     proj = create_project!(name="move-test-$(rand(1000:9999))")
     a = add_set!(proj; name="set-A")

--- a/frontend/src/components/ImageTable.vue
+++ b/frontend/src/components/ImageTable.vue
@@ -175,6 +175,35 @@ async function saveNote(img: CciaImage, val: string) {
   }
 }
 
+// ── Reference image ───────────────────────────────────────────────────────────
+// One image per set, nominated by the user as representative. It is a SET property, not a task
+// param: the 8-bit import derives its shared intensity window from it, so every image in the set
+// lands in one intensity space. The user picks it because they are the one who knows which movie
+// looks like what they usually see — the alternative is asking for a raw intensity number, which
+// only someone eyeballing a histogram can answer.
+function isReference(img: CciaImage) {
+  return project.sets.find(s => s.uid === props.setUid)?.referenceImage === img.uid
+}
+
+async function toggleReference(img: CciaImage) {
+  const projectUid = projectMeta.current?.uid
+  if (!projectUid) return
+  const set = project.sets.find(s => s.uid === props.setUid)
+  const prev = set?.referenceImage ?? null
+  const next = prev === img.uid ? null : img.uid          // clicking the current star clears it
+  project.setReferenceImage(props.setUid, next)           // reflect immediately
+  try {
+    const res = await fetch('/api/sets/reference', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectUid, setUid: props.setUid, imageUid: next ?? '' }),
+    })
+    if (!res.ok) throw new Error((await res.json()).error ?? res.statusText)
+  } catch (e) {
+    project.setReferenceImage(props.setUid, prev)         // revert on failure
+    log.error(`Failed to set reference image: ${e instanceof Error ? e.message : String(e)}`, { source: 'import' })
+  }
+}
+
 // ── Include / exclude ─────────────────────────────────────────────────────────
 // Excluded images stay visible but greyed, can't be selected, and are skipped by every run.
 const NOTE_KEY = '__note'
@@ -765,6 +794,13 @@ onUnmounted(stopResize)
               v-tooltip.right="qcFor(img)!.long">
               <i class="pi pi-flag" /> QC
             </span>
+            <button class="ref-star cc-btn cc-btn-bare cc-btn-icon" :class="{ on: isReference(img) }"
+              @click.stop="toggleReference(img)"
+              v-tooltip.right="isReference(img)
+                ? 'Reference image for this set — click to clear'
+                : 'Set as the set\'s reference image (the representative one others are matched to)'">
+              <i :class="isReference(img) ? 'pi pi-star-fill' : 'pi pi-star'" />
+            </button>
             <span v-if="isExcluded(img)" class="excl-badge"
               v-tooltip.right="img.note ? `Excluded: ${img.note}` : 'Excluded from processing'">
               <i class="pi pi-ban" /> Excluded
@@ -1082,6 +1118,12 @@ th:hover .resize-handle::after { opacity: 1; }
    palette); the shape-distinct triangle icon carries the meaning, colour is secondary. */
 .warn-icon-btn { color: var(--cc-sev-warn); }   /* + cc-btn cc-btn-bare cc-btn-icon */
 .warn-icon-btn:hover { filter: brightness(1.2); }
+
+/* Reference-image star — a SET-level nomination, so exactly one row shows it filled. Dim until
+   hovered when unset, so eight unset stars don't compete with the QC and exclusion badges. */
+.ref-star { opacity: .25; }
+.ref-star:hover { opacity: .7; }
+.ref-star.on { opacity: 1; color: var(--cc-accent); }
 
 /* QC badge — advisory "output looks off" flag (non-metadata findings; distinct from the calibration
    warning icon). Uses the canonical severity tokens. */

--- a/frontend/src/stores/project.ts
+++ b/frontend/src/stores/project.ts
@@ -45,6 +45,10 @@ export interface CciaImage {
 export interface CciaSet {
   uid: string
   name: string
+  /** uid of the image the user nominated as representative of this set, or null. A property of the
+   *  SET, not of any task — the 8-bit import derives its shared intensity window from it, and other
+   *  "process this set the way this image says" consumers read the same field. See model/set.jl. */
+  referenceImage: string | null
   images: CciaImage[]
 }
 
@@ -136,7 +140,7 @@ export const useProjectStore = defineStore('project', () => {
   }
 
   function addSetFromApi(uid: string, name: string): CciaSet {
-    const s: CciaSet = { uid, name, images: [] }
+    const s: CciaSet = { uid, name, referenceImage: null, images: [] }
     sets.value.push(s)
     activeSetUid.value = s.uid
     return s
@@ -178,7 +182,7 @@ export const useProjectStore = defineStore('project', () => {
   // Unlike addSetFromApi, does NOT switch the active set — a move shouldn't yank the user away.
   function ensureSet(uid: string, name: string): CciaSet {
     let s = sets.value.find(x => x.uid === uid)
-    if (!s) { s = { uid, name, images: [] }; sets.value.push(s) }
+    if (!s) { s = { uid, name, referenceImage: null, images: [] }; sets.value.push(s) }
     return s
   }
 
@@ -252,6 +256,13 @@ export const useProjectStore = defineStore('project', () => {
   }
 
   // Reflect an include/exclude (+ note) change immediately, no reload. Only the provided keys change.
+  /** Reflect a reference-image change locally (the POST is the caller's). One per set, so
+   *  nominating a new image implicitly clears the old star. */
+  function setReferenceImage(setUid: string, imageUid: string | null) {
+    const set = sets.value.find(s => s.uid === setUid)
+    if (set) set.referenceImage = imageUid
+  }
+
   function setInclusion(imageUid: string, patch: { included?: boolean; note?: string }) {
     for (const set of sets.value) {
       const img = set.images.find(i => i.uid === imageUid)
@@ -295,5 +306,5 @@ export const useProjectStore = defineStore('project', () => {
     return order.map(n => ({ name: n, values: [...vals.get(n)!] }))
   }
 
-  return { sets, activeSetUid, napariImageUid, napariReloadTick, requestNapariReload, dataVersion, bumpDataVersion, dataVersionFor, activeSet, setUidOfImage, imageByUid, getImageSelection, setImageSelection, getImageSort, setImageSort, loadFromApi, clear, addSetFromApi, deleteSet, addImages, addImagesFromApi, deleteImage, ensureSet, moveImage, updateImageStatus, updateImageMeta, refreshImageMeta, addAttrKey, removeAttrKey, setAttrValues, imageAttr, imageAttrsFor, setInclusion, removeLabelSet }
+  return { sets, activeSetUid, napariImageUid, napariReloadTick, requestNapariReload, dataVersion, bumpDataVersion, dataVersionFor, activeSet, setUidOfImage, imageByUid, getImageSelection, setImageSelection, getImageSort, setImageSort, loadFromApi, clear, addSetFromApi, deleteSet, addImages, addImagesFromApi, deleteImage, ensureSet, moveImage, updateImageStatus, updateImageMeta, refreshImageMeta, addAttrKey, removeAttrKey, setAttrValues, imageAttr, imageAttrsFor, setInclusion, setReferenceImage, removeLabelSet }
 })


### PR DESCRIPTION
A set can nominate one image as **representative**. Phase 1 of replacing the hand-typed 8-bit intensity window.

## Why this exists

#440 added `rescaleFixedMin`/`rescaleFixedMax` so a set could share one intensity window — necessary, because confetti identity is the ratio between channels and per-channel percentile windows gave the same channel a 3× different gain across nine images.

But it asks the user for a **raw intensity number**. The `1500` used on this repo's own set was picked by me, from histograms, after several measurements — a normal user has no way to arrive at it.

"This movie looks like what I usually see" is a judgement they *can* make, and they're the one who knows which images are a bit off. So the user nominates an image; the consuming task derives the number.

## What's here

- **`CciaSet.meta["referenceImage"]`** with `reference_image_uid` / `set_reference_image!` in `model/set.jl`. Deliberately task-agnostic — the import is the first consumer, not the owner.
- **`POST /api/sets/reference`** to nominate or clear.
- **`referenceImage` on the set payload** — on the set rather than each image, so the table renders one star without scanning, and an unset reference is a plain `null` instead of nine images each denying it.
- **A star in the image table.** Outline when unset, filled when set, dimmed until hover so eight empty stars don't compete with the QC and exclusion badges. Clicking the current star clears it. Optimistic update with revert on failure, matching the inclusion and note handlers.

## The load-bearing detail

`reference_image_uid` returns `nothing` when the nominated image has **left the set** — deleted or moved. So "there is no usable reference" is one answer, and no consumer has to re-check membership itself. That's the case most likely to rot, and it's tested.

Unset is the normal state and stays usable: a consumer falls back to its per-image behaviour.

## Not in this PR

Phase 2, which needed `robust_hist_max` from #437 (now merged): the import derives its window as `reference robust max × leeway`, stores it on the set so a tenth image imported later lands in the same space, and a new QC flags images the window clips — naming a better candidate, which by construction is the image with the largest robust max.

Deriving from main's *old* literal max × leeway would have been 1.5 × a hot pixel, which is why this was split.

## Tests

Package **3487** (8 new: persistence, one-per-set replacement, clearing, rejecting an image outside the set, dangling reference), Python **394**, API 55 testsets, frontend **723**, `vue-tsc -b` clean.

Two things the repo's own checks caught that I'd otherwise have shipped: three `CciaSet` construction sites missing the new field — visible only to `vue-tsc -b`, not `--noEmit` — and a hex fallback (`var(--cc-accent, #f0b429)`) that the design-token test rejects.

**Unrelated papercut noticed:** `npm run typecheck` emits ~295 untracked `*.vue.js` files into `frontend/src/`, which aren't gitignored. They also inflate the vitest count (142 files/1306 tests vs the real 73/723, because compiled `.test.js` duplicates get collected). Left alone as out of scope, but worth an ignore rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)