### PR TITLE
fix(af): the neutral ratio was a pedestal, not zero

### DIFF
--- a/docs/todo/AF_QUANTISATION.md
+++ b/docs/todo/AF_QUANTISATION.md
@@ -64,6 +64,22 @@ This does not touch the speckle. It was a separate defect the investigation surf
    corrected signal — unlike the old Gaussian, which blurred the output. Note it would barely help here:
    with the denominator at background 98.6% of the time there is almost nothing to smooth.
 
+4. **A set-wide ceiling waits on a mechanism that does not exist yet.** AF's derived ceiling has a
+   real comparability problem — measured **1.71x** across the nine `kSUFux` movies (one experiment, one
+   channel pair, identical settings), and the existing AF QC is provably blind to it, which is why
+   `ceiling` is banked as a cohort metric. The fix is not a typed absolute window: `channel_ranges`'
+   `fixed=(lo, hi)` is in raw intensity units a user can reason about, whereas AF's ceiling is a
+   dimensionless ratio (~15–21 here) — the gain knob that was deliberately removed. The right shape is
+   "derive it from the set's reference image and apply it set-wide".
+
+   **But #443 landed only the NOMINATION** (`reference_image_uid` / `set_reference_image!`); no consumer
+   reads it yet. The derive-and-apply half is **in flight as #445** (`feat/import-reference-window`),
+   for the 8-bit import — its designed first consumer. Building a second copy for AF while that is open
+   is precisely the divergent re-implementation the set field exists to prevent, so AF waits for #445 to
+   land and then follows its shape (a `reference_window`-style helper the task calls, not its own path) — and on (1) and (2)
+   above, because on 8-bit input with the reference inactive 98.6% of the time, a shared ceiling would
+   make images consistently coarse rather than comparably precise.
+
 ## Why this is not just a TODO item
 
 It looks like one bug and is three separate things — an output-mapping defect (fixed), an input-precision

