### PR TITLE
feat(af): correct by channel dominance, not by division

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -116,15 +116,25 @@ median filter, a Gaussian, a rolling ball, a wavelet denoiser — each one added
 particular dataset, none of them revisited afterwards. A parameter that exists because one image once
 needed it is not a setting, it's a fossil.
 
-They're gone. You pick which channel to correct and which to correct it against; the background levels
-and the rescale ceiling are derived from the image's own histogram (triangle thresholding, Zack et al.
-1977). The one surviving knob chooses *how* they're derived, not what they are.
+They're gone. You pick which channel to correct and which channels compete with it; each channel's
+background level is derived from its own histogram (triangle thresholding, Zack et al. 1977). The one
+surviving knob chooses *how* that's derived, not what it is.
 
-The reason to prefer derivation over a knob here is that nobody can set these by eye. A rescale ceiling
-is "the brightest real voxel", and on one test image a **single** voxel out of 5.88 billion was setting
-it — a value you cannot see, cannot guess, and would get wrong on the next image in the set. Whether it
-landed well *is* checkable after the fact, so that became QC (`clippedFrac`, `levelsUsedFrac`) instead
-of a parameter.
+The reason to prefer derivation over a knob is that nobody can set these by eye. There used to be a
+rescale ceiling — "the brightest real voxel" — and on one test image a **single** voxel out of 5.88
+billion was setting it. A value you cannot see, cannot guess, and would get wrong on the next image in
+the set.
+
+That ceiling is now gone too, along with the division it scaled. Correction keeps the share of each
+voxel that a channel dominates — `out = b × b²/Σbᵢ²` over the competing channels — so the output stays
+in input counts and there is nothing left to normalise. Dividing had a structural flaw: it goes to zero
+wherever the target isn't brighter than the reference, so a cell carrying **two** reporters was hollowed
+into a dim rim, its centre — where both channels are bright and the ratio sits at 1 — pushed to zero. A
+hollow cell doesn't segment, and segmentation runs next.
+
+**Why isn't the exponent a setting?** Because that's how the dozen fossils got in. p=2 was compared
+against p=1 and p=8 on real overlapping cells; if a dataset ever genuinely needs a different value, that
+measurement is the trigger to expose it, not a guess in advance.
 
 ## How it was built
 

--- a/app/src/preview.jl
+++ b/app/src/preview.jl
@@ -30,7 +30,12 @@ const PREVIEW_PORT   = 7656
 # `funName`, fell through to the segmentation path and raised "no models in preview params", with
 # nothing anywhere reporting that the process was old. Bump BOTH sides together whenever the reply shape
 # or the set of previewable tasks changes.
-const PREVIEW_PROTOCOL = 3
+#
+# 4 is also the first bump where a stale worker would NOT fail loudly: it carries the old ratio
+# `af_correct_frame`, so it would keep returning well-formed ratio previews — hollowed-out overlapping
+# cells and all — while the backend believes the power weight is being shown. A preview that silently
+# disagrees with the run is the one outcome this feature must never produce.
+const PREVIEW_PROTOCOL = 4
 const PREVIEW_WORKER = joinpath(@__DIR__, "..", "..", "preview", "preview_worker.py")
 
 mutable struct PreviewWorker

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -71,21 +71,18 @@ const COHORT_METRICS = Dict{String,Vector{String}}(
     # window fails to cover — and the outlier flag says so without anyone re-reading pixels.
     "importImages.omezarr"           => ["nChannels", "nZ", "nT", "nChannelsClipped", "nChannelsFlat",
                                          "nChannelsSaturated", "windowNeeded"],
-    # AF correction: cohort-comparable BECAUSE the output ceiling is derived per image rather than
-    # dialled in — so an image whose corrected channel clipped far more, or used far less of the
-    # output range, than its peers had its background/ceiling derived differently, which is a staining
-    # or acquisition outlier rather than a parameter someone typed. That was not checkable while the
-    # window came from hand-tuned percentiles: every image got its own, so there was nothing to compare.
+    # AF correction: both metrics describe the ACQUISITION, which is what makes them comparable across a
+    # set shot in one session. `saturatedFrac` is the fraction of input voxels clipped at the sensor —
+    # measured across the nine kSUFux movies it spanned 0.001% to 0.018%, a 13x spread at identical
+    # settings, so the outlier is a real difference in gain or expression rather than a parameter
+    # someone typed. `levelsUsedFrac` says how coarsely the corrected channel ends up quantised.
     #
-    # `ceiling` is here for a different and stronger reason: it is the ONLY one of the three that can
-    # see two images drifting onto different intensity scales. The corrected output is
-    # `ratio / ceiling * rescale`, so if two images' ratios differ by a constant factor their ceilings
-    # differ by that factor and their outputs come out identical — a 1.86x ceiling difference moved
-    # clippedFrac and levelsUsedFrac by 0.000 (measured). Since the corrected channel is what gets
-    # segmented, measured and then POOLED across a set, that is the failure that quietly invalidates a
-    # comparison. It is cohort-only by nature: a single image's ceiling is neither right nor wrong.
-    # Measured on the nine kSUFux movies (one experiment, one channel pair, identical settings): 1.71x.
-    "cleanupImages.afCorrect"        => ["clippedFrac", "levelsUsedFrac", "ceiling"],
+    # There is deliberately no `ceiling` here. It was carried as a cohort metric to catch two images
+    # drifting onto different intensity scales, on the reasoning that the corrected output was
+    # `ratio / ceiling * rescale`. The output is now in input counts — no ceiling, nothing derived
+    # per image to drift. (And the premise was weak anyway: acquisition drift means intensities are not
+    # comparable between intravital movies regardless of what this task does.)
+    "cleanupImages.afCorrect"        => ["saturatedFrac", "levelsUsedFrac"],
 )
 
 """

--- a/app/src/tasks/cleanupImages/af_correct.jl
+++ b/app/src/tasks/cleanupImages/af_correct.jl
@@ -3,17 +3,22 @@ struct AfCorrect <: CciaTask end
 """
     af_combinations_for_python(params, raw) -> Dict
 
-The `afCombinations` bag as the PYTHON side needs it: `divisionChannels` resolved from channel NAMES
-to 0-based indices, and `quotientChannel` resolved to the combination's key (the channel being
+The `afCombinations` bag as the PYTHON side needs it: `competingChannels` resolved from channel NAMES
+to 0-based indices, and `targetChannel` resolved to the combination's key (the channel being
 corrected). Names come from the **default** version deliberately — a corrected variant inherits them
 by versioned fallback and may carry no list of its own.
 
 **Shared by the run and the task preview, and it has to be.** Exactly the shape of the cellpose bug
 (`cellpose_models_for_python`): the frontend sends names, Python wants indices, and the preview sends
 the frontend's params. Real saved params on a live project carry
-`divisionChannels = ["CH4", "CD169-Kat"]` where `"CH4"` is not in that image's `imChannelNames` at all
+`competingChannels = ["CH4", "CD169-Kat"]` where `"CH4"` is not in that image's `imChannelNames` at all
 — a stale name that silently resolves to nothing. Keeping one translator means the preview drops it
 exactly where the run does, rather than the two disagreeing about which channels were used.
+
+**The target is dropped from its own competitor list.** It is already the numerator's channel, so
+naming it again would square its term into the denominator twice and quietly halve the channel's own
+output. Silently dropped rather than rejected because the two lists are separate widgets and picking
+the same channel in both is an easy slip with one obvious intent.
 """
 function af_combinations_for_python(params::AbstractDict, raw::AbstractDict)::Dict{String,Any}
     channel_names_raw = versioned_get_field(raw, "imChannelNames", VERSIONED_DEFAULT_VAL)
@@ -27,10 +32,10 @@ function af_combinations_for_python(params::AbstractDict, raw::AbstractDict)::Di
     for (k, v) in af_combos_raw
         entry = Dict{String,Any}(String(ck) => cv for (ck, cv) in v)
 
-        # divisionChannels: channel names → 0-based indices (an already-translated index passes
+        # competingChannels: channel names → 0-based indices (an already-translated index passes
         # through, so this is idempotent — a REPL or chain caller may hand back a converted dict)
         idx_channels = Int[]
-        for ch in get(entry, "divisionChannels", [])
+        for ch in get(entry, "competingChannels", [])
             if ch isa Integer
                 push!(idx_channels, Int(ch))
                 continue
@@ -38,14 +43,13 @@ function af_combinations_for_python(params::AbstractDict, raw::AbstractDict)::Di
             idx = findfirst(==(String(ch)), ch_names)
             isnothing(idx) || push!(idx_channels, idx - 1)
         end
-        entry["divisionChannels"] = idx_channels
 
-        # quotientChannel: resolve name → 0-based index → use as the af_combos key
-        raw_quot = get(entry, "quotientChannel", [])
-        delete!(entry, "quotientChannel")
+        # targetChannel: resolve name → 0-based index → use as the af_combos key
+        raw_target = get(entry, "targetChannel", [])
+        delete!(entry, "targetChannel")
         combo_key = String(k)
-        if !isempty(raw_quot)
-            q = first(raw_quot)
+        if !isempty(raw_target)
+            q = first(raw_target)
             if q isa Integer
                 combo_key = string(Int(q))
             else
@@ -53,6 +57,11 @@ function af_combinations_for_python(params::AbstractDict, raw::AbstractDict)::Di
                 isnothing(idx) || (combo_key = string(idx - 1))
             end
         end
+
+        # the target competes with the OTHERS, never with itself — see the docstring
+        target_idx = tryparse(Int, combo_key)
+        entry["competingChannels"] = isnothing(target_idx) ? unique(idx_channels) :
+                                     filter(!=(target_idx), unique(idx_channels))
         af_combos[combo_key] = entry
     end
     af_combos
@@ -63,7 +72,7 @@ end
 # (`PreviewState.af_stats`). See `task_previewable` in task.jl.
 task_previewable(::AfCorrect) = true
 
-# The preview sends the FRONTEND's params, so `divisionChannels` arrive as channel NAMES. Same hook and
+# The preview sends the FRONTEND's params, so `competingChannels` arrive as channel NAMES. Same hook and
 # same reason as cellpose's: sharing the compute does not make the params shared.
 function preview_params(::AfCorrect, params::AbstractDict, img::CciaImage)::Dict{String,Any}
     out = Dict{String,Any}(String(k) => v for (k, v) in params)
@@ -76,50 +85,41 @@ end
 
 QC for AF correction, from the per-channel output stats the runner writes.
 
-This task used to be QC-exempt, with a comment calling itself the weakest exemption in the codebase:
-over-subtraction *does* have an objective signal — the fraction of voxels clipped — but nothing
-reported it. Now that the output ceiling is derived rather than dialled in, that signal is exactly
-what says whether the derivation landed, so the exemption is gone.
+This task used to be QC-exempt, with a comment calling itself the weakest exemption in the codebase.
+Two objective signals, and neither is about the correction's own arithmetic — the correction has no
+free parameter left to land badly:
 
-Two ways it can be wrong, in opposite directions:
+* **saturated input** → the channel was clipped at the sensor, before we saw it. `saturatedFrac`. No
+  correction recovers a clipped voxel's true value, so this is a warning about the acquisition and the
+  action is at the microscope. Measured across the nine kSUFux movies, CH3 saturation ranged from
+  0.001% to 0.018% of voxels — a 13x spread within one experiment at identical settings.
+* **coarse output** → the corrected channel occupies few of the available levels.
+  `levelsUsed / levelsAvailable`. Under the hand-tuned percentile window that preceded all of this,
+  99% of a real image landed in ~13 of 255 levels and nothing ever flagged it.
 
-* **ceiling too low** → bright structure flattens against the top of the range. `clippedFrac`.
-* **ceiling too high** → the data crams into a handful of levels and quantisation is thrown away.
-  `levelsUsed / levelsAvailable`. Measured under the percentile window this replaced: 99% of a real
-  image landed in ~13 of 255 levels, which nothing ever flagged.
-
-There is a **third** way, and it is not a finding here on purpose: the ceiling can land fine for this
-image and still differ from every other image in the set, which puts them on different intensity
-scales. Nothing per-image can see that — a ceiling is neither right nor wrong on its own — and the two
-fractions above are provably blind to it (a 1.86x ceiling difference moved both by 0.000; the corrected
-output is literally identical). So `ceiling` is returned as a plain **cohort metric** and the
-outlier detector in `qc_cohort.jl` is what flags the odd image out. Measured on the nine kSUFux movies
-— one experiment, one channel pair, identical settings — the derived ceiling spanned **1.71x**.
+`clippedFrac` and `ceiling` are gone with the ratio. The output is `b * weight` with `weight <= 1`, so
+it can never reach the top of the range — the clipping metric was structurally ~0. And there is no
+derived ceiling to compare across a set, which is what the `ceiling` cohort metric existed to catch.
 
 Advisory only, per `docs/MODULES.md` — never an `error`, never a gate.
 """
 function af_qc_findings(per_channel::AbstractDict)
     findings = Vector{Dict{String,Any}}()
-    worst_clipped, worst_levels = 0.0, 1.0
-    # The corrected channels' ceilings, for the cohort comparison. Max rather than mean: with one
-    # corrected channel (the common case) they are the same number, and with several the largest is
-    # the one that decides how much range the others give up.
-    ceiling = 0.0
+    worst_saturated, worst_levels = 0.0, 1.0
     for (ch, s) in sort(collect(per_channel); by = first)
-        clipped = Float64(get(s, "clippedFrac", 0.0))
-        used    = Float64(get(s, "levelsUsed", 0))
-        avail   = max(1.0, Float64(get(s, "levelsAvailable", 1)))
-        frac    = used / avail
-        worst_clipped = max(worst_clipped, clipped)
-        worst_levels  = min(worst_levels, frac)
-        ceiling       = max(ceiling, Float64(get(s, "ceiling", 0.0)))
+        saturated = Float64(get(s, "saturatedFrac", 0.0))
+        used      = Float64(get(s, "levelsUsed", 0))
+        avail     = max(1.0, Float64(get(s, "levelsAvailable", 1)))
+        frac      = used / avail
+        worst_saturated = max(worst_saturated, saturated)
+        worst_levels    = min(worst_levels, frac)
 
-        if clipped > 0.01
+        if saturated > 0.001
             push!(findings, Dict{String,Any}(
-                "level" => "warn", "code" => "af-clipped",
-                "short" => "Channel $ch clipped",
-                "detail" => "$(round(clipped * 100; digits = 1))% of voxels hit the top of the " *
-                            "range — bright structure is flattened. Try a lower background method."))
+                "level" => "warn", "code" => "af-saturated-input",
+                "short" => "Channel $ch saturated",
+                "detail" => "$(round(saturated * 100; digits = 2))% of input voxels are at the top " *
+                            "of the range. Lower the gain or laser power and reacquire."))
         end
         if frac < 0.2
             push!(findings, Dict{String,Any}(
@@ -129,7 +129,7 @@ function af_qc_findings(per_channel::AbstractDict)
                             "channel is quantised coarsely."))
         end
     end
