### PR TITLE
perf(api): route by lookup table, not a 156-branch chain (boot 57s -> 11s)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -36,6 +36,19 @@ natively, which is *why* it stays — what keeps Python in the loop is the clust
 the file format. Full breakdown in
 [`docs/prompts/python-audit-report.md`](docs/prompts/python-audit-report.md).
 
+**Julia is fast — so why did the server take a minute to answer its first request?**
+It wasn't running anything; it was *compiling*. Two separate slowdowns turned out to be the same
+bug wearing different clothes: **one oversized unit that Julia has to compile in full before any of
+it runs.** The test suite was a single 8,000-line `@testset`, so the whole thing was compiled before
+the first assertion (~90 s of a 200 s run). The HTTP router was a single 156-branch `if/elseif`,
+which forces the compiler to infer *every* handler even though one route runs (42 s of a 53 s boot).
+Both fixes are the same move — stop putting everything in one unit: the suite body moved behind an
+`include`, and the router became a lookup table, so only the handler you actually hit gets compiled.
+Test suite 214 s → 78 s, server start 57 s → 11 s, CI 17.6 min → ~5.5 min. The lesson that keeps
+paying: measure where the time goes before optimising. Splitting the router into smaller *functions*
+changed nothing — it was still one compilation request — and an earlier plan to restructure the whole
+API layer was abandoned once the profiler showed it would have bought seconds.
+
 **Why keep all analysis out of the frontend?**
 So the core package can run and be tested from the Julia REPL with no interface attached. The same
 task code runs identically whether it's called from a test, the REPL, or the GUI. The API is a thin

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -197,340 +197,197 @@ end)
 
 # ── HTTP router ───────────────────────────────────────────────────────────────
 
+# Routing is a LOOKUP TABLE, not an if/elseif chain. It used to be one — 156 branches — and that
+# cost 42s of a 53s server boot, on every restart (measured with --trace-compile-timing; it showed
+# up as ONE method, the handle_stream closure that inlines the chain). Compiling the chain forces
+# the compiler to infer EVERY handler call even though exactly one runs. With a table only the
+# invoked handler compiles: boot 54s -> 11s, compile 50s -> 6s.
+#
+# Splitting the chain into per-method functions does NOT fix it — measured, no change — because it
+# is still one compilation request over the same call tree. The win comes from never putting all
+# the handler calls in one inferable unit. (Same shape as the 8k-line @testset that cost ~90s of a
+# 200s test run: one oversized unit dominating compilation.)
+#
+# Add a route by adding a table entry. Do NOT merge these back into a chain — the
+# "HTTP router — the full route table still dispatches" testset pins every path.
 function handle_http(req::HTTP.Request, body_bytes::Vector{UInt8})
     target = String(req.target)
     path   = split(HTTP.URI(target).path, '?')[1]
     method = req.method
 
-    # ── GET ─────────────────────────────────────────────────────────────────────
-    if method == "GET"
-        status, body = if path == "/api/health"
-            200, JSON3.write((; ok=true, version="CeceliaAPI"))
-        elseif path == "/api/diagnostics"
-            api_diagnostics(req)
-        elseif path == "/api/app/worktrees"
-            api_app_worktrees(req)
-        elseif path == "/api/diagnostics/packages"
-            api_packages(req)
-        elseif path == "/api/version"
-            api_version(req)
-        elseif path == "/api/update/check"
-            api_update_check(req)
-        elseif path == "/api/setup/defaults"
-            api_setup_defaults(req)
-        elseif path == "/api/setup/validate"
-            api_setup_validate(req)
-        elseif path == "/api/projects"
-            api_projects_list(req)
-        elseif path == "/api/projects/bundles"
-            api_projects_bundles(req)
-        elseif path == "/api/projects/bundle-info"
-            api_projects_bundle_info(req)
-        elseif path == "/api/fs/list"
-            api_fs_list(req)
-        elseif path == "/api/images"
-            api_images_list(req)
-        elseif path == "/api/images/meta"
-            api_images_meta(req)
-        elseif path == "/api/images/tasklog"
-            api_images_tasklog(req)
-        elseif path == "/api/tasks/history"
-            api_tasks_history(req)
-        elseif path == "/api/tasks/recent"
-            api_tasks_recent(req)
-        elseif path == "/api/qc/cohort"
-            api_qc_cohort(req)
-        elseif path == "/api/qc/cohort/runs"
-            api_qc_cohort_runs(req)
-        elseif path == "/api/analysis/lineage"
-            api_analysis_lineage(req)
-        elseif path == "/api/analysis/populations"
-            api_analysis_populations(req)
-        elseif path == "/api/analysis/measures"
-            api_analysis_measures(req)
-        elseif path == "/api/analysis/behaviour"
-            api_analysis_behaviour(req)
-        elseif path == "/api/analysis/clusters"
-            api_analysis_clusters(req)
-        elseif path == "/api/analysis/spatial"
-            api_analysis_spatial(req)
-        elseif path == "/api/analysis/chains"
-            api_analysis_chains(req)
-        elseif path == "/api/repl/api"
-            api_repl_api(req)
-        elseif path == "/api/observer/briefing"
-            api_observer_briefing(req)
-        elseif path == "/api/lablog"
-            api_lablog_read(req)
-        elseif path == "/api/tasks/definitions"
-            api_task_definitions(req)
-        elseif path == "/api/maintenance/patches"
-            api_maintenance_patches(req)
-        elseif path == "/api/tasks/custom-modules"
-            api_custom_modules_status(req)
-        elseif path == "/api/tasks/funparams"
-            api_task_fun_params(req)
-        elseif path == "/api/pools"
-            api_pools_list(req)
-        elseif path == "/api/tasks"
-            api_tasks_list(req)
-        elseif path == "/api/chains"
-            api_chains_list(req)
-        elseif path == "/api/chains/get"
-            api_chains_get(req)
-        elseif path == "/api/chains/runs"
-            api_chains_runs(req)
-        elseif path == "/api/chains/run"
-            api_chains_run(req)
-        elseif path == "/api/logs/recent"
-            api_logs_recent()
-        elseif path == "/api/observer/status"
-            api_observer_status(req)
-        elseif path == "/api/napari/status"
-            api_napari_status(req)
-        elseif path == "/api/napari/gpu"
-            api_napari_gpu_get(req)
-        elseif path == "/api/preview/status"
-            api_preview_status(req)
-        elseif path == "/api/notebooks"
-            api_notebooks_list(req)
-        elseif path == "/api/notebooks/content"
-            api_notebooks_content(req)
-        elseif path == "/api/notebooks/status"
-            api_notebooks_status(req)
-        elseif path == "/api/notebooks/snapshots"
-            api_notebooks_snapshots(req)
-        elseif path == "/api/gating/channels"
-            api_gating_channels(req)
-        elseif path == "/api/gating/popmap"
-            api_gating_popmap(req)
-        elseif path == "/api/gating/stats"
-            api_gating_stats(req)
-        elseif path == "/api/gating/membership"
-            api_gating_membership(req)
-        elseif path == "/api/gating/plotmeta"
-            api_gating_plotmeta(req)
-        elseif path == "/api/gating/plotdata"
-            api_gating_plotdata(req)
-        elseif path == "/api/gating/density"
-            api_gating_density(req)
-        elseif path == "/api/images/geometry"
-            api_image_geometry(req)
-        elseif path == "/api/crop/info"
-            api_crop_info(req)
-        elseif path == "/api/crop/frame"
-            api_crop_frame(req)
-        elseif path == "/api/plots/umap"
-            api_plots_umap(req)
-        elseif path == "/api/plots/definitions"
-            api_plot_definitions(req)
-        elseif path == "/api/plots/populations"
-            api_plot_populations(req)
-        elseif path == "/api/plots/attrs"
-            api_plot_attrs(req)
-        elseif path == "/api/tracking/motion-dims"
-            api_motion_dims(req)
-        elseif path == "/api/storage/summary"
-            api_storage_summary(req)
-        elseif path == "/api/movies"
-            api_movies_list(req)
-        else
-            404, JSON3.write((; error="Not found: $path"))
-        end
-        return status, body
-    end
+    table = method == "GET"  ? _GET_ROUTES :
+            method == "POST" ? _POST_ROUTES : nothing
+    table === nothing && return 405, JSON3.write((; error="Method not allowed: $method"))
 