--- a/docs/todo/AF_QUANTISATION.md
+++ b/docs/todo/AF_QUANTISATION.md
@@ -1,0 +1,71 @@
+# AF correction on 8-bit data — where the speckle comes from
+
+**Status:** measured 2026-08-01, one fix landed, the rest is a decision for Dominik. Opened because the
+AF preview made a long-standing property of the correction visible for the first time: the corrected
+channel shows a carpet of single-pixel speckle.
+
+The easy explanation — "dividing by a noisy denominator amplifies noise, and the Gaussian we removed
+used to hide it" — is **wrong on this data**, and acting on it would have added a filter that fixes
+nothing. What follows is what the numbers actually say.
+
+## Measured
+
+`kSUFux/Or1L8a` (drift-corrected, `uint8`, 180×4×13×546×518), CH1 corrected against CH4, frame 89.
+Derived: background 39, AF background 33, ceiling 15.06, rescale 255.
+
+| Quantity | Value |
+|---|---|
+| CH1 usable range above its background | **30 counts** (33 → 63 robust max) |
+| CH4 above its own background | **1.45%** of voxels |
+| voxels where the denominator is zero (`corr == 0`) | **98.62%** |
+| voxels where both channels are at background | 98.23% |
+| output counts per 1 input count | **17** (6.6% of full scale) |
+| output levels occupied | 77 of 256 |
+| voxels differing from their 3×3 neighbourhood by >1 step | 0.39% |
+
+## What that means
+
+**For ~99% of the image there is no division.** Both terms carry `+1` so a zero denominator is safe,
+which means wherever the reference channel is at its background the ratio degenerates to `img + 1`. The
+result is then scaled as if it were a ratio, so **one input count becomes ~17 output counts**.
+
+The speckle is therefore **quantisation, magnified** — not noise amplified by a division. The input is
+8-bit with roughly 30 usable counts above background; the ratio can only take ~15 distinct values; and
+each is stretched to 17 counts of the output. A single count of photon/sensor noise becomes a 6.6%-of-
+full-scale speck. The Gaussian hid this by interpolating between the steps, which is why removing it
+appeared to "introduce" noise it merely stopped concealing.
+
+**No arithmetic in `af_correct_frame` can recover levels the input never had.** That is the part worth
+being blunt about, because it rules out a whole family of tempting fixes.
+
+## Fixed: the neutral point was a pedestal
+
+`ratio == 1` means "no excess over the reference" — exactly what AF correction removes — so it must come
+out as 0. It used to map to `rescale / c_max`, i.e. **17 of 255 for every background voxel**: 6.6% of the
+range spent on nothing, and a background region's mean intensity reading 17 instead of 0 for every
+downstream measurement. Now anchored (`(ratio - 1) / (c_max - 1)`); voxels dimmer than the reference clip
+to 0, which is the same statement. Measured after: background is 0 for **99.60%** of voxels.
+
+This does not touch the speckle. It was a separate defect the investigation surfaced.
+
+## Open — needs a scientific decision, not a code change
+
+1. **The 8-bit input is the actual cause.** Both versions of this image are `uint8`; the 8-bit
+   conversion happens at import, and AF correction then divides what is left. Correcting the 16-bit
+   source *before* the 8-bit conversion would give the ratio real precision. That is a pipeline-ORDER
+   question (and interacts with the reference-image window work in #443), not something AF can fix
+   locally.
+2. **Is CH4 a useful AF reference for CH1 here?** It is above its own background for 1.45% of voxels, so
+   the correction is inactive almost everywhere — for this pair, AF correction is closer to a 17× gain
+   than to a correction. Either the reference is too dim to serve, or the triangle threshold on the
+   reference is too aggressive. Both are judgements about the data.
+3. **If smoothing ever comes back, smooth the DENOMINATOR only.** The reference channel is an estimate
+   of a slowly varying autofluorescence field, so smoothing *it* is principled and does not blur the
+   corrected signal — unlike the old Gaussian, which blurred the output. Note it would barely help here:
+   with the denominator at background 98.6% of the time there is almost nothing to smooth.
+
+## Why this is not just a TODO item
+
+It looks like one bug and is three separate things — an output-mapping defect (fixed), an input-precision
+limit (upstream), and a channel-choice question (scientific). Recording them together is the only way the
+next person doesn't re-run the same measurements to re-derive that the obvious fix is the wrong one.

--- a/frontend/src/stores/taskPreview.ts
+++ b/frontend/src/stores/taskPreview.ts
@@ -20,8 +20,8 @@ import { previewApi, type SvcError } from '../utils/serviceApi'
 import { debouncedLatest, type RunState } from '../utils/debouncedLatest'
 import {
   previewBlocker, previewNotice, previewSummary, baseOnlyWarning, tilingWarning,
-  compositeWarning,
-  PREVIEW_DEBOUNCE_MS,
+  compositeWarning, warmPollAction,
+  PREVIEW_DEBOUNCE_MS, WORKER_WARM_POLL_MS,
   type PreviewContext, type PreviewStatus, type PreviewBlocker,
 } from '../utils/taskPreview'
 import { useWsStore } from './ws'
@@ -116,7 +116,8 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
     // for a region that is no longer on screen. The layer the backend just set is replaced by the next
     // run; only the READOUT would lie, so only the readout is guarded.
     if (!isCurrent()) return
-    if (res?.starting) { starting.value = true; return }
+    // 202: the worker is warming. Wait it out and re-request — nothing else will.
+    if (res?.starting) { starting.value = true; pollUntilWarm(); return }
     starting.value = false
     counts.value = res?.counts ?? null
     fallback2d.value = Boolean(res?.fallback2d)
@@ -156,6 +157,47 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
     scheduler.schedule(context.value)
   }
 
