### PR TITLE
fix(qc): AF findings rendered "→ undefined"; drop the range warning

### DIFF
--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -119,6 +119,12 @@ const QC_TEXT = Dict{String,@NamedTuple{short::String, long::String}}(
         short = "Image has no pixel size",
         long  = "Set the pixel size, or read the µm scale settings as pixels — 1 µm/px was assumed."),
 
+    # AF correction (af_qc_findings). The only finding this task has: the correction itself has no free
+    # parameter left to land behaviourally wrong, so the one objective signal is about the INPUT.
+    "af.saturated_input" => (
+        short = "Channel {channel} saturated",
+        long  = "Input voxels are clipped at the top of the range, so their true value is already lost — lower the gain or laser power and reacquire."),
+
     # output geometry (qc_canvas_expansion)
     "output.canvas_expansion" => (
         short = "Output canvas grew +{pct}% in XY",

--- a/app/src/tasks/cleanupImages/af_correct.jl
+++ b/app/src/tasks/cleanupImages/af_correct.jl
@@ -86,20 +86,30 @@ end
 QC for AF correction, from the per-channel output stats the runner writes.
 
 This task used to be QC-exempt, with a comment calling itself the weakest exemption in the codebase.
-Two objective signals, and neither is about the correction's own arithmetic — the correction has no
-free parameter left to land badly:
+It now has exactly ONE finding, because the correction has no free parameter left to land badly and the
+only objective signal is about the INPUT:
 
 * **saturated input** → the channel was clipped at the sensor, before we saw it. `saturatedFrac`. No
   correction recovers a clipped voxel's true value, so this is a warning about the acquisition and the
   action is at the microscope. Measured across the nine kSUFux movies, CH3 saturation ranged from
   0.001% to 0.018% of voxels — a 13x spread within one experiment at identical settings.
-* **coarse output** → the corrected channel occupies few of the available levels.
-  `levelsUsed / levelsAvailable`. Under the hand-tuned percentile window that preceded all of this,
-  99% of a real image landed in ~13 of 255 levels and nothing ever flagged it.
 
-`clippedFrac` and `ceiling` are gone with the ratio. The output is `b * weight` with `weight <= 1`, so
-it can never reach the top of the range — the clipping metric was structurally ~0. And there is no
-derived ceiling to compare across a set, which is what the `ceiling` cohort metric existed to catch.
+**`af-low-range` is deleted, not re-tuned, and that is the interesting part.** It warned when the output
+used under 20% of the dtype's levels. That was a real signal under the RATIO, whose output was stretched
+to fill the range through a derived ceiling — using little of it meant the ceiling had been derived too
+high. The power weight outputs in INPUT COUNTS, so a 16-bit channel carrying signal in the low thousands
+legitimately occupies a sliver: measured on Dominik's own runs, 735-3576 of 65536 levels (1.1-5.5%) on
+every channel of every image. The threshold survived the mechanism change with its premise inverted, so
+it fired on everything and meant nothing. `levelsUsedFrac` is still banked and still a COHORT metric —
+an image far below its peers is informative even when the absolute number is not.
+
+Nothing replaced it. The tempting substitute was "warn when a target channel was almost entirely
+suppressed", but there is no observed instance of that, so the threshold would have been invented rather
+than derived — the trap `docs/MODULES.md` names ("do not invent a meaningless metric"). If such a case
+ever appears it supplies both the failure mode and the number.
+
+`clippedFrac` and `ceiling` went with the ratio too: the output is `b * weight` with `weight <= 1`, so it
+can never reach the top of the range, and there is no derived ceiling left to drift across a set.
 
 Advisory only, per `docs/MODULES.md` — never an `error`, never a gate.
 """
@@ -110,23 +120,18 @@ function af_qc_findings(per_channel::AbstractDict)
         saturated = Float64(get(s, "saturatedFrac", 0.0))
         used      = Float64(get(s, "levelsUsed", 0))
         avail     = max(1.0, Float64(get(s, "levelsAvailable", 1)))
-        frac      = used / avail
         worst_saturated = max(worst_saturated, saturated)
-        worst_levels    = min(worst_levels, frac)
+        worst_levels    = min(worst_levels, used / avail)
 
         if saturated > 0.001
-            push!(findings, Dict{String,Any}(
-                "level" => "warn", "code" => "af-saturated-input",
-                "short" => "Channel $ch saturated",
-                "detail" => "$(round(saturated * 100; digits = 2))% of input voxels are at the top " *
-                            "of the range. Lower the gain or laser power and reacquire."))
-        end
-        if frac < 0.2
-            push!(findings, Dict{String,Any}(
-                "level" => "warn", "code" => "af-low-range",
-                "short" => "Channel $ch uses little of the range",
-                "detail" => "$(Int(round(used))) of $(Int(round(avail))) levels — the corrected " *
-                            "channel is quantised coarsely."))
+            # short = problem; long = the action; FIGURES GO IN `detail`, as a Dict. This used to
+            # hand-roll the finding with a `detail` STRING and no `long` at all, which the QC panel
+            # rendered as "Channel N saturated → undefined" — visible in the GUI from the day AF QC
+            # shipped. `qc_finding` + QC_TEXT is the one way to build a finding.
+            push!(findings, qc_finding("warn", "af.saturated_input"; channel = ch,
+                detail = Dict{String,Any}(
+                    "saturatedFrac" => round(saturated; digits = 5),
+                    "saturatedPct"  => round(saturated * 100; digits = 3))))
         end
     end
     findings, (; saturated = worst_saturated, levels = worst_levels)

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -1692,58 +1692,100 @@ end
 
 @testset "AF correction QC — the exemption that got retired" begin
     # This task carried a QC-EXEMPT comment calling itself the weakest exemption in the codebase.
-    # The correction has no free parameter left to land badly, so the two objective signals are about
-    # the INPUT (was it clipped at the sensor?) and the output's quantisation.
+    # It now has exactly ONE finding: the correction has no free parameter left to land badly, so the
+    # only objective signal is about the INPUT.
     ok = Dict{String,Any}("1" => Dict{String,Any}(
         "saturatedFrac" => 0.0001, "levelsUsed" => 200, "levelsAvailable" => 256))
     @test isempty(Cecelia.af_qc_findings(ok)[1])
 
-    # Two independent ways it goes wrong — a single-sided check would miss half of them.
     saturated = Dict{String,Any}("1" => Dict{String,Any}(
         "saturatedFrac" => 0.05, "levelsUsed" => 200, "levelsAvailable" => 256))
     f, w = Cecelia.af_qc_findings(saturated)
-    @test length(f) == 1 && f[1]["code"] == "af-saturated-input" && f[1]["level"] == "warn"
+    @test length(f) == 1 && f[1]["code"] == "af.saturated_input" && f[1]["level"] == "warn"
     @test w.saturated == 0.05
-    # the action belongs at the microscope: a clipped voxel's value is gone before this task runs
-    @test occursin("gain", f[1]["detail"])
 
-    # coarse output: the data crams into a few levels. Measured on real data under the percentile
-    # window this replaced — 99% of an image in ~13 of 255 levels, which nothing ever flagged.
-    low = Dict{String,Any}("2" => Dict{String,Any}(
-        "saturatedFrac" => 0.0, "levelsUsed" => 13, "levelsAvailable" => 256))
-    f2, w2 = Cecelia.af_qc_findings(low)
-    @test length(f2) == 1 && f2[1]["code"] == "af-low-range"
-    @test occursin("13 of 256", f2[1]["detail"])
-    @test w2.levels < 0.06
+    # THE BUG THIS REPLACED: the finding was hand-rolled with a `detail` STRING and no `long` at all,
+    # so the QC panel rendered "Channel 1 saturated → undefined" — visible in the GUI from the day AF
+    # QC shipped, because `lib/qc.ts` reads `f.long`. House convention (see drift_correct.jl):
+    # short = problem, long = the action, FIGURES in `detail` as a Dict.
+    @test f[1]["short"] == "Channel 1 saturated"
+    @test !isempty(get(f[1], "long", ""))
+    @test occursin("gain", f[1]["long"])                    # the action, imperative
+    @test f[1]["detail"] isa AbstractDict                   # figures, NOT a string
+    @test f[1]["detail"]["saturatedPct"] == 5.0
+    # ...and it comes from the copy catalog, so it re-renders at read time like every other finding
+    @test haskey(Cecelia.QC_TEXT, "af.saturated_input")
+    @test f[1]["key"] == "af.saturated_input"
 
     # advisory only, per docs/MODULES.md — never an error, never a gate
-    for d in (saturated, low)
-        @test all(x -> x["level"] == "warn", Cecelia.af_qc_findings(d)[1])
-    end
+    @test all(x -> x["level"] == "warn", f)
+
+    # `af-low-range` IS GONE, and re-tuning it would be wrong. It warned when the output used <20% of
+    # the dtype's levels — a real signal under the RATIO, whose output was stretched to fill the range
+    # through a derived ceiling. The power weight outputs INPUT COUNTS, so a 16-bit channel with signal
+    # in the low thousands legitimately occupies a sliver: measured on real runs, 735-3576 of 65536
+    # levels (1.1-5.5%) on EVERY channel of EVERY image. The premise inverted with the mechanism.
+    coarse = Dict{String,Any}("2" => Dict{String,Any}(
+        "saturatedFrac" => 0.0, "levelsUsed" => 775, "levelsAvailable" => 65536))
+    f2, w2 = Cecelia.af_qc_findings(coarse)
+    @test isempty(f2)                              # 1.2% of the range is NORMAL now, not a warning
+    @test w2.levels < 0.02                         # ...but the metric is still banked
+    @test !any(x -> occursin("range", x["code"]), Cecelia.af_qc_findings(coarse)[1])
 
     # worst-case rollup across channels, since QC banks one number per image
-    both = merge(saturated, low)
+    both = merge(saturated, coarse)
     _, w3 = Cecelia.af_qc_findings(both)
     @test w3.saturated == 0.05         # worst = most saturated
-    @test w3.levels < 0.06             # worst = least range used
+    @test w3.levels < 0.02             # worst = least range used
 
-    # Both metrics describe the ACQUISITION, which is what makes them comparable across a set shot in
-    # one session. Measured across the nine kSUFux movies, CH3 saturation spanned 0.001%-0.018% — a 13x
-    # spread at identical settings, so an outlier is a real difference rather than a typed parameter.
+    # `levelsUsedFrac` stays a COHORT metric: an image far below its peers is informative even when the
+    # absolute number is not. `saturatedFrac` describes the acquisition — measured across the nine
+    # kSUFux movies it spanned 0.001%-0.018%, a 13x spread at identical settings.
     @test COHORT_METRICS["cleanupImages.afCorrect"] == ["saturatedFrac", "levelsUsedFrac"]
-
-    # `ceiling` is GONE, and deliberately: it was banked to catch two images drifting onto different
-    # intensity scales, on the reasoning that the output was `ratio / ceiling * rescale`. The output is
-    # in input counts now — there is no ceiling, so there is nothing derived per image to drift.
     @test !("ceiling" in COHORT_METRICS["cleanupImages.afCorrect"])
     @test !("clippedFrac" in COHORT_METRICS["cleanupImages.afCorrect"])
+
+    # ratio-era stats files are ignored, not warned on
     ceiling_era = Dict{String,Any}("1" => Dict{String,Any}(
         "clippedFrac" => 0.9, "levelsUsed" => 200, "levelsAvailable" => 256, "ceiling" => 999.0))
-    @test isempty(Cecelia.af_qc_findings(ceiling_era)[1])   # old keys are ignored, not warned on
+    @test isempty(Cecelia.af_qc_findings(ceiling_era)[1])
 
     # A stats file missing the key must read as 0.0, not throw.
     @test Cecelia.af_qc_findings(Dict{String,Any}("1" => Dict{String,Any}(
         "levelsUsed" => 200, "levelsAvailable" => 256)))[2].saturated == 0.0
+end
+
+@testset "every QC finding carries the fields the GUI reads" begin
+    # `lib/qc.ts` renders `${f.short}\n→ ${f.long}`, so a finding without `long` displays the literal
+    # string "undefined" to the user. AF shipped exactly that for months because it hand-rolled its
+    # finding dict instead of calling `qc_finding`. Nothing checked, so nothing caught it.
+    #
+    # Enforced structurally: no producer may build a finding dict by hand. `qc_finding` is the one
+    # constructor, and it cannot omit `long` or put a string in `detail`.
+    src = String[]
+    for (root, _, files) in walkdir(joinpath(dirname(dirname(pathof(Cecelia))), "src"))
+        for f in files
+            endswith(f, ".jl") || continue
+            push!(src, joinpath(root, f))
+        end
+    end
+    @test !isempty(src)
+    offenders = String[]
+    for path in src
+        endswith(path, "qc.jl") && continue          # the constructor itself
+        for (i, line) in enumerate(eachline(path))
+            occursin(r"\"level\"\s*=>\s*\"(warn|info)\"", line) &&
+                push!(offenders, "$(basename(path)):$i")
+        end
+    end
+    @test offenders == []
+
+    # and the constructor's own contract: `long` always present, `detail` only ever structured
+    f = Cecelia.qc_finding("warn", "af.saturated_input"; channel = 2,
+                           detail = Dict{String,Any}("saturatedPct" => 1.5))
+    @test haskey(f, "long") && !isempty(f["long"])
+    @test f["detail"] isa AbstractDict
+    @test !(Cecelia.qc_finding("warn", "x.y", "s", "l")["long"] |> isempty)
 end
 
 @testset "AF params are just channels" begin


### PR DESCRIPTION
Two AF QC defects Dominik hit in the GUI — one pre-existing, one mine from #450.

## "Channel N saturated → undefined"

![the symptom] Visible since AF QC shipped in **#437**.

`lib/qc.ts` renders `${f.short}\n→ ${f.long}`, and `af_qc_findings` never set `long`. It hand-rolled the finding dict and put its prose in `detail` — which the contract reserves for a **Dict of figures**:

```ts
interface QcFinding { level; code; short: string; long: string; detail?: Record<string, unknown> }
```

Wrong key *and* wrong type. AF was the only producer doing it, because it was the only one not calling `qc_finding`.

Now routed through `qc_finding` + `QC_TEXT` like everything else, so the wording is reviewable as a set and **re-renders at read time** instead of being frozen into every banked sidecar. House convention, from the sibling drift task: *short = the problem, long = the action, figures in `detail`*.

**Enforced, not described.** A new testset walks `app/src` and fails on any hand-rolled `"level" => "warn"` dict, and asserts `qc_finding` can't produce a finding without `long` or with a string `detail`. Nothing checked this, which is how a user-visible "undefined" survived for months.

## `af-low-range` is deleted, not re-tuned

It warned when the output used under 20% of the dtype's levels. That was a **real** signal under the ratio, whose output was stretched to fill the range through a derived ceiling — using little of it meant the ceiling had been derived too high.

#450 replaced that with the power weight, whose output is in **input counts**. A 16-bit channel carrying signal in the low thousands legitimately occupies a sliver. Measured on Dominik's own runs:

```
i0FSPZ  ch1  775/65536   ch2 2033/65536   ch3 3576/65536    (1.2% - 5.5%)
mkh3Tu  ch1  735/65536   ch2 2080/65536   ch3 1957/65536
```

The threshold survived the mechanism change with its premise inverted, so it fired on every channel of every image and meant nothing. **That one is mine.**

`levelsUsedFrac` is still banked and still a **cohort** metric — an image far below its peers is informative even where the absolute number is not.

## Nothing replaced it, deliberately

The tempting substitute was "warn when a target channel was almost entirely suppressed". There is **no observed instance** of that, so the threshold would have been invented rather than derived — the trap `docs/MODULES.md` names ("do not invent a meaningless metric"). If such a case ever appears it supplies both the failure mode and the number.

AF is left with one finding, `af.saturated_input` — measured (0.001–0.018% across nine movies at identical settings), and the action is at the microscope.

## Note

Uses the canonical `{channel}` placeholder rather than a new `{ch}`. The existing catalog allow-list test caught that on the first run, which is the assertion doing exactly its job.

## Tests

3498 Julia package / API / 419 Python / 750 frontend + typecheck. `pixi run ui-copy` clean on every enforced surface.

Independent of #455 (Python-only) — either order merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
