### PR TITLE
fix(preview): a 202 while the worker warms was a dead end

### DIFF
--- a/frontend/src/stores/taskPreview.ts
+++ b/frontend/src/stores/taskPreview.ts
@@ -20,8 +20,8 @@ import { previewApi, type SvcError } from '../utils/serviceApi'
 import { debouncedLatest, type RunState } from '../utils/debouncedLatest'
 import {
   previewBlocker, previewNotice, previewSummary, baseOnlyWarning, tilingWarning,
-  compositeWarning,
-  PREVIEW_DEBOUNCE_MS,
+  compositeWarning, warmPollAction,
+  PREVIEW_DEBOUNCE_MS, WORKER_WARM_POLL_MS,
   type PreviewContext, type PreviewStatus, type PreviewBlocker,
 } from '../utils/taskPreview'
 import { useWsStore } from './ws'
@@ -116,7 +116,8 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
     // for a region that is no longer on screen. The layer the backend just set is replaced by the next
     // run; only the READOUT would lie, so only the readout is guarded.
     if (!isCurrent()) return
-    if (res?.starting) { starting.value = true; return }
+    // 202: the worker is warming. Wait it out and re-request — nothing else will.
+    if (res?.starting) { starting.value = true; pollUntilWarm(); return }
     starting.value = false
     counts.value = res?.counts ?? null
     fallback2d.value = Boolean(res?.fallback2d)
@@ -156,6 +157,47 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
     scheduler.schedule(context.value)
   }
 
+  // ── waiting out a cold worker ───────────────────────────────────────────────
+  // A request that arrives while the worker is still importing gets `202 {starting}` instead of a
+  // result, and the worker cannot call back when it is ready. That made the 202 a DEAD END: the UI sat
+  // on "Starting…" until the user happened to change a parameter again, so toggling the preview on — or
+  // editing a param during the ~18 s warm-up — looked like a preview that never finished. So poll, and
+  // re-issue the request that got the 202. Decision logic is `warmPollAction` (pure, tested).
+  let warmTimer: ReturnType<typeof setTimeout> | null = null
+  let warmStartedAt = 0
+
+  function cancelWarmPoll() {
+    if (warmTimer !== null) { clearTimeout(warmTimer); warmTimer = null }
+  }
+
+  function pollUntilWarm() {
+    if (warmTimer !== null) return          // one loop at a time, however many 202s arrive
+    warmStartedAt = Date.now()
+    const tick = async () => {
+      warmTimer = null
+      await refreshStatus()
+      // refreshStatus sets `starting` from the backend; it is authoritative from here on
+      switch (warmPollAction(status.value, Date.now() - warmStartedAt,
+                             { enabled: enabled.value, pinned: pinned.value })) {
+        case 'stop':                        // user turned it off or pinned — their choice, not an error
+          starting.value = false
+          return
+        case 'request':
+          starting.value = false
+          request()
+          return
+        case 'abandon':
+          starting.value = false
+          error.value = 'The preview worker did not start.'
+          errorCode.value = 'timeout'
+          return
+        default:
+          warmTimer = setTimeout(tick, WORKER_WARM_POLL_MS)
+      }
+    }
+    warmTimer = setTimeout(tick, WORKER_WARM_POLL_MS)
+  }
+
   /** The module page keeps this current; a change re-previews (debounced). */
   function setContext(ctx: PreviewContext | null) {
     context.value = ctx
@@ -182,6 +224,7 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
   async function stop() {
     enabled.value = false
     scheduler.cancel()               // drop pending + supersede in flight, so no late mask lands
+    cancelWarmPoll()                 // …and stop waiting on a worker we are about to shut down
     clearResult()
     error.value = ''
     errorCode.value = ''

--- a/frontend/src/utils/taskPreview.test.ts
+++ b/frontend/src/utils/taskPreview.test.ts
@@ -3,6 +3,7 @@ import {
   previewBlocker, hasPreviewableModel, blockerMessage, previewNotice, previewSummary,
   FALLBACK_2D_WARN, baseOnlyWarning, tilingWarning, compositeWarning,
   paramsBlocker, hasAfCombination,
+  warmPollAction, WORKER_WARM_POLL_MS, WORKER_WARM_TIMEOUT_MS,
   type PreviewContext, type PreviewStatus,
 } from './taskPreview'
 
@@ -415,5 +416,53 @@ describe('previewSummary', () => {
     expect(d).not.toMatch(/may vary/i)
     expect(FALLBACK_2D_WARN.short.split(' ').length).toBeLessThanOrEqual(4)   // short really is short
     expect(d.split(' ').length).toBeLessThanOrEqual(20)                       // one line, not an essay
+  })
+})
+
+// ── waiting out a cold worker ──────────────────────────────────────────────────────────────────────
+//
+// THE BUG: a request made while the worker was still importing got `202 {starting: true}`, and the store
+// set `starting` and returned. Nothing re-requested, and the worker cannot call back — so the UI sat on
+// "Starting…" until the user happened to change a parameter again. Reported as "the preview sometimes
+// just doesn't finish", triggered by toggling the thunderbolt or editing a param during the ~18 s warm.
+describe('warmPollAction', () => {
+  const on = { enabled: true, pinned: false }
+  const warm = (o: Partial<PreviewStatus> = {}): PreviewStatus =>
+    ({ alive: true, starting: false, imageUid: 'i', zarrPath: 'z', taskDir: 't', ...o })
+
+  it('re-requests once the worker is alive and no longer starting', () => {
+    expect(warmPollAction(warm(), 5_000, on)).toBe('request')
+  })
+
+  it('keeps waiting while the worker is still starting', () => {
+    expect(warmPollAction(warm({ starting: true }), 5_000, on)).toBe('wait')
+    expect(warmPollAction(warm({ alive: false }), 5_000, on)).toBe('wait')
+    expect(warmPollAction(null, 5_000, on)).toBe('wait')       // status fetch failed; try again
+  })
+
+  it('gives up at the deadline rather than spinning forever', () => {
+    // the whole point: an unresolved spinner is indistinguishable from a hang, which IS the bug
+    expect(warmPollAction(warm({ alive: false }), WORKER_WARM_TIMEOUT_MS, on)).toBe('abandon')
+    expect(warmPollAction(warm({ starting: true }), WORKER_WARM_TIMEOUT_MS + 1, on)).toBe('abandon')
+  })
+
+  it('a ready worker beats the deadline — do not abandon a result we could still use', () => {
+    expect(warmPollAction(warm(), WORKER_WARM_TIMEOUT_MS * 10, on)).toBe('request')
+  })
+
+  it('stops silently when the user turns the preview off or pins it', () => {
+    // their action, not a failure: surfacing it as an error would be the wrong kind of loud
+    expect(warmPollAction(warm({ starting: true }), 1_000, { enabled: false, pinned: false }))
+      .toBe('stop')
+    expect(warmPollAction(warm({ starting: true }), 1_000, { enabled: true, pinned: true }))
+      .toBe('stop')
+    // ...and that takes precedence over the deadline, so a late abandon cannot raise an error either
+    expect(warmPollAction(warm({ alive: false }), WORKER_WARM_TIMEOUT_MS * 2,
+                          { enabled: false, pinned: false })).toBe('stop')
+  })
+
+  it('the poll interval is well under the timeout, or the wait would never retry', () => {
+    expect(WORKER_WARM_POLL_MS).toBeGreaterThan(0)
+    expect(WORKER_WARM_POLL_MS).toBeLessThan(WORKER_WARM_TIMEOUT_MS / 10)
   })
 })