-    findings, (; clipped = worst_clipped, levels = worst_levels, ceiling = ceiling)
+    findings, (; saturated = worst_saturated, levels = worst_levels)
 end
 
 function _run_task(task::AfCorrect, img::CciaImage, params::Dict{String,Any};
@@ -161,7 +161,11 @@ function _run_task(task::AfCorrect, img::CciaImage, params::Dict{String,Any};
 
     on_log("[INFO] Input:  $im_path")
     on_log("[INFO] Output: $im_correction_path")
-    on_log("[INFO] Combinations: $(length(af_combos))")
+    # log the RESOLVED sets, not just a count: names that match no channel are dropped here, and so is
+    # a target named inside its own competitor list — both silent otherwise
+    for k in sort(collect(keys(af_combos)))
+        on_log("[INFO] ch$k competes with $(get(af_combos[k], "competingChannels", Int[]))")
+    end
 
     qc_out_path = joinpath(task_run_dir(img._dir), "af_output_stats.json")
 
@@ -170,7 +174,7 @@ function _run_task(task::AfCorrect, img::CciaImage, params::Dict{String,Any};
            imCorrectionPath = im_correction_path,
            afCombinations   = af_combos,
            # the one remaining choice, global to every combination (was two percentiles per
-           # combination plus a rescale window, all now derived — see `af_division_stats`)
+           # combination plus a rescale window, all now derived — see `af_weight_stats`)
            backgroundMethod = string(get(params, "backgroundMethod", "triangle")),
            qcOutPath        = qc_out_path),
         task_run_dir(img._dir);
@@ -186,8 +190,8 @@ function _run_task(task::AfCorrect, img::CciaImage, params::Dict{String,Any};
         versioned_set_field!(raw, "filepath", out_filename, out_value_name)
     end
 
-    # QC: the derived ceiling is the one thing that can go wrong invisibly, and it has an objective
-    # signal — how much of the output range got used, and how much was clipped away.
+    # QC: the correction itself has no free parameter left to land badly, so the objective signals are
+    # the input's saturation and how coarsely the output ends up quantised — see `af_qc_findings`.
     if isfile(qc_out_path)
         try
             stats = JSON3.read(read(qc_out_path, String))
@@ -195,15 +199,11 @@ function _run_task(task::AfCorrect, img::CciaImage, params::Dict{String,Any};
                                       for (k, s) in stats)
             findings, worst = af_qc_findings(per_ch)
             write_qc(img, "cleanupImages.afCorrect", out_value_name, findings;
-                     metrics = Dict{String,Any}("clippedFrac" => worst.clipped,
+                     metrics = Dict{String,Any}("saturatedFrac" => worst.saturated,
                                                 "levelsUsedFrac" => worst.levels,
-                                                # cohort-only: meaningless alone, an outlier against
-                                                # its set means this image is on a different scale
-                                                "ceiling" => worst.ceiling,
                                                 "byChannel" => per_ch))
-            on_log("[QC] clipped $(round(worst.clipped * 100; digits = 2))% of voxels; " *
-                   "$(round(worst.levels * 100; digits = 1))% of the output range used; " *
-                   "ceiling $(round(worst.ceiling; digits = 2)).")
+            on_log("[QC] $(round(worst.saturated * 100; digits = 3))% of input voxels saturated; " *
+                   "$(round(worst.levels * 100; digits = 1))% of the output range used.")
         catch e
             on_log("[QC] could not compute AF QC: $e")
         end

--- a/app/src/tasks/cleanupImages/af_correct.json
+++ b/app/src/tasks/cleanupImages/af_correct.json
@@ -22,25 +22,25 @@
       "label": "Channel combinations",
       "type": "group",
       "repeatable": true,
-      "labelKey": "quotientChannel",
+      "labelKey": "targetChannel",
       "default": {},
-      "tip": "One entry per channel, with its AF reference channels",
+      "tip": "One entry per channel, with the channels it competes with",
       "params": [
         {
-          "key": "quotientChannel",
+          "key": "targetChannel",
           "label": "Channel to correct",
           "type": "channelSelection",
           "multiple": false,
           "default": [],
-          "tip": "The channel whose autofluorescence will be corrected"
+          "tip": "The channel to correct"
         },
         {
-          "key": "divisionChannels",
-          "label": "Division channels (AF reference)",
+          "key": "competingChannels",
+          "label": "Competing channels",
           "type": "channelSelection",
           "multiple": true,
           "default": [],
-          "tip": "Channels whose signal is used as the autofluorescence reference for correction"
+          "tip": "Channels that share signal with this one"
         }
       ]
     },
@@ -57,10 +57,6 @@
         {
           "label": "Otsu",
           "value": "otsu"
-        },
-        {
-          "label": "None",
-          "value": "none"
         }
       ],
       "tip": "How the background level of each channel is found"

--- a/app/src/tasks/cleanupImages/af_correct_run.py
+++ b/app/src/tasks/cleanupImages/af_correct_run.py
@@ -1,21 +1,21 @@
 """
 Autofluorescence correction task.
 
-Reads an OME-ZARR image, applies per-channel AF correction (ratio against
-reference channels), and writes the result as a new OME-ZARR multiscale store.
-Called by the Julia AfCorrect task handler.
+Reads an OME-ZARR image, corrects each channel by the share of every voxel it dominates against its
+competing channels, and writes the result as a new OME-ZARR multiscale store. Called by the Julia
+AfCorrect task handler.
 
 Parameter contract (JSON written by Julia):
   imPath           - absolute path to input .ome.zarr
   imCorrectionPath - absolute path to write corrected .ome.zarr
   afCombinations   - dict keyed by string channel index ("0", "1", …):
-      divisionChannels - list of 0-based integer channel indices (the AF reference)
-  backgroundMethod - "triangle" | "otsu" | "none", global to every combination
+      competingChannels - list of 0-based integer channel indices sharing signal with it
+  backgroundMethod - "triangle" | "otsu", global to every combination
   qcOutPath        - where to write per-channel output stats for QC
 
 A combination is **just channels**. Everything that used to be a number here — two background
 percentiles, a rescale window, a median filter, a gaussian, a rolling ball, a top hat, a denoiser, an
-inverse channel — is either derived from the data (`correction_utils.af_division_stats`) or gone. Those
+inverse channel — is either derived from the data (`correction_utils.af_weight_stats`) or gone. Those
 parameters accreted while fitting individual datasets and were never revisited; a correction task
 should correct, not carry a filter toolbox.
 """
@@ -92,14 +92,18 @@ def run(params):
         # disagree. See zarr_utils.write_calibration.
         zarr_utils.write_calibration(staging, dim_utils)
 
-    # Per-channel output stats for QC. The ceiling is derived now, so whether it landed well is the
-    # one thing that can go wrong invisibly — and it has an objective signal in both directions
-    # (clipped away at the top, or crammed into too few levels). See `af_qc_findings` in af_correct.jl.
+    # Per-channel output stats for QC. The correction has no free parameter left to land badly, so the
+    # objective signals are the INPUT's saturation (clipped at the sensor, unrecoverable here) and how
+    # coarsely the output ends up quantised. See `af_qc_findings` in af_correct.jl.
+    #
+    # `.get` with a default, not `[...]`: this log line referenced `clippedFrac` by subscript and threw
+    # `KeyError` on a real run AFTER the corrected store had already been written — the work was done and
+    # the task still failed. A progress log must never be able to fail a completed run.
     if qc_out_path:
         write_json_atomic(qc_out_path, output_stats)
         for ch, s in sorted(output_stats.items()):
-            log.log(f">> ch{ch}: clipped {s['clippedFrac'] * 100:.2f}%, "
-                    f"{s['levelsUsed']}/{s['levelsAvailable']} levels used")
+            log.log(f">> ch{ch}: {s.get('saturatedFrac', 0.0) * 100:.3f}% of input saturated, "
+                    f"{s.get('levelsUsed', 0)}/{s.get('levelsAvailable', 0)} levels used")
 
     log.progress(3, 3)
     log.log('>> done')

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -1723,88 +1723,84 @@ end
 end
 
 @testset "AF correction QC — the exemption that got retired" begin
-    # This task carried a QC-EXEMPT comment calling itself the weakest exemption in the codebase:
-    # over-subtraction HAS an objective signal (the clipped fraction) but nothing reported it. Now
-    # that the output ceiling is derived rather than typed in, that signal is what says whether the
-    # derivation landed — so the exemption is gone and this is its replacement.
+    # This task carried a QC-EXEMPT comment calling itself the weakest exemption in the codebase.
+    # The correction has no free parameter left to land badly, so the two objective signals are about
+    # the INPUT (was it clipped at the sensor?) and the output's quantisation.
     ok = Dict{String,Any}("1" => Dict{String,Any}(
-        "clippedFrac" => 0.0001, "levelsUsed" => 200, "levelsAvailable" => 256))
+        "saturatedFrac" => 0.0001, "levelsUsed" => 200, "levelsAvailable" => 256))
     @test isempty(Cecelia.af_qc_findings(ok)[1])
 
-    # Two ways it goes wrong, in OPPOSITE directions — a single-sided check would miss half of them.
-    clipped = Dict{String,Any}("1" => Dict{String,Any}(
-        "clippedFrac" => 0.05, "levelsUsed" => 200, "levelsAvailable" => 256))
-    f, w = Cecelia.af_qc_findings(clipped)
-    @test length(f) == 1 && f[1]["code"] == "af-clipped" && f[1]["level"] == "warn"
-    @test w.clipped == 0.05
+    # Two independent ways it goes wrong — a single-sided check would miss half of them.
+    saturated = Dict{String,Any}("1" => Dict{String,Any}(
+        "saturatedFrac" => 0.05, "levelsUsed" => 200, "levelsAvailable" => 256))
+    f, w = Cecelia.af_qc_findings(saturated)
+    @test length(f) == 1 && f[1]["code"] == "af-saturated-input" && f[1]["level"] == "warn"
+    @test w.saturated == 0.05
+    # the action belongs at the microscope: a clipped voxel's value is gone before this task runs
+    @test occursin("gain", f[1]["detail"])
 
-    # ceiling too HIGH: the data crams into a few levels. Measured on real data under the percentile
+    # coarse output: the data crams into a few levels. Measured on real data under the percentile
     # window this replaced — 99% of an image in ~13 of 255 levels, which nothing ever flagged.
     low = Dict{String,Any}("2" => Dict{String,Any}(
-        "clippedFrac" => 0.0, "levelsUsed" => 13, "levelsAvailable" => 256))
+        "saturatedFrac" => 0.0, "levelsUsed" => 13, "levelsAvailable" => 256))
     f2, w2 = Cecelia.af_qc_findings(low)
     @test length(f2) == 1 && f2[1]["code"] == "af-low-range"
     @test occursin("13 of 256", f2[1]["detail"])
     @test w2.levels < 0.06
 
     # advisory only, per docs/MODULES.md — never an error, never a gate
-    for d in (clipped, low)
+    for d in (saturated, low)
         @test all(x -> x["level"] == "warn", Cecelia.af_qc_findings(d)[1])
     end
 
     # worst-case rollup across channels, since QC banks one number per image
-    both = merge(clipped, low)
+    both = merge(saturated, low)
     _, w3 = Cecelia.af_qc_findings(both)
-    @test w3.clipped == 0.05          # worst = most clipped
-    @test w3.levels < 0.06            # worst = least range used
+    @test w3.saturated == 0.05         # worst = most saturated
+    @test w3.levels < 0.06             # worst = least range used
 
-    # Cohort-comparable BECAUSE the ceiling is derived per image: an image that clipped far more than
-    # its peers is a staining/acquisition outlier. Not checkable while the window was hand-tuned.
-    @test COHORT_METRICS["cleanupImages.afCorrect"] == ["clippedFrac", "levelsUsedFrac", "ceiling"]
-    # ...and the keys must be the ones _run_task actually banks, or the cohort route reads nothing
-    @test Set(COHORT_METRICS["cleanupImages.afCorrect"]) ⊆
-          Set(["clippedFrac", "levelsUsedFrac", "ceiling"])
+    # Both metrics describe the ACQUISITION, which is what makes them comparable across a set shot in
+    # one session. Measured across the nine kSUFux movies, CH3 saturation spanned 0.001%-0.018% — a 13x
+    # spread at identical settings, so an outlier is a real difference rather than a typed parameter.
+    @test COHORT_METRICS["cleanupImages.afCorrect"] == ["saturatedFrac", "levelsUsedFrac"]
 
-    # THE CEILING IS BANKED BUT NEVER WARNED ON — and that split is the point, not an oversight.
-    # A ceiling cannot be judged from one image; it is only wrong relative to a cohort. So it must
-    # ride through as a metric with no finding attached, and the outlier detector does the judging.
-    ceil_ok = Dict{String,Any}("1" => Dict{String,Any}(
-        "clippedFrac" => 0.0, "levelsUsed" => 200, "levelsAvailable" => 256, "ceiling" => 24.09))
-    f4, w4 = Cecelia.af_qc_findings(ceil_ok)
-    @test isempty(f4)                 # a wildly different ceiling is NOT a per-image finding
-    @test w4.ceiling ≈ 24.09
+    # `ceiling` is GONE, and deliberately: it was banked to catch two images drifting onto different
+    # intensity scales, on the reasoning that the output was `ratio / ceiling * rescale`. The output is
+    # in input counts now — there is no ceiling, so there is nothing derived per image to drift.
+    @test !("ceiling" in COHORT_METRICS["cleanupImages.afCorrect"])
+    @test !("clippedFrac" in COHORT_METRICS["cleanupImages.afCorrect"])
+    ceiling_era = Dict{String,Any}("1" => Dict{String,Any}(
+        "clippedFrac" => 0.9, "levelsUsed" => 200, "levelsAvailable" => 256, "ceiling" => 999.0))
+    @test isempty(Cecelia.af_qc_findings(ceiling_era)[1])   # old keys are ignored, not warned on
 
-    # An absurd ceiling is still not a finding — same reason. This is what stops someone "fixing" it
-    # by adding a threshold that cannot exist.
-    f5, w5 = Cecelia.af_qc_findings(Dict{String,Any}("1" => Dict{String,Any}(
-        "clippedFrac" => 0.0, "levelsUsed" => 200, "levelsAvailable" => 256, "ceiling" => 999.0)))
-    @test isempty(f5)
-    @test w5.ceiling ≈ 999.0
-
-    # Rolled up as the MAX across corrected channels: with one channel they agree, with several the
-    # largest is the one that decides how much range the others give up.
-    _, w6 = Cecelia.af_qc_findings(Dict{String,Any}(
-        "1" => Dict{String,Any}("clippedFrac" => 0.0, "levelsUsed" => 200,
-                                "levelsAvailable" => 256, "ceiling" => 14.06),
-        "2" => Dict{String,Any}("clippedFrac" => 0.0, "levelsUsed" => 200,
-                                "levelsAvailable" => 256, "ceiling" => 24.09)))
-    @test w6.ceiling ≈ 24.09
-
-    # Older stats files predate the key; absence must read as 0.0, not throw.
-    @test Cecelia.af_qc_findings(ok)[2].ceiling == 0.0
+    # A stats file missing the key must read as 0.0, not throw.
+    @test Cecelia.af_qc_findings(Dict{String,Any}("1" => Dict{String,Any}(
+        "levelsUsed" => 200, "levelsAvailable" => 256)))[2].saturated == 0.0
 end
 
 @testset "AF params are just channels" begin
     # The spec grew into a bag of ~20 numbers while fitting individual datasets and was never
     # revisited. A combination is now the two things it is actually about; everything else is derived
-    # (`af_division_stats`) or was a filter that belongs to a filtering task.
+    # (`af_weight_stats`) or was a filter that belongs to a filtering task.
     spec = Cecelia._task_spec(Cecelia.AfCorrect())
     keys_top = [string(get(p, "key", "")) for p in get(spec, "params", [])]
     @test keys_top == ["valueName", "afCombinations", "backgroundMethod"]
 
     combo = only(p for p in get(spec, "params", []) if string(get(p, "key", "")) == "afCombinations")
     @test [string(get(p, "key", "")) for p in get(combo, "params", [])] ==
