### PR TITLE
fix(tasks): reconcile a repeatable group's entries against the spec

### DIFF
--- a/frontend/src/tasks/paramValues.test.ts
+++ b/frontend/src/tasks/paramValues.test.ts
@@ -172,3 +172,83 @@ describe('preferredValueName', () => {
     expect(preferredValueName(available, 'imFilepath', 'driftCorrected')).toBe('default')
   })
 })
+
+// ── repeatable groups ────────────────────────────────────────────────────────
+// The AF spec, whose combinations are a repeatable group. This shape had NO coverage, which is how a
+// group's entries went years without being reconciled against the spec.
+const AF_DEF = {
+  task: 'afCorrect', fun_name: 'cleanupImages.afCorrect', label: 'AF correction',
+  category: 'Cleanup',
+  params: [
+    { key: 'valueName', label: 'Image', type: 'valueNameSelection', default: 'default',
+      field: 'filepaths' },
+    { key: 'afCombinations', label: 'Channel combinations', type: 'group', repeatable: true,
+      labelKey: 'targetChannel', default: {},
+      params: [
+        { key: 'targetChannel', label: 'Channel to correct', type: 'channelSelection', default: [] },
+        { key: 'competingChannels', label: 'Competing channels', type: 'channelSelection',
+          default: [] },
+      ] },
+    { key: 'backgroundMethod', label: 'Background detection', type: 'select', default: 'triangle' },
+  ],
+} as unknown as TaskDef
+
+describe('buildParamValues — repeatable group entries', () => {
+  it('keeps entries whose sub-params the spec still declares', () => {
+    const saved: ParamValues = {
+      afCombinations: {
+        '0': { targetChannel: ['CH3'], competingChannels: ['CH2', 'CH4'] },
+        '1': { targetChannel: ['CH4'], competingChannels: ['CH2', 'CH3'] },
+      },
+    }
+    const v = buildParamValues(AF_DEF, saved)
+    expect(v.afCombinations).toEqual(saved.afCombinations)
+  })
+
+  it('reconciles a RENAMED sub-param instead of showing a blank entry', () => {
+    // the real symptom: quotientChannel/divisionChannels -> targetChannel/competingChannels. The entry
+    // count survived, every channel picker was blank, and it read as "my params weren't remembered".
+    const preRename: ParamValues = {
+      afCombinations: { '0': { quotientChannel: ['CH3'], divisionChannels: ['CH4'] } },
+    }
+    const v = buildParamValues(AF_DEF, preRename) as
+      { afCombinations: Record<string, ParamValues> }
+    // the dead sub-keys must not survive into the run payload or be re-persisted
+    expect(v.afCombinations['0']).not.toHaveProperty('quotientChannel')
+    expect(v.afCombinations['0']).not.toHaveProperty('divisionChannels')
+    // ...and the declared ones are present, at their defaults, so the form renders real controls
+    expect(v.afCombinations['0']).toEqual({ targetChannel: [], competingChannels: [] })
+  })
+
+  it('drops the pre-#437 fossil bag that live projects still store', () => {
+    // measured on zolIMa / 4kS67f: entries carrying a dozen params deleted from the spec in #437 and
+    // re-persisted on every run since, because the group was passed through verbatim
+    const fossils: ParamValues = {
+      afCombinations: {
+        '0': {
+          quotientChannel: ['CH1'], divisionChannels: ['CH4'],
+          channelPercentile: 0.98, correctionMin: 0, correctionMax: 255, correctionMode: 'divide',
+          medianFilter: 3, denoiseFun: 'wavelet', generateInverse: false, topHatRadius: 10,
+        },
+      },
+    }
+    const v = buildParamValues(AF_DEF, fossils) as
+      { afCombinations: Record<string, ParamValues> }
+    expect(Object.keys(v.afCombinations['0']).sort())
+      .toEqual(['competingChannels', 'targetChannel'])
+  })
+
+  it('an empty or absent group stays empty rather than becoming null', () => {
+    expect(buildParamValues(AF_DEF, {}).afCombinations).toEqual({})
+    expect(buildParamValues(AF_DEF, { afCombinations: {} }).afCombinations).toEqual({})
+  })
+
+  it('the group still round-trips through flattenParams', () => {
+    const saved: ParamValues = {
+      afCombinations: { '0': { targetChannel: ['CH3'], competingChannels: ['CH4'] } },
+    }
+    const flat = flattenParams(AF_DEF, buildParamValues(AF_DEF, saved))
+    expect(flat.afCombinations).toEqual(saved.afCombinations)
+    expect(missingParamKeys(AF_DEF, flat)).toEqual([])
+  })
+})

