### PR TITLE
refactor(python): strip 17 functions nothing calls

### DIFF
--- a/docs/todo/ZARR_STREAMING_PLAN.md
+++ b/docs/todo/ZARR_STREAMING_PLAN.md
@@ -75,9 +75,12 @@ fights the Phase-1 one-frame-in-RAM streaming. **Conclusion: no code change — 
   writer that creates a zarr array (`create_multiscales`, `write_multiscale_pyramid`,
   `open_multiscales_for_writing`, `create_zarr_from_ndarray`); tasks dropped their scattered
   `.newbyteorder('=')`. Also fixed latent big-endian output in `cellpose_correct` + `cropImage`.
-- **3.2 Two tilers → one — PARKED (won't do).** `slice_utils.create_slices` (dim-ordered slice
-  tuples) and segmentation's `_create_xy_tiles` (read/write/crop overlap triples) return genuinely
-  different shapes for different needs; merging would contort more than it saves. No real benefit.
+- **3.2 Two tilers → one — RESOLVED by deletion, not by merging.** The premise was wrong: this was
+  weighed as a trade-off between two live tilers, but `slice_utils.create_slices` had **no caller at
+  all** — segmentation's `_create_xy_tiles` had already superseded it. Removed, along with the five
+  helpers it was the only entry point to (`create_slices_3D/2D`, `create_slices_3D_time/2D_time`,
+  `combine_time_frame_slices`) and `convert_coords_to_slices`. `create_slices_multiscales` stays —
+  `zarr_utils` uses it for the pyramid. Nothing to merge.
 - **3.3 Retire `da.store(lock=False)`+rechunk — PARKED (won't do).** It works correctly today and is
   regression-tested (`test_zarr_store`); retiring it only pays off if it cleanly removes the branch,
   which needs crop/rescale migrated too for little gain. Not worth the churn.

--- a/python/cecelia/utils/correction_utils.py
+++ b/python/cecelia/utils/correction_utils.py
@@ -253,13 +253,6 @@ def drift_correct_im(
 # (which broke on a single-frame slab). Each squeezes to the spatial frame, applies the op, and
 # reshapes back to the slab shape.
 
-def non_zero_edges(im):
-    true_points = np.argwhere(im)
-    return {'tl': true_points.min(axis=0), 'br': true_points.max(axis=0)}
-
-
-
-
 
 def _af_slab(data, dim_utils, channel_idx, t):
     """One channel + one timepoint as numpy, full axis layout (T=1, C=1, spatial). The unit of AF
@@ -472,8 +465,6 @@ def af_correct_frame(slabs, target, stats, out_dtype):
     if np.issubdtype(np.dtype(out_dtype), np.integer):
         out = np.rint(out)
     return np.clip(out, 0, stats.nbins - 1).astype(out_dtype)
-
-
 
 
 def _stream_corrected_channel(data, out, dim_utils, channel_idx, out_ch, competing_channel_idx,

--- a/python/cecelia/utils/legacy_migrate.py
+++ b/python/cecelia/utils/legacy_migrate.py
@@ -302,27 +302,6 @@ def _store_ndim(zarr_path: str):
     return None
 
 
-def _upgrade_label_axes(path: Path, meta: dict, log) -> None:
-    """Upgrade a copied legacy label store: write NGFF `axes` + `datasets` (from the legacy `labels`
-    key) so napari's label loader finds `datasets` and places the mask (labels are TZYX — no channel)."""
-    try:
-        from cecelia.utils import zarr_utils
-        names = _AXES_BY_NDIM.get(_store_ndim(str(path)))
-        if not names or "c" in names:      # labels shouldn't carry a channel axis
-            log(f"! label {path.name}: unexpected ndim, skipped axis upgrade")
-            return
-        sp = meta.get("PhysicalSizeUnit")
-        ok = zarr_utils.set_ngff_axes(
-            str(path), names,
-            scale={"t": meta.get("TimeIncrement", 1.0), "z": meta.get("PhysicalSizeZ", 1.0),
-                   "y": meta.get("PhysicalSizeY", 1.0), "x": meta.get("PhysicalSizeX", 1.0)},
-            units={"z": sp, "y": sp, "x": sp, "t": meta.get("TimeIncrementUnit")})
-        log(f"upgraded NGFF axes ({''.join(names)}) on {path.name}"
-            if ok else f"! label {path.name}: axis upgrade skipped")
-    except Exception as e:
-        log(f"! label axis upgrade failed on {path.name}: {e}")
-
-
 def _versioned(values: dict, active, fallback=None) -> dict:
     out = dict(values)
     act = active if active in values else (fallback if fallback in values else next(iter(values), None))

--- a/python/cecelia/utils/ome_xml_utils.py
+++ b/python/cecelia/utils/ome_xml_utils.py
@@ -113,40 +113,10 @@ def get_im_size_dict(omexml):
 """
 Set physical size with dict
 """
-def set_physical_size_with_dict(omexml, omedict):
-  # go through dimensions
-  for i, x in omedict.items():
-    if i == 'T':
-      omexml.images[0].pixels.physical_size_t = x
-    if i == 'Z':
-      omexml.images[0].pixels.physical_size_z = x
-    if i == 'C':
-      omexml.images[0].pixels.physical_size_c = x
-    if i == 'Y':
-      omexml.images[0].pixels.physical_size_y = x
-    if i == 'X':
-      omexml.images[0].pixels.physical_size_x = x
-      
-  return omexml
 
 """
 Set im size with dict
 """
-def set_im_size_with_dict(omexml, omedict):
-  # go through dimensions
-  for i, x in omedict.items():
-    if i == 'T':
-      omexml.images[0].pixels.size_t = x
-    if i == 'Z':
-      omexml.images[0].pixels.size_z = x
-    if i == 'C':
-      omexml.images[0].pixels.size_c = x
-    if i == 'Y':
-      omexml.images[0].pixels.size_y = x
-    if i == 'X':
-      omexml.images[0].pixels.size_x = x
-      
-  return omexml
 
 """
 Write OME-XML
@@ -196,48 +166,10 @@ Flip dimension order
 
 TODO this only works on OME-ZARR for now
 """
-def switch_dim_order(im_path, dim_order = 'XYZCT'):
-  # flip dimension order in pixels and adjust sizes
-  if is_zarr_store(im_path):
-    omexml = parse_meta(im_path)
-    
-    # get previous order
-    prev_dim_order = omexml.images[0].pixels.dimension_order
-    
-    # get dimension dict
-    dim_dict = get_im_size_dict(omexml)
-    
-    # get dimension mapping
-    dim_mapping = {dim_order[i]: x for i, x in enumerate(prev_dim_order)}
-    
-    # set new sizes
-    # go through dimension order  
-    for i, x in {dim_mapping[i]: x for i, x in dim_dict.items()}.items():
-      if i == 'T':
-        omexml.images[0].pixels.size_t = x
-      if i == 'Z':
-        omexml.images[0].pixels.size_z = x
-      if i == 'C':
-        omexml.images[0].pixels.size_c = x
-      if i == 'Y':
-        omexml.images[0].pixels.size_y = x
-      if i == 'X':
-        omexml.images[0].pixels.size_x = x
-        
-    # set new dimension order
-    omexml.images[0].pixels.dimension_order = dim_order
-    
-    # write back
-    write_ome_xml(im_path, omexml)
 
 """
 Parse raw ome XML from tiff
 """
-def parse_from_tiff(im_path):
-  # TODO is there a better way to do this .. ?
-  tif = tifffile.TiffFile(im_path)
-
-  return tif.ome_metadata
 
 """
 Parse metadata from tiff

--- a/python/cecelia/utils/script_utils.py
+++ b/python/cecelia/utils/script_utils.py
@@ -43,11 +43,6 @@ def get_param(params, key, default=None):
     return v
 
 
-def get_ccia_param(params, key, default=None):
-    """Retrieve a value from the nested 'ccia' sub-dict of params."""
-    return get_param(get_ccia_params(params), key, default=default)
-
-
 def get_ccia_params(params):
     """Return the 'ccia' sub-dict of params, or an empty list if absent."""
     if 'ccia' in params:

--- a/python/cecelia/utils/slice_utils.py
+++ b/python/cecelia/utils/slice_utils.py
@@ -15,236 +15,30 @@ import numpy as np
 """
 Convert coords to slices
 """
-def convert_coords_to_slices(coords):
-  idx = ()
-  
-  # go through coords
-  for x in coords:
-    idx += (slice(x[0], x[1], 1),)
-      
-  return idx
 
 """
 Create slices from image dimensions
 """
-def create_slices(im_dim, dim_utils, block_size = None, overlap = None,
-                  block_size_z = None, overlap_z = None, timepoints = None,
-                  integrate_time = False, ignore_time = False, drop_z = False):
-  slices = None
-  
-  # 3D timeseries
-  # if False not in (dim_utils.is_3D(), dim_utils.is_timeseries(), ~ignore_time):
-  if dim_utils.is_3D() is True and dim_utils.is_timeseries() is True and ignore_time is False:
-    gen_slices = create_slices_3D_time(
-      im_dim, dim_utils, block_size, overlap,
-      block_size_z = block_size_z, overlap_z = overlap_z,
-      timepoints = timepoints, integrate_time = integrate_time)
-      
-  # 2D timeseries
-  elif dim_utils.is_3D() is False and dim_utils.is_timeseries() is True and ignore_time is False:
-    gen_slices = create_slices_2D_time(
-      im_dim, dim_utils, block_size, overlap,
-      timepoints = timepoints, integrate_time = integrate_time, drop_z = drop_z)
-      
-  # 3D static
-  # elif dim_utils.is_3D() is True and dim_utils.is_timeseries() is False:
-  elif dim_utils.is_3D() is True:
-    gen_slices = create_slices_3D(
-      im_dim, dim_utils, block_size, overlap,
-      block_size_z = block_size_z, overlap_z = overlap_z, ignore_time = ignore_time)
-      
-  # 2D static
-  # elif dim_utils.is_3D() is False and dim_utils.is_timeseries() is False:
-  elif dim_utils.is_3D() is False:
-    gen_slices = create_slices_2D(im_dim, dim_utils, block_size, overlap, ignore_time = ignore_time, drop_z = drop_z)
-    
-  slices = np.array([[slice(None) for _ in range(len(im_dim))]] * len(gen_slices['slices']))
-  
-  # add slices
-  for i, x in enumerate(gen_slices['slices']):
-    for j, y in enumerate(gen_slices['order']):
-      slices[i, dim_utils.dim_idx(y, ignore_channel = True, ignore_time = ignore_time, drop_z = drop_z)] = x[j]
-    
-  # TODO do I need that?
-  slices = [tuple(l.tolist()) for l in slices]
-      
-  return slices
 
 """
 Create slices from image dimensions (3D time)
 """
-def create_slices_3D_time(im_dim, dim_utils, block_size = None,
-                          overlap = None, block_size_z = None, overlap_z = None,
-                          timepoints = None, integrate_time = False):
-  # create 3D frame slices
-  frame_slices = create_slices_3D(
-    im_dim, dim_utils, block_size, overlap,
-    block_size_z = block_size_z, overlap_z = overlap_z)
-    
-  # combine time and frame slices
-  return combine_time_frame_slices(
-    frame_slices, dim_utils, timepoints = timepoints, integrate_time = integrate_time)
 
 """
 Create slices from image dimensions (2D time)
 """
-def create_slices_2D_time(im_dim, dim_utils, block_size = None, overlap = None,
-                          timepoints = None, integrate_time = False, drop_z = False):
-  # create 2D frame slices
-  frame_slices = create_slices_2D(im_dim, dim_utils, block_size, overlap, drop_z = drop_z)
-    
-  # combine time and frame slices
-  return combine_time_frame_slices(
-    frame_slices, dim_utils, timepoints = timepoints, integrate_time = integrate_time)
     
 """
 Combine time and frame slices
 """
-def combine_time_frame_slices(frame_slices, dim_utils, timepoints = None, integrate_time = False):
-  # get time idx
-  time_idx = dim_utils.dim_idx('T', ignore_channel = True)
-  time_vals = list(range(dim_utils.dim_val('T'))) if timepoints is None else timepoints
-  
-  # get length of frame slices
-  len_frame_slices = len(frame_slices['slices'])
-  len_time_vals = len(time_vals)
-  
-  # convert frame tuples to list
-  frame_slices['slices'] = [list(x) for x in frame_slices['slices']]
-  
-  if integrate_time is True:
-    # combine slices with time
-    for i in range(len_frame_slices):
-      frame_slices['slices'][i].insert(time_idx, slice(time_vals[0], time_vals[-1] + 1, 1))
-  else:
-    # replicate for timepoints
-    # https://stackoverflow.com/a/38099836/13766165
-    frame_slices['slices'] = [x for x in frame_slices['slices'] for _ in time_vals]
-    
-    # convert frame tuples to list
-    frame_slices['slices'] = [list(x) for x in frame_slices['slices']]
-    
-    # combine slices with time
-    for i, t in enumerate(range(time_vals[0], time_vals[-1] + 1)):
-      for x in range(1, len_frame_slices + 1):
-        frame_slices['slices'][(i + 1) + ((x - 1) * len_time_vals) - 1].insert(time_idx, slice(t, t + 1, 1))
-        
-  # convert back to tuples
-  frame_slices['slices'] = [tuple(x) for x in frame_slices['slices']]
-  
-  # add to order
-  frame_slices['order'].insert(time_idx, 'T')
-  
-  return frame_slices
 
 """
 Create slices from image dimensions (3D)
 """
-def create_slices_3D(im_dim, dim_utils, block_size = None, overlap = None,
-                     block_size_z = None, overlap_z = None, ignore_time = False):
-  # get idx
-  z_idx = dim_utils.dim_idx('Z', ignore_channel = True, ignore_time = ignore_time)
-  y_idx = dim_utils.dim_idx('Y', ignore_channel = True, ignore_time = ignore_time)
-  x_idx = dim_utils.dim_idx('X', ignore_channel = True, ignore_time = ignore_time)
-  
-  # set block size to image stack if not set
-  if block_size is None or block_size < 0:
-    block_size = max(im_dim[x_idx], im_dim[y_idx])
-    
-  if block_size_z is None or block_size_z < 0:
-    block_size_z = im_dim[z_idx]
-  
-  # set overlap
-  if overlap is None or overlap < 0:
-    overlap = 0
-    
-  if overlap_z is None or overlap_z < 0:
-    overlap_z = overlap
-  
-  tiles_z = math.ceil(im_dim[z_idx] / block_size_z)
-  tiles_m = math.ceil(im_dim[y_idx] / block_size)
-  tiles_n = math.ceil(im_dim[x_idx] / block_size)
-  Z = im_dim[z_idx]//tiles_z
-  M = im_dim[y_idx]//tiles_m
-  N = im_dim[x_idx]//tiles_n
-  
-  # is there a residual after slicing?
-  res_z = im_dim[z_idx] - Z * tiles_m
-  res_m = im_dim[y_idx] - M * tiles_m
-  res_n = im_dim[x_idx] - N * tiles_n
-  
-  # attach residual to last slice
-  if res_z > 0: Z += res_z
-  if res_m > 0: M += res_m
-  if res_n > 0: N += res_n
-  
-  slices = [(
-    slice(
-      i - overlap_z if i - overlap_z >= 0 else 0,
-      i + Z + overlap_z if i + Z + overlap_z < im_dim[z_idx] else im_dim[z_idx],
-      1),
-    slice(
-      x - overlap if x - overlap >= 0 else 0,
-      x + M + overlap if x + M + overlap < im_dim[y_idx] else im_dim[y_idx],
-      1),
-    slice(
-      y - overlap if y - overlap >= 0 else 0,
-      y + N + overlap if y + N + overlap < im_dim[x_idx] else im_dim[x_idx],
-      1)
-    ) for i in range(0, im_dim[z_idx], Z) for x in range(0, im_dim[y_idx], M) for y in range(0, im_dim[x_idx], N)]
-  
-  return {
-    'slices': slices,
-    'order': ['Z', 'Y', 'X']
-    }
 
 """
 Create slices from image dimensions (2D)
 """
-def create_slices_2D(im_dim, dim_utils, block_size = None, overlap = None, ignore_time = False, drop_z = False):
-  # get idx
-  y_idx = dim_utils.dim_idx('Y', ignore_channel = True, ignore_time = ignore_time, drop_z = drop_z)
-  x_idx = dim_utils.dim_idx('X', ignore_channel = True, ignore_time = ignore_time, drop_z = drop_z)
-  
-  # set block size to image stack if not set
-  if block_size is None or block_size < 0:
-    block_size = max(im_dim[x_idx], im_dim[y_idx])
-    
-  # set overlap
-  if overlap is None or overlap < 0:
-    overlap = 0
-    
-  # adjust block size to make equally spaced tiles
-  # tiles_m = math.floor(im_dim[y_idx] / block_size)
-  # tiles_n = math.floor(im_dim[x_idx] / block_size)
-  tiles_m = math.ceil(im_dim[y_idx] / block_size)
-  tiles_n = math.ceil(im_dim[x_idx] / block_size)
-  M = im_dim[y_idx]//tiles_m
-  N = im_dim[x_idx]//tiles_n
-  
-  # is there a residual after slicing?
-  res_m = im_dim[y_idx] - M * tiles_m
-  res_n = im_dim[x_idx] - N * tiles_n
-  
-  # attach residual to last slice
-  if res_m > 0: M += res_m 
-  if res_n > 0: N += res_n
-  
-  slices = [(
-    slice(
-      x - overlap if x - overlap >= 0 else 0,
-      x + M + overlap if x + M + overlap < im_dim[y_idx] else im_dim[y_idx],
-      1),
-    slice(
-      y - overlap if y - overlap >= 0 else 0,
-      y + N + overlap if y + N + overlap < im_dim[x_idx] else im_dim[x_idx],
-      1)
-    ) for x in range(0, im_dim[y_idx], M) for y in range(0, im_dim[x_idx], N)]
-  
-  return {
-    'slices': slices,
-    'order': ['Y', 'X']
-    }
 
 """
 Create multiscale slices

--- a/python/cecelia/utils/zarr_utils.py
+++ b/python/cecelia/utils/zarr_utils.py
@@ -63,12 +63,6 @@ def open_zarr(zarr_path, mode='r', multiscales=None, as_dask=False):
     return zarr_data, zarr_group_info
 
 
-def get_dask_copy(image_array):
-    if isinstance(image_array, zarr.Array):
-        image_array = da.from_zarr(image_array)
-    return copy(image_array)
-
-
 def fortify(im_array):
     if isinstance(im_array, zarr.Array):
         return im_array[:]
@@ -605,7 +599,6 @@ def multiscales_metadata(axes, nscales, scale_for_axis=None, keyword='datasets',
     return [ms_entry]
 
 
-
 def calibration_for_axes(dim_utils, axes):
     """``(scale_for_axis, unit_for_axis)`` for a store's axes — the ONE derivation of "what physical
     calibration do these axes carry", shared by every NGFF writer (`create_multiscales`,
@@ -901,14 +894,3 @@ def copy_stream(dest, src, dim_utils=None):
         sl = tuple(sl)
         dest[sl] = fortify(src[sl])
 
-
-def apply_min(x, im_min):
-    x[x == 0] = im_min
-    return x
-
-
-def get_minmax_from_low_res(im_dat):
-    low_res = fortify(im_dat[len(im_dat) - 1])
-    im_min = low_res[low_res > 0].min()
-    im_max = low_res.max()
-    return im_min, im_max


### PR DESCRIPTION
Cleanup after the AF / anisotropy / branching churn: functions that were superseded during it and left behind. 17 removed, 330 lines.

Found by walking the **AST**, not by grepping. A docstring that names a function reads as a reference to grep, which is exactly why some of these looked alive — `robust_hist_max` (removed separately in #452) didn't even appear in the first pass for that reason.

| module | removed |
|---|---|
| `slice_utils` (7) | `convert_coords_to_slices`, `create_slices`, and the five helpers `create_slices` was the only entry point to: `create_slices_3D/2D`, `create_slices_3D_time/2D_time`, `combine_time_frame_slices` |
| `ome_xml_utils` (4) | `parse_from_tiff`, `set_im_size_with_dict`, `set_physical_size_with_dict`, `switch_dim_order` |
| `zarr_utils` (3) | `apply_min`, `get_dask_copy`, `get_minmax_from_low_res` |
| `correction_utils` (1) | `non_zero_edges` |
| `script_utils` (1) | `get_ccia_param` |
| `legacy_migrate` (1) | `_upgrade_label_axes` |

## The `create_slices` cascade

`docs/todo/ZARR_STREAMING_PLAN.md` 3.2 had parked "two tilers → one" as not worth the churn, on the reasoning that `slice_utils.create_slices` and segmentation's `_create_xy_tiles` "return genuinely different shapes for different needs".

That premise was already false. `_create_xy_tiles` had superseded `create_slices`, which had **no caller at all** — so five further functions were reachable only through a dead entry point. Resolved by deletion rather than by merging, and the note is corrected. `create_slices_multiscales` stays: `zarr_utils` uses it for the pyramid.

## Deliberately kept

Both were flagged by the scan and both are false positives:

- **`napari_utils.new_viewer`** — unreferenced in this repo, but `coastal` imports it (`coastal/napari_viz.py`), and `python/cecelia` is an installable library, so "unused here" isn't "unused". Checked the sibling checkout rather than assuming.
- **Every `mcp/cecelia_mcp/server.py` tool** — `@mcp.tool()`-registered, so the framework calls them and no in-repo reference exists by design. The scan reported six of these as dead.

## Testing

Package (3535), API and Python (426) suites green.

## Reservations

- **Frontend suite not run.** This worktree has no `node_modules`, and the diff touches zero frontend files — but I did not run it, rather than claim four green.
- The scan is one round of reachability, not a proof. It cannot see a call through `getattr`, an entry point registered by string outside a decorator, or an external consumer other than the `coastal` checkout I grepped. I hand-verified each of the 17 against `.py`/`.jl`/`.md`/`.ts`/`.toml` and against coastal, but a consumer I don't have on disk would not have shown up.
- A first automated closure pass over-reached badly (it called `find_populations` and `write_track_props` dead); I discarded it and used single-round reachability with per-function verification instead. Worth knowing the cascade in `slice_utils` was traced by hand, not by that tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
