### PR TITLE
feat: version every Julia↔Python boundary, not just the preview worker

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -125,14 +125,30 @@ function _ensure_viewer!()::Bool
         # sending commands to one window while the user looks at the other.
         if _viewer_ref[] === nothing
             probe = NapariViewer()
-            try
-                send(probe, Dict("type" => "ping"))
-                _viewer_ref[] = probe
-                @info "Adopted existing Napari bridge on port $(probe.port)"
-                return true
+            adopted = try
+                reply = send(probe, Dict("type" => "ping"))
+                # Adopt only a bridge whose command surface MATCHES. One running older code answers a
+                # ping perfectly and then misreads a command — which is how a stale bridge has twice
+                # surfaced as something else entirely (`unexpected keyword argument 'mask'`, a bare
+                # "Preview failed"). Treating a mismatch as not-adoptable is the same rule the preview
+                # worker follows; see NAPARI_PROTOCOL.
+                protocol = get(reply, "protocol", nothing)
+                if protocol == NAPARI_PROTOCOL
+                    _viewer_ref[] = probe
+                    @info "Adopted existing Napari bridge on port $(probe.port)"
+                    true
+                else
+                    @warn "Napari bridge on port $(probe.port) speaks protocol " *
+                          "$(isnothing(protocol) ? "<pre-protocol>" : protocol), not $NAPARI_PROTOCOL " *
+                          "— its code predates a change to the command surface. Replacing it; the " *
+                          "viewer reopens where you left it (layer props are autosaved)."
+                    Cecelia._kill_listeners_on_port(NAPARI_PORT)
+                    false
+                end
             catch
-                # none running — fall through to launch a fresh one
+                false   # none running — fall through to launch a fresh one
             end
+            adopted && return true
         end
         @info "Launching Napari bridge..."
         v = NapariViewer()

--- a/app/src/napari.jl
+++ b/app/src/napari.jl
@@ -2,6 +2,18 @@ using HTTP, JSON3
 
 const NAPARI_PORT   = 7655
 const NAPARI_BRIDGE = joinpath(@__DIR__, "..", "..", "napari", "napari_bridge.py")
+
+# Command-surface version the backend expects, mirroring `napari_bridge.PROTOCOL`. A bridge already
+# listening on the port is ADOPTED rather than relaunched — deliberately, because it holds the user's
+# open viewer window — but that means bridge code can outlive the backend that started it (a crash, a
+# Ctrl-C, a branch switch). A mismatched bridge is not a graceful degradation: it has surfaced as
+# `unexpected keyword argument 'mask'` and as a bare "Preview failed", neither naming the cause.
+#
+# Bump BOTH sides together whenever the command surface changes: a new/renamed command, a changed
+# argument, or a changed reply. Asserted equal by the "language boundaries agree on their protocol"
+# testset. Losing the window on a mismatch is recoverable — layer props and the T/Z position are
+# autosaved (`save_layer_props`), so a relaunch reopens where the user was.
+const NAPARI_PROTOCOL = 1
 # Python interpreter comes from `python_bin_path()` (config default "python3"), resolved within
 # the activated Pixi env — i.e. launch via `pixi run`. No hardcoded venv path; see docs/SHIPPING.md.
 

--- a/app/src/py_runner.jl
+++ b/app/src/py_runner.jl
@@ -13,6 +13,23 @@ _app_dir() = dirname(@__DIR__)                       # app/src → app/
 # python/pyproject.toml + the pixi `cecelia` dep) is what makes `import cecelia.*` resolve inside them.
 _python_dir() = joinpath(dirname(_app_dir()), "python")   # app/ → repo-root/python/
 