-    # ── POST ────────────────────────────────────────────────────────────────────
-    if method == "POST"
-        return if path == "/api/projects/list"
-            api_projects_list(req)
-        elseif path == "/api/pools/set"
-            api_pool_set(body_bytes)
-        elseif path == "/api/tasks/custom-modules/reload"
-            api_custom_modules_reload(body_bytes)
-        elseif path == "/api/projects/create"
-            api_projects_create(body_bytes)
-        elseif path == "/api/projects/load"
-            api_projects_load(body_bytes)
-        elseif path == "/api/projects/boards"
-            api_projects_boards(body_bytes)
-        elseif path == "/api/projects/animations"
-            api_projects_animations(body_bytes)
-        elseif path == "/api/projects/canvases"
-            api_projects_canvases(body_bytes)
-        elseif path == "/api/board-assets/save"
-            api_board_asset_save(body_bytes)
-        elseif path == "/api/board-assets/delete"
-            api_board_asset_delete(body_bytes)
-        elseif path == "/api/board-assets/copy"
-            api_board_asset_copy(body_bytes)
-        elseif path == "/api/projects/rename"
-            api_projects_rename(body_bytes)
-        elseif path == "/api/projects/delete"
-            api_projects_delete(body_bytes)
-        elseif path == "/api/sets/create"
-            api_sets_create(body_bytes)
-        elseif path == "/api/sets/delete"
-            api_sets_delete(body_bytes)
-        elseif path == "/api/images/register"
-            api_images_register(body_bytes)
-        elseif path == "/api/import/scan-legacy"
-            api_import_scan_legacy(body_bytes)
-        elseif path == "/api/import/register-legacy"
-            api_import_register_legacy(body_bytes)
-        elseif path == "/api/images/delete"
-            api_images_delete(body_bytes)
-        elseif path == "/api/images/move"
-            api_images_move(body_bytes)
-        elseif path == "/api/images/attr/create"
-            api_images_attr_create(body_bytes)
-        elseif path == "/api/images/attr/delete"
-            api_images_attr_delete(body_bytes)
-        elseif path == "/api/images/attr/set"
-            api_images_attr_set(body_bytes)
-        elseif path == "/api/images/channelnames"
-            api_images_channelnames(body_bytes)
-        elseif path == "/api/images/meta/set"
-            api_images_meta_set(body_bytes)
-        elseif path == "/api/images/inclusion/set"
-            api_images_inclusion_set(body_bytes)
-        elseif path == "/api/qc/cohort/check"
-            api_qc_cohort_check(body_bytes)
-        elseif path == "/api/lablog/append"
-            api_lablog_append(body_bytes)
-        elseif path == "/api/lablog/capture"
-            api_lablog_capture(body_bytes)
-        elseif path == "/api/observer/feedback"
-            api_observer_feedback(body_bytes)
-        elseif path == "/api/observer/clear"
-            api_observer_clear(body_bytes)
-        elseif path == "/api/observer/register"
-            api_observer_register(body_bytes)
-        elseif path == "/api/lablog/dismiss"
-            api_lablog_dismiss(body_bytes)
-        elseif path == "/api/images/meta/resync"
-            api_images_meta_resync(body_bytes)
-        elseif path == "/api/images/labels/delete"
-            api_images_delete_labels(body_bytes)
-        elseif path == "/api/chains/save"
-            api_chains_save(body_bytes)
-        elseif path == "/api/chains/delete"
-            api_chains_delete(body_bytes)
-        elseif path == "/api/notebooks/launch"
-            api_notebooks_launch(body_bytes)
-        elseif path == "/api/notebooks/write"
-            api_notebooks_write(body_bytes)
-        elseif path == "/api/notebooks/create"
-            api_notebooks_create(body_bytes)
-        elseif path == "/api/notebooks/describe"
-            api_notebooks_describe(body_bytes)
-        elseif path == "/api/notebooks/delete"
-            api_notebooks_delete(body_bytes)
-        elseif path == "/api/notebooks/duplicate"
-            api_notebooks_duplicate(body_bytes)
-        elseif path == "/api/notebooks/revise"
-            api_notebooks_revise(body_bytes)
-        elseif path == "/api/notebooks/snapshot"
-            api_notebooks_snapshot(body_bytes)
-        elseif path == "/api/notebooks/restore"
-            api_notebooks_restore(body_bytes)
-        elseif path == "/api/notebooks/prune"
-            api_notebooks_prune(body_bytes)
-        elseif path == "/api/notebooks/shutdown"
-            api_notebooks_shutdown(body_bytes)
-        elseif path == "/api/notebooks/restart"
-            api_notebooks_restart(body_bytes)
-        elseif path == "/api/notebooks/build-sysimage"
-            api_notebooks_build_sysimage(body_bytes)
-        elseif path == "/api/setup/init"
-            api_setup_init(body_bytes)
-        elseif path == "/api/app/shutdown"
-            api_app_shutdown(body_bytes)
-        elseif path == "/api/app/restart"
-            api_app_restart(body_bytes)
-        elseif path == "/api/app/switch-worktree"
-            api_app_switch_worktree(body_bytes)
-        elseif path == "/api/napari/open"
-            api_napari_open(body_bytes)
-        elseif path == "/api/napari/close"
-            api_napari_close(body_bytes)
-        elseif path == "/api/napari/screenshot"
-            api_napari_screenshot(body_bytes)
-        elseif path == "/api/napari/apply-view-state"
-            api_napari_apply_view_state(body_bytes)
-        elseif path == "/api/napari/view-state"
-            api_napari_view_state(body_bytes)
-        elseif path == "/api/napari/overlay-legend"
-            api_napari_overlay_legend(body_bytes)
-        elseif path == "/api/napari/record-timelapse"
-            api_napari_record_timelapse(body_bytes)
-        elseif path == "/api/napari/record-animation"
-            api_napari_record_animation(body_bytes)
-        elseif path == "/api/napari/apply-movie-config"
-            api_napari_apply_movie_config(body_bytes)
-        elseif path == "/api/napari/restart"
-            api_napari_restart(body_bytes)
-        elseif path == "/api/napari/gpu"
-            api_napari_gpu_set(body_bytes)
-        elseif path == "/api/napari/configure-autosave"
-            api_napari_configure_autosave(body_bytes)
-        elseif path == "/api/napari/show-labels"
-            api_napari_show_labels(body_bytes)
-        elseif path == "/api/napari/refresh-labels"
-            api_napari_refresh_labels(body_bytes)
-        elseif path == "/api/napari/show-populations"
-            api_napari_show_populations(body_bytes)
-        elseif path == "/api/napari/show-tracks"
-            api_napari_show_tracks(body_bytes)
-        elseif path == "/api/napari/colour-labels"
-            api_napari_colour_labels(body_bytes)
-        elseif path == "/api/napari/colour-branch-labels"
-            api_napari_colour_branch_labels(body_bytes)
-        elseif path == "/api/napari/start-selection"
-            api_napari_start_selection(body_bytes)
-        elseif path == "/api/napari/selection-scope"
-            api_napari_selection_scope(body_bytes)
-        elseif path == "/api/napari/stop-selection"
-            api_napari_stop_selection(body_bytes)
-        elseif path == "/api/napari/event"
-            api_napari_event(body_bytes)
-        elseif path == "/api/preview/start"
-            api_preview_start(body_bytes)
-        elseif path == "/api/preview/stop"
-            api_preview_stop(body_bytes)
-        elseif path == "/api/preview/run"
-            api_preview_run(body_bytes)
-        elseif path == "/api/gating/pop/add"
-            api_gating_pop_add(body_bytes)
-        elseif path == "/api/gating/pop/set-gate"
-            api_gating_pop_set_gate(body_bytes)
-        elseif path == "/api/gating/pop/delete"
-            api_gating_pop_delete(body_bytes)
-        elseif path == "/api/gating/pop/update"
-            api_gating_pop_update(body_bytes)
-        elseif path == "/api/gating/pop/rename"
-            api_gating_pop_rename(body_bytes)
-        elseif path == "/api/gating/copy"
-            api_gating_copy(body_bytes)
-        elseif path == "/api/images/value-name-check"
-            api_images_value_name_check(body_bytes)
-        elseif path == "/api/plot_data"
-            api_plot_data(body_bytes)
-        elseif path == "/api/repl"
-            api_repl(body_bytes)
-        elseif path == "/api/repl/config"
-            api_repl_config(body_bytes)
-        elseif path == "/api/update/apply"
-            api_update_apply(body_bytes)
-        elseif path == "/api/storage/reclaim"
-            api_storage_reclaim(body_bytes)
-        else
-            404, JSON3.write((; error="Not found: $path"))
-        end
-    end
-
-    405, JSON3.write((; error="Method not allowed: $method"))
+    handler = get(table, path, nothing)   # SubString hashes as its String — no copy per request
+    handler === nothing && return 404, JSON3.write((; error="Not found: $path"))
+    handler(req, body_bytes)
 end