-          ["quotientChannel", "divisionChannels"]
+          ["targetChannel", "competingChannels"]
+
+    # `none` is NOT offered: the weight is a ratio of intensities, so an unsubtracted pedestal makes
+    # background voxels split evenly and survive. Measured on kSUFux/Or1L8a: 92.1% of background voxels
+    # come out non-zero and cell-to-background contrast collapses to 6.8x.
+    bg = only(p for p in get(spec, "params", []) if string(get(p, "key", "")) == "backgroundMethod")
+    @test [string(get(o, "value", "")) for o in get(bg, "options", [])] == ["triangle", "otsu"]
+
+    # No exponent param. This task deleted four numbers with no defensible value (channelPercentile,
+    # correctionPercentile, correctionMin, correctionMax) and a user-facing sharpness dial is that same
+    # thing returning — see `AF_WEIGHT_EXPONENT`.
+    @test !("exponent" in keys_top)
+    @test !("weightExponent" in keys_top)
 
     # the deleted ones, named so a future session doesn't reintroduce them one at a time
     gone = ["correctionMin", "correctionMax", "correctionGain", "channelPercentile",
@@ -8556,21 +8552,37 @@ Cecelia.live_outputs(::_BadLiveTask, ::AbstractDict) = error("boom")
             # the real saved shape from a live project: channel NAMES, including one ("CH4") that is
             # not in this image's channel list at all — it resolves to nothing, exactly as the run does
             params = Dict{String,Any}("afCombinations" => Dict("1" => Dict{String,Any}(
-                "divisionChannels" => ["CH4", "CD169-Kat"],
-                "quotientChannel"  => ["mem-TOM"])))
+                "competingChannels" => ["CH4", "CD169-Kat"],
+                "targetChannel"     => ["mem-TOM"])))
             out = Cecelia.preview_params_for_run(Cecelia.AfCorrect(), params, img)
-            # quotientChannel re-keys the combination to the channel being corrected (mem-TOM → 2)
+            # targetChannel re-keys the combination to the channel being corrected (mem-TOM → 2)
             @test collect(keys(out["afCombinations"])) == ["2"]
-            @test out["afCombinations"]["2"]["divisionChannels"] == [3]
-            @test !haskey(out["afCombinations"]["2"], "quotientChannel")
+            @test out["afCombinations"]["2"]["competingChannels"] == [3]
+            @test !haskey(out["afCombinations"]["2"], "targetChannel")
 
             # idempotent: already-translated indices survive a second pass (a chain or REPL caller)
             again = Cecelia.preview_params_for_run(Cecelia.AfCorrect(), out, img)
-            @test again["afCombinations"]["2"]["divisionChannels"] == [3]
+            @test again["afCombinations"]["2"]["competingChannels"] == [3]
 
             # and the composite delegates to AF, since that is the step it can preview
             comp = Cecelia._task_from_fun_name("cleanupImages.afDriftCorrect")
-            @test Cecelia.preview_params_for_run(comp, params, img)["afCombinations"]["2"]["divisionChannels"] == [3]
+            @test Cecelia.preview_params_for_run(comp, params, img)["afCombinations"]["2"]["competingChannels"] == [3]
+
+            # A target named inside its OWN competitor list is dropped, not squared into the denominator
+            # a second time — that would quietly halve the channel's own output. Two separate widgets,
+            # so picking the same channel in both is an easy slip with one obvious intent.
+            self_ref = Dict{String,Any}("afCombinations" => Dict("1" => Dict{String,Any}(
+                "competingChannels" => ["mem-TOM", "CD169-Kat"],
+                "targetChannel"     => ["mem-TOM"])))
+            selfed = Cecelia.preview_params_for_run(Cecelia.AfCorrect(), self_ref, img)
+            @test selfed["afCombinations"]["2"]["competingChannels"] == [3]
+
+            # ...and duplicates collapse, so a name listed twice cannot double its weight either
+            dupes = Dict{String,Any}("afCombinations" => Dict("1" => Dict{String,Any}(
+                "competingChannels" => ["CD169-Kat", "CD169-Kat"],
+                "targetChannel"     => ["mem-TOM"])))
+            @test Cecelia.preview_params_for_run(Cecelia.AfCorrect(), dupes,
+                                                 img)["afCombinations"]["2"]["competingChannels"] == [3]
         end
     end
 
@@ -8580,6 +8592,21 @@ Cecelia.live_outputs(::_BadLiveTask, ::AbstractDict) = error("boom")
         @test Cecelia.PREVIEW_PORT ∉ (7655, 7660, 8080, 5173)
         # not alive until launched — `preview_alive` must never report true for a null process
         @test !Cecelia.preview_alive(Cecelia.PreviewWorker())
+    end
+
+    @testset "the preview protocol matches on both sides" begin
+        # A running worker is ADOPTED, not relaunched, so the two constants are the only thing stopping
+        # stale worker code from serving a backend it was not started by. They live in different
+        # languages and were bumped by hand three times with nothing checking they agreed.
+        #
+        # Protocol 4 is why this test exists: a stale protocol-3 worker carries the old ratio
+        # `af_correct_frame`, so it returns well-formed previews of the WRONG method rather than
+        # failing. Forgetting one side would be invisible.
+        worker = joinpath(dirname(dirname(pathof(Cecelia))), "..", "preview", "preview_worker.py")
+        @test isfile(worker)
+        m = match(r"^PROTOCOL\s*=\s*(\d+)"m, read(worker, String))
+        @test m !== nothing
+        @test parse(Int, m.captures[1]) == Cecelia.PREVIEW_PROTOCOL
     end
 
     @testset "img_labels_path resolves registered and in-progress stores" begin

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -204,14 +204,17 @@ only where one code carries two wordings — see the note on the catalog. The fo
 - **If the metric is comparable across a set's images, add it to `COHORT_METRICS`** (`app/src/qc_cohort.jl`,
   `"mycat.myTask" => ["nCells", …]`) so cohort-outlier detection and the observer pick it up for free.
 - **A metric may be cohort-only — banked with NO finding attached — and that is not an oversight.**
-  Some numbers cannot be judged from one image but are decisive against a set. AF correction's derived
-  `ceiling` is the example: one image's ceiling is neither right nor wrong, but two images with
-  different ceilings are on different intensity scales, and since the corrected channel is what gets
-  measured and pooled, that silently invalidates the comparison. There is no threshold to warn on, so
-  it rides through as a metric and `qc_cohort.jl`'s outlier detector does the judging. Note the trap it
-  closes: the task's *other* two metrics are provably blind to it — a 1.86x ceiling difference moved
-  both by 0.000 — so "we already have QC here" was not the same as "this is covered". When a metric has
-  no sensible per-image threshold, bank it and say why, rather than inventing one.
+  Some numbers cannot be judged from one image but are decisive against a set. `importImages.omezarr`'s
+  `windowNeeded` is the example: the 8-bit ceiling one image asked for is neither right nor wrong, but
+  the window a *set* needs is `max(windowNeeded)` across it, so the number only means something in
+  company. There is no threshold to warn on, so it rides through as a metric and `qc_cohort.jl`'s
+  outlier detector does the judging. Measured across nine movies: 609–1498, a 2.46x spread. When a
+  metric has no sensible per-image threshold, bank it and say why, rather than inventing one.
+  > **Don't reach for this to justify a metric you can't otherwise defend.** AF correction carried a
+  > derived `ceiling` here on the reasoning that two images with different ceilings sit on different
+  > intensity scales. Both halves of that turned out weak: the ratio it scaled is gone, and intravital
+  > intensities aren't comparable between movies anyway — acquisition drift swamps it. "Cohort-only"
+  > must mean *the number is real and only interpretable in company*, not *I couldn't find a threshold*.
 - **Set-scope / Python tasks:** compute per-image stats in Python and hand them back via a `qcOutPath`
   JSON the Julia handler reads (the `segment.cellpose` / clustering pattern — `qcOutPath` param →
   `write_qc` per image), so counting stays where the data is.

--- a/docs/todo/QC_OBSERVER_PLAN.md
+++ b/docs/todo/QC_OBSERVER_PLAN.md
@@ -108,10 +108,13 @@ the observer redesign lands. Each slice: pure helper unit-tested + wiring + doc 
   only if on-demand proves insufficient.
 - `qc_flag_fired` / `:flagged` node state + hold (needs QC_PLAN.md advisory-vs-blocking ratification).
 - ~~afCorrect~~ / cellposeCorrect QC (no agreed objective metric — see the QC-coverage notes).
-  **afCorrect shipped in #437** and is no longer parked: once the rescale ceiling became derived rather
-  than a knob, "did it land well" got an objective signal in both directions — `clippedFrac` (burnt off
-  the top) and `levelsUsedFrac` (crammed into too few levels). Both are cohort metrics
-  (`af_qc_findings`). Denoise stays parked; perceptual quality still has no metric.
+  **afCorrect shipped in #437** and is no longer parked. The metrics changed when the ratio was replaced
+  by the power weight: the correction has no free parameter left to land badly, so the two signals are
+  `saturatedFrac` (the INPUT was clipped at the sensor — the action is at the microscope) and
+  `levelsUsedFrac` (the output is coarsely quantised). Both are cohort metrics (`af_qc_findings`).
+  `clippedFrac` went with the rescale: output is `b × weight` with `weight ≤ 1`, so it can never reach
+  the top of the range and the metric was structurally ~0. Denoise stays parked; perceptual quality
+  still has no metric.
 - A separate Claude-vs-Cecelia badge *icon* — v1 uses one badge coloured by worst unseen level; a
   distinct author icon is a nice-to-have.
 

--- a/docs/todo/TASK_PREVIEW_PLAN.md
+++ b/docs/todo/TASK_PREVIEW_PLAN.md
@@ -30,7 +30,7 @@ Previewability is a property of a task's *compute*, not of a category:
 | Task | Preview output | Crop-safe? |
 |---|---|---|
 | `segment.cellpose` | labels | Yes — modulo tile seams and whole-image normalisation |
-| `cleanupImages.afCorrect` | image | Yes — per-pixel channel unmixing. Preserves the input shape, but needs **whole-image globals** (`af_division_stats`: two background levels + a ceiling), so the preview derives them once over the whole image and caches them, exactly as cellpose caches `norm_params` |
+| `cleanupImages.afCorrect` | image | Yes — per-pixel channel competition. Preserves the input shape, but needs **whole-image globals** (`af_weight_stats`: one background level per participating channel), so the preview derives them once over the whole image and caches them, exactly as cellpose caches `norm_params` |
 | `cleanupImages.cellposeCorrect` (denoise) | image | Yes in principle, but **not a build target** — see *Denoise waits for coastal* |
 | `cleanupImages.driftCorrect` | — | **No.** `drift_correction_shifts` derives shifts from the whole timecourse; a crop cannot produce the real shifts, and the shifts are the thing you would want to judge. Declares nothing. |
 
@@ -221,7 +221,7 @@ same shape, and a denoise preview then costs one trait declaration. Recorded in 
 pin, where someone bumping cellpose will actually read it.
 
 So denoise is not a build target here, and **AF is the image-kind consumer instead** — it is also the harder