+# Version of the JULIA↔PYTHON PARAMS CONTRACT, mirroring `script_utils.CONTRACT_VERSION`. Travels to
+# every runner as `CECELIA_PY_CONTRACT` (see `run_py`) and is checked in `script_params`, so the guard
+# costs nothing per task and cannot be forgotten by a new runner.
+#
+# What it protects: a runner is spawned FRESH from disk every run, while the Julia process that builds
+# its params can be stale (Revise does not always reload `app/src` after a branch switch or a merge
+# under a live server). So the two halves can disagree about the params' shape with nothing to say so.
+#
+# BUMP THIS whenever the contract changes in a way a stale caller would get wrong: a param key renamed
+# or removed, a value's type or units changed, a new REQUIRED key. Not for additive optional keys — an
+# older caller omitting one is handled by the runner's own default. Asserted equal to the Python side by
+# the "language boundaries agree on their protocol" testset.
+#
+# 1: the contract as of the guard's introduction — the state after `divisionChannels` →
+#    `competingChannels` and `quotientChannel` → `targetChannel` (the rename that motivated it).
+const PY_CONTRACT_VERSION = 1
+
 """
     task_run_dir(base_dir) -> String
 
@@ -83,9 +100,20 @@ function run_py(script_rel::AbstractString, params, task_dir::AbstractString;
     # runner's zarr write picks it up through `zarr_utils.store_compressor` without each task having
     # to declare and forward it. Read per call on the Python side, so flipping the Settings choice
     # applies to the next task with no restart.
+    # The params CONTRACT version, so a runner can refuse a params file written by a backend running
+    # older code than the Python it is calling. `app/src` is Revise-tracked and a branch switch or a
+    # merge under a live server does not always reload it, so the Julia half can be a version behind
+    # while every runner is loaded fresh from disk. That has bitten once already: a param rename landed
+    # on disk, the running backend kept the previous translator, and the runner died with
+    # `invalid literal for int() with base 10: 'CH3'` — naming neither the cause nor the fix.
+    #
+    # An ENV VAR rather than a params field, on purpose: the params payload stays exactly the shape each
+    # runner documents, and a developer replaying a saved params file by hand simply has no variable set,
+    # which `script_utils` treats as "skip the check" rather than as a failure.
     cmd  = addenv(`$(python_bin_path()) $py_script --params $params_file`,
                   "PYTHONPATH" => pythonpath,
-                  "CECELIA_IMAGE_COMPRESSOR" => image_compressor())
+                  "CECELIA_IMAGE_COMPRESSOR" => image_compressor(),
+                  "CECELIA_PY_CONTRACT" => string(PY_CONTRACT_VERSION))
     proc = run(pipeline(cmd; stdout = out_pipe, stderr = out_pipe); wait = false)
     close(out_pipe.in)
     on_process(proc)

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -8565,19 +8565,49 @@ Cecelia.live_outputs(::_BadLiveTask, ::AbstractDict) = error("boom")
         @test !Cecelia.preview_alive(Cecelia.PreviewWorker())
     end
 
-    @testset "the preview protocol matches on both sides" begin
-        # A running worker is ADOPTED, not relaunched, so the two constants are the only thing stopping
-        # stale worker code from serving a backend it was not started by. They live in different
-        # languages and were bumped by hand three times with nothing checking they agreed.
+    @testset "language boundaries agree on their protocol" begin
+        # THE PROBLEM THIS TABLE SOLVES. Julia and Python each hold their own copy of a version, and the
+        # only thing keeping them equal is that someone remembers to change both. Measured record before
+        # this test existed: the preview pair was bumped by hand three times and the fourth was nearly
+        # missed; the napari bridge and the params contract had no version at all.
         #
-        # Protocol 4 is why this test exists: a stale protocol-3 worker carries the old ratio
-        # `af_correct_frame`, so it returns well-formed previews of the WRONG method rather than
-        # failing. Forgetting one side would be invisible.
-        worker = joinpath(dirname(dirname(pathof(Cecelia))), "..", "preview", "preview_worker.py")
-        @test isfile(worker)
-        m = match(r"^PROTOCOL\s*=\s*(\d+)"m, read(worker, String))
-        @test m !== nothing
-        @test parse(Int, m.captures[1]) == Cecelia.PREVIEW_PROTOCOL
+        # A mismatch is never a clean failure. A stale peer answers the handshake perfectly and then
+        # misreads the actual work — it has surfaced as `unexpected keyword argument 'mask'`, as a bare
+        # "Preview failed", and as `invalid literal for int() with base 10: 'CH3'`, none of which name the
+        # cause. So every boundary gets a version, and every version gets asserted here.
+        #
+        # A fourth boundary = one more row.
+        repo = joinpath(dirname(dirname(pathof(Cecelia))), "..")
+        boundaries = [
+            # (what,            python file,                          python const,       julia value)
+            ("preview worker",  "preview/preview_worker.py",           "PROTOCOL",         Cecelia.PREVIEW_PROTOCOL),
+            ("napari bridge",   "napari/napari_bridge.py",             "PROTOCOL",         Cecelia.NAPARI_PROTOCOL),
+            ("params contract", "python/cecelia/utils/script_utils.py", "CONTRACT_VERSION", Cecelia.PY_CONTRACT_VERSION),
+        ]
+        for (what, rel, const_name, julia_value) in boundaries
+            path = joinpath(repo, rel)
+            @test isfile(path)
+            m = match(Regex("^" * const_name * raw"\s*=\s*(\d+)", "m"), read(path, String))
+            @test m !== nothing
+            m === nothing && continue
+            py = parse(Int, m.captures[1])
+            @test py == julia_value
+            py == julia_value ||
+                @warn "$what: Python says $py, Julia says $julia_value — bump BOTH sides" rel
+        end
+    end
+
+    @testset "the params contract is checked where every runner already goes" begin
+        # The guard lives in `script_params`, not in each runner, so a NEW runner is covered by writing
+        # nothing. Asserted on the source because the check runs in a subprocess we do not spawn here.
+        su = read(joinpath(dirname(dirname(pathof(Cecelia))), "..",
+                           "python", "cecelia", "utils", "script_utils.py"), String)
+        @test occursin("def check_contract_version", su)
+        @test occursin(r"def script_params\(\):(?s).{0,600}check_contract_version\(\)", su)
+        # ...and run_py is what supplies it, as an env var rather than a params field
+        pr = read(joinpath(dirname(dirname(pathof(Cecelia))), "src", "py_runner.jl"), String)
+        @test occursin("CECELIA_PY_CONTRACT", pr)
+        @test occursin("PY_CONTRACT_VERSION", pr)
     end
 
     @testset "img_labels_path resolves registered and in-progress stores" begin

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,32 @@ scripts (e.g. `"writers/…"`) under `python/cecelia/`, and sets `PYTHONPATH=pyt
 can `import cecelia.*`. Dependency split: light IO deps in `python/pyproject.toml`; heavy/conda/
 per-platform deps in `pixi.toml`. See [`docs/todo/PY_PACKAGING_PLAN.md`](todo/PY_PACKAGING_PLAN.md).
 
+### Every language boundary carries a version
+
+Julia and Python meet at three places, and **each one can end up with the two halves running different
+code**. Two of them hold a long-lived Python process that is *adopted* rather than relaunched (it
+outlives a backend crash or Ctrl-C on purpose); the third spawns Python fresh every run, so it is the
+**Julia** half that goes stale — `app/src` is Revise-tracked and a branch switch or a merge under a
+live server does not always reload it.
+
+| Boundary | Julia | Python | Mismatch → |
+|---|---|---|---|
+| napari bridge (:7655) | `NAPARI_PROTOCOL` (`app/src/napari.jl`) | `PROTOCOL` (`napari/napari_bridge.py`) | refuse to adopt, kill the port, relaunch |
+| preview worker (:7656) | `PREVIEW_PROTOCOL` (`app/src/preview.jl`) | `PROTOCOL` (`preview/preview_worker.py`) | refuse to adopt, relaunch |
+| task params (`run_py`) | `PY_CONTRACT_VERSION` (`app/src/py_runner.jl`) | `CONTRACT_VERSION` (`cecelia.utils.script_utils`) | the runner exits, naming the restart |
+
+**Bump both sides together**, and add a row rather than a bespoke check. The pairs are asserted equal by
+the `language boundaries agree on their protocol` testset — before it existed the preview pair had been
+bumped by hand three times and the fourth was nearly missed.
+
+Why versions at all, rather than trusting the processes to match: a mismatch is **never a clean
+failure**. A stale peer answers the handshake perfectly and then misreads the actual work. The three
+real occurrences read as `unexpected keyword argument 'mask'`, a bare `Preview failed`, and
+`invalid literal for int() with base 10: 'CH3'` — none of which named the cause. The params guard lives
+in `script_params` (the one function every runner already calls) so a new runner is covered without
+doing anything, and an ABSENT `CECELIA_PY_CONTRACT` is allowed through so replaying a saved params file
+by hand still works.
+
 ### Layer ownership
 
 | Concern | Layer | Notes |

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -247,6 +247,20 @@ The params file lands in `task_run_dir(<obj>._dir)` (the run's task dir — `<_d
 a temp dir; consistent across every task) and the Python script deletes it after reading. Pass the
 exact params your runner expects as the second arg (a `NamedTuple` or `Dict`).
 
+> **If you change the params CONTRACT, bump `PY_CONTRACT_VERSION`** (`app/src/py_runner.jl`) *and*
+> `CONTRACT_VERSION` (`cecelia.utils.script_utils`). A key renamed or removed, a changed type or unit, a
+> new REQUIRED key — not an additive optional one. `run_py` ships the version as
+> `CECELIA_PY_CONTRACT` and `script_params` refuses a mismatch, because your runner is spawned fresh
+> from disk while the backend calling it may be running older code (`app/src` is Revise-tracked and does
+> not always reload). Without it a rename surfaces inside the runner as something like
+> `invalid literal for int() with base 10: 'CH3'`. The two constants are asserted equal by the
+> `language boundaries agree on their protocol` testset — see
+> [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) → *Every language boundary carries a version*.
+>
+> **Channel params are indices, never names.** Resolve them Julia-side (the `*_for_python` translators)
+> and read them with `script_utils.channel_indices` / `channel_index`, which name the translator and the
+> fix when a name slips through. Enforced by `NoBareChannelCoercionTest`.
+
 > **Migration note:** several existing tasks (cleanup/segment/tracking) still inline the spawn loop
 > and bootstrap `sys.path` in their runner — that older pattern works but is being migrated to
 > `run_py`. **New tasks must use `run_py`.** `clustPops.cluster` is the reference example.

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -121,6 +121,23 @@ The bridge's `execute_command` dispatches on `cmd["type"]`. Adding a new command
 
 Errors are returned as `{"type": "error", "msg": "..."}` — `send()` raises on these so Julia's try/catch blocks catch them.
 
+### The surface is VERSIONED — bump both sides
+
+`ping` reports `protocol`, and `_ensure_viewer!` **only adopts a bridge whose value matches**
+`NAPARI_PROTOCOL` (`app/src/napari.jl`); a mismatch kills the port listener and relaunches. Bump both
+whenever the surface changes shape — a new or renamed command, a changed argument, a changed reply.
+
+This exists because adoption is deliberate: the bridge outlives a backend crash or Ctrl-C so the user
+keeps their viewer window, which also means it can be running code from before a branch switch. That is
+not a graceful degradation — a stale bridge answers `ping` perfectly and then misreads the command,
+which has surfaced as `unexpected keyword argument 'mask'` and as a bare "Preview failed". Losing the
+window on a mismatch is cheap: layer props and the T/Z position are autosaved, so the relaunch reopens
+where the user was.
+
+The same rule covers the preview worker and the `run_py` params contract — one table in
+[`docs/ARCHITECTURE.md`](ARCHITECTURE.md) → *Every language boundary carries a version*, asserted by the
+`language boundaries agree on their protocol` testset.
+
 ---
 
 ## Movie recording (`record_timelapse`)

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -43,6 +43,19 @@ WS_MAX_SIZE = 64 * 1024 * 1024
 # bridge's uptime and spot a STALE bridge (it survives a backend restart; see docs/NAPARI.md restart rules)
 _STARTED_AT = time.time()
 
+#: Command-surface version, reported by `ping` and checked before the backend ADOPTS this process.
+#: Mirrored by `NAPARI_PROTOCOL` in app/src/napari.jl; a test asserts the two agree.
+#:
+#: Uptime was already reported here "to spot a stale bridge", but that left the judgement to a human
+#: reading a number. A bridge outlives the backend by design (adopted after a crash or a Ctrl-C), so it
+#: can be running code from before a branch switch while the backend sends it commands from after —
+#: which is not a graceful degradation: it surfaced once as `unexpected keyword argument 'mask'` and
+#: once as a bare "Preview failed", neither naming the real cause.
+#:
+#: Bump whenever the command surface changes shape: a new/renamed command, a changed argument, or a
+#: changed reply. 1: the surface as of the protocol's introduction.
+PROTOCOL = 1
+
 # name of the Shapes layer used for spatial cell selection (linked brushing → flow plots)
 SELECTION_LAYER = "Cell selection"
 
@@ -1727,7 +1740,7 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
     t = cmd.get("type")
     try:
         if t == "ping":
-            return {"type": "pong", "started_at": _STARTED_AT}
+            return {"type": "pong", "started_at": _STARTED_AT, "protocol": PROTOCOL}
 
         elif t == "gl_info":
             return {"type": "gl_info", **_gl_info()}

--- a/python/cecelia/tests/test_script_utils.py
+++ b/python/cecelia/tests/test_script_utils.py
@@ -154,3 +154,49 @@ class NoBareChannelCoercionTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class ContractVersionTest(unittest.TestCase):
+    """The params-contract guard: a runner must refuse a params file from an older backend.
+
+    A runner is spawned FRESH from disk every run while the Julia process building its params can be
+    stale (`app/src` is Revise-tracked and does not always reload after a branch switch or a merge under
+    a live server). That asymmetry is invisible without a handshake — it surfaced once as
+    `invalid literal for int() with base 10: 'CH3'`, which named neither the cause nor the fix.
+    """
+
+    def test_a_matching_version_passes(self):
+        v = script_utils.CONTRACT_VERSION
+        self.assertEqual(script_utils.check_contract_version({'CECELIA_PY_CONTRACT': str(v)}), v)
+
+    def test_an_absent_variable_is_allowed_through(self):
+        # not launched by run_py: a developer replaying a saved params file by hand, or an external
+        # caller. Deliberately NOT a failure — the guard must not make manual replay impossible.
+        self.assertIsNone(script_utils.check_contract_version({}))
+        self.assertIsNone(script_utils.check_contract_version({'CECELIA_PY_CONTRACT': ''}))
+
+    def test_an_unparseable_value_never_fails_a_run(self):
+        # the guard is a safety net, not a gate: it must not become the thing that breaks a working run
+        self.assertIsNone(script_utils.check_contract_version({'CECELIA_PY_CONTRACT': 'v2'}))
+
+    def test_a_mismatch_exits_and_names_the_fix(self):
+        older = str(script_utils.CONTRACT_VERSION - 1)
+        with self.assertRaises(SystemExit) as ctx:
+            script_utils.check_contract_version({'CECELIA_PY_CONTRACT': older})
+        msg = str(ctx.exception)
+        self.assertIn(older, msg)                                # what the backend sent
+        self.assertIn(str(script_utils.CONTRACT_VERSION), msg)   # what this runner speaks
+        self.assertIn('Revise', msg)                             # why the two disagree
+        self.assertIn('Restart the backend', msg)                # what to do
+
+    def test_a_newer_backend_is_also_refused(self):
+        # symmetric: Python behind Julia is just as broken as Julia behind Python
+        with self.assertRaises(SystemExit):
+            script_utils.check_contract_version(
+                {'CECELIA_PY_CONTRACT': str(script_utils.CONTRACT_VERSION + 1)})
+
+    def test_script_params_runs_the_check(self):
+        # the guard sits at the one function every runner already calls, so a NEW runner is covered by
+        # writing nothing at all — that is the whole point of putting it here
+        import inspect
+        self.assertIn('check_contract_version', inspect.getsource(script_utils.script_params))

--- a/python/cecelia/utils/script_utils.py
+++ b/python/cecelia/utils/script_utils.py
@@ -13,6 +13,19 @@ import argparse
 import json
 import os
 
+#: Version of the JULIA<->PYTHON PARAMS CONTRACT, mirroring `PY_CONTRACT_VERSION` in
+#: app/src/py_runner.jl. Checked in `script_params`, so every runner is covered without doing anything.
+#:
+#: The asymmetry this exists for: a runner is spawned FRESH from disk every run, while the Julia process
+#: that builds its params can be stale — `app/src` is Revise-tracked and a branch switch or a merge under
+#: a live server does not always reload it. So Python can be a version ahead of the Julia calling it,
+#: with nothing to say so. Observed once as `invalid literal for int() with base 10: 'CH3'` after a param
+#: rename landed on disk while the running backend kept the previous translator.
+#:
+#: Bump BOTH sides together for a renamed/removed key, a changed type or unit, or a new REQUIRED key —
+#: not for an additive optional one. A test asserts the two constants agree.
+CONTRACT_VERSION = 1
+
 
 class StdoutLogger:
     """Minimal logger that writes to stdout so Julia can stream every line."""
@@ -101,13 +114,47 @@ def get_ccia_params(params):
     return list()
 
 
+def check_contract_version(env=None):
+    """Refuse a params file written by a backend running older code than this runner.
+
+    `run_py` passes `CECELIA_PY_CONTRACT`; an ABSENT variable means "not launched by run_py" — a
+    developer replaying a saved params file by hand, or an external caller — and is deliberately allowed
+    through rather than treated as a failure. Only a PRESENT-and-different value is fatal, because that
+    can only mean the two halves disagree about the params' shape.
+
+    Raises `SystemExit` rather than `ValueError`: this is a launch precondition, not a data problem, and
+    a runner has no way to recover from it. The message names the fix, because the fix is not obvious
+    from anything the params contain.
+    """
+    want = (env if env is not None else os.environ).get('CECELIA_PY_CONTRACT')
+    if want in (None, ''):
+        return None
+    try:
+        want_i = int(want)
+    except (TypeError, ValueError):
+        return None                     # unparseable → treat as absent, never fail a run over the guard
+    if want_i != CONTRACT_VERSION:
+        raise SystemExit(
+            f'[ERROR] Params contract mismatch: the backend sent version {want_i}, this runner speaks '
+            f'{CONTRACT_VERSION}. The Julia and Python halves are running different code — almost '
+            f'always a backend that was already running when the branch changed, because app/src is '
+            f'Revise-tracked and does not always reload. Restart the backend.')
+    return want_i
+
+
 def script_params():
     """
     Read and return the JSON params file passed via --params.
 
     The file is deleted after reading so temp files don't accumulate.
     Returns None if --params is not provided or the file does not exist.