+
+# ── GET ─────────────────────────────────────────────────────────────────────
+const _GET_ROUTES = Dict{String, Function}(
+    "/api/health" => (req, body_bytes) -> (200, JSON3.write((; ok=true, version="CeceliaAPI"))),
+    "/api/diagnostics" => (req, body_bytes) -> (api_diagnostics(req)),
+    "/api/app/worktrees" => (req, body_bytes) -> (api_app_worktrees(req)),
+    "/api/diagnostics/packages" => (req, body_bytes) -> (api_packages(req)),
+    "/api/version" => (req, body_bytes) -> (api_version(req)),
+    "/api/update/check" => (req, body_bytes) -> (api_update_check(req)),
+    "/api/setup/defaults" => (req, body_bytes) -> (api_setup_defaults(req)),
+    "/api/setup/validate" => (req, body_bytes) -> (api_setup_validate(req)),
+    "/api/projects" => (req, body_bytes) -> (api_projects_list(req)),
+    "/api/projects/bundles" => (req, body_bytes) -> (api_projects_bundles(req)),
+    "/api/projects/bundle-info" => (req, body_bytes) -> (api_projects_bundle_info(req)),
+    "/api/fs/list" => (req, body_bytes) -> (api_fs_list(req)),
+    "/api/images" => (req, body_bytes) -> (api_images_list(req)),
+    "/api/images/meta" => (req, body_bytes) -> (api_images_meta(req)),
+    "/api/images/tasklog" => (req, body_bytes) -> (api_images_tasklog(req)),
+    "/api/tasks/history" => (req, body_bytes) -> (api_tasks_history(req)),
+    "/api/tasks/recent" => (req, body_bytes) -> (api_tasks_recent(req)),
+    "/api/qc/cohort" => (req, body_bytes) -> (api_qc_cohort(req)),
+    "/api/qc/cohort/runs" => (req, body_bytes) -> (api_qc_cohort_runs(req)),
+    "/api/analysis/lineage" => (req, body_bytes) -> (api_analysis_lineage(req)),
+    "/api/analysis/populations" => (req, body_bytes) -> (api_analysis_populations(req)),
+    "/api/analysis/measures" => (req, body_bytes) -> (api_analysis_measures(req)),
+    "/api/analysis/behaviour" => (req, body_bytes) -> (api_analysis_behaviour(req)),
+    "/api/analysis/clusters" => (req, body_bytes) -> (api_analysis_clusters(req)),
+    "/api/analysis/spatial" => (req, body_bytes) -> (api_analysis_spatial(req)),
+    "/api/analysis/chains" => (req, body_bytes) -> (api_analysis_chains(req)),
+    "/api/repl/api" => (req, body_bytes) -> (api_repl_api(req)),
+    "/api/observer/briefing" => (req, body_bytes) -> (api_observer_briefing(req)),
+    "/api/lablog" => (req, body_bytes) -> (api_lablog_read(req)),
+    "/api/tasks/definitions" => (req, body_bytes) -> (api_task_definitions(req)),
+    "/api/maintenance/patches" => (req, body_bytes) -> (api_maintenance_patches(req)),
+    "/api/tasks/custom-modules" => (req, body_bytes) -> (api_custom_modules_status(req)),
+    "/api/tasks/funparams" => (req, body_bytes) -> (api_task_fun_params(req)),
+    "/api/pools" => (req, body_bytes) -> (api_pools_list(req)),
+    "/api/tasks" => (req, body_bytes) -> (api_tasks_list(req)),
+    "/api/chains" => (req, body_bytes) -> (api_chains_list(req)),
+    "/api/chains/get" => (req, body_bytes) -> (api_chains_get(req)),
+    "/api/chains/runs" => (req, body_bytes) -> (api_chains_runs(req)),
+    "/api/chains/run" => (req, body_bytes) -> (api_chains_run(req)),
+    "/api/logs/recent" => (req, body_bytes) -> (api_logs_recent()),
+    "/api/observer/status" => (req, body_bytes) -> (api_observer_status(req)),
+    "/api/napari/status" => (req, body_bytes) -> (api_napari_status(req)),
+    "/api/napari/gpu" => (req, body_bytes) -> (api_napari_gpu_get(req)),
+    "/api/preview/status" => (req, body_bytes) -> (api_preview_status(req)),
+    "/api/notebooks" => (req, body_bytes) -> (api_notebooks_list(req)),
+    "/api/notebooks/content" => (req, body_bytes) -> (api_notebooks_content(req)),
+    "/api/notebooks/status" => (req, body_bytes) -> (api_notebooks_status(req)),
+    "/api/notebooks/snapshots" => (req, body_bytes) -> (api_notebooks_snapshots(req)),
+    "/api/gating/channels" => (req, body_bytes) -> (api_gating_channels(req)),
+    "/api/gating/popmap" => (req, body_bytes) -> (api_gating_popmap(req)),
+    "/api/gating/stats" => (req, body_bytes) -> (api_gating_stats(req)),
+    "/api/gating/membership" => (req, body_bytes) -> (api_gating_membership(req)),
+    "/api/gating/plotmeta" => (req, body_bytes) -> (api_gating_plotmeta(req)),
+    "/api/gating/plotdata" => (req, body_bytes) -> (api_gating_plotdata(req)),
+    "/api/gating/density" => (req, body_bytes) -> (api_gating_density(req)),
+    "/api/images/geometry" => (req, body_bytes) -> (api_image_geometry(req)),
+    "/api/crop/info" => (req, body_bytes) -> (api_crop_info(req)),
+    "/api/crop/frame" => (req, body_bytes) -> (api_crop_frame(req)),
+    "/api/plots/umap" => (req, body_bytes) -> (api_plots_umap(req)),
+    "/api/plots/definitions" => (req, body_bytes) -> (api_plot_definitions(req)),
+    "/api/plots/populations" => (req, body_bytes) -> (api_plot_populations(req)),
+    "/api/plots/attrs" => (req, body_bytes) -> (api_plot_attrs(req)),
+    "/api/tracking/motion-dims" => (req, body_bytes) -> (api_motion_dims(req)),
+    "/api/storage/summary" => (req, body_bytes) -> (api_storage_summary(req)),
+    "/api/movies" => (req, body_bytes) -> (api_movies_list(req)),
+)
+
+# ── POST ─────────────────────────────────────────────────────────────────────
+const _POST_ROUTES = Dict{String, Function}(
+    "/api/projects/list" => (req, body_bytes) -> (api_projects_list(req)),
+    "/api/pools/set" => (req, body_bytes) -> (api_pool_set(body_bytes)),
+    "/api/tasks/custom-modules/reload" => (req, body_bytes) -> (api_custom_modules_reload(body_bytes)),
+    "/api/projects/create" => (req, body_bytes) -> (api_projects_create(body_bytes)),
+    "/api/projects/load" => (req, body_bytes) -> (api_projects_load(body_bytes)),
+    "/api/projects/boards" => (req, body_bytes) -> (api_projects_boards(body_bytes)),
+    "/api/projects/animations" => (req, body_bytes) -> (api_projects_animations(body_bytes)),
+    "/api/projects/canvases" => (req, body_bytes) -> (api_projects_canvases(body_bytes)),
+    "/api/board-assets/save" => (req, body_bytes) -> (api_board_asset_save(body_bytes)),
+    "/api/board-assets/delete" => (req, body_bytes) -> (api_board_asset_delete(body_bytes)),
+    "/api/board-assets/copy" => (req, body_bytes) -> (api_board_asset_copy(body_bytes)),
+    "/api/projects/rename" => (req, body_bytes) -> (api_projects_rename(body_bytes)),
+    "/api/projects/delete" => (req, body_bytes) -> (api_projects_delete(body_bytes)),
+    "/api/sets/create" => (req, body_bytes) -> (api_sets_create(body_bytes)),
+    "/api/sets/delete" => (req, body_bytes) -> (api_sets_delete(body_bytes)),
+    "/api/images/register" => (req, body_bytes) -> (api_images_register(body_bytes)),
+    "/api/import/scan-legacy" => (req, body_bytes) -> (api_import_scan_legacy(body_bytes)),
+    "/api/import/register-legacy" => (req, body_bytes) -> (api_import_register_legacy(body_bytes)),
+    "/api/images/delete" => (req, body_bytes) -> (api_images_delete(body_bytes)),
+    "/api/images/move" => (req, body_bytes) -> (api_images_move(body_bytes)),
+    "/api/images/attr/create" => (req, body_bytes) -> (api_images_attr_create(body_bytes)),
+    "/api/images/attr/delete" => (req, body_bytes) -> (api_images_attr_delete(body_bytes)),
+    "/api/images/attr/set" => (req, body_bytes) -> (api_images_attr_set(body_bytes)),
+    "/api/images/channelnames" => (req, body_bytes) -> (api_images_channelnames(body_bytes)),
+    "/api/images/meta/set" => (req, body_bytes) -> (api_images_meta_set(body_bytes)),
+    "/api/images/inclusion/set" => (req, body_bytes) -> (api_images_inclusion_set(body_bytes)),
+    "/api/qc/cohort/check" => (req, body_bytes) -> (api_qc_cohort_check(body_bytes)),
+    "/api/lablog/append" => (req, body_bytes) -> (api_lablog_append(body_bytes)),
+    "/api/lablog/capture" => (req, body_bytes) -> (api_lablog_capture(body_bytes)),
+    "/api/observer/feedback" => (req, body_bytes) -> (api_observer_feedback(body_bytes)),
+    "/api/observer/clear" => (req, body_bytes) -> (api_observer_clear(body_bytes)),
+    "/api/observer/register" => (req, body_bytes) -> (api_observer_register(body_bytes)),
+    "/api/lablog/dismiss" => (req, body_bytes) -> (api_lablog_dismiss(body_bytes)),
+    "/api/images/meta/resync" => (req, body_bytes) -> (api_images_meta_resync(body_bytes)),
+    "/api/images/labels/delete" => (req, body_bytes) -> (api_images_delete_labels(body_bytes)),
+    "/api/chains/save" => (req, body_bytes) -> (api_chains_save(body_bytes)),
+    "/api/chains/delete" => (req, body_bytes) -> (api_chains_delete(body_bytes)),
+    "/api/notebooks/launch" => (req, body_bytes) -> (api_notebooks_launch(body_bytes)),
+    "/api/notebooks/write" => (req, body_bytes) -> (api_notebooks_write(body_bytes)),
+    "/api/notebooks/create" => (req, body_bytes) -> (api_notebooks_create(body_bytes)),
+    "/api/notebooks/describe" => (req, body_bytes) -> (api_notebooks_describe(body_bytes)),
+    "/api/notebooks/delete" => (req, body_bytes) -> (api_notebooks_delete(body_bytes)),
+    "/api/notebooks/duplicate" => (req, body_bytes) -> (api_notebooks_duplicate(body_bytes)),
+    "/api/notebooks/revise" => (req, body_bytes) -> (api_notebooks_revise(body_bytes)),
+    "/api/notebooks/snapshot" => (req, body_bytes) -> (api_notebooks_snapshot(body_bytes)),
+    "/api/notebooks/restore" => (req, body_bytes) -> (api_notebooks_restore(body_bytes)),
+    "/api/notebooks/prune" => (req, body_bytes) -> (api_notebooks_prune(body_bytes)),
+    "/api/notebooks/shutdown" => (req, body_bytes) -> (api_notebooks_shutdown(body_bytes)),
+    "/api/notebooks/restart" => (req, body_bytes) -> (api_notebooks_restart(body_bytes)),
+    "/api/notebooks/build-sysimage" => (req, body_bytes) -> (api_notebooks_build_sysimage(body_bytes)),
+    "/api/setup/init" => (req, body_bytes) -> (api_setup_init(body_bytes)),
+    "/api/app/shutdown" => (req, body_bytes) -> (api_app_shutdown(body_bytes)),
+    "/api/app/restart" => (req, body_bytes) -> (api_app_restart(body_bytes)),
+    "/api/app/switch-worktree" => (req, body_bytes) -> (api_app_switch_worktree(body_bytes)),
+    "/api/napari/open" => (req, body_bytes) -> (api_napari_open(body_bytes)),
+    "/api/napari/close" => (req, body_bytes) -> (api_napari_close(body_bytes)),
+    "/api/napari/screenshot" => (req, body_bytes) -> (api_napari_screenshot(body_bytes)),
+    "/api/napari/apply-view-state" => (req, body_bytes) -> (api_napari_apply_view_state(body_bytes)),
+    "/api/napari/view-state" => (req, body_bytes) -> (api_napari_view_state(body_bytes)),
+    "/api/napari/overlay-legend" => (req, body_bytes) -> (api_napari_overlay_legend(body_bytes)),
+    "/api/napari/record-timelapse" => (req, body_bytes) -> (api_napari_record_timelapse(body_bytes)),
+    "/api/napari/record-animation" => (req, body_bytes) -> (api_napari_record_animation(body_bytes)),
+    "/api/napari/apply-movie-config" => (req, body_bytes) -> (api_napari_apply_movie_config(body_bytes)),
+    "/api/napari/restart" => (req, body_bytes) -> (api_napari_restart(body_bytes)),
+    "/api/napari/gpu" => (req, body_bytes) -> (api_napari_gpu_set(body_bytes)),
+    "/api/napari/configure-autosave" => (req, body_bytes) -> (api_napari_configure_autosave(body_bytes)),
+    "/api/napari/show-labels" => (req, body_bytes) -> (api_napari_show_labels(body_bytes)),
+    "/api/napari/refresh-labels" => (req, body_bytes) -> (api_napari_refresh_labels(body_bytes)),
+    "/api/napari/show-populations" => (req, body_bytes) -> (api_napari_show_populations(body_bytes)),
+    "/api/napari/show-tracks" => (req, body_bytes) -> (api_napari_show_tracks(body_bytes)),
+    "/api/napari/colour-labels" => (req, body_bytes) -> (api_napari_colour_labels(body_bytes)),
+    "/api/napari/colour-branch-labels" => (req, body_bytes) -> (api_napari_colour_branch_labels(body_bytes)),
+    "/api/napari/start-selection" => (req, body_bytes) -> (api_napari_start_selection(body_bytes)),
+    "/api/napari/selection-scope" => (req, body_bytes) -> (api_napari_selection_scope(body_bytes)),
+    "/api/napari/stop-selection" => (req, body_bytes) -> (api_napari_stop_selection(body_bytes)),
+    "/api/napari/event" => (req, body_bytes) -> (api_napari_event(body_bytes)),
+    "/api/preview/start" => (req, body_bytes) -> (api_preview_start(body_bytes)),
+    "/api/preview/stop" => (req, body_bytes) -> (api_preview_stop(body_bytes)),
+    "/api/preview/run" => (req, body_bytes) -> (api_preview_run(body_bytes)),
+    "/api/gating/pop/add" => (req, body_bytes) -> (api_gating_pop_add(body_bytes)),
+    "/api/gating/pop/set-gate" => (req, body_bytes) -> (api_gating_pop_set_gate(body_bytes)),
+    "/api/gating/pop/delete" => (req, body_bytes) -> (api_gating_pop_delete(body_bytes)),
+    "/api/gating/pop/update" => (req, body_bytes) -> (api_gating_pop_update(body_bytes)),
+    "/api/gating/pop/rename" => (req, body_bytes) -> (api_gating_pop_rename(body_bytes)),
+    "/api/gating/copy" => (req, body_bytes) -> (api_gating_copy(body_bytes)),
+    "/api/images/value-name-check" => (req, body_bytes) -> (api_images_value_name_check(body_bytes)),
+    "/api/plot_data" => (req, body_bytes) -> (api_plot_data(body_bytes)),
+    "/api/repl" => (req, body_bytes) -> (api_repl(body_bytes)),
+    "/api/repl/config" => (req, body_bytes) -> (api_repl_config(body_bytes)),
+    "/api/update/apply" => (req, body_bytes) -> (api_update_apply(body_bytes)),
+    "/api/storage/reclaim" => (req, body_bytes) -> (api_storage_reclaim(body_bytes)),
+)
+
 
 # ── WebSocket handler ─────────────────────────────────────────────────────────
 

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -2290,3 +2290,154 @@ end
     # Anti-vacuity: a walk over nothing reports a clean bill of health, so pin that we really looked.
     @test scanned > 100
 end