--- a/frontend/src/tasks/paramValues.ts
+++ b/frontend/src/tasks/paramValues.ts
@@ -16,12 +16,41 @@
 import type { TaskDef, ParamValues } from './types'
 
 /**
+ * One entry of a repeatable `group`, reconciled against the group's declared sub-params.
+ *
+ * Section children are stored FLAT in the entry (that is what `ParamRenderer.addGroupEntry` writes), so
+ * they are read flat here too.
+ */
+function buildGroupEntry(params: TaskDef['params'][number]['params'], saved: ParamValues): ParamValues {
+  const out: ParamValues = {}
+  for (const p of params ?? []) {
+    if (p.type === 'section') {
+      for (const sp of p.params ?? []) out[sp.key] = saved[sp.key] ?? sp.default ?? null
+    } else {
+      out[p.key] = saved[p.key] ?? p.default ?? null
+    }
+  }
+  return out
+}
+
+/**
  * Form values for every param the spec declares, preferring `saved` and falling back to the param's
  * default. Sections are containers: their children are read from the FLAT key (that is how they are
  * stored) with a legacy nested record honoured first.
  *
  * Use this for a server-saved record AND for a restored draft — anything that may predate the current
  * spec. `null` (not `undefined`) is the "no value" marker, because null survives JSON.
+ *
+ * **A `group`'s ENTRIES are reconciled too, not passed through.** This used to take the saved group
+ * verbatim, which meant the invariant above stopped at the top level: a group entry kept sub-keys the
+ * spec no longer declares and never gained the ones it does. Real cost, measured on live projects —
+ * `zolIMa` and `4kS67f` still stored AF combinations carrying `channelPercentile`, `correctionMax`,
+ * `medianFilter`, `denoiseFun` and a dozen more, deleted from the spec in #437 and re-persisted on every
+ * run since. And when `quotientChannel`/`divisionChannels` were renamed to
+ * `targetChannel`/`competingChannels`, the entries survived while their contents did not: the form
+ * showed the right NUMBER of combinations with every channel picker blank, which reads as "my params
+ * weren't remembered". Same reconciliation as the top level: known keys survive, new sub-params get
+ * their defaults, sub-params that no longer exist drop out.
  */
 export function buildParamValues(def: TaskDef, saved: ParamValues): ParamValues {
   const vals: ParamValues = {}
@@ -33,6 +62,13 @@ export function buildParamValues(def: TaskDef, saved: ParamValues): ParamValues 
         sectionVals[sp.key] = savedSection[sp.key] ?? saved[sp.key] ?? sp.default ?? null
       }
       vals[p.key] = sectionVals
+    } else if (p.type === 'group') {
+      const savedGroup = ((saved[p.key] ?? p.default ?? {}) as Record<string, unknown>)
+      const groupVals: Record<string, ParamValues> = {}
+      for (const [entryKey, entry] of Object.entries(savedGroup)) {
+        groupVals[entryKey] = buildGroupEntry(p.params, (entry ?? {}) as ParamValues)
+      }
+      vals[p.key] = groupVals
     } else {
       vals[p.key] = saved[p.key] ?? p.default ?? null
     }


### PR DESCRIPTION
Found while chasing "why aren't my AF params retained" after #450.

## The bug

`buildParamValues` enforces the invariant *every param the spec declares appears in the payload* — but only at the **top level**. A `group` was taken verbatim (`saved[p.key] ?? p.default`), so its entries kept sub-keys the spec no longer declares and never gained the ones it does.

Not hypothetical. Measured on live projects: `zolIMa` and `4kS67f` still store AF combinations carrying

```
channelPercentile  correctionMin  correctionMax  correctionMode  medianFilter
denoiseFun  generateInverse  topHatRadius  rollingBallRadius  ...
```

— all deleted from the spec in **#437**, carried into every run payload since, and re-persisted on each run.

It became *visible* when #450 renamed `quotientChannel`/`divisionChannels` → `targetChannel`/`competingChannels`: the entries survived while their contents didn't, so the form showed the right **number** of combinations with every channel picker blank. Which reads as "my params weren't remembered" — that's how it surfaced.

## The fix

Group entries are reconciled the same way the top level is: known sub-keys survive, new ones get their defaults, dead ones drop out. Section children are read flat, matching what `ParamRenderer.addGroupEntry` writes.

## Why it lasted

The `group` shape had **no test coverage at all** in `paramValues.test.ts`. Five tests added — the happy path, a renamed sub-param, the #437 fossil bag, an empty group, and the `flattenParams` round-trip. Mutation-verified: two fail against the verbatim pass-through.

## What this does NOT fix

A value shadowed by an in-progress **draft**. Drafts win over the server record deliberately (an un-run edit mustn't be clobbered) and are in-memory, so a draft written before a spec change now reconciles to bare defaults until a full page reload drops it. Whether a draft that reconciles to nothing but defaults should yield to the server record is a separate question and not decided here.

## Tests

741 frontend + typecheck. No backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
