### PR TITLE
fix(prod): the launcher orphaned the server's children too

### DIFF
--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -250,6 +250,25 @@ end
     dev_ports = sort(parse.(Int, strip.(split(m.captures[1], ","))))
     @test dev_ports == sort([Cecelia.NAPARI_PORT, Cecelia.PREVIEW_PORT, NOTEBOOKS_PORT])
     @test occursin("for p in CHILD_PORTS", dev)          # …and they are actually freed, not just listed
+
+    # PROD's supervisor (`app.py`) had the same hole: `proc.terminate()` kills the Julia server and
+    # leaves its three grandchildren running. It closes it by REUSING the route above rather than
+    # carrying a third copy of platform port-killing — so assert the reuse and, crucially, the ORDER:
+    # attempting a graceful stop AFTER terminate would be pointless, and the diff that introduces that
+    # mistake looks almost identical to the correct one.
+    app = read(joinpath(@__DIR__, "..", "..", "app.py"), String)
+    @test occursin("/api/app/shutdown", app)
+    @test occursin("_stop_gracefully(proc)", app)
+    # Assert the order inside the teardown block itself: the graceful attempt must come before the
+    # terminate it is meant to avoid. Comparing positions in the whole file would pass even if the two
+    # were in unrelated places, which is exactly the bug being guarded against.
+    let tail = app[findlast("finally", app)[1]:end]
+        i_graceful = findfirst("_stop_gracefully(proc)", tail)
+        i_term     = findfirst("proc.terminate()", tail)
+        @test i_graceful !== nothing
+        @test i_term !== nothing
+        @test i_graceful[1] < i_term[1]
+    end
 end
 
 @testset "API: packages" begin

--- a/app.py
+++ b/app.py
@@ -47,6 +47,37 @@ def _server_ready(timeout: float = 180.0) -> bool:
     return False
 
 
+def _stop_gracefully(proc, timeout: float = 20.0) -> bool:
+    """Ask the server to stop ITS OWN children, then exit. True if it did.
+
+    `proc.terminate()` kills the Julia server and nothing else. The server is the parent of three
+    resident processes — the napari bridge (:7655), the task-preview worker (:7656) and the Pluto
+    notebooks server (:7660) — and they are grandchildren in their own process groups, so they survive
+    it. That left them running with no backend able to reach them: the preview worker in particular
+    holds a warm cellpose model's VRAM, and an orphan is then silently ADOPTED by the next launch, which
+    is how a worker running stale code outlived several restarts.
+
+    `POST /api/app/shutdown` already stops all three and then exits, and it is the path the in-app Quit
+    button uses — so this REUSES it rather than adding a third copy of platform-specific port-killing
+    (Julia has one in `_kill_listeners_on_port`, the dev supervisor another in `api/dev.jl::_free_port`).
+    Failure just falls through to terminate/kill, which is where this always ended up.
+    """
+    try:
+        req = urllib.request.Request(
+            f"{URL}/api/app/shutdown", data=b"{}",
+            headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            if resp.status != 200:
+                return False
+    except Exception:
+        return False          # hung, already gone, or too early to have a server — not worth reporting
+    try:
+        proc.wait(timeout=timeout)
+        return True
+    except subprocess.TimeoutExpired:
+        return False          # it accepted the request but did not exit; caller escalates
+
+
 def _apply_pending_update() -> None:
     """Apply an update staged by a previous run (the `.pending-update` marker + `.update-staging/
     payload`), before the server starts — when nothing is using the files. Best-effort: logs and
@@ -120,7 +151,10 @@ def main() -> int:
         except KeyboardInterrupt:
             return 0
         finally:
-            if proc.poll() is None:
+            # Ctrl-C, a crash, or the window being closed all land here. Ask the server to take its
+            # children down with it first (see `_stop_gracefully`); terminate/kill only if that fails,
+            # which is what this did unconditionally before — and which orphaned all three.
+            if proc.poll() is None and not _stop_gracefully(proc):
                 proc.terminate()
                 try:
                     proc.wait(timeout=10)

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -66,8 +66,20 @@ User clicks the desktop icon
   → app.py polls http://localhost:8080/api/health until {ok:true}
   → app.py opens the default browser at http://localhost:8080
   → Cecelia is running
-  → User closes the launcher window → app.py SIGTERMs the Julia server → clean shutdown
+  → User closes the launcher window → app.py asks the server to shut down (POST /api/app/shutdown),
+    which stops its own children first; SIGTERM only if that fails → clean shutdown
 ```
+
+**Why the launcher asks rather than just SIGTERMs.** The server is the parent of three resident
+processes — the napari bridge (:7655), the task-preview worker (:7656), the Pluto notebooks server
+(:7660) — and they are grandchildren in their own process groups, so killing the server leaves them
+running. That is not merely untidy: the preview worker holds a warm cellpose model's VRAM with nothing
+able to reach it, and an orphan gets silently **adopted** by the next launch, which is how a worker
+running stale code can outlive several restarts. `POST /api/app/shutdown` already stops all three (it is
+the in-app Quit path), so the launcher reuses it instead of carrying a third copy of platform-specific
+port-killing — the other two live in Julia's `_kill_listeners_on_port` and `api/dev.jl::_free_port`.
+Asserted by *"shutdown stops EVERY resident child"* in `api/test/runtests.jl`, which covers all three
+supervisors and checks the ORDER (a graceful attempt after the terminate would be pointless).
 
 The same-origin design (server serves the frontend) is what removes all the friction: the frontend
 calls `/api/...` and `ws://<host>/ws` relatively, so it works identically whether served by Vite in


### PR DESCRIPTION
The prod counterpart of the `api/dev.jl` fix. Tracked as the known remaining gap when that landed.

`proc.terminate()` kills the Julia server and nothing else. The server is the parent of three resident
processes — napari bridge (:7655), task-preview worker (:7656), Pluto notebooks (:7660) — and they are
grandchildren in their own process groups, so they survive it. The preview worker then holds a warm
cellpose model's VRAM with nothing able to reach it, and the orphan gets silently **adopted** by the next
launch, which is how a worker running stale code can outlive several restarts.

Closed by **reusing `POST /api/app/shutdown`** — which already stops all three and is the in-app Quit
path — rather than adding a third copy of platform-specific port-killing beside Julia's
`_kill_listeners_on_port` and `api/dev.jl::_free_port`. Terminate/kill remains the fallback for a hung or
already-dead server, which is where this unconditionally ended up before.

The test asserts the **order** inside the teardown block, not merely that both calls exist: a graceful
attempt placed after the terminate would be pointless, and that diff looks almost identical to the
correct one. Verified by inverting it — 1 failure, as intended.

All three supervisors are now covered by one testset rather than a check per file.

Residual, unchanged: if the server is genuinely hung it cannot answer, so terminate/kill still orphans
the children in that case. Fixing that would need the third copy of port-killing this PR exists to avoid.

API suite 18/18 in that testset, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