+
+# ── HTTP router: the full route table dispatches ─────────────────────────────────
+# SAFETY NET for turning the router from a 156-branch if/elseif chain into lookup tables. That chain
+# was ONE method costing 42s of a 53s server boot (--trace-compile-timing); a table compiles only the
+# handler you actually hit. Nothing tested ROUTING before this — the suite calls handlers directly —
+# so the refactor could have dropped a route into a 404 that only shows up in the browser.
+#
+#  * DISPATCH — every (method, path) must reach a handler. `handle_http` is a plain function, so no
+#    socket is needed. A router miss is 404 with body "Not found: <path>"; a handler's own 404 says
+#    something else, so the two are distinguishable. Reaching a handler and throwing still counts —
+#    the point is that routing happened.
+#  * INVENTORY — the `/api/...` literals in server.jl must equal this table exactly, so adding or
+#    removing a route without updating it fails here rather than in production.
+@testset "HTTP router — the full route table still dispatches" begin
+    GET_ROUTES = [
+        "/api/analysis/behaviour", "/api/analysis/chains",
+        "/api/analysis/clusters", "/api/analysis/lineage",
+        "/api/analysis/measures", "/api/analysis/populations",
+        "/api/analysis/spatial", "/api/app/worktrees",
+        "/api/chains", "/api/chains/get",
+        "/api/chains/run", "/api/chains/runs",
+        "/api/crop/frame", "/api/crop/info",
+        "/api/diagnostics", "/api/diagnostics/packages",
+        "/api/fs/list", "/api/gating/channels",
+        "/api/gating/density", "/api/gating/membership",
+        "/api/gating/plotdata", "/api/gating/plotmeta",
+        "/api/gating/popmap", "/api/gating/stats",
+        "/api/health", "/api/images",
+        "/api/images/geometry", "/api/images/meta",
+        "/api/images/tasklog", "/api/lablog",
+        "/api/logs/recent", "/api/maintenance/patches",
+        "/api/movies", "/api/napari/gpu",
+        "/api/napari/status", "/api/notebooks",
+        "/api/notebooks/content", "/api/notebooks/snapshots",
+        "/api/notebooks/status", "/api/observer/briefing",
+        "/api/observer/status", "/api/plots/attrs",
+        "/api/plots/definitions", "/api/plots/populations",
+        "/api/plots/umap", "/api/pools",
+        "/api/preview/status", "/api/projects",
+        "/api/projects/bundle-info", "/api/projects/bundles",
+        "/api/qc/cohort", "/api/qc/cohort/runs",
+        "/api/repl/api", "/api/setup/defaults",
+        "/api/setup/validate", "/api/storage/summary",
+        "/api/tasks", "/api/tasks/custom-modules",
+        "/api/tasks/definitions", "/api/tasks/funparams",
+        "/api/tasks/history", "/api/tasks/recent",
+        "/api/tracking/motion-dims", "/api/update/check",
+        "/api/version",
+    ]
+    POST_ROUTES = [
+        "/api/app/restart", "/api/app/shutdown",
+        "/api/app/switch-worktree", "/api/board-assets/copy",
+        "/api/board-assets/delete", "/api/board-assets/save",
+        "/api/chains/delete", "/api/chains/save",
+        "/api/gating/copy", "/api/gating/pop/add",
+        "/api/gating/pop/delete", "/api/gating/pop/rename",
+        "/api/gating/pop/set-gate", "/api/gating/pop/update",
+        "/api/images/attr/create", "/api/images/attr/delete",
+        "/api/images/attr/set", "/api/images/channelnames",
+        "/api/images/delete", "/api/images/inclusion/set",
+        "/api/images/labels/delete", "/api/images/meta/resync",
+        "/api/images/meta/set", "/api/images/move",
+        "/api/images/register", "/api/images/value-name-check",
+        "/api/import/register-legacy", "/api/import/scan-legacy",
+        "/api/lablog/append", "/api/lablog/capture",
+        "/api/lablog/dismiss", "/api/napari/apply-movie-config",
+        "/api/napari/apply-view-state", "/api/napari/close",
+        "/api/napari/colour-branch-labels", "/api/napari/colour-labels",
+        "/api/napari/configure-autosave", "/api/napari/event",
+        "/api/napari/gpu", "/api/napari/open",
+        "/api/napari/overlay-legend", "/api/napari/record-animation",
+        "/api/napari/record-timelapse", "/api/napari/refresh-labels",
+        "/api/napari/restart", "/api/napari/screenshot",
+        "/api/napari/selection-scope", "/api/napari/show-labels",
+        "/api/napari/show-populations", "/api/napari/show-tracks",
+        "/api/napari/start-selection", "/api/napari/stop-selection",
+        "/api/napari/view-state", "/api/notebooks/build-sysimage",
+        "/api/notebooks/create", "/api/notebooks/delete",
+        "/api/notebooks/describe", "/api/notebooks/duplicate",
+        "/api/notebooks/launch", "/api/notebooks/prune",
+        "/api/notebooks/restart", "/api/notebooks/restore",
+        "/api/notebooks/revise", "/api/notebooks/shutdown",
+        "/api/notebooks/snapshot", "/api/notebooks/write",
+        "/api/observer/clear", "/api/observer/feedback",
+        "/api/observer/register", "/api/plot_data",
+        "/api/pools/set", "/api/preview/run",
+        "/api/preview/start", "/api/preview/stop",
+        "/api/projects/animations", "/api/projects/boards",
+        "/api/projects/canvases", "/api/projects/create",
+        "/api/projects/delete", "/api/projects/list",
+        "/api/projects/load", "/api/projects/rename",
+        "/api/qc/cohort/check", "/api/repl",
+        "/api/repl/config", "/api/sets/create",
+        "/api/sets/delete", "/api/setup/init",
+        "/api/storage/reclaim", "/api/tasks/custom-modules/reload",
+        "/api/update/apply",
+    ]
+    UNSAFE = [
+        "/api/app/restart", "/api/app/shutdown",
+        "/api/import/register-legacy", "/api/import/scan-legacy",
+        "/api/napari/apply-movie-config", "/api/napari/apply-view-state",
+        "/api/napari/restart", "/api/napari/stop-selection",
+        "/api/notebooks/build-sysimage", "/api/notebooks/launch",
+        "/api/notebooks/restart", "/api/notebooks/shutdown",
+        "/api/preview/run", "/api/preview/start",
+        "/api/preview/stop", "/api/storage/reclaim",
+        "/api/update/apply",
+    ]
+    # counts pinned below: 65 GET, 91 POST, 17 not live-called
+
+    # Served in handle_stream BEFORE handle_http (binary/Range responses), not part of the tables.
+    STREAM_ROUTES = ["/api/board-assets", "/api/movies/file"]
+
+    # Would genuinely restart/shut down/spawn a worker if called with an empty body. Their PRESENCE is
+    # still pinned by the inventory half; only the live call is skipped.
+    unsafe = Set(UNSAFE)
+
+    function dispatched(method, path)
+        try
+            st, body = handle_http(HTTP.Request(method, path), UInt8[])
+            !(st == 404 && occursin("Not found: $path", String(body)))
+        catch
+            true    # reached a handler and it threw — routing still happened
+        end
+    end
+
+    missed, checked = String[], 0
+    for (m, routes) in (("GET", GET_ROUTES), ("POST", POST_ROUTES)), p in routes
+        p in unsafe && continue
+        checked += 1
+        dispatched(m, p) || push!(missed, "$m $p")
+    end
+    @test isempty(missed)
+    isempty(missed) || @info "routes that no longer dispatch" missed
+
+    # Anti-vacuity: a loop over nothing passes trivially.
+    @test checked >= 130
+    @test length(GET_ROUTES) == 65 && length(POST_ROUTES) == 91
+
+    # A path nobody registered must still 404, else "dispatched" means nothing.
+    @test !dispatched("GET",  "/api/definitely-not-a-route")
+    @test !dispatched("POST", "/api/definitely-not-a-route")
+    # …and an unrouted METHOD falls through to 405, so method association is real.
+    @test first(handle_http(HTTP.Request("DELETE", "/api/health"), UInt8[])) == 405
+
+    # INVENTORY — every /api literal in server.jl is accounted for, and vice versa. Structure-agnostic
+    # on purpose: it keeps working whatever shape the router takes next.
+    src = read(joinpath(@__DIR__, "..", "src", "server.jl"), String)
+    literals = Set(strip(m.match, '"') for m in eachmatch(r"\"/api/[^\"]+\"", src))
+    @test literals == Set(vcat(GET_ROUTES, POST_ROUTES, STREAM_ROUTES))
+end

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,9 +33,19 @@ Settings → Debug console UI shows a note to this effect.
 
 ## Conventions
 