-test, because its correction depends on statistics no crop can see (`correction_utils.af_division_stats`).
+test, because its correction depends on statistics no crop can see (`correction_utils.af_weight_stats`).
 
 (Both drafted while AF still had a filter toolbox. `_af_denoise_frame` — skimage tv/wavelet denoising
 *inside* AF correction, unrelated to the cellpose denoise task despite the name — was deleted with the

--- a/frontend/src/utils/taskPreview.test.ts
+++ b/frontend/src/utils/taskPreview.test.ts
@@ -129,12 +129,12 @@ describe('paramsBlocker', () => {
   // so AF, which has `afCombinations` and no models, was reported not-runnable despite the backend
   // declaring it previewable. Silently: no button, no message.
   it('accepts an AF task with a division channel', () => {
-    expect(paramsBlocker({ afCombinations: { '2': { divisionChannels: [3] } } })).toBeNull()
+    expect(paramsBlocker({ afCombinations: { '2': { competingChannels: [3] } } })).toBeNull()
   })
 
   it('names what an AF task is missing rather than hiding', () => {
     expect(paramsBlocker({ afCombinations: {} })).toBe('no-af-channels')
-    expect(paramsBlocker({ afCombinations: { '2': { divisionChannels: [] } } })).toBe('no-af-channels')
+    expect(paramsBlocker({ afCombinations: { '2': { competingChannels: [] } } })).toBe('no-af-channels')
     expect(paramsBlocker({ afCombinations: { '2': {} } })).toBe('no-af-channels')
     expect(blockerMessage('no-af-channels')).toBe('Add a division channel to preview')
   })
@@ -159,7 +159,7 @@ describe('paramsBlocker', () => {
 
   it('flows through previewBlocker for both task shapes', () => {
     const afCtx = ctx({ funName: 'cleanupImages.afCorrect',
-                        params: { afCombinations: { '2': { divisionChannels: [3] } } } })
+                        params: { afCombinations: { '2': { competingChannels: [3] } } } })
     expect(previewBlocker(afCtx, status(), on)).toBeNull()
     const emptyAf = ctx({ funName: 'cleanupImages.afCorrect', params: { afCombinations: {} } })
     expect(previewBlocker(emptyAf, status(), on)).toBe('no-af-channels')
@@ -168,16 +168,16 @@ describe('paramsBlocker', () => {
 
 describe('hasAfCombination', () => {
   it('needs at least one combination naming a reference channel', () => {
-    expect(hasAfCombination({ afCombinations: { '2': { divisionChannels: [3] } } })).toBe(true)
-    expect(hasAfCombination({ afCombinations: { '1': { divisionChannels: [] },
-                                               '2': { divisionChannels: [0, 3] } } })).toBe(true)
+    expect(hasAfCombination({ afCombinations: { '2': { competingChannels: [3] } } })).toBe(true)
+    expect(hasAfCombination({ afCombinations: { '1': { competingChannels: [] },
+                                               '2': { competingChannels: [0, 3] } } })).toBe(true)
     expect(hasAfCombination({ afCombinations: {} })).toBe(false)
     expect(hasAfCombination(null)).toBe(false)
   })
 
   it('survives a malformed value instead of throwing', () => {
     expect(hasAfCombination({ afCombinations: 'nope' as unknown })).toBe(false)
-    expect(hasAfCombination({ afCombinations: { '2': { divisionChannels: 'x' as unknown } } })).toBe(false)
+    expect(hasAfCombination({ afCombinations: { '2': { competingChannels: 'x' as unknown } } })).toBe(false)
   })
 })
 

--- a/frontend/src/utils/taskPreview.ts
+++ b/frontend/src/utils/taskPreview.ts
@@ -79,16 +79,16 @@ export function paramsBlocker(params: Record<string, unknown> | null): PreviewBl
 }
 
 /**
- * True when at least one AF combination names a division channel — the AF analogue of
- * `hasPreviewableModel`. A combination with no reference channel is not a correction (the worker
+ * True when at least one AF combination names a competing channel — the AF analogue of
+ * `hasPreviewableModel`. A combination with nothing to compete against is not a correction (the worker
  * raises), and an empty bag is the state the form starts in.
  */
 export function hasAfCombination(params: Record<string, unknown> | null): boolean {
   const combos = (params as { afCombinations?: unknown } | null)?.afCombinations
   if (!combos || typeof combos !== 'object') return false
   return Object.values(combos as Record<string, unknown>).some(c => {
-    const div = (c as { divisionChannels?: unknown } | null)?.divisionChannels
-    return Array.isArray(div) && div.length > 0
+    const competing = (c as { competingChannels?: unknown } | null)?.competingChannels
+    return Array.isArray(competing) && competing.length > 0
   })
 }
 

--- a/preview/preview_worker.py
+++ b/preview/preview_worker.py
@@ -53,11 +53,12 @@ from cecelia.utils.segmentation_utils import count_labels
 # stable and the wait short. Runs stay EXACT — see `_compute_norm_params(max_frames=…)`.
 NORM_FRAMES = 20
 
-#: `(z, xy)` stride for AF's global values. Two full passes over a 181-frame movie cost 148 s; at
-#: (2, 4) the same derivation costs 24 s and gave an IDENTICAL ceiling plus identical background
-#: levels on real data. Safe only because the ceiling is a count-thresholded max — subsampling a true
-#: max is biased low by construction, which is exactly why the percentile window it replaced could not
-#: be made cheap. Runs stay exact: they pass no stride.
+#: `(z, xy)` stride for the correction's global values. A full pass over a 181-frame movie costs tens of
+#: seconds; at (2, 4) the same derivation gives byte-identical background levels on real data. Safe
+#: because every value is an interior histogram threshold and the channel has a background population to
+#: find it in — the one assumption, spelled out on `correction_utils.af_weight_stats`. Unlike the true
+#: max of the percentile window this all replaced, which is biased low by construction and so could
+#: never be made cheap. Runs stay exact: they pass no stride.
 AF_PREVIEW_STRIDE = (2, 4)
 
 #: Reply-shape + backend-set version. The backend refuses to adopt a worker that doesn't match and
@@ -66,7 +67,13 @@ AF_PREVIEW_STRIDE = (2, 4)
 #: 3: layers carry `source`, the viewer layer they derive from, so the bridge can mirror its colormap.
 #:    Bumped even though the bridge falls back gracefully: an adopted protocol-2 worker would omit it
 #:    and quietly render every corrected channel grey, which reads as "the fix didn't work".
-PROTOCOL = 3
+#: 4: AF correction is the power weight, not a ratio. `derived` carries `background` /
+#:    `competingBackgrounds` / `saturatedFrac` / `exponent` where it carried `ceiling` / `background` /
+#:    `afBackground`. This bump is the load-bearing kind: an adopted protocol-3 worker still has the old
+#:    `af_correct_frame`, so it would keep serving RATIO previews — hollowed-out overlapping cells and
+#:    all — against a backend that believes it is showing the new method. Silently, and the preview's
+#:    entire purpose is to agree with the run.
+PROTOCOL = 4
 
 HOST = "127.0.0.1"
 PORT = int(os.environ.get("CECELIA_PREVIEW_PORT", "7656"))
@@ -139,29 +146,27 @@ class PreviewState:
                 levels, model_params, max_frames=NORM_FRAMES)
         return self._norm[key]
 
-    def af_stats(self, im_path, levels, dim_utils, channel_idx, division_channels, method):
-        """AF's global values — both background levels and the output ceiling — cached.
+    def af_stats(self, im_path, levels, dim_utils, channel_idx, competing_channels, method):
+        """The correction's global values — one background level per participating channel — cached.
 
-        The AF analogue of `norm_params`, and the same bargain. Measured on `zolIMa/ldYr8J`
-        (181 × 4 × 31 × 1024²): deriving these costs **148 s** because it is two full passes over the
-        movie, against **5-7 ms** to correct one visible plane with them. So the first preview of an
-        image is slow and every one after it is instant.
+        The AF analogue of `norm_params`, and the same bargain: deriving these costs a full pass over
+        the movie (tens of seconds), against **5-7 ms** to correct one visible plane with them. So the
+        first preview of an image is slow and every one after it is instant.
 
-        The key is what the values actually depend on: the image, the channel pair, and the background
-        method. Nothing else — so switching the method correctly misses the cache, and moving the view
-        correctly hits it.
+        The key is what the values actually depend on: the image, the participating channels, and the
+        background method. Nothing else — so switching the method correctly misses the cache, and moving
+        the view correctly hits it.
 
-        `AF_PREVIEW_STRIDE` is the one concession to the cold start, and it is safe for a specific
-        reason: the ceiling is a COUNT-thresholded max, not a true max, so it survives subsampling
-        (measured identical at z::2 / xy::4 / both, at 24 s instead of 148 s), and the two background
-        levels are interior thresholds that never moved. A true max could not be subsampled at all —
-        that was the whole problem with the percentile window this replaced.
+        `AF_PREVIEW_STRIDE` is the one concession to the cold start, and it is safe because every value
+        here is now an interior threshold over a histogram, which subsampling does not move. (It was
+        safe before for a more delicate reason — the ceiling was a COUNT-thresholded max rather than a
+        true max — and that reason is gone along with the ceiling.)
         """
-        key = (im_path, int(channel_idx), tuple(sorted(int(d) for d in division_channels)), method)
+        channels = [int(channel_idx)] + [int(c) for c in competing_channels]
+        key = (im_path, int(channel_idx), tuple(sorted(int(c) for c in competing_channels)), method)
         if key not in self._af:
-            self._af[key] = correction_utils.af_division_stats(
-                self.image_zarr(im_path)[0], dim_utils,
-                int(channel_idx), [int(d) for d in division_channels],
+            self._af[key] = correction_utils.af_weight_stats(
+                self.image_zarr(im_path)[0], dim_utils, channels,
                 background_method=method, spatial_stride=AF_PREVIEW_STRIDE)
         return self._af[key]
 
@@ -385,11 +390,12 @@ def _preview_cellpose(ctx):
 def _preview_af(ctx):
     """AF-correct the visible region, one Image layer per corrected channel.
 
-    The whole reason this is possible in a fraction of a second: `af_division_stats` computes the two
-    background levels and the output ceiling over the WHOLE image — 148 s on a 181-frame movie — and
-    they are cached here, while `af_correct_frame` is pure per-voxel arithmetic on the crop. Those
-    globals are exactly what must NOT come from the visible region: derive them from a crop and the
-    preview is normalised differently from the run, which is the one thing it exists to rule out.
+    The whole reason this is possible in a fraction of a second: `af_weight_stats` derives one
+    background level per participating channel over the WHOLE image — tens of seconds on a 181-frame
+    movie — and they are cached here, while `af_correct_frame` is pure per-voxel arithmetic on the crop.
+    Those globals are exactly what must NOT come from the visible region: derive them from a crop and
+    the preview subtracts a different background than the run, which is the one thing it exists to
+    rule out.
 
     Outputs an IMAGE, not labels, so the reply carries `kind: 'image'` per layer and the receiver adds
     them beside the originals for A/B comparison.
@@ -406,13 +412,14 @@ def _preview_af(ctx):
     layers, stats_out = [], {}
 
     for ch in sorted(combos):
-        div = [int(d) for d in (combos[ch].get('divisionChannels') or [])]
-        if not div:
+        competing = [int(d) for d in (combos[ch].get('competingChannels') or [])]
+        if not competing:
             continue
-        stats = STATE.af_stats(ctx.im_path, ctx.levels, ctx.dim_utils, ch, div, method)
-        # the same summary the run uses across several AF references (`_af_correction_slab`)
-        corr_slab = np.max(np.stack([tile[d] for d in div], axis=0), axis=0)
-        corrected = correction_utils.af_correct_frame(tile[ch], corr_slab, stats, out_dtype)
+        stats = STATE.af_stats(ctx.im_path, ctx.levels, ctx.dim_utils, ch, competing, method)
+        # every participating channel stays separate — each contributes its own term to the weight's
+        # denominator, so there is nothing to collapse into a single reference image
+        slabs = {c: tile[c] for c in [ch] + competing}
+        corrected = correction_utils.af_correct_frame(slabs, ch, stats, out_dtype)
         # to the channel-less block shape (T/Z restored as length-1) so the receiver can place it at
         # `region` without knowing how the crop was flattened — same contract as the labels path
         block = np.reshape(corrected, block_shape)
@@ -420,10 +427,10 @@ def _preview_af(ctx):
         layers.append(_layer('image', f'{label} AF', block, axes, full_shape, source=label))
         # same helper the run's QC reports through, so the readout and the banked metric cannot
         # disagree about a name or a value
-        stats_out[str(ch)] = correction_utils.af_derived_values(stats)
+        stats_out[str(ch)] = correction_utils.af_derived_values(stats, ch)
 
     if not layers:
-        raise ValueError('no combination names a division channel')
+        raise ValueError('no combination names a competing channel')
 
     has_signal, why = _region_signal(ctx.im_path, ctx.bounds, tile)
     return {'hasSignal': has_signal, 'noSignalWhy': why,

--- a/python/cecelia/tests/test_af_correct_runner.py
+++ b/python/cecelia/tests/test_af_correct_runner.py
@@ -1,0 +1,162 @@
+"""End-to-end test of the AF task RUNNER — `app/src/tasks/cleanupImages/af_correct_run.py`.
+
+**Why this file exists.** `correction_utils` was well covered and every one of its 400+ tests passed,
+while the runner that calls it threw `KeyError: 'clippedFrac'` on a real image — from a *log line*, and
+only AFTER the corrected store had been fully written. The work was done and the task still failed.
+
+The runner is executed by path (`run_py`), never imported, so nothing in the package suite touched it.
+That is the same seam a napari-bridge dispatcher bug slipped through earlier: the unit under test was
+right and the thing that calls it was not. So this loads it the way the launcher does and runs it
+against a real (tiny) OME-ZARR, asserting the store, the QC sidecar and the log all survive.
+
+Skipped when `app/` is absent — an external `pip install cecelia` consumer gets the IO library only.
+"""
+import importlib.util
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import ome_types
+import zarr
+
+import cecelia.utils.ome_xml_utils as ome_xml_utils
+import cecelia.utils.zarr_utils as zarr_utils
+from cecelia.utils.dim_utils import DimUtils
+
+_RUNNER = (Path(__file__).resolve().parents[3]
+           / 'app' / 'src' / 'tasks' / 'cleanupImages' / 'af_correct_run.py')
+
+
+def _load_runner():
+    """Load the runner from its path, exactly as `run_py` does (it is not an importable module)."""
+    spec = importlib.util.spec_from_file_location('af_correct_run', _RUNNER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ome_xml(size_t, size_z, size_c, size_y, size_x):
+    channels = ''.join(
+        f'<Channel ID="Channel:0:{i}" Name="CH{i + 1}" SamplesPerPixel="1"/>' for i in range(size_c))
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06">
+  <Image ID="Image:0" Name="t">
+    <Pixels ID="Pixels:0" DimensionOrder="XYZCT" Type="uint16"
+            SizeT="{size_t}" SizeC="{size_c}" SizeZ="{size_z}" SizeY="{size_y}" SizeX="{size_x}"
+            PhysicalSizeX="0.5" PhysicalSizeY="0.5" PhysicalSizeZ="1.0"
+            PhysicalSizeXUnit="µm" PhysicalSizeYUnit="µm" PhysicalSizeZUnit="µm">
+      {channels}
+    </Pixels>
+  </Image>
+</OME>"""
+
+
+@unittest.skipUnless(_RUNNER.is_file(), f'runner not present at {_RUNNER}')
+class AfCorrectRunnerTest(unittest.TestCase):
+    SHAPE = dict(size_t=2, size_z=2, size_c=3, size_y=16, size_x=14)
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        self.runner = _load_runner()
+
+        omexml = ome_types.from_xml(_ome_xml(**self.SHAPE))
+        du = DimUtils(omexml, use_channel_axis=True)
+
+        # a plausible image: background pedestal + a bright blob per channel in a different place, so
+        # the channels genuinely compete somewhere and a background threshold has something to find
+        shape = [self.SHAPE['size_t'], self.SHAPE['size_c'], self.SHAPE['size_z'],
+                 self.SHAPE['size_y'], self.SHAPE['size_x']]
+        du.calc_image_dimensions(shape)
+        rng = np.random.default_rng(4)
+        data = np.full(shape, 30, dtype=np.uint16)
+        data += rng.integers(0, 6, size=shape, dtype=np.uint16)
+        c = du.dim_idx('C')
+        for ch, (y0, x0) in enumerate([(2, 2), (4, 4), (6, 6)]):
+            sl = [slice(None)] * len(shape)
+            sl[c] = slice(ch, ch + 1)
+            sl[du.dim_idx('Y')] = slice(y0, y0 + 6)
+            sl[du.dim_idx('X')] = slice(x0, x0 + 6)
+            data[tuple(sl)] += np.uint16(700 + 100 * ch)
+        # a couple of saturated voxels in ch0, so `saturatedFrac` is exercised non-zero
+        sat = [0] * len(shape)
+        sat[c] = 0
+        data[tuple(sat)] = np.iinfo(np.uint16).max
+
+        self.in_path = os.path.join(self.dir, 'in.ome.zarr')
+        _, level0, _ = zarr_utils.open_multiscales_for_writing(
+            self.in_path, tuple(shape), np.uint16, du, nscales=1)
+        level0[:] = data
+        ome_xml_utils.save_meta_in_zarr(self.in_path, omexml=omexml)
+        self.du, self.data = du, data
+
+    def _run(self, af_combinations, background_method='triangle'):
+        out_path = os.path.join(self.dir, 'out.ome.zarr')
+        qc_path = os.path.join(self.dir, 'af_output_stats.json')
+        self.runner.run({
+            'imPath': self.in_path,
+            'imCorrectionPath': out_path,
+            'afCombinations': af_combinations,
+            'backgroundMethod': background_method,
+            'qcOutPath': qc_path,
+        })
+        with open(qc_path, encoding='utf-8') as f:
+            return out_path, json.load(f)
+
+    def test_the_runner_completes_and_writes_a_store_plus_qc(self):
+        """The regression this file was created for: it used to write the store and THEN throw."""
+        out_path, qc = self._run({'0': {'competingChannels': [1, 2]},
+                                  '1': {'competingChannels': [0, 2]}})
+
+        # the store landed at its final path (staged_store only renames on success)
+        self.assertTrue(os.path.isdir(out_path))
+        out = zarr.open_group(out_path, mode='r')['0'][:]
+        self.assertEqual(out.shape, self.data.shape)
+        self.assertEqual(out.dtype, self.data.dtype)
+
+        # QC carries exactly the keys af_correct.jl's `af_qc_findings` reads, for the corrected channels
+        self.assertEqual(sorted(qc), ['0', '1'])
+        for ch in ('0', '1'):
+            for k in ('saturatedFrac', 'levelsUsed', 'levelsAvailable', 'background',
+                      'competingBackgrounds', 'exponent'):
+                self.assertIn(k, qc[ch], f'ch{ch} missing {k} — af_qc_findings reads it')
+        # ...and NOT the ratio-era keys the log line used to subscript
+        self.assertNotIn('clippedFrac', qc['0'])
+        self.assertNotIn('ceiling', qc['0'])
+
+    def test_a_channel_no_combination_covers_is_carried_through_untouched(self):
+        out_path, qc = self._run({'0': {'competingChannels': [1]}})
+        out = zarr.open_group(out_path, mode='r')['0'][:]
+        c = self.du.dim_idx('C')
+        for ch in (1, 2):                     # only channel 0 was corrected
+            sl = [slice(None)] * out.ndim
+            sl[c] = slice(ch, ch + 1)
+            self.assertTrue(np.array_equal(out[tuple(sl)], self.data[tuple(sl)]),
+                            f'ch{ch} was modified without a combination asking for it')
+        self.assertEqual(sorted(qc), ['0'])
+
+    def test_the_corrected_output_stays_in_input_counts(self):
+        """The property the whole change rests on — no rescale, so nothing may brighten."""
+        out_path, _ = self._run({'0': {'competingChannels': [1, 2]}})
+        out = zarr.open_group(out_path, mode='r')['0'][:]
+        c = self.du.dim_idx('C')
+        sl = [slice(None)] * out.ndim
+        sl[c] = slice(0, 1)
+        self.assertTrue(np.all(out[tuple(sl)].astype(np.int64)
+                               <= self.data[tuple(sl)].astype(np.int64)),
+                        'a corrected voxel came out brighter than its input')
+
+    def test_an_empty_combination_bag_still_completes(self):
+        # nothing to correct: every channel is carried through and the QC sidecar is empty, not missing
+        out_path, qc = self._run({})
+        out = zarr.open_group(out_path, mode='r')['0'][:]
+        self.assertTrue(np.array_equal(out, self.data))
+        self.assertEqual(qc, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/cecelia/tests/test_correction_utils.py
+++ b/python/cecelia/tests/test_correction_utils.py
@@ -21,7 +21,6 @@ import ome_types
 
 import cecelia.utils.zarr_utils as zu
 import cecelia.utils.correction_utils as cu
-import cecelia.utils.intensity_utils as iu
 import cecelia.utils.intensity_utils as intensity_utils
 from cecelia.utils.dim_utils import DimUtils
 
@@ -93,7 +92,7 @@ class AfStreamingEquivalenceTest(unittest.TestCase):
     channel, a rolling ball, a top hat, two denoisers, a gaussian — and one pinned the output sum
     against a golden captured from the pre-streaming implementation. They were **deleted rather than
     repaired**: a channel combination is now just channels, everything else is derived
-    (`af_division_stats`), and the golden described a method that was deliberately replaced. Pinning
+    (`af_weight_stats`), and the golden described a method that was deliberately replaced. Pinning
     the old numbers would have pinned the behaviour we set out to remove.
 
     What survives is the property that still means something: streaming to disk must not change the
@@ -134,7 +133,7 @@ class AfStreamingEquivalenceTest(unittest.TestCase):
     def test_divide_and_passthrough(self):
         # ch0 corrected against ch1; ch1 covered by no combination, so carried through UNCHANGED
         du = _dim_utils(size_t=3, size_z=1, size_c=2, size_y=19, size_x=14)
-        out = self._run(du, {"0": {"divisionChannels": [1]}})
+        out = self._run(du, {"0": {"competingChannels": [1]}})
         rng = np.random.default_rng(1)
         base = rng.integers(0, 4000, size=tuple(du.im_dim), dtype=np.uint16)
         c = du.dim_idx('C')
@@ -151,12 +150,12 @@ class AfStreamingEquivalenceTest(unittest.TestCase):
     def test_every_background_method_runs(self):
         du = _dim_utils(size_t=2, size_z=1, size_c=2, size_y=16, size_x=12)
         for m in intensity_utils.BACKGROUND_METHODS:
-            self._run(du, {"0": {"divisionChannels": [1]}}, background_method=m)
+            self._run(du, {"0": {"competingChannels": [1]}}, background_method=m)
 
     def test_an_unknown_background_method_is_refused(self):
         du = _dim_utils(size_t=2, size_z=1, size_c=2, size_y=16, size_x=12)
         with self.assertRaises(ValueError):
-            self._run(du, {"0": {"divisionChannels": [1]}}, background_method='nope')
+            self._run(du, {"0": {"competingChannels": [1]}}, background_method='nope')
 
 
 class SourceHandleAgnosticTest(unittest.TestCase):
@@ -186,7 +185,7 @@ class SourceHandleAgnosticTest(unittest.TestCase):
         du = _dim_utils(size_t=3, size_z=1, size_c=2, size_y=19, size_x=14)
         rng = np.random.default_rng(3)
         arr = rng.integers(0, 4000, size=tuple(du.im_dim), dtype=np.uint16)
-        combos = {"0": {"divisionChannels": [1]}}
+        combos = {"0": {"competingChannels": [1]}}
 
         class _Log:
             def log(self, *_a, **_k): pass
@@ -227,10 +226,10 @@ class SourceHandleAgnosticTest(unittest.TestCase):
 
 
 class AfPreviewSeamTest(unittest.TestCase):
-    """`af_division_stats` + `af_correct_frame` composed must BE the run.
+    """`af_weight_stats` + `af_correct_frame` composed must BE the run.
 
     The task preview corrects only the region on screen, which is possible because the global values
-    (both background levels and the output ceiling) are separable from the per-voxel work. That split
+    (one background level per participating channel) are separable from the per-voxel work. That split
     is the whole feature, and it is only worth anything if the two halves recombine into exactly what a
     run produces — otherwise the preview shows a result the run won't reproduce, which is the one thing
     it exists to avoid.
@@ -247,16 +246,14 @@ class AfPreviewSeamTest(unittest.TestCase):
         c_axis, t_axis = du.dim_idx('C'), du.dim_idx('T')
         for method in intensity_utils.BACKGROUND_METHODS:
             run_out = np.zeros(data.shape, data.dtype)
-            cu._stream_division_channel(data, run_out, du, channel_idx=1, out_ch=1,
-                                        correction_channel_idx=[3], background_method=method)
+            cu._stream_corrected_channel(data, run_out, du, channel_idx=1, out_ch=1,
+                                         competing_channel_idx=[3], background_method=method)
 
             # ── what the preview does: stats once, then the per-voxel part per region ──
-            stats = cu.af_division_stats(data, du, 1, [3], background_method=method)
+            stats = cu.af_weight_stats(data, du, [1, 3], background_method=method)
             for t in range(du.dim_val('T')):
                 corrected = cu.af_correct_frame(
-                    cu._af_slab(data, du, 1, t),
-                    cu._af_correction_slab(data, du, [3], t, 'maximum', 75),
-                    stats, data.dtype)
+                    cu._af_slabs(data, du, [1, 3], t), 1, stats, data.dtype)
                 sl = [slice(None)] * data.ndim
                 sl[t_axis] = slice(t, t + 1)
                 sl[c_axis] = slice(1, 2)
@@ -271,17 +268,15 @@ class AfPreviewSeamTest(unittest.TestCase):
         """
         du = _dim_utils(**self.SHAPE)
         data = self._data(du, seed=12)
-        stats = cu.af_division_stats(data, du, 1, [3])
+        stats = cu.af_weight_stats(data, du, [1, 3])
         y, x = du.dim_idx('Y'), du.dim_idx('X')
-        full = cu.af_correct_frame(cu._af_slab(data, du, 1, 0),
-                                   cu._af_correction_slab(data, du, [3], 0, 'maximum', 75),
-                                   stats, data.dtype)
+        slabs = cu._af_slabs(data, du, [1, 3], 0)
+        full = cu.af_correct_frame(slabs, 1, stats, data.dtype)
         box = [slice(None)] * data.ndim
         box[y] = slice(8, 20)
         box[x] = slice(5, 25)
-        crop = cu.af_correct_frame(cu._af_slab(data, du, 1, 0)[tuple(box)],
-                                   cu._af_correction_slab(data, du, [3], 0, 'maximum', 75)[tuple(box)],
-                                   stats, data.dtype)
+        crop = cu.af_correct_frame({ch: s[tuple(box)] for ch, s in slabs.items()},
+                                   1, stats, data.dtype)
         self.assertTrue(np.array_equal(full[tuple(box)], crop),
                         'a previewed region must equal that region of the full correction')
 
@@ -292,121 +287,275 @@ class AfPreviewSeamTest(unittest.TestCase):
         data = self._data(du, seed=13)
         a = np.zeros(data.shape, data.dtype)
         b = np.zeros(data.shape, data.dtype)
-        cu._stream_division_channel(data, a, du, channel_idx=1, out_ch=1, correction_channel_idx=[3])
-        stats = cu.af_division_stats(data, du, 1, [3])
-        cu._stream_division_channel(data, b, du, channel_idx=1, out_ch=1, correction_channel_idx=[3],
-                                    stats=stats)
+        cu._stream_corrected_channel(data, a, du, channel_idx=1, out_ch=1,
+                                     competing_channel_idx=[3])
+        stats = cu.af_weight_stats(data, du, [1, 3])
+        cu._stream_corrected_channel(data, b, du, channel_idx=1, out_ch=1,
+                                     competing_channel_idx=[3], stats=stats)
         self.assertTrue(np.array_equal(a, b))
 
 
-class AfDerivedValuesTest(unittest.TestCase):
-    """The three values that used to be dialled in are now derived — pin what they are.
+class AfWeightMechanismTest(unittest.TestCase):
+    """What the power weight actually does, pinned as arithmetic rather than as a golden image.
 
-    Replaces `channelPercentile`, `correctionPercentile`, `correctionMin` and `correctionMax`.
+    Replaces a class that pinned the derived ceiling — `AF_CEILING_MIN_COUNT`, the floor fraction, the
+    lone-hot-voxel guard, the proportional-gain blindness. All of it described a rescale that no longer
+    exists: the output is in input counts now, so there is no ceiling to derive, subsample, defend
+    against a hot voxel, or compare across a set.
     """
 
     SHAPE = dict(size_t=3, size_z=5, size_c=4, size_y=32, size_x=30)
 
-    def test_none_means_no_background_subtraction(self):
+    def _stats(self, backgrounds, exponent=cu.AF_WEIGHT_EXPONENT, nbins=256):
+        """A hand-built stats object, so the per-voxel arithmetic can be checked without an image."""
+        return cu.AfWeightStats(backgrounds=dict(backgrounds),
+                                saturated={ch: 0.0 for ch in backgrounds},
+                                exponent=exponent, nbins=nbins)
+
+    # ── the per-voxel form ────────────────────────────────────────────────────
+
+    def test_a_channel_with_no_competition_passes_through_untouched(self):
+        """The property that makes the output "input counts": alone, the weight is exactly 1.
+
+        Under the ratio this same voxel came out rescaled by `rescale / ceiling` — one input count became
+        ~17 output counts on a real 8-bit image, so the corrected channel's brightness depended on a
+        derived number rather than on the data.
+        """
+        stats = self._stats({0: 10.0, 1: 10.0})
+        target = np.array([[10, 30, 60, 255]], dtype=np.uint8)
+        other = np.full_like(target, 10)                      # competitor at its own background
+        out = cu.af_correct_frame({0: target, 1: other}, 0, stats, np.uint8)
+        np.testing.assert_array_equal(out, np.array([[0, 20, 50, 245]], dtype=np.uint8))
+
+    def test_two_equally_bright_channels_split_the_voxel_evenly(self):
+        """No channel wins territory for being brighter overall — the symmetry the mutual ratio lacked.
+
+        This is also the case the ratio destroyed: equal channels put the ratio at 1, which mapped to
+        zero, so a cell carrying both reporters was hollowed out from the centre.
+        """
+        stats = self._stats({0: 0.0, 1: 0.0})
+        a = np.array([[40, 100]], dtype=np.uint8)
+        out0 = cu.af_correct_frame({0: a, 1: a.copy()}, 0, stats, np.uint8)
+        out1 = cu.af_correct_frame({0: a, 1: a.copy()}, 1, stats, np.uint8)
+        np.testing.assert_array_equal(out0, np.array([[20, 50]], dtype=np.uint8))   # b/2, not 0
+        np.testing.assert_array_equal(out0, out1)
+
+    def test_n_equally_bright_channels_each_keep_one_nth(self):
+        # generalises the pair case, and pins that competitors are NOT collapsed into one reference
+        stats = self._stats({0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0})
+        a = np.array([[120]], dtype=np.uint8)
+        for n in (2, 3, 4):
+            slabs = {ch: a.copy() for ch in range(n)}
+            out = cu.af_correct_frame(slabs, 0, stats, np.uint8)
+            self.assertEqual(int(out[0, 0]), 120 // n, f'{n} equal channels must split {n} ways')
+
+    def test_the_brighter_channel_keeps_more_by_a_fixed_power(self):
+        """`out_a / out_b == (b_a / b_b) ** (p + 1)` — the whole behaviour in one identity."""
+        p = 3
+        stats = self._stats({0: 0.0, 1: 0.0}, exponent=p, nbins=65536)
+        a = np.array([[2000]], dtype=np.uint16)
+        b = np.array([[1000]], dtype=np.uint16)
+        out_a = cu.af_correct_frame({0: a, 1: b}, 0, stats, np.uint16)
+        out_b = cu.af_correct_frame({0: a, 1: b}, 1, stats, np.uint16)
+        self.assertAlmostEqual(float(out_a[0, 0]) / float(out_b[0, 0]), 2.0 ** (p + 1), delta=0.05)
+
+    def test_the_output_never_exceeds_the_input(self):
+        """Why there is no `clippedFrac` any more: `weight <= 1`, so clipping is structurally impossible.
+
+        Under the ratio this was a real failure mode — a ceiling derived too low flattened bright
+        structure against the top of the range, which is exactly what that metric watched for.
+        """
+        rng = np.random.default_rng(21)
+        stats = self._stats({0: 5.0, 1: 5.0, 2: 5.0})
+        slabs = {ch: rng.integers(0, 256, size=(40, 40)).astype(np.uint8) for ch in range(3)}
+        out = cu.af_correct_frame(slabs, 0, stats, np.uint8)
+        self.assertTrue(np.all(out.astype(int) <= np.clip(slabs[0].astype(int) - 5, 0, None)),
+                        'the correction must never brighten a voxel')
+
+    def test_background_voxels_come_out_zero_without_dividing_by_zero(self):
+        # den == 0 everywhere nothing is above background: the `where=` branch, not a division by zero
+        stats = self._stats({0: 20.0, 1: 20.0})
+        slabs = {0: np.full((8, 8), 15, np.uint8), 1: np.full((8, 8), 20, np.uint8)}
+        with np.errstate(divide='raise', invalid='raise'):
+            out = cu.af_correct_frame(slabs, 0, stats, np.uint8)
+        self.assertEqual(int(out.max()), 0)
+
+    def test_the_integer_output_is_rounded_not_truncated(self):
+        """The output is in input counts, so values are often single digits and truncation biases every
+        one of them down by ~half a count. Measured on one plane of kSUFux/Or1L8a: truncating shifts the
+        mean by -0.072 counts and forces 4.9% of real output to zero, against +0.002 and 4.0% rounding.
+        """
+        stats = self._stats({0: 0.0, 1: 0.0})
+        # b0=3, b1=2 -> weight 9/13, out = 3 * 9/13 = 2.077 -> 2 either way
+        # b0=5, b1=3 -> weight 25/34, out = 5 * 25/34 = 3.676 -> 4 rounded, 3 truncated
+        a = np.array([[3, 5]], dtype=np.uint8)
+        c = np.array([[2, 3]], dtype=np.uint8)
+        out = cu.af_correct_frame({0: a, 1: c}, 0, stats, np.uint8)
+        np.testing.assert_array_equal(out, np.array([[2, 4]], dtype=np.uint8))
+
+    def test_a_float_output_is_left_unrounded(self):
+        stats = self._stats({0: 0.0, 1: 0.0})
+        a = np.array([[5]], dtype=np.uint8)
+        c = np.array([[3]], dtype=np.uint8)
+        out = cu.af_correct_frame({0: a, 1: c}, 0, stats, np.float32)
+        self.assertAlmostEqual(float(out[0, 0]), 5.0 * 25.0 / 34.0, places=5)
+
+    def test_a_target_absent_from_the_slabs_is_refused(self):
+        stats = self._stats({0: 0.0, 1: 0.0})
+        with self.assertRaises(ValueError):
+            cu.af_correct_frame({1: np.zeros((4, 4), np.uint8)}, 0, stats, np.uint8)
+
+    def test_a_channel_with_no_derived_background_is_refused(self):
+        """Refused rather than defaulted. A missing background would silently skip subtraction, so that
+        channel's pedestal would enter the denominator and over-suppress the target — a wrong answer
+        that looks like a working one. It means the stats were derived for a different channel set."""
+        stats = self._stats({0: 5.0})                      # nothing for channel 1
+        slabs = {0: np.full((4, 4), 40, np.uint8), 1: np.full((4, 4), 40, np.uint8)}
+        with self.assertRaises(ValueError) as ctx:
+            cu.af_correct_frame(slabs, 0, stats, np.uint8)
+        self.assertIn('1', str(ctx.exception))
+
+    def test_naming_the_target_among_its_own_competitors_changes_nothing(self):
+        """A slip the Julia side filters out (`af_combinations_for_python`); nothing downstream may
+        depend on that filtering having happened. Squaring the target's own term into the denominator a
+        second time would quietly halve its output.
+
+        Two layers stop it: `af_weight_stats` dedupes the channel list, and `af_correct_frame` takes the
+        slabs as a **dict keyed by channel**, so a channel physically cannot appear twice.
+        """
+        du = _dim_utils(**self.SHAPE)
+        data = np.random.default_rng(5).integers(0, 4000, size=tuple(du.im_dim), dtype=np.uint16)
+        plain = cu.af_weight_stats(data, du, [1, 3])
+        dupes = cu.af_weight_stats(data, du, [1, 3, 1, 3])
+        self.assertEqual(plain.backgrounds, dupes.backgrounds)
+        self.assertEqual(plain.saturated, dupes.saturated)
+        slabs = cu._af_slabs(data, du, [1, 3, 1], 0)
+        self.assertEqual(sorted(slabs), [1, 3])
+        np.testing.assert_array_equal(cu.af_correct_frame(slabs, 1, plain, data.dtype),
+                                      cu.af_correct_frame(slabs, 1, dupes, data.dtype))
+
+    # ── the derived globals ───────────────────────────────────────────────────
+
+    def test_a_background_is_derived_per_channel(self):
         du = _dim_utils(**self.SHAPE)
         data = np.random.default_rng(1).integers(0, 4000, size=tuple(du.im_dim), dtype=np.uint16)
-        s = cu.af_division_stats(data, du, 1, [3], background_method='none')
-        self.assertEqual(s.val1, 0.0)
-        self.assertEqual(s.val2, 0.0)
+        s = cu.af_weight_stats(data, du, [1, 3])
+        self.assertEqual(sorted(s.backgrounds), [1, 3])
+        self.assertEqual(s.exponent, cu.AF_WEIGHT_EXPONENT)
 
-    def test_the_ceiling_never_collapses_into_the_background(self):
-        # the trap on `robust_hist_max`: the background bin dominates, so an over-large count would
-        # return a ceiling inside it and make the rescale degenerate
-        du = _dim_utils(**self.SHAPE)
-        data = np.zeros(tuple(du.im_dim), dtype=np.uint16)   # every voxel identical
-        s = cu.af_division_stats(data, du, 1, [3], ceiling_min_count=10 ** 9)
-        self.assertGreater(s.c_max, 0.0)
-        self.assertGreaterEqual(s.c_max, s.nbins * cu.AF_CEILING_FLOOR_FRAC)
-
-    def test_a_lone_hot_voxel_does_not_set_the_ceiling(self):
-        """The measured failure: on a real 181-frame movie the top six occupied ratio bins held ONE
-        voxel each, so one voxel in 5.88 billion set the output scale."""
-        du = _dim_utils(**self.SHAPE)
-        data = np.zeros(tuple(du.im_dim), dtype=np.uint16)
-        c = du.dim_idx('C')
-        # a broad dim signal in the target channel, no AF anywhere -> ratio ~= signal
+    def _pedestal_image(self, du, pedestal=30, blob=900):
+        """A flat background with one bright blob in each channel — enough of a histogram for a
+        threshold to be derived from, unlike a single spike."""
+        data = np.full(tuple(du.im_dim), pedestal, dtype=np.uint16)
+        y, x = du.dim_idx('Y'), du.dim_idx('X')
         sl = [slice(None)] * data.ndim
-        sl[c] = slice(1, 2)
-        data[tuple(sl)] = 40
-        clean = cu.af_division_stats(data, du, 1, [3], background_method='none',
-                                     ceiling_min_count=100)
-        # now plant ONE hot voxel, orders of magnitude brighter
-        hot = [0] * data.ndim
-        hot[c] = 1
-        data[tuple(hot)] = 65535
-        with_hot = cu.af_division_stats(data, du, 1, [3], background_method='none',
-                                        ceiling_min_count=100)
-        self.assertEqual(clean.c_max, with_hot.c_max,
-                         'one hot voxel moved the derived ceiling')
-        # ...whereas the true max would have been dragged all the way up
-        self.assertGreater(cu.af_division_stats(data, du, 1, [3], background_method='none',
-                                                ceiling_min_count=1).c_max,
-                           with_hot.c_max)
+        sl[y] = slice(2, 8)
+        sl[x] = slice(2, 8)
+        data[tuple(sl)] = blob
+        return data, tuple(sl)
 
-    def test_a_spatial_stride_gives_the_same_ceiling(self):
-        # what makes the cheap pass honest: measured identical under z::2 / xy::4 / both on real data
+    def test_without_background_subtraction_the_background_survives(self):
+        """Why the task JSON does not offer `'none'`, as a test rather than as a comment.
+
+        The weight is a ratio of intensities, so an unsubtracted pedestal makes background voxels split
+        evenly between the channels and come out non-zero. Measured on kSUFux/Or1L8a: 92.1% of
+        background voxels survive and cell-to-background contrast collapses to 6.8x.
+        """
+        du = _dim_utils(size_t=1, size_z=1, size_c=2, size_y=24, size_x=24)
+        data, blob = self._pedestal_image(du)
+        slabs = cu._af_slabs(data, du, [0, 1], 0)
+
+        none_stats = cu.af_weight_stats(data, du, [0, 1], background_method='none')
+        self.assertEqual(none_stats.backgrounds, {0: 0.0, 1: 0.0})
+        survived = cu.af_correct_frame(slabs, 0, none_stats, data.dtype)
+
+        derived = cu.af_weight_stats(data, du, [0, 1], background_method='triangle')
+        self.assertGreater(derived.backgrounds[0], 0.0)
+        cleaned = cu.af_correct_frame(slabs, 0, derived, data.dtype)
+
+        # outside the blob is background in both channels; it must not survive a derived background
+        bg = np.ones(survived.shape, bool)
+        bg[blob] = False
+        self.assertGreater(int(survived[bg].max()), 0, 'background survives without subtraction')
+        self.assertEqual(int(cleaned[bg].max()), 0, 'a derived background must remove the pedestal')
+
+    def test_saturated_reports_the_input_clipped_at_the_sensor(self):
+        """The QC signal that replaced `clippedFrac`. A clipped voxel's true value is gone before this
+        task sees it — measured across the nine kSUFux movies, CH3 saturation spanned 0.001% to 0.018%
+        at identical acquisition settings."""
+        du = _dim_utils(size_t=1, size_z=1, size_c=2, size_y=10, size_x=10)
+        data = np.zeros(tuple(du.im_dim), dtype=np.uint8)
+        c, y = du.dim_idx('C'), du.dim_idx('Y')
+        sl = [slice(None)] * data.ndim
+        sl[c] = slice(0, 1)
+        sl[y] = slice(0, 1)            # one row of 10 in a 10x10 channel
+        data[tuple(sl)] = 255
+        s = cu.af_weight_stats(data, du, [0, 1])
+        self.assertAlmostEqual(s.saturated[0], 0.10, places=6)
+        self.assertAlmostEqual(s.saturated[1], 0.0, places=6)
+
+    def test_a_spatial_stride_gives_the_same_backgrounds(self):
+        """What makes the preview's cheap pass honest, and it is EXACT — not merely close.
+
+        The preview derives its globals from a strided read (`AF_PREVIEW_STRIDE`) while the run reads
+        every voxel. If those disagree the preview subtracts a different background than the run, which
+        is the one thing the feature exists to rule out. Measured here at `(1,1)`, `(1,2)` and `(2,4)`:
+        the same background to the count.
+
+        **It holds because the image HAS a background population**, which is what a threshold needs to
+        find. On structureless uniform noise there is none, and the triangle threshold then swings
+        wildly under subsampling (measured on `rng.integers(0, 4000)`: 3178 → 544 → 196). That is a
+        degenerate input rather than a realistic one — a fluorescence channel is mostly background — but
+        it is the assumption the strided pass rests on, so it is written down here and on
+        `af_weight_stats` rather than left implicit. The previous implementation had the same exposure
+        and no test covered it.
+        """
         du = _dim_utils(**self.SHAPE)
-        data = np.random.default_rng(2).integers(0, 4000, size=tuple(du.im_dim), dtype=np.uint16)
-        full = cu.af_division_stats(data, du, 1, [3])
-        strided = cu.af_division_stats(data, du, 1, [3], spatial_stride=(1, 2))
-        self.assertAlmostEqual(full.c_max, strided.c_max, delta=full.nbins * 0.1)
+        rng = np.random.default_rng(2)
+        # a real channel: a background pedestal with sensor noise, plus signal over part of the frame
+        data = np.full(tuple(du.im_dim), 30, dtype=np.uint16)
+        data += rng.integers(0, 8, size=data.shape, dtype=np.uint16)
+        y, x = du.dim_idx('Y'), du.dim_idx('X')
+        sl = [slice(None)] * data.ndim
+        sl[y] = slice(4, 20)
+        sl[x] = slice(4, 20)
+        data[tuple(sl)] += 900
 
-    def test_output_stats_report_both_failure_directions(self):
+        full = cu.af_weight_stats(data, du, [1, 3])
+        for stride in ((1, 2), (2, 4)):
+            strided = cu.af_weight_stats(data, du, [1, 3], spatial_stride=stride)
+            self.assertEqual(full.backgrounds, strided.backgrounds,
+                             f'stride {stride} moved a derived background')
+
+    # ── what the run banks and the preview reads out ──────────────────────────
+
+    def test_output_stats_carry_what_qc_acts_on(self):
         du = _dim_utils(**self.SHAPE)
         data = np.random.default_rng(3).integers(0, 4000, size=tuple(du.im_dim), dtype=np.uint16)
-        stats = cu.af_division_stats(data, du, 1, [3])
+        stats = cu.af_weight_stats(data, du, [1, 3])
         out = np.zeros(data.shape, data.dtype)
-        s = cu._stream_division_channel(data, out, du, channel_idx=1, out_ch=1,
-                                        correction_channel_idx=[3], stats=stats)
-        for k in ('clippedFrac', 'levelsUsed', 'levelsAvailable', 'trueMax', 'p999'):
+        s = cu._stream_corrected_channel(data, out, du, channel_idx=1, out_ch=1,
+                                         competing_channel_idx=[3], stats=stats)
+        for k in ('levelsUsed', 'levelsAvailable', 'trueMax', 'p999',
+                  'saturatedFrac', 'background', 'competingBackgrounds', 'exponent'):
             self.assertIn(k, s)
-        self.assertGreaterEqual(s['clippedFrac'], 0.0)
+        self.assertNotIn('clippedFrac', s)     # structurally ~0 now — see af_output_stats
+        self.assertNotIn('ceiling', s)         # there is no rescale to have a ceiling for
         self.assertLessEqual(s['levelsUsed'], s['levelsAvailable'])
 
-    def test_output_stats_carry_the_derived_values_themselves(self):
-        """The fractions cannot stand in for the ceiling, so the ceiling has to be reported too."""
+    def test_the_readout_and_the_banked_metric_come_from_one_helper(self):
+        """`af_derived_values` is shared by the run's QC and the preview's readout precisely so the two
+        cannot drift on a key name or a value."""
         du = _dim_utils(**self.SHAPE)
         data = np.random.default_rng(3).integers(0, 4000, size=tuple(du.im_dim), dtype=np.uint16)
-        stats = cu.af_division_stats(data, du, 1, [3])
+        stats = cu.af_weight_stats(data, du, [1, 3])
         out = np.zeros(data.shape, data.dtype)
-        s = cu._stream_division_channel(data, out, du, channel_idx=1, out_ch=1,
-                                        correction_channel_idx=[3], stats=stats)
-        self.assertAlmostEqual(s['ceiling'], stats.c_max)
-        self.assertAlmostEqual(s['background'], stats.val1)
-        self.assertAlmostEqual(s['afBackground'], stats.val2)
-
-    def test_a_proportional_gain_difference_is_invisible_to_both_fractions(self):
-        """Why the ceiling is banked at all — and the reason it is a COHORT metric, not a warning.
-
-        Two images whose ratios differ by a constant factor derive proportionally different ceilings
-        and produce identical corrected output, so `clippedFrac` and `levelsUsedFrac` cannot tell them
-        apart while their intensity scales differ by that factor. Measured across the nine kSUFux
-        movies (one experiment, one channel pair, identical settings): a 1.71x spread in the ceiling.
-        """
-        rng = np.random.default_rng(7)
-        ratios = rng.gamma(shape=2.0, scale=3.0, size=200_000)
-        rescale = 255.0
-
-        def stats_for(scale):
-            c_max = float(iu.robust_hist_max(np.bincount((ratios * scale).astype(int))))
-            corrected = np.clip(ratios * scale / c_max * rescale, 0, rescale).astype(np.uint8)
-            hist = np.bincount(corrected, minlength=256)[:256]
-            return c_max, cu.af_output_stats(
-                hist, cu.AfDivisionStats(val1=0, val2=0, c_max=c_max, nbins=256, rescale=rescale))
-
-        c1, s1 = stats_for(1.0)
-        c2, s2 = stats_for(2.0)
-
-        self.assertGreater(c2 / c1, 1.5)                       # the scales really do differ...
-        self.assertEqual(s1['clippedFrac'], s2['clippedFrac'])  # ...and neither fraction moves at all
-        self.assertEqual(s1['levelsUsed'], s2['levelsUsed'])
-        self.assertNotAlmostEqual(s1['ceiling'], s2['ceiling'])  # only the banked ceiling shows it
-
+        s = cu._stream_corrected_channel(data, out, du, channel_idx=1, out_ch=1,
+                                         competing_channel_idx=[3], stats=stats)
+        self.assertAlmostEqual(s['background'], stats.backgrounds[1])
+        self.assertEqual(s['competingBackgrounds'], {'3': stats.backgrounds[3]})
+        for k, v in cu.af_derived_values(stats, 1).items():
+            self.assertEqual(s[k], v, f'{k} differs between the readout and the banked metric')
 
 
 class PyramidRefactorTest(unittest.TestCase):

--- a/python/cecelia/utils/correction_utils.py
+++ b/python/cecelia/utils/correction_utils.py
@@ -278,12 +278,14 @@ def _af_write_slab(out, dim_utils, channel_idx, t, slab):
     out[tuple(sl)] = slab
 
 
-def _af_correction_slab(data, dim_utils, correction_channel_idx, t, summary_mode, summary_percentile):
-    """Summary correction image (max, or percentile, across the division channels) for one frame."""
-    stack = np.stack([_af_slab(data, dim_utils, x, t) for x in correction_channel_idx], axis=0)
-    if summary_mode == 'percentile':
-        return np.percentile(stack, summary_percentile, axis=0)
-    return np.max(stack, axis=0)
+def _af_slabs(data, dim_utils, channels, t):
+    """One frame of EVERY channel taking part in a correction, keyed by channel index.
+
+    Replaces a `max`-across-the-references summary. The competing channels have to stay separate: each
+    one contributes its own term to the weight's denominator, so collapsing them to a single reference
+    image (which is what divide-mode AF did) throws away exactly the information the weight needs.
+    """
+    return {int(ch): _af_slab(data, dim_utils, int(ch), t) for ch in channels}
 
 
 def _af_subtract(slab, subtract_val):
@@ -297,56 +299,65 @@ def _af_subtract(slab, subtract_val):
     return f
 
 
-#: The GLOBAL scalars divide-mode AF needs before it can correct a single pixel. Whole-image by
-#: definition, which is why they are a separate, cacheable step — see `af_division_stats`.
-AfDivisionStats = collections.namedtuple('AfDivisionStats', 'val1 val2 c_max nbins rescale')
+#: The GLOBAL values the power weight needs before it can correct a single voxel: one background level
+#: per participating channel. Whole-image by definition, which is why they are a separate, cacheable
+#: step — see `af_weight_stats`. ``saturated`` rides along because the same pass already has the
+#: histograms, and input saturation is the one thing about this correction worth warning about.
+AfWeightStats = collections.namedtuple('AfWeightStats', 'backgrounds saturated exponent nbins')
 
-#: How many voxels a value must reach before the ceiling will sit at it. Measured on a real 181-frame
-#: movie: the top six occupied ratio bins held ONE voxel each, and this threshold gave an identical
-#: ceiling under every spatial stride tried (z::2, xy::4, both), where the true max did not. Lower
-#: values track the data more closely but sample worse — 100 drifted ~10% under striding, 1 000 by 2%,
-#: 10 000 not at all. See docs/todo/TASK_PREVIEW_PLAN.md.
-AF_CEILING_MIN_COUNT = 10_000
+#: How sharply a channel must dominate a voxel to keep it: ``weight = b_t^p / Σ b_i^p``.
+#:
+#: **Deliberately not a user parameter.** This task previously carried `channelPercentile`,
+#: `correctionPercentile`, `correctionMin` and `correctionMax` — four numbers with no defensible value,
+#: fitted per dataset and never revisited — and deleting them was the point of the current design. A
+#: user-facing sharpness dial is that same thing coming back. p=2 was compared against p=1 and p=8 on
+#: real overlapping reporter cells (kSUFux/Or1L8a): p=1 leaves too much of the losing channel, p=8
+#: approaches a hard cut without gaining separation. If a dataset ever genuinely needs a different
+#: value, that measurement is the trigger to expose it — not a guess in advance.
+AF_WEIGHT_EXPONENT = 2
 
-#: Fraction of the ratio's own range the derived ceiling may never fall below. Guards the trap in
-#: `robust_hist_max`: the background bin dominates the histogram, so a min-count larger than the
-#: signal population would return a ceiling inside the background and collapse the rescale.
-AF_CEILING_FLOOR_FRAC = 0.02
 
+def af_weight_stats(
+        data, dim_utils, channels, background_method='triangle',
+        timepoints=None, spatial_stride=(1, 1), exponent=AF_WEIGHT_EXPONENT):
+    """The one thing the power weight needs that a single region cannot supply: a background level per
+    participating channel. Derived, not dialled in
+    (`intensity_utils.background_threshold`, Zack's triangle by default).
 
-def af_division_stats(
-        data, dim_utils, channel_idx, correction_channel_idx,
-        background_method='triangle', summary_mode='maximum', summary_percentile=75,
-        timepoints=None, spatial_stride=(1, 1), ceiling_min_count=None):
-    """Everything divide-mode AF needs that a single region cannot supply: the two background levels
-    and the output ceiling. All three **derived**, none dialled in.
+    Background subtraction is **not optional** here, and that is worth stating because
+    `BACKGROUND_METHODS` still offers `'none'` for other callers. The weight is a ratio of channel
+    intensities, so an unsubtracted pedestal makes background voxels split evenly between the channels
+    and survive. Measured on kSUFux/Or1L8a: **92.1%** of background voxels come out non-zero and
+    cell-to-background contrast collapses from effectively unbounded to **6.8x**. The task JSON
+    therefore does not offer `'none'`.
 
-    * ``val1`` — background of the target channel
-    * ``val2`` — the level above which the AF reference counts as autofluorescence
-    * ``c_max`` — the ratio that maps to full scale, as an outlier-rejected maximum
+    Split out from the streaming writer so the **task preview** can pay for it once and cache it, then
+    correct just the region on screen with `af_correct_frame` (the analogue of cellpose's
+    `norm_params` → `predict_slice`). Global by definition: derived from a crop it would subtract a
+    different background in the previewed region than in the run, i.e. lie about the thing being judged.
 
-    These replace `channelPercentile`, `correctionPercentile`, `correctionMin` and `correctionMax`,
-    four numbers with no defensible value that were fitted per dataset and never revisited. The
-    background pair now comes from `intensity_utils.background_threshold` (Zack's triangle by default)
-    and the ceiling from `intensity_utils.robust_hist_max`.
+    ONE pass, where divide-mode AF needed two — it had to build the ratio distribution to find an
+    output ceiling, and there is no ceiling any more (the output is in input counts). Measured on the
+    kSUFux movies that halves this step, ~39 s → ~20 s per channel pair.
 
-    Split out from the streaming writer so the **task preview** can pay for them once and cache them,
-    then correct just the region on screen with `af_correct_frame` (the analogue of cellpose's
-    `norm_params` → `predict_slice`). They are global by definition: computing them from a crop would
-    subtract a different background in the previewed region than in the run, i.e. lie about the one
-    thing being tuned.
-
-    Two passes, because the ratio cannot be formed until the backgrounds are known. Both are
-    subsamplable and the defaults are measured, not guessed:
+    Both subsampling knobs are kept for the preview's benefit:
 
     * ``timepoints`` — which frames to gather from. ``None`` = all.
-    * ``spatial_stride`` — ``(z, xy)`` stride WITHIN each frame. Prefer this over dropping frames: it
-      keeps every timepoint represented, and the count-thresholded ceiling is invariant to it
-      (identical answer at ``(2, 4)``, which cost 24 s against 148 s for the full read).
+    * ``spatial_stride`` — ``(z, xy)`` stride WITHIN each frame. Prefer it over dropping frames: it
+      keeps every timepoint represented.
 
-    A note on why the ceiling is derived here and not handed in: it is a property of the corrected
-    ratio, so it cannot be known before the backgrounds are, and it must be identical for the run and
-    the preview or the preview's brightness is a lie.
+    **Subsampling is exact only because the channel has a background population to find.** The preview
+    reads strided while the run reads every voxel, and they must agree to the count or the preview
+    subtracts a different background than the run. They do, on real data and on any image with a
+    background peak. On structureless noise there is no such population and the triangle threshold
+    swings under subsampling (measured on uniform `rng.integers(0, 4000)`: 3178 → 544 → 196 at strides
+    (1,1) → (1,2) → (2,4)). A fluorescence channel is mostly background so this is a degenerate rather
+    than a realistic input, but it is the assumption the cheap pass rests on. Pinned by
+    `test_a_spatial_stride_gives_the_same_backgrounds`.
+
+    ``saturated`` is the fraction of each channel's voxels sitting at the dtype maximum, i.e. clipped
+    on acquisition. It is free here (the histograms are already built) and it is the honest QC signal
+    for this task: a clipped voxel's true value is gone, and no correction recovers it.
     """
     T = dim_utils.dim_val('T') if dim_utils.is_timeseries() else 1
     ts = range(T) if timepoints is None else list(timepoints)
@@ -355,162 +366,188 @@ def af_division_stats(
 
     dt = data.dtype
     integer = np.issubdtype(dt, np.integer)
-    rescale = float(np.iinfo(dt).max) if integer else 255.0
     nbins = (int(np.iinfo(dt).max) + 1) if integer else 256
-    hi = float(nbins)                     # the ratio's ceiling: (maxval+1)/1
+
+    # dict.fromkeys dedupes while keeping order: a channel named twice must not be counted twice, and
+    # a target listed inside its own competitors would otherwise square that term into the denominator
+    # a second time (the Julia side rejects that case outright — see `af_combinations_for_python`).
+    channels = [int(c) for c in dict.fromkeys(int(c) for c in channels)]
 
     def _stride(a):
         return a[..., ::zst, ::xyst, ::xyst] if (strided and a.ndim >= 3) else a
 
-    # ── pass 1: the two background levels ───────────────────────────────────
-    H_ch, H_corr = np.zeros(nbins, np.int64), np.zeros(nbins, np.int64)
+    hists = {ch: np.zeros(nbins, np.int64) for ch in channels}
     for t in ts:
-        ch = _stride(_af_slab(data, dim_utils, channel_idx, t))
-        H_ch += np.bincount(np.clip(ch, 0, nbins - 1).astype(np.int64).ravel(), minlength=nbins)[:nbins]
-        ci = _stride(_af_correction_slab(data, dim_utils, correction_channel_idx, t,
-                                         summary_mode, summary_percentile))
-        H_corr += np.bincount(np.clip(np.rint(ci), 0, nbins - 1).astype(np.int64).ravel(),
-                              minlength=nbins)[:nbins]
-    val1 = float(intensity_utils.background_threshold(H_ch, background_method))
-    val2 = float(intensity_utils.background_threshold(H_corr, background_method))
+        for ch in channels:
+            a = _stride(_af_slab(data, dim_utils, ch, t))
+            hists[ch] += np.bincount(np.clip(a, 0, nbins - 1).astype(np.int64).ravel(),
+                                     minlength=nbins)[:nbins]
 
-    # ── pass 2: the ceiling, from the corrected-ratio distribution ──────────
-    H_ratio = np.zeros(nbins, np.int64)
-    for t in ts:
-        img = _af_subtract(_stride(_af_slab(data, dim_utils, channel_idx, t)), val1)
-        corr = _af_subtract(_stride(_af_correction_slab(data, dim_utils, correction_channel_idx, t,
-                                                       summary_mode, summary_percentile)), val2)
-        ratio = (img + 1.0) / (corr + 1.0)
-        H_ratio += np.bincount(np.clip(ratio / hi * (nbins - 1), 0, nbins - 1).astype(np.int64).ravel(),
-                               minlength=nbins)[:nbins]
-
-    # Scale the count threshold by the sampling fraction, so a strided pass asks for proportionally
-    # fewer voxels and lands on the same ceiling as a full one.
-    if ceiling_min_count is None:
-        frac = 1.0 / (zst * xyst * xyst) * (len(ts) / max(1, T))
-        ceiling_min_count = max(1, int(round(AF_CEILING_MIN_COUNT * frac)))
-    c_max = intensity_utils.robust_hist_max(H_ratio, ceiling_min_count) / (nbins - 1) * hi
-    # the trap documented on `robust_hist_max`: the background bin dominates, so an over-large count
-    # can return a ceiling inside it. Never let the window collapse.
-    c_max = max(float(c_max), hi * AF_CEILING_FLOOR_FRAC)
-
-    return AfDivisionStats(val1=val1, val2=val2, c_max=c_max, nbins=nbins, rescale=rescale)
+    backgrounds = {ch: float(intensity_utils.background_threshold(hists[ch], background_method))
+                   for ch in channels}
+    saturated = {ch: float(hists[ch][nbins - 1]) / max(1.0, float(hists[ch].sum()))
+                 for ch in channels}
+    return AfWeightStats(backgrounds=backgrounds, saturated=saturated,
+                         exponent=int(exponent), nbins=nbins)
 
 
-def af_correct_frame(img_slab, corr_slab, stats, out_dtype):
-    """Divide-mode AF for ONE frame: subtract both backgrounds, divide, map to the stored dtype.
+def af_correct_frame(slabs, target, stats, out_dtype):
+    """Correct ONE frame of ONE channel: keep the share of each voxel this channel dominates.
 
-    Takes the two raw slabs already read — the target channel and the summarised AF reference — so it
-    is pure compute with no data access. That is what lets the preview hand it a CROP while the run
-    hands it a whole frame, and it is why the preview cannot drift from the run.
+        b_i    = max(raw_i - background_i, 0)      for the target and every competing channel
+        out_t  = b_t * b_t^p / Σ_i b_i^p
 
-    Four lines of arithmetic, and deliberately nothing else. It used to carry a median filter, a
-    gaussian, a rolling-ball and a top-hat, none of which are autofluorescence correction — they were
-    a small image-processing toolbox that accreted in this task while fitting individual datasets.
+    Takes the raw slabs already read, keyed by channel index, so it is pure compute with no data
+    access. That is what lets the preview hand it a CROP while the run hands it a whole frame, and it
+    is why the preview cannot drift from the run.
 
-    The gaussian is the one worth explaining, because it was not cosmetic: dividing by a small noisy
-    denominator amplifies noise, and the blur hid that. **Noise suppression is the denoise step's job**
-    (pre-cellpose, now in coastal), so keeping a second, weaker version of it here meant every
-    corrected channel was silently blurred whether or not it was going to be denoised anyway. It also
-    matters less than it did: the derived AF background sits higher than the hand-tuned percentile it
-    replaced, so more of the reference channel is zeroed, the denominator is 1 more often, and there is
-    simply less division to amplify anything.
+    **The output is in input counts.** Where the target is the only channel present the weight is 1 and
+    the voxel passes through untouched; where a competitor is brighter it is suppressed towards zero.
+    Nothing is rescaled, so there is no ceiling to derive and no window to get wrong — and the output
+    can never exceed the input, so there is nothing to clip either.
 
-    ``stats.c_max`` is the ratio that maps to full scale, derived in `af_division_stats` as an
-    outlier-rejected maximum. Every value in this function comes from the data.
+    This replaces a mutual ratio, ``out = (b_t + 1)/(b_c + 1) / ceiling * rescale``, whose problem was
+    structural: it goes to zero wherever the target is not brighter than the reference, so a cell
+    carrying BOTH reporters was hollowed into a dim rim — the centre, where both channels are bright and
+    the ratio sits near 1, went to zero. Measured on real overlapping reporter cells with overall gain
+    cancelled (kSUFux/Or1L8a and bNnmQL, one plane each), the co-positive cell came out at **3-7%** of a
+    clean single-reporter cell's brightness under the ratio, against **149-358%** here. A hollow cell is
+    not a cosmetic problem: segmentation runs next, and a ring with a zero centre either fails to be
+    detected or splits.
+
+    Two properties the ratio did not have, both falling out of the form rather than added machinery: it
+    is symmetric (no channel wins territory for being brighter overall), and it takes any number of
+    competitors in one expression instead of chaining pairwise ratios.
+
+    Deliberately nothing else here. This function used to carry a median filter, a gaussian, a
+    rolling-ball and a top-hat, none of which are autofluorescence correction. The gaussian is the one
+    worth explaining, because it was not cosmetic: dividing by a small noisy denominator amplifies
+    noise, and the blur hid that. **Noise suppression is the denoise step's job** (pre-cellpose, now in
+    coastal), so keeping a second, weaker version here silently blurred every corrected channel.
+
+    ``p`` is `AF_WEIGHT_EXPONENT` — see that constant for why it is not a user parameter.
     """
-    img = _af_subtract(img_slab, stats.val1)
-    corr = _af_subtract(corr_slab, stats.val2)
-    ratio = (img + 1.0) / (corr + 1.0)
-    denom = stats.c_max if stats.c_max > 0 else 1.0
-    return np.clip(ratio / denom * stats.rescale, 0, stats.rescale).astype(out_dtype)
+    p = int(stats.exponent)
+    target = int(target)
+    channels = [int(ch) for ch in slabs]
+    if target not in channels:
+        raise ValueError(f'target channel {target} is not among the slabs given ({sorted(channels)})')
+    # A channel with no derived background would silently skip subtraction, so its pedestal would enter
+    # the denominator and over-suppress the target. Refuse instead: it means the stats were derived for a
+    # different channel set than the one being corrected, which no caller can want.
+    missing = [ch for ch in channels if ch not in stats.backgrounds]
+    if missing:
+        raise ValueError(f'no derived background for channel(s) {missing}; '
+                         f'stats cover {sorted(stats.backgrounds)}')
+
+    b = {int(ch): _af_subtract(slab, stats.backgrounds[int(ch)]) for ch, slab in slabs.items()}
+
+    num = b[target] ** p
+    den = num.copy()
+    for ch, v in b.items():
+        if ch != target:
+            den += v ** p
+    # den == 0 exactly where every channel sits at or below its own background — nothing to attribute.
+    # `where` leaves those voxels at the zeros `out=` already holds rather than dividing by zero.
+    weight = np.divide(num, den, out=np.zeros_like(num), where=den > 0)
+    out = b[target] * weight
+
+    # ROUND to the integer output, don't truncate. Output is in input counts now, so the values are
+    # often single digits and a bare `astype` biases every one of them down by ~half a count. Measured
+    # on one plane of kSUFux/Or1L8a (85,526 non-zero voxels): truncating shifts the mean by -0.072
+    # counts and forces 4.9% of real output to zero, against +0.002 and 4.0% when rounding. It mattered
+    # less under the ratio, whose output was multiplied up by `rescale / ceiling` first.
+    if np.issubdtype(np.dtype(out_dtype), np.integer):
+        out = np.rint(out)
+    return np.clip(out, 0, stats.nbins - 1).astype(out_dtype)
 
 
 
 
-def _stream_division_channel(data, out, dim_utils, channel_idx, out_ch, correction_channel_idx,
-                             background_method='triangle', summary_mode='maximum',
-                             summary_percentile=75, stats=None, logfile_utils=None):
-    """Divide-mode AF for one channel, streamed one timepoint at a time into ``out`` (peak memory =
-    one frame, not the whole channel).
+def _stream_corrected_channel(data, out, dim_utils, channel_idx, out_ch, competing_channel_idx,
+                              background_method='triangle', stats=None, logfile_utils=None):
+    """Correct one channel, streamed one timepoint at a time into ``out`` (peak memory = one frame,
+    not the whole channel).
 
-    Everything global comes from `af_division_stats`, everything per-voxel from `af_correct_frame`.
+    Everything global comes from `af_weight_stats`, everything per-voxel from `af_correct_frame`.
     Pass ``stats`` to reuse an already-computed set — that is how the preview and the run stay
     identical. Returns `af_output_stats` for the corrected channel so the caller can bank QC.
+
+    Reads the target plus every competing channel per frame, which is the same number of slabs the
+    divide-mode path read to build its `max`-collapsed reference — so no extra IO, it just keeps them
+    separate.
     """
     T = dim_utils.dim_val('T') if dim_utils.is_timeseries() else 1
+    channels = [int(channel_idx)] + [int(c) for c in competing_channel_idx]
     if stats is None:
-        stats = af_division_stats(data, dim_utils, channel_idx, correction_channel_idx,
-                                  background_method=background_method, summary_mode=summary_mode,
-                                  summary_percentile=summary_percentile)
+        stats = af_weight_stats(data, dim_utils, channels, background_method=background_method)
     if logfile_utils is not None:
-        logfile_utils.log(f'>> ch{channel_idx}: background {stats.val1:.0f} / AF {stats.val2:.0f}, '
-                          f'ceiling {stats.c_max:.1f} ({background_method})')
+        others = ', '.join(f'ch{c} {stats.backgrounds.get(int(c), 0.0):.0f}'
+                           for c in competing_channel_idx)
+        logfile_utils.log(
+            f'>> ch{channel_idx}: background {stats.backgrounds.get(int(channel_idx), 0.0):.0f} '
+            f'({background_method}), competing against {others}, p={stats.exponent}')
 
     # Output histogram, accumulated as we go — the objective signal the QC exemption in af_correct.jl
     # said was missing. Free: one bincount per frame we already hold.
     H_out = np.zeros(stats.nbins, np.int64)
 
     for t in range(T):
-        corrected = af_correct_frame(
-            _af_slab(data, dim_utils, channel_idx, t),
-            _af_correction_slab(data, dim_utils, correction_channel_idx, t,
-                                summary_mode, summary_percentile),
-            stats, out.dtype)
+        corrected = af_correct_frame(_af_slabs(data, dim_utils, channels, t),
+                                     channel_idx, stats, out.dtype)
         H_out += np.bincount(np.clip(corrected, 0, stats.nbins - 1).astype(np.int64).ravel(),
                              minlength=stats.nbins)[:stats.nbins]
         _af_write_slab(out, dim_utils, out_ch, t, corrected)
 
-    return af_output_stats(H_out, stats)
+    return af_output_stats(H_out, stats, channel_idx)
 
 
-def af_derived_values(stats):
-    """The three values AF derives instead of asking for, as a plain JSON-friendly dict.
+def af_derived_values(stats, target):
+    """The values this correction derives instead of asking for, as a plain JSON-friendly dict.
 
     One helper because two callers report them and they must not drift: the run banks them in QC
     (`af_output_stats`) and the preview shows them as its readout. They were briefly written out by
     hand in both places, which is how the two would have started disagreeing about a key name.
+
+    There is no ``ceiling`` any more — the output is in input counts, so nothing is rescaled and there
+    is no derived full-scale value to report or to compare across a set.
     """
+    target = int(target)
     return {
-        'ceiling': float(stats.c_max),
-        'background': float(stats.val1),
-        'afBackground': float(stats.val2),
+        'background': float(stats.backgrounds.get(target, 0.0)),
+        'competingBackgrounds': {str(ch): float(v) for ch, v in sorted(stats.backgrounds.items())
+                                 if ch != target},
+        'saturatedFrac': float(stats.saturated.get(target, 0.0)),
+        'exponent': int(stats.exponent),
     }
 
 
-def af_output_stats(hist, stats):
-    """Did the derived ceiling land well? The numbers a user (or QC) acts on.
+def af_output_stats(hist, stats, target):
+    """What the correction did to this channel — the numbers a user (or QC) acts on.
 
-    * ``clippedFrac`` — fraction pushed to the dtype ceiling. Should be near zero; if it isn't, the
-      ceiling was derived too low and real signal is being flattened.
+    * ``saturatedFrac`` — fraction of the channel's INPUT voxels sitting at the dtype maximum, i.e.
+      clipped on acquisition. This is the honest warning for this task: a clipped voxel's true value is
+      gone before we see it, so no correction recovers it and the right fix is at the microscope.
     * ``levelsUsed`` / ``levelsAvailable`` — how much of the output range the data occupies. Low means
-      the ceiling is too high and quantisation is being thrown away: under the percentile window this
-      replaced, 99% of a real image landed in ~13 of 255 levels.
+      the channel is quantised coarsely. Under the hand-tuned percentile window that preceded all of
+      this, 99% of a real image landed in ~13 of 255 levels and nothing flagged it.
 
-    Also reports the derived values THEMSELVES — ``ceiling``, ``background``, ``afBackground`` — which
-    the two fractions above provably cannot stand in for. The corrected output is
-    ``ratio / ceiling * rescale``, so two images whose ratios differ by a constant factor derive
-    proportionally different ceilings and produce **byte-identical** output: measured, a 1.86x ceiling
-    difference moved ``clippedFrac`` and ``levelsUsedFrac`` by 0.000. That is the exact case where
-    intensities stop being comparable between images, so it has to be banked as its own number.
-    Nothing here can judge it — one image's ceiling is neither right nor wrong on its own; it is only
-    meaningful against its cohort, which is why it is a cohort metric and not a warning
-    (`af_qc_findings` in af_correct.jl). On the nine kSUFux movies — one experiment, one channel pair,
-    identical settings — the derived ceiling spanned 1.71x (14.06 to 24.09).
+    There is deliberately no ``clippedFrac``. The output is ``b_t * weight`` with ``weight <= 1``, so it
+    can never exceed ``raw - background`` and therefore never reaches the dtype ceiling — the metric
+    would be structurally ~0 and say nothing. Under the ratio it was the signal that the derived
+    ceiling had landed too low; there is no ceiling now.
 
     Reported by the run (QC) and by the preview (readout), from one helper so the two agree.
     """
-    rescale = stats.rescale
-    hi = int(rescale)
+    hi = int(stats.nbins) - 1
     s = intensity_utils.clip_stats(hist, 0, hi)
     nz = np.nonzero(hist)[0]
     return {
-        'clippedFrac': float(s.get('clipHighFrac', 0.0)),
         'levelsUsed': int(nz.size),
         'levelsAvailable': hi + 1,
         'trueMax': int(s.get('trueMax', 0)),
         'p999': int(s.get('p999', 0)),
-        **af_derived_values(stats),
+        **af_derived_values(stats, target),
     }
 
 
@@ -543,14 +580,16 @@ def af_correct_image(input_image, af_combinations, dim_utils, logfile_utils,
                      background_method='triangle', out=None, output_stats=None):
     """Correct autofluorescence for all channels, streamed ONE TIMEPOINT AT A TIME per channel.
 
-    A **channel combination is now just channels**: which channel to correct, and which to correct it
-    against. Everything that was a number in the UI — two background percentiles, a rescale window, a
-    median filter, a gaussian, a rolling ball, a top hat, a denoiser, an inverse channel — is either
-    derived (`af_division_stats`) or gone. Those parameters accreted while fitting individual datasets
-    and were a bag nobody revisited; a correction task should correct, not carry a filter toolbox.
+    A **channel combination is now just channels**: which channel to correct, and which channels
+    compete with it. Everything that was a number in the UI — two background percentiles, a rescale
+    window, a median filter, a gaussian, a rolling ball, a top hat, a denoiser, an inverse channel — is
+    either derived (`af_weight_stats`) or gone. Those parameters accreted while fitting individual
+    datasets and were a bag nobody revisited; a correction task should correct, not carry a filter
+    toolbox.
 
-    ``background_method`` is the one remaining choice, global to every combination — how the two
-    background levels are derived (`intensity_utils.BACKGROUND_METHODS`).
+    ``background_method`` is the one remaining choice, global to every combination — how each channel's
+    background level is derived (`intensity_utils.BACKGROUND_METHODS`, minus ``'none'``: see
+    `af_weight_stats`).
 
     Peak memory is a single channel-frame — casting a whole channel-timecourse to float64 (~47 GB on
     a large movie) was the OOM. When ``out`` is None a numpy array is allocated and returned (legacy /
@@ -569,11 +608,11 @@ def af_correct_image(input_image, af_combinations, dim_utils, logfile_utils,
     output_stats = {} if output_stats is None else output_stats
     for i in range(n_channels):
         x = af_combinations.get(i)
-        div_channels = x.get('divisionChannels', []) if x is not None else []
-        if div_channels:
-            output_stats[str(i)] = _stream_division_channel(
+        competing = x.get('competingChannels', []) if x is not None else []
+        if competing:
+            output_stats[str(i)] = _stream_corrected_channel(
                 input_image, out, dim_utils, channel_idx=i, out_ch=i,
-                correction_channel_idx=div_channels,
+                competing_channel_idx=competing,
                 background_method=background_method,
                 logfile_utils=logfile_utils)
         else:

--- a/python/cecelia/utils/intensity_utils.py
+++ b/python/cecelia/utils/intensity_utils.py
@@ -114,8 +114,14 @@ def robust_hist_max(hist, min_count=None, min_frac=ROBUST_MAX_MIN_FRAC,
     **Trap:** the background bin usually holds far more voxels than anything else, so a ``min_count``
     larger than the signal population returns the *background* level rather than nothing — a ceiling
     at or below the peak, which makes a rescale window degenerate. The caller owns that check, because
-    only it knows which bins are background: see `correction_utils.af_division_stats`, which floors the
-    ceiling above the derived background.
+    only it knows which bins are background — see `rescale_to_8bit_run.py`, the remaining caller that
+    needs an output window at all.
+
+    **Second trap, from the AF task that used to call this:** clipped input piles every saturated voxel
+    into one bin, so a count threshold can land on a *clipping artefact* rather than on signal. Measured
+    on the kSUFux movies, that bin held 55-90k voxels where its neighbours held ~1k, and the threshold
+    decided the ceiling in 4 of 9 images purely on whether the pile cleared it. Ask for a fraction of
+    the image rather than an absolute count if the image size is not fixed.
     """
     h = np.asarray(hist)
     if min_count is None:


### PR DESCRIPTION
Replaces divide-mode AF correction with a channel-dominance weight. Validated on a real run (Or1L8a via `cleanupImages.afDriftCorrect`).

## Why

The ratio goes to zero wherever the target isn't brighter than its reference, so a cell carrying **two** reporters was hollowed into a dim rim — the centre, where both channels are bright and the ratio sits at 1, pushed to zero. A hollow cell doesn't segment, and segmentation runs next.

Measured on real overlapping reporter cells with overall gain cancelled (`Or1L8a`, `bNnmQL`, one plane each) — brightness of the co-positive cell as a fraction of a clean single-reporter cell of the same channel:

| | yellow (CH3) | blue (CH4) |
|---|---|---|
| raw | 1.65 / 1.33 | 4.24 / 2.20 |
| ratio (before) | 0.00 / 0.00 | **0.07 / 0.03** |
| weight (after) | 0.30 / 0.38 | **3.58 / 1.49** |

Across all nine drift-corrected kSUFux movies, both methods show **zero cross-leak**; the ratio keeps a median 0.00x/0.09x of the raw counts in the overlap against 0.29x/0.68x here.

## What

```
b_i   = max(raw_i - background_i, 0)
out_t = b_t * b_t^p / Σ_i b_i^p        over {target} ∪ competingChannels
```

Output is in **input counts** (fidelity slope 1.001/1.000 on clean cells) and can never exceed its input — no ceiling to derive, nothing to clip. Symmetric by construction, and takes any number of competitors in one expression instead of chained pairwise ratios.

- `af_division_stats` → `af_weight_stats`: one background per channel, **one pass instead of two**, so the preview's cold start roughly halves
- `af_correct_frame(slabs, target, stats, dtype)` — competitors stay separate; the `max`-across-references collapse is gone
- integer output **rounded**, not truncated (measured −0.072 count bias and 4.9% of real output zeroed, vs +0.002 / 4.0%)
- `p = AF_WEIGHT_EXPONENT = 2`, deliberately **not** a parameter — this task deleted four numbers with no defensible value and a sharpness dial is that returning

## Params

`quotientChannel` → `targetChannel`, `divisionChannels` → `competingChannels`. A target named inside its own competitor list is dropped (and the resolved sets logged) — squaring its own term into the denominator twice would halve its output. `backgroundMethod` loses **"none"**: measured, an unsubtracted pedestal leaves **92.1%** of background voxels non-zero and collapses cell-to-background contrast to 6.8x.

## QC

`clippedFrac` (structurally ~0 now, since `weight ≤ 1`) and `ceiling` give way to **`saturatedFrac`** — the fraction of *input* voxels clipped at the sensor, unrecoverable here, fixed at the microscope. Across the nine movies: 0.001–0.018% at identical settings. `COHORT_METRICS` → `["saturatedFrac", "levelsUsedFrac"]`.

## Two things this fixes that tests were not catching

**`PREVIEW_PROTOCOL` 3 → 4.** A running worker is *adopted*, not relaunched, and a stale protocol-3 worker still carries the old ratio `af_correct_frame` — so it would keep serving well-formed previews of the **wrong method** against a backend that believes otherwise. Silently. A new test asserts the Julia and Python constants agree; they'd been bumped by hand three times with nothing checking.

**The task runner had no test at all.** `af_correct_run.py` is executed by path, never imported, so the package suite never touched it — and its QC log line still subscripted `clippedFrac`, throwing `KeyError` on a real run *after* the corrected store had been written. Work done, task failed anyway. `test_af_correct_runner.py` now loads it the way `run_py` does and runs it against a synthetic OME-ZARR; mutation-verified against the original bug.

## Two claims corrected, not left standing

The derived ceiling saturating at 222.9 in 4 of 9 movies (a CH3 clipping spike clearing the 10,000-voxel bar) is **cosmetic**, not a defect — against the spike-excluded ceiling it loses 0.3% of signal voxels and 0 of 119 objects. And cross-image intensity comparability isn't attainable on intravital data (acquisition drift swamps it), so the `ceiling` cohort metric was over-justified. `docs/MODULES.md` now warns against reaching for "cohort-only" to defend a metric that simply has no threshold.

## Breaking

Corrected output **values change** — existing AF-corrected images need re-running to be comparable with new ones. Saved `afCombinations` carry the old key names and read as empty, so those combinations need re-picking.

## Relation to #448

#448 is **merged and now in this branch**; it is superseded rather than reverted, and the conflicts it created are resolved toward the weight. Three of them needed a decision, not a mechanical pick:

- `af_correct_frame`'s docstring now describes what it replaces **accurately** — the post-#448 form, `clip((ratio - 1) / (ceiling - 1), 0, 1) * rescale`. That makes the flaw explicit rather than incidental: every voxel with `ratio <= 1` maps to zero, and a co-positive cell's centre is exactly where the target isn't the brighter channel. #448 fixed a real and *different* bug (a `rescale / c_max` pedestal on every background voxel) and couldn't have touched this one.
- #448's `test_a_voxel_dimmer_than_its_reference_is_also_zero` asserted the **opposite** of the new behaviour — and was right, for the ratio. Replaced by `test_a_voxel_dimmer_than_a_competitor_is_SUPPRESSED_not_zeroed` rather than dropped silently, so the deliberate change is pinned and the old assertion's reason is recorded.
- `docs/todo/AF_QUANTISATION.md` **rewritten, not deleted.** Its output-mapping half is resolved (no rescale → no 17×-per-input-count magnification, no set-wide ceiling); its input-precision half is untouched and still open — correcting the 16-bit source before the 8-bit import, and whether a reference above its own background for 1.45% of voxels can serve at all.

## Tests

426 Python (4 new runner + 13 new mechanism) · 3535 Julia package (3 new) · API · 736 frontend + typecheck. All green.

Not exercised: the other eight movies were compared by script, not by an actual task run; `p=2` rests on one image's overlapping cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)