### PR TITLE
feat(import): flag channels that clipped at the detector, on every import

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -51,7 +51,7 @@ Last audited: 2026-07-16 (full six-area ground-truth read; against `main` @ c1ce
 - **tracking_utils**: `BayesianTrackingUtils.track_objects` (btrack) + `write_track_props` (new `{vn}__tracks.h5ad`).
 - **clustering_utils**: shared Leiden engine (`find_populations` + `split_back_and_write`); used by both cluster runners.
 - **correction_utils**: AF + drift correction (drift shifts, AF channel correct, denoise/rolling-ball/top-hat).
-- **intensity_utils**: whole-stack intensity statistics from streamed per-channel histograms — `channel_histograms`, `hist_percentile`, derived background level (`background_threshold`/`triangle_threshold`), `clip_stats`. Used by AF correction and segmentation normalisation.
+- **intensity_utils**: whole-stack intensity statistics from streamed per-channel histograms — `channel_histograms`, `hist_percentile`, derived background level (`background_threshold`/`triangle_threshold`), `clip_stats`, and clipping-at-acquisition detection (`is_saturated`/`saturation_stats` — STRUCTURAL, a pile-up in the brightest occupied bin, so it works on a 12-bit sensor stored in 16-bit words where a dtype-max test reads 0). Used by AF correction, segmentation normalisation and the import saturation QC.
 - **dim_utils**: `DimUtils` — dimension-order/index/physical-size/slice reasoning off an ome-types OME object. Core dependency of most tasks.
 - **slice_utils**: numpy slice-tuple generators for tiled 2D/3D(+time) processing + downsample strides.
 - **napari_utils**: project-agnostic napari layer builders (`add_image`/`add_labels`/`add_tracks`), hex↔rgba, clip planes, view snapshot, movie recording, colour-by helpers. Imported by the bridge (and coastal).

--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -279,6 +279,25 @@ end
 const _Z_RATIO_MIN = 0.02
 const _Z_RATIO_MAX = 50
 
+# Materiality floor for the clipping FINDING: the fraction of a channel's voxels sitting at the
+# detector ceiling above which it is worth interrupting someone.
+#
+# **This is a chosen number, not a fitted one, and it should be re-set by the first real case.**
+# `intensity_utils.is_saturated` decides whether a channel clipped AT ALL — structural, measured, and
+# it stays the gate on detection. But detection is not the same as materiality: measured over all 36
+# channels of the nine `kSUFux` movies (one session), the four it flags hold 415-534 voxels of ~377 M
+# at the ceiling — 1.1-1.4e-6. That is real clipping of trivial extent, and "lower the gain" is not
+# an actionable thing to tell someone about 500 voxels, on 4 of every 9 imports.
+#
+# 1e-4 is ~37 000 voxels on an image that size: unambiguously truncated structure rather than a few
+# hot cells, and ~70x above the worst trace case observed. Nothing in that session would warn. It is
+# set from what would damage a MEASUREMENT, because there is no material case in hand to fit to.
+#
+# The metric (`saturation_metrics`) is banked regardless of this floor: a trace-level count is still
+# worth having, because the cohort comparison is relative and will surface an image clipping far more
+# than its session peers without anyone choosing an absolute level.
+const _SATURATION_WARN_FRAC = 1e-4
+
 _cal_num(v) = v === nothing ? nothing : (v isa Real ? Float64(v) : tryparse(Float64, string(v)))
 _cal_int(v, default::Int) = (n = _cal_num(v); n === nothing ? default : round(Int, n))
 _cal_txt(v) = (v === nothing || (v isa AbstractString && isempty(v))) ? nothing : string(v)
@@ -356,9 +375,11 @@ end
 """
     saturation_qc_findings(meta) -> Vector
 
-One `warn` per channel that CLIPPED AT ACQUISITION, from the persisted `meta["saturation"]` (written
-by `ImportOmezarr`, which checks every import). PURE → unit-tested. Empty when the check didn't run
-(an image imported before it existed, or a non-integer store).
+One `warn` per channel that clipped at acquisition **materially** — detected by
+`intensity_utils.is_saturated` AND with at least `_SATURATION_WARN_FRAC` of its voxels at the ceiling.
+From the persisted `meta["saturation"]` (written by `ImportOmezarr`, which checks every import).
+PURE → unit-tested. Empty when the check didn't run (an image imported before it existed, or a
+non-integer store), and empty for trace-level clipping — which the METRICS still record.
 
 Advisory, like all QC — but this is the one import finding a user can only act on *before* the
 experiment: clipped values are gone, so no correction, threshold or rescale recovers them. Hence the
@@ -372,6 +393,10 @@ function saturation_qc_findings(meta::AbstractDict)
     fs = Dict{String,Any}[]
     for ch in _saturation_channels(meta)
         get(ch, "saturated", false) === true || continue
+        # detected AND material — see _SATURATION_WARN_FRAC. A trace pile-up is recorded in the
+        # metrics but does not raise a finding.
+        frac = _cal_num(get(ch, "topFrac", nothing))
+        (isnothing(frac) || frac < _SATURATION_WARN_FRAC) && continue
         i = _cal_int(get(ch, "index", nothing), 0)
         push!(fs, qc_finding("warn", "import.channel_saturated"; channel = i,
             # the COUNT, not a percentage: measured on a real session the clipped fraction is ~1e-6,

--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -76,6 +76,11 @@ const QC_TEXT = Dict{String,@NamedTuple{short::String, long::String}}(
         short = "Voxel depth has no unit",
         long  = "A Z step is recorded without a unit — re-enter it with a unit."),
 
+    # clipping at acquisition (import.channel_saturated)
+    "import.channel_saturated" => (
+        short = "Channel {channel} clipped at the detector",
+        long  = "Lower the gain or exposure when acquiring — clipped values cannot be recovered."),
+
 
     # HMM (hmm_states_qc_findings / hmm_transitions_qc_findings)
     "hmm.no_states_decoded" => (
@@ -348,6 +353,73 @@ function import_metrics(meta::AbstractDict)
     isempty(d) ? nothing : d
 end
 
+"""
+    saturation_qc_findings(meta) -> Vector
+
+One `warn` per channel that CLIPPED AT ACQUISITION, from the persisted `meta["saturation"]` (written
+by `ImportOmezarr`, which checks every import). PURE → unit-tested. Empty when the check didn't run
+(an image imported before it existed, or a non-integer store).
+
+Advisory, like all QC — but this is the one import finding a user can only act on *before* the
+experiment: clipped values are gone, so no correction, threshold or rescale recovers them. Hence the
+imperative long text points at the acquisition, not at a parameter.
+
+Detection lives in `intensity_utils.is_saturated` and is structural (a pile-up in the brightest
+occupied bin), so it holds for a 12-bit sensor stored in 16-bit words — where the obvious
+"fraction at the dtype maximum" test reads 0 on visibly clipped data.
+"""
+function saturation_qc_findings(meta::AbstractDict)
+    fs = Dict{String,Any}[]
+    for ch in _saturation_channels(meta)
+        get(ch, "saturated", false) === true || continue
+        i = _cal_int(get(ch, "index", nothing), 0)
+        push!(fs, qc_finding("warn", "import.channel_saturated"; channel = i,
+            # the COUNT, not a percentage: measured on a real session the clipped fraction is ~1e-6,
+            # which rounds to "0.0001%" and tells the user nothing. "534 voxels at 4095" is judgeable.
+            detail = Dict{String,Any}("channel"        => i,
+                                      "topValue"       => _cal_num(get(ch, "topValue", nothing)),
+                                      "clippedVoxels"  => _cal_num(get(ch, "topCount", nothing)))))
+    end
+    fs
+end
+
+# `meta["saturation"]["channels"]`, normalised to String-keyed Dicts. JSON3 hands back Symbol keys
+# (CLAUDE.md → JSON3 gotcha), and this is read from the persisted ccid on every QC recompute.
+function _saturation_channels(meta::AbstractDict)::Vector{Dict{String,Any}}
+    s = get(meta, "saturation", nothing)
+    s isa AbstractDict || return Dict{String,Any}[]
+    chans = get(Dict{String,Any}(String(k) => v for (k, v) in s), "channels", nothing)
+    chans isa AbstractVector || return Dict{String,Any}[]
+    out = Dict{String,Any}[]
+    for ch in chans
+        ch isa AbstractDict && push!(out, Dict{String,Any}(String(k) => v for (k, v) in ch))
+    end
+    out
+end
+
+"""
+    saturation_metrics(meta) -> Union{Dict,Nothing}
+
+Cohort-comparable saturation counts: `nChannelsSaturated` and `maxClippedFrac` (the worst channel's
+clipped fraction). `nothing` when the check didn't run.
+
+Cohort-comparable because both describe the ACQUISITION, not a parameter anyone typed — so an image
+clipping far more than its session peers is a real gain/expression difference. Measured across nine
+movies from one session, 4 had a clipped channel and 5 did not, which is exactly the spread an
+outlier flag should surface.
+"""
+function saturation_metrics(meta::AbstractDict)
+    chans = _saturation_channels(meta)
+    isempty(chans) && return nothing
+    n = 0; worst = 0.0
+    for ch in chans
+        get(ch, "saturated", false) === true && (n += 1)
+        v = _cal_num(get(ch, "topFrac", nothing))
+        isnothing(v) || (worst = max(worst, v))
+    end
+    Dict{String,Any}("nChannelsSaturated" => n, "maxClippedFrac" => worst)
+end
+
 # Compute + persist an image's import QC. Re-reads the PERSISTED ccid meta (not the possibly stale
 # in-memory `img.meta`) so it's correct from any call site — import, resync, metadata edit. Writes
 # even when clean (empty findings), so a fixed image overwrites its stale warning. Recomputed from
@@ -357,9 +429,11 @@ function write_metadata_qc!(img::CciaImage)
     isfile(ccid) || return
     raw      = read_ccid_raw(ccid)
     meta     = Dict{String,Any}(String(k) => v for (k, v) in get(raw, "meta", Dict{String,Any}()))
-    findings = metadata_qc_findings(meta)
+    findings = vcat(metadata_qc_findings(meta), saturation_qc_findings(meta))
 
     metrics = import_metrics(meta)
+    sm      = saturation_metrics(meta)
+    isnothing(sm) || (metrics = merge(isnothing(metrics) ? Dict{String,Any}() : metrics, sm))
 
     if isnothing(metrics)
         write_qc(img, "importImages.omezarr", VERSIONED_DEFAULT_VAL, findings)

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -64,7 +64,11 @@ const COHORT_METRICS = Dict{String,Vector{String}}(
     "clustRegions.cluster"           => ["nCells", "nClusters", "largestClusterFrac"],
     # import: nChannels/nZ/nT for every image — an odd channel count / dimensionality vs peers means
     # the wrong file was imported or the acquisition was misconfigured. Banked by qc.jl import_metrics.
-    "importImages.omezarr"           => ["nChannels", "nZ", "nT"],
+    # `nChannelsSaturated`/`maxClippedFrac` describe the ACQUISITION rather than a parameter, so they
+    # are comparable across a set shot in one session — an image clipping far more than its peers is a
+    # real gain/expression difference. See qc.jl saturation_metrics.
+    "importImages.omezarr"           => ["nChannels", "nZ", "nT",
+                                         "nChannelsSaturated", "maxClippedFrac"],
     # AF correction: both metrics describe the ACQUISITION, which is what makes them comparable across a
     # set shot in one session. `saturatedFrac` is the fraction of input voxels clipped at the sensor —
     # measured across the nine kSUFux movies it spanned 0.001% to 0.018%, a 13x spread at identical

--- a/app/src/tasks/importImages/omezarr.jl
+++ b/app/src/tasks/importImages/omezarr.jl
@@ -688,6 +688,34 @@ function _run_task(task::ImportOmezarr, img::CciaImage, params::Dict{String,Any}
         end
     end
 
+    # Clipping at ACQUISITION, checked on every import. A channel the detector clipped has lost
+    # information nothing downstream recovers, and import is the only point where the useful answer is
+    # still "re-acquire with less gain". One streamed pass over the store we just wrote (~3 s/GB), in
+    # the io pool alongside the conversion. Advisory: a failure here never fails the import.
+    let run_dir     = task_run_dir(img._dir),
+        result_file = joinpath(run_dir, "saturation.$(string(rand(UInt32); base = 16)).result.json")
+        ok_s = run_py("tasks/importImages/saturation_run.py",
+            (; imPath = zarr_out, resultPath = result_file), run_dir;
+            on_log = on_log, on_progress = on_progress, on_process = on_process)
+        if ok_s && isfile(result_file)
+            try
+                res   = JSON3.read(read(result_file, String))
+                chans = get(res, :channels, nothing)
+                if !isnothing(chans)
+                    zarr_meta["saturation"] = Dict{String,Any}(
+                        "channels" => [Dict{String,Any}(String(k) => v for (k, v) in ch) for ch in chans],
+                    )
+                    n = count(ch -> get(ch, :saturated, false) === true, chans)
+                    n > 0 && on_log("[WARN] $n channel(s) clipped at acquisition — see QC")
+                end
+            catch e
+                @warn "Could not read saturation result" exception = e
+            finally
+                rm(result_file; force = true)
+            end
+        end
+    end
+
     # Copy our import-time corrections back INTO the zarr's own calibration (`.zattrs` + OME-XML),
     # so napari renders the same numbers ccid.json / `img_physical_sizes` (analysis) will use —
     # otherwise the ImageJ Z-spacing fix and the per-plane DeltaT time interval live only in

--- a/app/src/tasks/importImages/saturation_run.py
+++ b/app/src/tasks/importImages/saturation_run.py
@@ -1,0 +1,79 @@
+"""
+Detect channels that CLIPPED AT ACQUISITION, from the store the import just wrote.
+
+Runs on every import. A clipped channel has lost information the pipeline cannot recover — no
+correction, threshold or rescale puts it back — so the only useful moment to say so is at import,
+while the answer is still "re-acquire with less gain" rather than "re-do the analysis".
+
+Detection is `intensity_utils.is_saturated`: structural (a pile-up in the brightest occupied bin),
+so it does not need to know the detector's bit depth. That matters here — measured on the nine
+`kSUFux` movies, the sensor clips at 4095 inside 16-bit words, so the obvious test (fraction of
+voxels at the dtype maximum) reports zero on data that is visibly clipped. See that docstring.
+
+Cost: one streamed pass over the store, ~3 s/GB measured (5.3 s for a 1.74 GB store). Deliberately a
+FULL pass rather than a strided one — the threshold is a voxel count, so subsampling scales the
+pile-up down with it and flips marginal channels.
+
+Parameter contract (JSON written by Julia):
+  imPath     - absolute path to the .ome.zarr the import just wrote
+  resultPath - absolute path to write the result JSON to
+
+Result JSON: {"channels": [{"index", "saturated", "topValue", "topCount", "topFrac"}, …]} — the Julia
+handler turns this into ccid meta + QC findings. `{}` when the store cannot be read as integer data
+(nothing to say, and a QC pass must never fail an otherwise-good import).
+"""
+
+import cecelia.utils.script_utils as script_utils
+import cecelia.utils.zarr_utils as zarr_utils
+import cecelia.utils.intensity_utils as intensity_utils
+from cecelia.utils.dim_utils import DimUtils
+from cecelia.utils.atomic_io import write_json_atomic
+import cecelia.utils.ome_xml_utils as ome_xml_utils
+
+
+def run(params):
+    log = script_utils.get_logfile_utils(params)
+
+    im_path     = params['imPath']
+    result_path = params['resultPath']
+    result = {}
+
+    log.progress(0, 2)
+    try:
+        dim_utils = DimUtils(ome_xml_utils.load_ome_xml(im_path))
+        levels, _ = zarr_utils.open_as_zarr(im_path, as_dask=True)
+        level0 = levels[0]
+        dim_utils.calc_image_dimensions(level0.shape)
+        c_idx = dim_utils.dim_idx('C') if 'C' in dim_utils.im_dim_order else None
+
+        log.log(f'>> checking {level0.dtype} {level0.shape} for clipping at acquisition')
+        log.progress(1, 2)
+        hists = intensity_utils.channel_histograms(level0, c_idx)
+
+        channels = []
+        for i, h in enumerate(hists):
+            stats = intensity_utils.saturation_stats(h)
+            stats['index'] = i
+            channels.append(stats)
+            log.log(f'   ch{i}: {"SATURATED" if stats["saturated"] else "ok"} '
+                    f'(top occupied value {stats["topValue"]}, '
+                    f'{stats["topCount"]} voxels = {stats["topFrac"] * 100:.4f}%)')
+        result = {'channels': channels}
+    except Exception as e:
+        # Advisory QC on a store that already converted successfully: report and move on. A
+        # non-integer dtype (channel_histograms raises) or an unreadable OME is not an import failure.
+        log.log(f'>> [WARN] could not check for saturation: {e}')
+
+    write_json_atomic(result_path, result)
+    log.progress(2, 2)
+
+
+def main():
+    params = script_utils.script_params()
+    if params is None:
+        return
+    run(params)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -7188,6 +7188,31 @@ end
         @test isempty(Cecelia.saturation_qc_findings(clean))
         @test Cecelia.saturation_metrics(clean)["nChannelsSaturated"] == 0
 
+        # TRACE clipping: structurally detected, but far too small to act on. This is the real measured
+        # case — 4 of 36 channels across nine kSUFux movies sit at 1.1-1.4e-6, i.e. ~500 voxels of
+        # 377 M. No finding (telling someone to lower the gain over 500 voxels is not actionable), but
+        # the metric MUST still record it: the cohort comparison is relative, so it is what surfaces an
+        # image clipping far more than its session peers.
+        trace = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [
+            mk(0, true; top = 4095, frac = 1.4e-6, n = 534),
+        ]))
+        @test isempty(Cecelia.saturation_qc_findings(trace))
+        tm = Cecelia.saturation_metrics(trace)
+        @test tm["nChannelsSaturated"] == 1
+        @test tm["maxClippedFrac"] == 1.4e-6
+
+        # …and just above the floor it does warn
+        material = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [
+            mk(0, true; top = 4095, frac = 2.0e-4, n = 75_000),
+        ]))
+        @test length(Cecelia.saturation_qc_findings(material)) == 1
+
+        # a channel with no recorded fraction is not guessed at
+        noneframe = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [
+            Dict{String,Any}("index" => 0, "saturated" => true, "topValue" => 4095),
+        ]))
+        @test isempty(Cecelia.saturation_qc_findings(noneframe))
+
         # JSON3 round-trip — the real path: persisted ccid meta comes back with Symbol keys
         rt   = JSON3.read(JSON3.write(meta))
         rtm  = Dict{String,Any}(String(k) => v for (k, v) in rt)

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -7152,6 +7152,52 @@ end
 
     end
 
+    @testset "clipping-at-acquisition findings" begin
+        mk(i, sat; top = 4095, frac = 0.0, n = 0) =
+            Dict{String,Any}("index" => i, "saturated" => sat, "topValue" => top,
+                             "topCount" => n, "topFrac" => frac)
+        meta = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [
+            mk(0, false; top = 1032, frac = 1.0e-6),
+            mk(1, true;  top = 4095, frac = 0.00018, n = 534),   # clipped at the 12-bit ceiling
+            mk(2, false; top = 2854, frac = 1.0e-6),
+        ]))
+
+        fs = Cecelia.saturation_qc_findings(meta)
+        @test length(fs) == 1                              # only the clipped channel
+        @test fs[1]["code"] == "import.channel_saturated"
+        @test fs[1]["level"] == "warn"                     # advisory, never a gate
+        @test fs[1]["detail"]["channel"] == 1
+        # the effective ceiling is reported because it is NOT the dtype maximum on 12-bit-in-16-bit
+        @test fs[1]["detail"]["topValue"] == 4095.0
+        # the COUNT is what a reader can judge; the fraction is ~1e-6 and rounds away
+        @test fs[1]["detail"]["clippedVoxels"] == 534.0
+
+        m = Cecelia.saturation_metrics(meta)
+        @test m["nChannelsSaturated"] == 1
+        @test m["maxClippedFrac"] == 0.00018
+
+        # the check didn't run (pre-existing image, or a non-integer store) → say nothing at all
+        @test isempty(Cecelia.saturation_qc_findings(Dict{String,Any}()))
+        @test Cecelia.saturation_metrics(Dict{String,Any}()) === nothing
+        @test isempty(Cecelia.saturation_qc_findings(
+            Dict{String,Any}("saturation" => Dict{String,Any}())))
+
+        # nothing clipped → no findings, but the metrics still bank (a measured zero is a result, and
+        # the cohort needs it to tell "clean" apart from "not checked")
+        clean = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [mk(0, false)]))
+        @test isempty(Cecelia.saturation_qc_findings(clean))
+        @test Cecelia.saturation_metrics(clean)["nChannelsSaturated"] == 0
+
+        # JSON3 round-trip — the real path: persisted ccid meta comes back with Symbol keys
+        rt   = JSON3.read(JSON3.write(meta))
+        rtm  = Dict{String,Any}(String(k) => v for (k, v) in rt)
+        @test length(Cecelia.saturation_qc_findings(rtm)) == 1
+        @test Cecelia.saturation_metrics(rtm)["nChannelsSaturated"] == 1
+
+        # the finding renders — a `{channel}` placeholder with no substitution throws (see qc_text)
+        @test occursin("1", fs[1]["short"])
+    end
+
     # Julia and Python each carry the compressor table — a bioformats2raw command line cannot read a
     # Python constant, and the API serves the list to Settings. Same arrangement as the calibration
     # writers (CLAUDE.md -> *Calibration - three copies, one stamp*): two copies, one contract test.

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -272,8 +272,10 @@ dim-channel cost above is then unavoidable arithmetic).
 
 **Reference:** `zarr_utils.store_compressor` (the measured codec table that replaced it);
 `intensity_utils` retains the whole-stack histogram helpers the work produced, now used by AF
-correction and segmentation normalisation. The removed pieces — `image_window`, `is_saturated`
-(structural detection of clipping at acquisition), `rescale_stack_to_uint8` — are in git history.
+correction, segmentation normalisation and the import saturation check. `image_window` and
+`rescale_stack_to_uint8` are gone (git history). `is_saturated` was removed with the feature and then
+**brought back for its own sake**: clipping at acquisition is worth reporting whatever the bit depth,
+and it is now a standard QC pass on every import (`saturation_run.py`, `qc.jl::saturation_qc_findings`).
 
 ---
 

--- a/docs/todo/AF_QUANTISATION.md
+++ b/docs/todo/AF_QUANTISATION.md
@@ -81,6 +81,19 @@ That is worth being blunt about, because it rules out a whole family of tempting
    them. Note also that (1) and (2) above are unchanged by the input now being 16-bit rather than
    8-bit — that removes the input-precision limit, but not the output-mapping question.
 
+5. **`saturatedFrac` is blind to this data's detector — measured.** `af_weight_stats` computes it as
+   the fraction of voxels sitting at the **dtype** maximum. On the nine `kSUFux` movies the sensor is
+   12-bit stored in 16-bit words: every channel clips at **4095** while the dtype maximum is 65535, so
+   `saturatedFrac` reads **0.00000 for every channel of every movie** — including `PsD5Xc` ch2, which
+   holds 105 voxels piled at 4095 against a median of 1 in the bins below it.
+
+   The metric is not wrong, its validity domain is narrower than it looks: it is correct only when the
+   data fills its dtype. Keeping images at their acquired bit depth (`docs/FUTURE.md`) makes
+   12-bit-in-16-bit the normal case, so it will now read 0 on most real input. `intensity_utils.is_saturated`
+   is the structural test (a pile-up in the brightest OCCUPIED bin, wherever that sits) and is already
+   used by the import QC — AF could bank its number from that instead. Not changed here because the AF
+   mechanism is recent and this is a decision about its QC, not a defect in the correction.
+
 ## Why this is not just a TODO item
 
 It looked like one bug and was three separate things — an output-mapping defect, an input-precision

--- a/docs/todo/AF_QUANTISATION.md
+++ b/docs/todo/AF_QUANTISATION.md
@@ -87,12 +87,18 @@ That is worth being blunt about, because it rules out a whole family of tempting
    `saturatedFrac` reads **0.00000 for every channel of every movie** — including `PsD5Xc` ch2, which
    holds 105 voxels piled at 4095 against a median of 1 in the bins below it.
 
-   The metric is not wrong, its validity domain is narrower than it looks: it is correct only when the
-   data fills its dtype. Keeping images at their acquired bit depth (`docs/FUTURE.md`) makes
-   12-bit-in-16-bit the normal case, so it will now read 0 on most real input. `intensity_utils.is_saturated`
-   is the structural test (a pile-up in the brightest OCCUPIED bin, wherever that sits) and is already
-   used by the import QC — AF could bank its number from that instead. Not changed here because the AF
-   mechanism is recent and this is a decision about its QC, not a defect in the correction.
+   **This is an artifact of a 12-bit sensor in a 16-bit container, and the container declares it** —
+   these files carry `SignificantBits="12"` alongside `Type="uint16"` in their OME-XML. So the fix is
+   not a different detector: it is to take the ceiling from `SignificantBits` (`2^12-1`) rather than
+   from the dtype, which keeps `saturatedFrac` the one-liner it is and makes it correct.
+
+   Two caveats before relying on that. `SignificantBits` is only as good as what the writer declared:
+   `4kS67f` says `16` while its data never exceeds 7311, so a declared ceiling reads 0 there too (in
+   that image nothing IS clipped, so it is not a false negative — but the number is not evidence of
+   anything either). And a metric tied to any declared ceiling is silent when the declaration is
+   wrong, where `intensity_utils.is_saturated` — structural, a pile-up in the brightest OCCUPIED bin
+   wherever it sits — needs no metadata at all. That is why the import QC uses the structural test;
+   AF, which already has the histogram, can use whichever suits its own reporting.
 
 ## Why this is not just a TODO item
 

--- a/python/cecelia/tests/test_intensity_utils.py
+++ b/python/cecelia/tests/test_intensity_utils.py
@@ -78,6 +78,17 @@ class TestIntensityUtils(unittest.TestCase):
         h[101:ceiling + 1] = (200_000 * np.exp(-(vals - 101) / 250.0)).astype(np.int64)
         return h
 
+    @classmethod
+    def _clipped(cls, ceiling, clip_at, n=4096):
+        """The same tail, but a detector that cannot represent anything above `clip_at` — so every
+        higher value is accumulated INTO that bin. Crude two-spike fixtures cannot tell the two
+        cases apart, which is the whole point of the test."""
+        h = cls._tail(ceiling, n)
+        spill = int(h[clip_at + 1:].sum())
+        h[clip_at + 1:] = 0
+        h[clip_at] += spill
+        return h
+
     def test_background_threshold_sits_between_the_peak_and_the_tail(self):
         """Triangle over a background peak with a long tail — the default, and what the AF correction
         derives its background pair from instead of two hand-tuned percentiles."""
@@ -102,6 +113,44 @@ class TestIntensityUtils(unittest.TestCase):
     def test_background_threshold_rejects_an_unknown_method(self):
         with self.assertRaises(ValueError):
             iu.background_threshold(self._tail(2000), method='mean')
+
+    def test_is_saturated_distinguishes_clipping_from_a_decaying_tail(self):
+        """A tail decays, so its top bin is the sparsest. Clipping inverts that — every value the
+        detector could not represent piles into the top bin."""
+        self.assertFalse(iu.is_saturated(self._tail(2000)))                   # natural end
+        self.assertTrue(iu.is_saturated(self._clipped(4000, clip_at=1200)))   # pile-up
+        self.assertFalse(iu.is_saturated(np.zeros(4096, dtype=np.int64)))     # empty
+        hot = self._tail(2000); hot[4095] = 1                                 # lone hot pixel
+        self.assertFalse(iu.is_saturated(hot))
+
+    def test_a_pile_up_below_the_count_floor_is_not_flagged(self):
+        """Both conditions are required: a two-voxel spike at the top is a hot pixel, not saturation."""
+        h = self._tail(2000)
+        h[2500] = 3                                   # above the tail, but nowhere near the floor
+        self.assertFalse(iu.is_saturated(h))
+
+    def test_is_saturated_does_not_depend_on_the_dtype_maximum(self):
+        """THE reason this test is structural rather than `fraction at the dtype max`.
+
+        Measured on the nine kSUFux movies: a 12-bit sensor stored in 16-bit words clips at 4095 while
+        the dtype maximum is 65535, so the dtype-max fraction reads 0.0 on visibly clipped data. One
+        movie held 105 voxels at 4095 against a median of 1 below it."""
+        h = np.zeros(65536, dtype=np.int64)           # 16-bit container...
+        h[100] = 5_000_000
+        vals = np.arange(101, 4096)
+        h[101:4096] = (200_000 * np.exp(-(vals - 101) / 250.0)).astype(np.int64)
+        spill = int(h[1200:].sum()); h[1200:] = 0; h[1200] = spill   # ...12-bit sensor clipping at 1200
+        self.assertTrue(iu.is_saturated(h))
+        self.assertEqual(float(h[65535]) / float(h.sum()), 0.0)      # the dtype-max test sees nothing
+
+    def test_saturation_stats_reports_the_numbers_behind_the_verdict(self):
+        s = iu.saturation_stats(self._clipped(4000, clip_at=1200))
+        self.assertTrue(s['saturated'])
+        self.assertEqual(s['topValue'], 1200)        # the detector's effective ceiling, not the dtype's
+        self.assertGreater(s['topCount'], 0)
+        self.assertGreater(s['topFrac'], 0.0)
+        clean = iu.saturation_stats(self._tail(2000))
+        self.assertFalse(clean['saturated'])
 
     def test_triangle_threshold_degenerate_histograms(self):
         self.assertEqual(iu.triangle_threshold(np.zeros(16, np.int64)), 0.0)

--- a/python/cecelia/utils/intensity_utils.py
+++ b/python/cecelia/utils/intensity_utils.py
@@ -97,9 +97,13 @@ def is_saturated(hist, min_count=None):
     data fills its dtype. Measured on the nine `kSUFux` movies, which are 12-bit sensor data stored in
     16-bit words: every channel clips at **4095** while the dtype maximum is 65535, so the dtype-max
     fraction reports **0.00000 for every channel of every movie** — including one with 105 voxels piled
-    at 4095 against a median of 1 in the bins below it, which this test flags. Keeping images at their
-    acquired bit depth (see docs/FUTURE.md) makes 12-bit-in-16-bit the normal case, so a detector tied
-    to the dtype is the wrong one to rely on.
+    at 4095 against a median of 1 in the bins below it, which this test flags.
+
+    That is an artifact of a 12-bit sensor in a 16-bit container, and the container DECLARES it —
+    those files carry ``SignificantBits="12"`` next to ``Type="uint16"``. So a dtype-max test is not
+    unfixable, it just has to read the ceiling from `SignificantBits`. The reason this one is
+    structural anyway: it needs no metadata, so it still holds when the declaration is absent or
+    wrong (`4kS67f` declares 16 significant bits while its data never exceeds 7311).
 
     **Use a FULL histogram, not a strided one.** The threshold is a voxel count, so subsampling scales
     the pile-up down with it and a marginal channel changes verdict: `kSUFux/RbC99T` ch2 holds 60 at

--- a/python/cecelia/utils/intensity_utils.py
+++ b/python/cecelia/utils/intensity_utils.py
@@ -72,6 +72,80 @@ def hist_percentile(hist, pct):
     return int(np.searchsorted(cdf, target))
 
 
+#: Floor and fraction for the `is_saturated` count threshold: a bin must hold at least
+#: ``max(floor, total * frac)`` voxels to count as a population rather than a hot pixel. Scale-free (a
+#: fraction of the image) with a floor so a small or synthetic histogram still behaves sensibly.
+SATURATION_MIN_FRAC = 1e-6
+SATURATION_MIN_FLOOR = 64
+
+
+def is_saturated(hist, min_count=None):
+    """Whether a channel CLIPPED AT ACQUISITION — its brightest occupied bin is shared by enough
+    voxels to be real signal rather than a hot pixel.
+
+    **Structural, so it needs no knowledge of the detector's bit depth**, and that is the whole point.
+    A fluorescence tail DECAYS — each brighter bin holds fewer voxels than the one below — so the top
+    occupied bin is the sparsest. Clipping inverts that: every value the detector could not represent
+    is accumulated into the top bin, which then holds MORE voxels than its neighbours. That pile-up is
+    the signature, wherever the ceiling happens to sit.
+
+    Both conditions are required. The count floor alone would flag any channel whose brightest bin
+    happens to be well populated; the pile-up alone would flag a two-voxel spike as saturation.
+
+    **Why not "fraction of voxels at the dtype maximum"** — the obvious one-liner, and what
+    `correction_utils.af_weight_stats` computes for its own `saturatedFrac`: it only works when the
+    data fills its dtype. Measured on the nine `kSUFux` movies, which are 12-bit sensor data stored in
+    16-bit words: every channel clips at **4095** while the dtype maximum is 65535, so the dtype-max
+    fraction reports **0.00000 for every channel of every movie** — including one with 105 voxels piled
+    at 4095 against a median of 1 in the bins below it, which this test flags. Keeping images at their
+    acquired bit depth (see docs/FUTURE.md) makes 12-bit-in-16-bit the normal case, so a detector tied
+    to the dtype is the wrong one to rely on.
+
+    **Use a FULL histogram, not a strided one.** The threshold is a voxel count, so subsampling scales
+    the pile-up down with it and a marginal channel changes verdict: `kSUFux/RbC99T` ch2 holds 60 at
+    the top bin under a ``::6`` stride (below the floor of 64, so not flagged) and ~360 unstrided.
+
+    **The threshold, measured.** Over all 36 channels of the nine `kSUFux` movies (one session,
+    identical settings) it flags **4, in 4 different movies** — independently reproducing the count the
+    earlier rescale work arrived at. The separation is real but not wide: flagged channels hold
+    1.10-1.42e-6 of their voxels at the ceiling, while the highest unflagged one holds 5.7e-7. Note
+    the ABSOLUTE counts are small (415-534 voxels of ~377 M), so this reports a true clipping event of
+    modest extent rather than a ruined channel — which is why the QC finding carries the voxel count
+    and leaves the judgement to the reader.
+    """
+    h = np.asarray(hist)
+    nz = np.nonzero(h)[0]
+    if nz.size < 2:
+        return False
+    if min_count is None:
+        min_count = max(int(SATURATION_MIN_FLOOR), int(int(h.sum()) * float(SATURATION_MIN_FRAC)))
+    top = int(nz[-1])
+    if int(h[top]) < int(min_count):
+        return False
+    # compare against the run of occupied bins just below, not a single neighbour, so one ragged bin
+    # in a sparse tail doesn't read as a pile-up
+    below = h[nz[max(0, nz.size - 11):nz.size - 1]]
+    return bool(int(h[top]) > float(np.median(below)))
+
+
+def saturation_stats(hist):
+    """`is_saturated` plus the numbers behind the verdict, JSON-friendly for QC.
+
+    `topValue` is where the pile-up sits — the detector's effective ceiling, which is worth reporting
+    because it is NOT the dtype maximum on sub-16-bit sensor data.
+    """
+    h = np.asarray(hist)
+    total = int(h.sum())
+    nz = np.nonzero(h)[0]
+    top = int(nz[-1]) if nz.size else 0
+    return {
+        'saturated': bool(is_saturated(h)),
+        'topValue': top,
+        'topCount': int(h[top]) if nz.size else 0,
+        'topFrac': (int(h[top]) / total) if total else 0.0,
+    }
+
+
 def triangle_threshold(hist):
     """Zack's triangle threshold on a histogram — the bin furthest from the line joining the
     histogram's peak to its last occupied bin.


### PR DESCRIPTION
Saturation detection as a standard import check, as discussed.

A clipped channel has lost information nothing downstream recovers. Import is the only point where the useful answer is still "re-acquire with less gain" rather than "re-do the analysis" — so this runs on every import, no param.

`is_saturated` was removed along with the 8-bit conversion it served (#452); it comes back for its own sake. Detection is **structural**: a fluorescence tail decays, so the brightest occupied bin is the sparsest, and clipping inverts that by piling every unrepresentable value into it.

## Why structural matters more than it used to

The obvious test — fraction of voxels at the **dtype** maximum, which is what `af_weight_stats` computes for its own `saturatedFrac` — only works when the data fills its dtype.

Measured on all 36 channels of the nine `kSUFux` movies: the sensor is 12-bit stored in 16-bit words, so every channel clips at **4095** while the dtype maximum is 65535. That test reads **0.00000 for every channel of every movie** — including `PsD5Xc` ch2, which holds 105 voxels at 4095 against a median of 1 in the bins below it.

Keeping images at their acquired bit depth (#452) makes 12-bit-in-16-bit the normal case, so a dtype-tied detector is now the wrong one to rely on. **Recorded as an open item in `AF_QUANTISATION.md` rather than changed here** — it's a call about AF's QC, not a defect in the correction, and that work is recent.

## What the threshold actually does — measured

- Flags **4 of 36 channels, in 4 of 9 movies**, independently reproducing the count the earlier rescale work arrived at.
- Separation is real but not wide: flagged channels hold **1.10–1.42e-6** of their voxels at the ceiling; the highest unflagged one holds **5.7e-7**.
- **The absolute extent is small — 415–534 voxels of ~377 M.** A true clipping event of trivial extent, not a ruined channel. So detection and the warning are split: `is_saturated` gates detection and the metric is always banked, while the FINDING additionally requires ≥0.01% of voxels at the ceiling. None of your nine movies warns. The finding carries the voxel **count**, not a percentage that renders as "0.0001%" and says nothing.
- The pass must be **full, not strided**: the threshold is a voxel count, so subsampling scales the pile-up down with it and flips marginal channels (`RbC99T` ch2 reads 60 at `::6`, ~360 unstrided).

## Cost

One streamed pass over the store just written — 5.3 s for 1.74 GB, 14.4 s for 3.0 GB — in the `io` pool alongside the conversion. Advisory throughout: a failure in the check never fails the import.

## Testing

Package (3504) and Python (423) suites green. Verified against a clean-main baseline that the new assertions actually run: QC framework 212 → 228, whole-suite delta entirely accounted for by that.

Verified end to end on real data, not only in tests: ran the runner through `run_py` on `kSUFux/PsD5Xc` — ch2 flagged at 415 voxels at 4095, ch3 correctly **not** flagged at 5 voxels, the finding rendering with its `{channel}` substitution, metrics banking.

## Reservations

- **The materiality floor (0.01%) is a chosen number, not a fitted one.** There is no material clipping case in your data to calibrate against, so it is set from what would damage a measurement (~37 000 voxels) rather than from the observed distribution. The first real case should re-set it. Stated as such at the constant.
- Detection and the warning are now separate: a trace pile-up is **banked as a metric but raises nothing**. So `nChannelsSaturated: 1` with no finding is an expected combination, which could read as a bug to someone who doesn't know the split.
- **Every import now pays the pass.** ~3–5 s/GB. Negligible against bf2raw for these files, but a very large PhenoCycler store would add minutes, and there is no opt-out.
- **Never run in the app.** The finding has not been seen rendered in the QC panel; only the Julia-side render was exercised.
- The 4-of-9 rate is one session on one instrument. The threshold's floor (`max(64, total × 1e-6)`) is inherited from the rescale work, and this data is the only evidence for it.
- `maxClippedFrac` is banked for every checked image including clean ones (a measured zero differs from "not checked"), so cohort stats on it will be dominated by near-zero values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)