+  // ── waiting out a cold worker ───────────────────────────────────────────────
+  // A request that arrives while the worker is still importing gets `202 {starting}` instead of a
+  // result, and the worker cannot call back when it is ready. That made the 202 a DEAD END: the UI sat
+  // on "Starting…" until the user happened to change a parameter again, so toggling the preview on — or
+  // editing a param during the ~18 s warm-up — looked like a preview that never finished. So poll, and
+  // re-issue the request that got the 202. Decision logic is `warmPollAction` (pure, tested).
+  let warmTimer: ReturnType<typeof setTimeout> | null = null
+  let warmStartedAt = 0
+
+  function cancelWarmPoll() {
+    if (warmTimer !== null) { clearTimeout(warmTimer); warmTimer = null }
+  }
+
+  function pollUntilWarm() {
+    if (warmTimer !== null) return          // one loop at a time, however many 202s arrive
+    warmStartedAt = Date.now()
+    const tick = async () => {
+      warmTimer = null
+      await refreshStatus()
+      // refreshStatus sets `starting` from the backend; it is authoritative from here on
+      switch (warmPollAction(status.value, Date.now() - warmStartedAt,
+                             { enabled: enabled.value, pinned: pinned.value })) {
+        case 'stop':                        // user turned it off or pinned — their choice, not an error
+          starting.value = false
+          return
+        case 'request':
+          starting.value = false
+          request()
+          return
+        case 'abandon':
+          starting.value = false
+          error.value = 'The preview worker did not start.'
+          errorCode.value = 'timeout'
+          return
+        default:
+          warmTimer = setTimeout(tick, WORKER_WARM_POLL_MS)
+      }
+    }
+    warmTimer = setTimeout(tick, WORKER_WARM_POLL_MS)
+  }
+
   /** The module page keeps this current; a change re-previews (debounced). */
   function setContext(ctx: PreviewContext | null) {
     context.value = ctx
@@ -182,6 +224,7 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
   async function stop() {
     enabled.value = false
     scheduler.cancel()               // drop pending + supersede in flight, so no late mask lands
+    cancelWarmPoll()                 // …and stop waiting on a worker we are about to shut down
     clearResult()
     error.value = ''
     errorCode.value = ''

--- a/frontend/src/utils/taskPreview.test.ts
+++ b/frontend/src/utils/taskPreview.test.ts
@@ -3,6 +3,7 @@ import {
   previewBlocker, hasPreviewableModel, blockerMessage, previewNotice, previewSummary,
   FALLBACK_2D_WARN, baseOnlyWarning, tilingWarning, compositeWarning,
   paramsBlocker, hasAfCombination,
+  warmPollAction, WORKER_WARM_POLL_MS, WORKER_WARM_TIMEOUT_MS,
   type PreviewContext, type PreviewStatus,
 } from './taskPreview'
 
@@ -415,5 +416,53 @@ describe('previewSummary', () => {
     expect(d).not.toMatch(/may vary/i)
     expect(FALLBACK_2D_WARN.short.split(' ').length).toBeLessThanOrEqual(4)   // short really is short
     expect(d.split(' ').length).toBeLessThanOrEqual(20)                       // one line, not an essay
+  })
+})
+
+// ── waiting out a cold worker ──────────────────────────────────────────────────────────────────────
+//
+// THE BUG: a request made while the worker was still importing got `202 {starting: true}`, and the store
+// set `starting` and returned. Nothing re-requested, and the worker cannot call back — so the UI sat on
+// "Starting…" until the user happened to change a parameter again. Reported as "the preview sometimes
+// just doesn't finish", triggered by toggling the thunderbolt or editing a param during the ~18 s warm.
+describe('warmPollAction', () => {
+  const on = { enabled: true, pinned: false }
+  const warm = (o: Partial<PreviewStatus> = {}): PreviewStatus =>
+    ({ alive: true, starting: false, imageUid: 'i', zarrPath: 'z', taskDir: 't', ...o })
+
+  it('re-requests once the worker is alive and no longer starting', () => {
+    expect(warmPollAction(warm(), 5_000, on)).toBe('request')
+  })
+
+  it('keeps waiting while the worker is still starting', () => {
+    expect(warmPollAction(warm({ starting: true }), 5_000, on)).toBe('wait')
+    expect(warmPollAction(warm({ alive: false }), 5_000, on)).toBe('wait')
+    expect(warmPollAction(null, 5_000, on)).toBe('wait')       // status fetch failed; try again
+  })
+
+  it('gives up at the deadline rather than spinning forever', () => {
+    // the whole point: an unresolved spinner is indistinguishable from a hang, which IS the bug
+    expect(warmPollAction(warm({ alive: false }), WORKER_WARM_TIMEOUT_MS, on)).toBe('abandon')
+    expect(warmPollAction(warm({ starting: true }), WORKER_WARM_TIMEOUT_MS + 1, on)).toBe('abandon')
+  })
+
+  it('a ready worker beats the deadline — do not abandon a result we could still use', () => {
+    expect(warmPollAction(warm(), WORKER_WARM_TIMEOUT_MS * 10, on)).toBe('request')
+  })
+
+  it('stops silently when the user turns the preview off or pins it', () => {
+    // their action, not a failure: surfacing it as an error would be the wrong kind of loud
+    expect(warmPollAction(warm({ starting: true }), 1_000, { enabled: false, pinned: false }))
+      .toBe('stop')
+    expect(warmPollAction(warm({ starting: true }), 1_000, { enabled: true, pinned: true }))
+      .toBe('stop')
+    // ...and that takes precedence over the deadline, so a late abandon cannot raise an error either
+    expect(warmPollAction(warm({ alive: false }), WORKER_WARM_TIMEOUT_MS * 2,
+                          { enabled: false, pinned: false })).toBe('stop')
+  })
+
+  it('the poll interval is well under the timeout, or the wait would never retry', () => {
+    expect(WORKER_WARM_POLL_MS).toBeGreaterThan(0)
+    expect(WORKER_WARM_POLL_MS).toBeLessThan(WORKER_WARM_TIMEOUT_MS / 10)
   })
 })