--- a/frontend/src/utils/taskPreview.ts
+++ b/frontend/src/utils/taskPreview.ts
@@ -304,3 +304,44 @@ export function previewSummary(
 
 /** Debounce window, ms. A pan emits events continuously and each run is real cellpose on the GPU. */
 export const PREVIEW_DEBOUNCE_MS = 400
+
+// ── waiting out a cold worker ──────────────────────────────────────────────────────────────────────
+//
+// A preview requested while the worker is still importing gets `202 {starting: true}` rather than a
+// result. That used to be a DEAD END: the store set `starting` and returned, so the UI sat on
+// "Starting…" until the user happened to change a parameter again — which is why toggling the preview
+// on, or editing a param during the ~18 s warm-up, looked like a preview that never finished.
+//
+// The worker cannot call back, so the client has to wait it out. This is the decision inside that wait,
+// kept pure so the give-up path is actually tested rather than assumed.
+
+/** How often to re-ask while the worker warms. */
+export const WORKER_WARM_POLL_MS = 1000
+/**
+ * How long to keep waiting. Generously above the measured cold start (17.7 s of imports, plus a
+ * whole-image statistic on the first request) — but bounded, because "Starting…" forever is the bug
+ * being fixed, and a spinner that never resolves is indistinguishable from a hang.
+ */
+export const WORKER_WARM_TIMEOUT_MS = 180_000
+
+export type WarmAction = 'request' | 'wait' | 'abandon' | 'stop'
+
+/**
+ * What to do next while waiting for the worker.
+ *
+ * - `stop` — the user turned the preview off or pinned it; stop polling and say nothing. Their action
+ *   is not an error, so it must not surface as one.
+ * - `request` — the worker answers and is not starting: re-issue the request that got the 202.
+ * - `abandon` — past the deadline. Report it; do not keep a spinner alive on hope.
+ * - `wait` — poll again.
+ */
+export function warmPollAction(
+  status: PreviewStatus | null,
+  elapsedMs: number,
+  opts: { enabled: boolean; pinned: boolean },
+): WarmAction {
+  if (!opts.enabled || opts.pinned) return 'stop'
+  if (status?.alive && !status.starting) return 'request'
+  if (elapsedMs >= WORKER_WARM_TIMEOUT_MS) return 'abandon'
+  return 'wait'
+}


### PR DESCRIPTION
Reported as "the preview sometimes just doesn't finish" — the control stuck on **"Starting…"**
indefinitely, triggered by toggling the thunderbolt or by changing a parameter.

Both triggers hit the same window. A request that arrives while the worker is still importing gets
`202 {starting: true}` instead of a result, and the worker has no way to call back when it becomes ready.
The store set `starting` and returned, so **nothing re-issued the request**: the spinner survived until
the user happened to change a parameter again, which is why it looked intermittent rather than broken.
Toggle-on launches the worker; a param edit during the ~18 s warm-up lands inside the same window.

So poll, and re-request. `warmPollAction` holds the decision (pure, tested):

- **request** once the worker is alive and no longer starting
- **wait** while it is starting, not yet alive, or the status fetch failed
- **stop** silently if the user turned the preview off or pinned it — their action is not a failure, and
  this takes precedence over the deadline so a late abandon cannot surface an error either
- **abandon** at a bounded deadline. Bounded on purpose: an unresolved spinner is indistinguishable from
  a hang, which is the bug being fixed, so "wait forever" is not the fix. A ready worker beats the
  deadline, so a slow status fetch cannot discard a usable result.

`vue-tsc` caught that `cancelWarmPoll` was declared and never wired into `stop()` — a timer would have
outlived the worker it was waiting for.

Split out of #446, which was merged while this was being written.

Frontend 736 passing (+6), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