+
+    Also verifies the params CONTRACT version (`check_contract_version`) — here rather than in each
+    runner, because this is the one function every runner already calls, so the guard cannot be
+    forgotten by a new one.
     """
+    check_contract_version()
+
     cli = argparse.ArgumentParser()
     cli.add_argument('--params', type=str, default=None)
     args = cli.parse_args()


### PR DESCRIPTION
Generalises the handshake I said #455 *didn't* attempt. **Stacked on #455** — base is `fix/af-channel-index-diagnosis`, so this diff is only the new work; GitHub retargets it to `main` when #455 merges.

## The audit

Julia and Python meet at three places. Only one could tell whether the two halves were running the same code:

| Boundary | Before |
|---|---|
| napari bridge (:7655) | adopted on a bare `ping` — **no version** |
| preview worker (:7656) | adopted, `PROTOCOL` checked ✓ |
| task params (`run_py`) | **nothing at all** |

The failure mode is identical at all three and **never a clean one**: a stale peer answers the handshake perfectly and then misreads the actual work. The three real occurrences read as `unexpected keyword argument 'mask'`, a bare `Preview failed`, and `invalid literal for int() with base 10: 'CH3'` — none named the cause, each cost an investigation.

## Two different asymmetries

Two boundaries hold a long-lived Python process that's **adopted** rather than relaunched — deliberately, since it outlives a backend crash or Ctrl-C.

The params boundary is the **opposite**, which is why it had no handshake: a task runner is spawned *fresh from disk every run*, so it's the **Julia** half that goes stale. `app/src` is Revise-tracked and a branch switch or a merge under a live server doesn't always reload it. That's exactly what bit us.

## What changed

**napari** — `ping` reports `protocol`; `_ensure_viewer!` adopts only on a match, else kills the port listener and relaunches. Losing the window is cheap: layer props and the T/Z position are autosaved, so it reopens where you were. (Uptime was *already* reported here "to spot a stale bridge" — which left the judgement to a human reading a number.)

**params** — `run_py` ships `PY_CONTRACT_VERSION` as the `CECELIA_PY_CONTRACT` env var; `script_params` refuses a mismatch.
- an **env var, not a params field**, so the payload keeps exactly the shape each runner documents
- an **absent** variable is allowed through — replaying a saved params file by hand must keep working
- the check lives in `script_params` because that's the one function every runner already calls, so a **new runner is covered by writing nothing**

## One table, one testset

The three pairs are asserted equal by a single testset with a **row per boundary** — a fourth boundary is a fourth row, not a bespoke check. That matters: before any test existed, the preview pair had been bumped by hand three times and the fourth was nearly missed.

## Verified, not assumed

- **mutation**: setting the bridge's `PROTOCOL` to 99 fails the Julia suite (I checked, because the test count alone didn't prove it ran)
- **end-to-end**: a runner spawned with `CECELIA_PY_CONTRACT=99` exits **1** with the diagnosis, so `run_py`'s clean-exit check fails the task instead of letting it half-run. A matching version passes the guard and proceeds.

## Docs

One table in `ARCHITECTURE.md` as the single place boundaries are listed, with pointers from `NAPARI.md` (command surface) and `MODULES.md` (when to bump, right next to `run_py`) — pointers rather than a restatement in each.

## Not covered

`mcp/` is an HTTP client of the Julia API rather than a spawned peer — different lifecycle, and API compatibility is its own story. Left alone.

The guard catches a contract change *someone remembered to version*. It cannot detect a stale process whose params shape happens to be unchanged — that would need Julia to compare its compiled state against disk, i.e. reimplementing Revise. What it does guarantee is that the class of mismatch that has actually bitten us now says so.

## Tests

438 Python / 3498 Julia package / API / 750 frontend + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