-- **Routing**: a flat dispatch in `server.jl` `handle_http(req, body_bytes)` — GET reads
+- **Routing**: two lookup tables in `server.jl` — `_GET_ROUTES` / `_POST_ROUTES`, both
+  `Dict{String, Function}` of `path => (req, body_bytes) -> handler(...)`. `handle_http` picks the
+  table by method, looks the path up and calls it (miss → `404`, unknown method → `405`). GET reads
   `HTTP.queryparams`, POST parses `JSON3.read(String(body_bytes))`. Each handler returns
-  `(status::Int, body)`.
+  `(status::Int, body)`. **Add a route by adding a table entry** — one line, same as before.
+  > **Do NOT turn these back into an `if/elseif` chain.** They used to be one, and it cost **42 s of
+  > a 53 s server boot**, on every restart. Compiling a 156-branch chain forces the compiler to infer
+  > *every* handler call though exactly one runs, and it lands in a single method (the
+  > `handle_stream` closure that inlines it). With a table only the invoked handler compiles: boot
+  > 54 s → 11 s, compile 50 s → 6 s. Splitting the chain into per-method functions does **not** help
+  > — measured, no change — because it is still one compilation request. A table is also faster per
+  > request (a hash lookup, not up to 156 string comparisons). Pinned by the *"HTTP router — the full
+  > route table still dispatches"* testset in `api/test/runtests.jl`.
 - **Response body**: a `String` (→ `Content-Type: application/json`) or an
   `AbstractVector{UInt8}` (→ `application/octet-stream`). The handler in `handle_stream`
   picks the content type from the body type — so a route serves binary just by returning