--- a/frontend/src/utils/taskPreview.ts
+++ b/frontend/src/utils/taskPreview.ts
@@ -304,3 +304,44 @@ export function previewSummary(
 
 /** Debounce window, ms. A pan emits events continuously and each run is real cellpose on the GPU. */
 export const PREVIEW_DEBOUNCE_MS = 400
+
+// ── waiting out a cold worker ──────────────────────────────────────────────────────────────────────
+//
+// A preview requested while the worker is still importing gets `202 {starting: true}` rather than a
+// result. That used to be a DEAD END: the store set `starting` and returned, so the UI sat on
+// "Starting…" until the user happened to change a parameter again — which is why toggling the preview
+// on, or editing a param during the ~18 s warm-up, looked like a preview that never finished.
+//
+// The worker cannot call back, so the client has to wait it out. This is the decision inside that wait,
+// kept pure so the give-up path is actually tested rather than assumed.
+
+/** How often to re-ask while the worker warms. */
+export const WORKER_WARM_POLL_MS = 1000
+/**
+ * How long to keep waiting. Generously above the measured cold start (17.7 s of imports, plus a
+ * whole-image statistic on the first request) — but bounded, because "Starting…" forever is the bug
+ * being fixed, and a spinner that never resolves is indistinguishable from a hang.
+ */
+export const WORKER_WARM_TIMEOUT_MS = 180_000
+
+export type WarmAction = 'request' | 'wait' | 'abandon' | 'stop'
+
+/**
+ * What to do next while waiting for the worker.
+ *
+ * - `stop` — the user turned the preview off or pinned it; stop polling and say nothing. Their action
+ *   is not an error, so it must not surface as one.
+ * - `request` — the worker answers and is not starting: re-issue the request that got the 202.
+ * - `abandon` — past the deadline. Report it; do not keep a spinner alive on hope.
+ * - `wait` — poll again.
+ */
+export function warmPollAction(
+  status: PreviewStatus | null,
+  elapsedMs: number,
+  opts: { enabled: boolean; pinned: boolean },
+): WarmAction {
+  if (!opts.enabled || opts.pinned) return 'stop'
+  if (status?.alive && !status.starting) return 'request'
+  if (elapsedMs >= WORKER_WARM_TIMEOUT_MS) return 'abandon'
+  return 'wait'
+}

--- a/python/cecelia/tests/test_correction_utils.py
+++ b/python/cecelia/tests/test_correction_utils.py
@@ -368,6 +368,39 @@ class AfDerivedValuesTest(unittest.TestCase):
         self.assertGreaterEqual(s['clippedFrac'], 0.0)
         self.assertLessEqual(s['levelsUsed'], s['levelsAvailable'])
 
+    def test_no_signal_and_no_autofluorescence_comes_out_as_ZERO(self):
+        """The neutral ratio (1.0) is what AF correction removes, so it must map to 0, not a pedestal.
+
+        Measured before this was anchored: on a real 8-bit image with a derived ceiling of 15.06, every
+        background voxel came out at 17 of 255 — 6.6% of the range spent on nothing, and a background
+        region's mean intensity reading 17 instead of 0 for everything downstream.
+        """
+        stats = cu.AfDivisionStats(val1=10, val2=10, c_max=15.06, nbins=256, rescale=255.0)
+        # both at background -> img 0, corr 0 -> ratio 1.0 -> neutral
+        flat = np.full((2, 4, 4), 10, dtype=np.uint8)
+        out = cu.af_correct_frame(flat, flat, stats, np.uint8)
+        self.assertTrue(np.all(out == 0), f'background did not come out as 0: {np.unique(out)}')
+
+    def test_a_voxel_dimmer_than_its_reference_is_also_zero(self):
+        stats = cu.AfDivisionStats(val1=0, val2=0, c_max=10.0, nbins=256, rescale=255.0)
+        img = np.full((1, 2, 2), 1, dtype=np.uint8)
+        corr = np.full((1, 2, 2), 50, dtype=np.uint8)     # reference far brighter -> ratio < 1
+        self.assertTrue(np.all(cu.af_correct_frame(img, corr, stats, np.uint8) == 0))
+
+    def test_the_ceiling_still_maps_to_full_scale(self):
+        """Anchoring the bottom must not move the top — the ceiling is what `af_division_stats` derived."""
+        stats = cu.AfDivisionStats(val1=0, val2=0, c_max=11.0, nbins=256, rescale=255.0)
+        img = np.full((1, 2, 2), 10, dtype=np.uint8)      # corr 0 -> ratio (10+1)/1 == c_max
+        out = cu.af_correct_frame(img, np.zeros((1, 2, 2), np.uint8), stats, np.uint8)
+        self.assertTrue(np.all(out == 255), f'ceiling did not reach full scale: {np.unique(out)}')
+
+    def test_a_degenerate_ceiling_does_not_divide_by_zero(self):
+        for c in (1.0, 0.5, 0.0):
+            stats = cu.AfDivisionStats(val1=0, val2=0, c_max=c, nbins=256, rescale=255.0)
+            out = cu.af_correct_frame(np.ones((1, 2, 2), np.uint8),
+                                      np.zeros((1, 2, 2), np.uint8), stats, np.uint8)
+            self.assertTrue(np.all(np.isfinite(out.astype(float))), f'c_max={c} produced non-finite')
+
     def test_output_stats_carry_the_derived_values_themselves(self):
         """The fractions cannot stand in for the ceiling, so the ceiling has to be reported too."""
         du = _dim_utils(**self.SHAPE)

--- a/python/cecelia/utils/correction_utils.py
+++ b/python/cecelia/utils/correction_utils.py
@@ -411,10 +411,22 @@ def af_correct_frame(img_slab, corr_slab, stats, out_dtype):
     The gaussian is the one worth explaining, because it was not cosmetic: dividing by a small noisy
     denominator amplifies noise, and the blur hid that. **Noise suppression is the denoise step's job**
     (pre-cellpose, now in coastal), so keeping a second, weaker version of it here meant every
-    corrected channel was silently blurred whether or not it was going to be denoised anyway. It also
-    matters less than it did: the derived AF background sits higher than the hand-tuned percentile it
-    replaced, so more of the reference channel is zeroed, the denominator is 1 more often, and there is
-    simply less division to amplify anything.
+    corrected channel was silently blurred whether or not it was going to be denoised anyway.
+
+    **`ratio == 1` is the neutral point, and it maps to 0.** Both terms carry `+1` so a zero denominator
+    is harmless, which means a voxel with no signal AND no autofluorescence lands on `ratio == 1` — "no
+    excess over the reference". That is what AF correction removes, so it must come out as zero.
+    Anchoring at `c_max` alone instead put it on a PEDESTAL of `rescale / c_max`: measured on a real
+    8-bit image (`kSUFux/Or1L8a`, CH1÷CH4, derived ceiling 15.06) every background voxel came out at
+    **17 of 255** rather than 0, which is 6.6% of the range spent on nothing, and made the mean intensity
+    of a background region 17 instead of 0 for everything downstream. Voxels dimmer than the reference
+    (`ratio < 1`) clip to 0, which is the same statement: no excess is no signal.
+
+    What this does NOT fix, because it cannot: on that image the reference channel is above its own
+    background for only **1.45%** of voxels, so for ~99% of them no division happens at all and the
+    result is `(img + 1)` scaled — one input count becomes ~17 output counts. The visible speckle is
+    8-bit QUANTISATION magnified, not noise amplified by a division, and no arithmetic here recovers
+    levels the 8-bit input never had. See docs/todo/AF_QUANTISATION.md.
 
     ``stats.c_max`` is the ratio that maps to full scale, derived in `af_division_stats` as an
     outlier-rejected maximum. Every value in this function comes from the data.
@@ -422,8 +434,12 @@ def af_correct_frame(img_slab, corr_slab, stats, out_dtype):
     img = _af_subtract(img_slab, stats.val1)
     corr = _af_subtract(corr_slab, stats.val2)
     ratio = (img + 1.0) / (corr + 1.0)
-    denom = stats.c_max if stats.c_max > 0 else 1.0
-    return np.clip(ratio / denom * stats.rescale, 0, stats.rescale).astype(out_dtype)
+    # span from the neutral ratio (1.0) to the ceiling, so "no excess" is 0 and the ceiling is full
+    # scale. Guarded because a degenerate ceiling <= 1 would otherwise divide by zero or invert.
+    span = stats.c_max - 1.0
+    if span <= 0:
+        span = stats.c_max if stats.c_max > 0 else 1.0
+    return np.clip((ratio - 1.0) / span * stats.rescale, 0, stats.rescale).astype(out_dtype)
 
 
 


### PR DESCRIPTION
**Needs your scientific sign-off, not just a code review** — it changes what an AF-corrected intensity
value is. Everything else in the recent PRs was infrastructure; this one is the science.

## The defect

Both terms of the ratio carry `+1`, so a zero denominator is harmless — which means a voxel with **no
signal and no autofluorescence** lands on `ratio == 1`, "no excess over the reference". That is exactly
what AF correction removes, so it should come out as 0. It came out as `rescale / c_max`.

Measured on `kSUFux/Or1L8a` (uint8, CH1÷CH4, derived ceiling 15.06): **every background voxel was 17 of
255**. 6.6% of the output range spent on nothing, and a background region's mean intensity reading 17
instead of 0 for every downstream measurement. After the fix, background is 0 for **99.60%** of voxels.

Voxels dimmer than their reference (`ratio < 1`) now clip to 0, which is the same statement: no excess is
no signal.

## The speckle: the obvious explanation was wrong

I set out to fix the visible speckle and did not, because the data says the intuitive cause isn't it.
"A ratio amplifies noise, and the Gaussian we removed used to hide it" would have justified adding a
filter that fixes nothing.

| | |
|---|---|
| CH4 above its own background | **1.45%** of voxels |
| voxels where the denominator is zero | **98.62%** |
| output counts per 1 input count | **17** (6.6% of full scale) |
| CH1 usable range above background | **30 counts** of 8-bit |
| output levels occupied | 77 of 256 |

For ~99% of the image no division happens: the ratio degenerates to `img + 1` and is then scaled as if it
were a ratio. The input is 8-bit with ~30 usable counts, so the ratio takes ~15 distinct values and each
is stretched to 17 output counts. The speckle is **8-bit quantisation magnified**, and no arithmetic in
`af_correct_frame` recovers levels the input never had.

## Left open deliberately (docs/todo/AF_QUANTISATION.md)

1. **The 8-bit input is the real cause.** Both versions of that image are `uint8` — the conversion happens
   at import and AF then divides what's left. Correcting the 16-bit source *first* would give the ratio
   real precision. Pipeline-order question, and it interacts with #443's reference-image window.
2. **Is CH4 a useful AF reference for CH1?** Active for 1.45% of voxels means this pair is closer to a 17×
   gain than a correction. Either the reference is too dim, or the triangle threshold on it is too
   aggressive. Both are judgements about the data, not the code.
3. **If smoothing returns, smooth the denominator only** — it's an estimate of a slowly varying AF field,
   so smoothing *it* is principled and doesn't blur the corrected signal. Would barely help here.

Package 3511, Python 408 (+4), all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