### PR DESCRIPTION
## The finding

The server took **~57s to answer its first request**, every restart. `--trace-compile-timing` says 53s of that is compilation — and **42s of it is one method**: the `handle_stream` closure, which inlines `handle_http`'s `if/elseif` chain. The *second* request takes 8 ms.

Compiling a 156-branch chain forces the compiler to infer **every** handler call, though exactly one route runs.

## The fix

`_GET_ROUTES` / `_POST_ROUTES` — `Dict{String, Function}` of `path => (req, body_bytes) -> handler(...)`. Only the handler you actually hit gets compiled.

Measured on this exact base (three scratch servers, spare ports, isolated `CECELIA_DEV_DIR`):

| | before | after |
|---|---|---|
| **boot to first healthy response** | **57 s** | **10–17 s** |
| compile time | 53.1 s | 6.2 s |
| statements compiled | 693 | ~195 |
| the 42 s closure | 42.4 s | gone |

What's left is `Cecelia.init_cecelia!` (1.1 s) and HTTP's listener (2.6 s).

## What didn't work, and why that matters

**Splitting the chain into per-method `route_get`/`route_post` functions did nothing** — 42.1 s vs 42.4 s. It is still *one compilation request* over the same call tree, so smaller source units don't help. The win requires never putting all the handler calls in one inferable unit.

I confirmed chain length was the cause **before** committing to the refactor, by stubbing both chains down to a single route: boot fell to 12 s and the closure to 0.9 s.

Same shape as #438, where an 8k-line `@testset` compiled as one top-level thunk cost ~90 s of a 200 s test run.

## The routing test this codebase never had

`api/test/runtests.jl` exercised handlers directly — **nothing asserted the routing table**. Refactoring 156 routes with no such test is how a route silently becomes a 404 that only shows up in the browser. Added, pinning every `(method, path)` two ways:

- **dispatch** — each must reach a handler. A router miss is `404` with `"Not found: <path>"`; a handler's own 404 says something else, so they're distinguishable. Reaching a handler and throwing still counts.
- **inventory** — the `/api/...` literals in `server.jl` must equal the list exactly, so adding or removing a route without updating it fails here.

**Verified to fail**: deleting `GET /api/movies` made *both* halves fire.

17 side-effecting routes (shutdown/restart/launch/reclaim/preview-start) are pinned by the inventory half but never invoked.

## Note on how this was rebased

#437 landed mid-work and added four routes. Rather than hand-merge a 500-line rewrite against them, I reset to the new `main` and **re-ran the generator** — same lesson as #438. The four new preview routes are included; nothing was removed.

## Reservations

- **Runtime dispatch changed shape.** Handlers are now called through a `Function`-valued `Dict`, so each call is a dynamic dispatch rather than a resolved branch. It should be *faster* per request (one hash lookup vs up to 156 string comparisons), but I measured compile time, not request latency.
- **156 closures are constructed at load.** Cheap — no compilation until called, and boot got 5× faster — but it is new allocation at startup.
- **The routing test adds ~13 s to `test-api`** (it really invokes 139 handlers). Worth it as the safety net, but it is real CI time.
- **Generated mechanically by script.** All branch bodies were single-line so the transform was uniform, and the test pins every route — but I did not read all 156 resulting lines individually.
- Not driven through a live browser session; dispatch is exercised by direct calls, and `handle_stream` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
