### PR TITLE
fix(qc): measure clipping against signal voxels, and call the threshold what it is

### DIFF
--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -285,24 +285,29 @@ end
 const _Z_RATIO_MIN = 0.02
 const _Z_RATIO_MAX = 50
 
-# Materiality floor for the clipping FINDING: the fraction of a channel's voxels sitting at the
-# detector ceiling above which it is worth interrupting someone.
+# Level at which clipping raises a FINDING, as a fraction of the channel's SIGNAL voxels (those above
+# the derived background) — see `intensity_utils.saturation_stats`, which reports both denominators.
 #
-# **This is a chosen number, not a fitted one, and it should be re-set by the first real case.**
-# `intensity_utils.is_saturated` decides whether a channel clipped AT ALL — structural, measured, and
-# it stays the gate on detection. But detection is not the same as materiality: measured over all 36
-# channels of the nine `kSUFux` movies (one session), the four it flags hold 415-534 voxels of ~377 M
-# at the ceiling — 1.1-1.4e-6. That is real clipping of trivial extent, and "lower the gain" is not
-# an actionable thing to tell someone about 500 voxels, on 4 of every 9 imports.
+# **This is a smoke alarm, not a calibrated threshold, and it cannot be calibrated from the data in
+# hand.** The number was re-derived rather than guessed once: measured over all 36 channels of the nine
+# `kSUFux` movies, the four that clip hold 3.9-7.2e-5 of their SIGNAL voxels at the ceiling (1.1-1.4e-6
+# of all voxels — the all-voxel figure is diluted by ~95% empty frame, which is why no threshold on it
+# could be argued about). Against signal the worst case is 0.007%. So that session contains no MATERIAL
+# clipping at all, on either denominator, and any level between the observed trace and 1% would be
+# separating "trace" from "nothing" rather than "material" from "trace".
 #
-# 1e-4 is ~37 000 voxels on an image that size: unambiguously truncated structure rather than a few
-# hot cells, and ~70x above the worst trace case observed. Nothing in that session would warn. It is
-# set from what would damage a MEASUREMENT, because there is no material case in hand to fit to.
+# 1% of signal voxels is therefore chosen to be ~140x above anything actually acquired: it exists to
+# catch unmistakable damage — a channel driven far into saturation — and to stay silent otherwise. It is
+# NOT a claim about where clipping starts to matter. The first genuinely clipped acquisition should
+# replace it.
 #
-# The metric (`saturation_metrics`) is banked regardless of this floor: a trace-level count is still
-# worth having, because the cohort comparison is relative and will surface an image clipping far more
-# than its session peers without anyone choosing an absolute level.
-const _SATURATION_WARN_FRAC = 1e-4
+# The number a user can act on is not a voxel fraction at all: it is how many CELLS have clipped voxels,
+# which needs labels and so belongs at measure time. Recorded as the successor in docs/TODO.md.
+#
+# The metrics are banked regardless of this level, and that is the point of the split: trace-level
+# counts are still worth having because the cohort comparison is RELATIVE, so it surfaces an image
+# clipping far more than its session peers without anyone choosing an absolute level.
+const _SATURATION_WARN_SIGNAL_FRAC = 1e-2
 
 _cal_num(v) = v === nothing ? nothing : (v isa Real ? Float64(v) : tryparse(Float64, string(v)))
 _cal_int(v, default::Int) = (n = _cal_num(v); n === nothing ? default : round(Int, n))
@@ -399,17 +404,19 @@ function saturation_qc_findings(meta::AbstractDict)
     fs = Dict{String,Any}[]
     for ch in _saturation_channels(meta)
         get(ch, "saturated", false) === true || continue
-        # detected AND material — see _SATURATION_WARN_FRAC. A trace pile-up is recorded in the
-        # metrics but does not raise a finding.
-        frac = _cal_num(get(ch, "topFrac", nothing))
-        (isnothing(frac) || frac < _SATURATION_WARN_FRAC) && continue
+        # detected AND unmistakable — see _SATURATION_WARN_SIGNAL_FRAC. A trace pile-up is recorded in
+        # the metrics but does not raise a finding. Normalised by SIGNAL voxels, not all voxels.
+        frac = _cal_num(get(ch, "clippedSignalFrac", nothing))
+        (isnothing(frac) || frac < _SATURATION_WARN_SIGNAL_FRAC) && continue
         i = _cal_int(get(ch, "index", nothing), 0)
         push!(fs, qc_finding("warn", "import.channel_saturated"; channel = i,
-            # the COUNT, not a percentage: measured on a real session the clipped fraction is ~1e-6,
-            # which rounds to "0.0001%" and tells the user nothing. "534 voxels at 4095" is judgeable.
+            # the COUNT plus the SIGNAL-relative percentage. Not the all-voxel fraction: measured on a
+            # real session that is ~1e-6, which rounds to "0.0001%" and says more about how much blank
+            # frame there is than about the clipping.
             detail = Dict{String,Any}("channel"        => i,
                                       "topValue"       => _cal_num(get(ch, "topValue", nothing)),
-                                      "clippedVoxels"  => _cal_num(get(ch, "topCount", nothing)))))
+                                      "clippedVoxels"  => _cal_num(get(ch, "topCount", nothing)),
+                                      "clippedSignalPct" => round(frac * 100, digits = 3))))
     end
     fs
 end
@@ -431,8 +438,10 @@ end
 """
     saturation_metrics(meta) -> Union{Dict,Nothing}
 
-Cohort-comparable saturation counts: `nChannelsSaturated` and `maxClippedFrac` (the worst channel's
-clipped fraction). `nothing` when the check didn't run.
+Cohort-comparable saturation counts: `nChannelsSaturated`, plus the worst channel's clipped fraction
+against its SIGNAL voxels (`maxClippedSignalFrac` — the one to compare, since it does not move with how
+much empty frame an acquisition contains) and against all voxels (`maxClippedFrac`, kept because it is
+already banked). `nothing` when the check didn't run.
 
 Cohort-comparable because both describe the ACQUISITION, not a parameter anyone typed — so an image
 clipping far more than its session peers is a real gain/expression difference. Measured across nine
@@ -442,13 +451,18 @@ outlier flag should surface.
 function saturation_metrics(meta::AbstractDict)
     chans = _saturation_channels(meta)
     isempty(chans) && return nothing
-    n = 0; worst = 0.0
+    n = 0; worst = 0.0; worst_sig = 0.0
     for ch in chans
         get(ch, "saturated", false) === true && (n += 1)
         v = _cal_num(get(ch, "topFrac", nothing))
         isnothing(v) || (worst = max(worst, v))
+        vs = _cal_num(get(ch, "clippedSignalFrac", nothing))
+        isnothing(vs) || (worst_sig = max(worst_sig, vs))
     end
-    Dict{String,Any}("nChannelsSaturated" => n, "maxClippedFrac" => worst)
+    # `maxClippedSignalFrac` is the cohort-interesting one — it does not move with how much empty frame
+    # an acquisition happens to contain. `maxClippedFrac` stays because it is already banked.
+    Dict{String,Any}("nChannelsSaturated" => n, "maxClippedFrac" => worst,
+                     "maxClippedSignalFrac" => worst_sig)
 end
 
 # Compute + persist an image's import QC. Re-reads the PERSISTED ccid meta (not the possibly stale

--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -302,7 +302,8 @@ const _Z_RATIO_MAX = 50
 # replace it.
 #
 # The number a user can act on is not a voxel fraction at all: it is how many CELLS have clipped voxels,
-# which needs labels and so belongs at measure time. Recorded as the successor in docs/TODO.md.
+# which needs labels and so belongs at measure time. Deferred until segmentation is reliable on real
+# data — recorded as this threshold's successor in docs/FUTURE.md.
 #
 # The metrics are banked regardless of this level, and that is the point of the split: trace-level
 # counts are still worth having because the cohort comparison is RELATIVE, so it surfaces an image

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -67,8 +67,8 @@ const COHORT_METRICS = Dict{String,Vector{String}}(
     # `nChannelsSaturated`/`maxClippedFrac` describe the ACQUISITION rather than a parameter, so they
     # are comparable across a set shot in one session — an image clipping far more than its peers is a
     # real gain/expression difference. See qc.jl saturation_metrics.
-    "importImages.omezarr"           => ["nChannels", "nZ", "nT",
-                                         "nChannelsSaturated", "maxClippedFrac"],
+    "importImages.omezarr"           => ["nChannels", "nZ", "nT", "nChannelsSaturated",
+                                         "maxClippedSignalFrac", "maxClippedFrac"],
     # AF correction: both metrics describe the ACQUISITION, which is what makes them comparable across a
     # set shot in one session. `saturatedFrac` is the fraction of input voxels clipped at the sensor —
     # measured across the nine kSUFux movies it spanned 0.001% to 0.018%, a 13x spread at identical

--- a/app/src/tasks/importImages/saturation_run.py
+++ b/app/src/tasks/importImages/saturation_run.py
@@ -56,8 +56,8 @@ def run(params):
             stats['index'] = i
             channels.append(stats)
             log.log(f'   ch{i}: {"SATURATED" if stats["saturated"] else "ok"} '
-                    f'(top occupied value {stats["topValue"]}, '
-                    f'{stats["topCount"]} voxels = {stats["topFrac"] * 100:.4f}%)')
+                    f'(top occupied value {stats["topValue"]}, {stats["topCount"]} voxels '
+                    f'= {stats["clippedSignalFrac"] * 100:.4f}% of signal)')
         result = {'channels': channels}
     except Exception as e:
         # Advisory QC on a store that already converted successfully: report and move on. A

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -7290,13 +7290,16 @@ end
     end
 
     @testset "clipping-at-acquisition findings" begin
-        mk(i, sat; top = 4095, frac = 0.0, n = 0) =
+        # `sigfrac` is the one the finding gates on — clipped voxels over SIGNAL voxels. `frac` (over
+        # ALL voxels) is still banked, so both are set.
+        mk(i, sat; top = 4095, frac = 0.0, n = 0, sigfrac = 0.0) =
             Dict{String,Any}("index" => i, "saturated" => sat, "topValue" => top,
-                             "topCount" => n, "topFrac" => frac)
+                             "topCount" => n, "topFrac" => frac, "clippedSignalFrac" => sigfrac)
         meta = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [
-            mk(0, false; top = 1032, frac = 1.0e-6),
-            mk(1, true;  top = 4095, frac = 0.00018, n = 534),   # clipped at the 12-bit ceiling
-            mk(2, false; top = 2854, frac = 1.0e-6),
+            mk(0, false; top = 1032, frac = 1.0e-6, sigfrac = 1.0e-5),
+            # unmistakably clipped: 2% of this channel's SIGNAL voxels piled at the 12-bit ceiling
+            mk(1, true;  top = 4095, frac = 0.00018, n = 534, sigfrac = 0.02),
+            mk(2, false; top = 2854, frac = 1.0e-6, sigfrac = 1.0e-5),
         ]))
 
         fs = Cecelia.saturation_qc_findings(meta)
@@ -7309,9 +7312,12 @@ end
         # the COUNT is what a reader can judge; the fraction is ~1e-6 and rounds away
         @test fs[1]["detail"]["clippedVoxels"] == 534.0
 
+        @test fs[1]["detail"]["clippedSignalPct"] == 2.0     # reported against SIGNAL, not all voxels
+
         m = Cecelia.saturation_metrics(meta)
         @test m["nChannelsSaturated"] == 1
         @test m["maxClippedFrac"] == 0.00018
+        @test m["maxClippedSignalFrac"] == 0.02
 
         # the check didn't run (pre-existing image, or a non-integer store) → say nothing at all
         @test isempty(Cecelia.saturation_qc_findings(Dict{String,Any}()))
@@ -7330,19 +7336,29 @@ end
         # 377 M. No finding (telling someone to lower the gain over 500 voxels is not actionable), but
         # the metric MUST still record it: the cohort comparison is relative, so it is what surfaces an
         # image clipping far more than its session peers.
+        # 7.2e-5 of SIGNAL voxels is the worst real case measured across nine movies — three orders
+        # below the smoke-alarm level, so it must not warn while still being banked.
         trace = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [
-            mk(0, true; top = 4095, frac = 1.4e-6, n = 534),
+            mk(0, true; top = 4095, frac = 1.4e-6, n = 534, sigfrac = 7.2e-5),
         ]))
         @test isempty(Cecelia.saturation_qc_findings(trace))
         tm = Cecelia.saturation_metrics(trace)
         @test tm["nChannelsSaturated"] == 1
         @test tm["maxClippedFrac"] == 1.4e-6
+        @test tm["maxClippedSignalFrac"] == 7.2e-5
 
-        # …and just above the floor it does warn
+        # …and just above the level it does warn
         material = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [
-            mk(0, true; top = 4095, frac = 2.0e-4, n = 75_000),
+            mk(0, true; top = 4095, frac = 2.0e-4, n = 75_000, sigfrac = 1.1e-2),
         ]))
         @test length(Cecelia.saturation_qc_findings(material)) == 1
+
+        # the ALL-voxel fraction must not be what decides it: a channel with a large all-voxel fraction
+        # but trace signal clipping stays quiet, and vice versa. This is the whole point of the change.
+        allvox = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [
+            mk(0, true; top = 4095, frac = 0.5, n = 999, sigfrac = 1.0e-6),
+        ]))
+        @test isempty(Cecelia.saturation_qc_findings(allvox))
 
         # a channel with no recorded fraction is not guessed at
         noneframe = Dict{String,Any}("saturation" => Dict{String,Any}("channels" => [

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -277,6 +277,30 @@ correction, segmentation normalisation and the import saturation check. `image_w
 **brought back for its own sake**: clipping at acquisition is worth reporting whatever the bit depth,
 and it is now a standard QC pass on every import (`saturation_run.py`, `qc.jl::saturation_qc_findings`).
 
+## Flag clipping per CELL, not as a voxel fraction
+
+**What.** Report how many CELLS have clipped voxels in a channel, at `segment.measureLabels` (or
+`tracking.track_measures`), instead of only what fraction of a channel's voxels piled at the detector
+ceiling at import.
+
+**Why it is better.** A voxel fraction is not answerable. "0.004% of signal voxels clipped" gives a
+user nothing to decide; "17 of 2 400 cells have truncated intensity in CH2" does — one affected cell in
+ten matters when you are comparing means, while 500 clipped voxels spread over a 377 M-voxel movie may
+not. It would also give the import check's threshold something real to be calibrated against: today
+`_SATURATION_WARN_SIGNAL_FRAC` is deliberately a smoke alarm ~140x above anything measured, because no
+material clipping case exists in any data we have (worst observed: 0.007% of signal voxels, across all
+36 channels of nine movies).
+
+**Why deferred.** It needs labels, and specifically labels good enough to trust a per-cell count from —
+so it waits on segmentation being reliable on real data (Dominik, 2026-08-04). Building it against
+uncertain segmentation would produce a number nobody can act on either, for a different reason.
+
+**Revisit when.** Segmentation is dependable on real acquisitions. The import check stays as it is until
+then: detection + metrics on every import, a finding only for unmistakable damage.
+
+**Reference:** `qc.jl::saturation_qc_findings` / `_SATURATION_WARN_SIGNAL_FRAC`,
+`intensity_utils.saturation_stats` (both denominators), `#456`/`#462`.
+
 ---
 
 ## Adding entries

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -135,6 +135,22 @@ port is incomplete without it. 🔹 needs-input
 
 ## Backlog
 
+**#00094** — **Clipping is reported as a voxel fraction, which nobody can act on**
+The import check (`importImages.omezarr` → `saturation_qc_findings`) tells you a channel clipped at the
+detector and what fraction of its signal voxels piled at the ceiling. Measured over all 36 channels of
+the nine `kSUFux` movies, the four that clip sit at 3.9-7.2e-5 of signal (0.004-0.007%) — real clipping
+of trivial extent. There is no material case in any data we have, so the level at which a finding fires
+(`_SATURATION_WARN_SIGNAL_FRAC`, 1% of signal) is deliberately a smoke alarm ~140x above anything
+observed, not a calibrated threshold. It says so at the constant.
+
+The quantity a person can answer is not a voxel fraction: it is **how many CELLS have clipped voxels in
+that channel**. One affected cell in ten matters when you are comparing means; 500 voxels spread over a
+377 M-voxel movie may not. That needs labels, so it belongs at `segment.measureLabels` (or
+`tracking.track_measures`) rather than at import — the import pass can only say clipping is present.
+
+Doing this would also give the import threshold something to be calibrated AGAINST, instead of the
+current situation where it can only be set from what would obviously be damage.
+
 **#00090** — **A third of a drift-corrected stack can be empty, and every task still processes it**
 Measured 2026-07-31 on `k3Tx90` (project `kSUFux`… actually `4kS67f`, 201×20×544×548): drift correction
 expands the canvas and pads with zeros, and on that image **z 0–2 and z 16–20 are all-zero across every

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -135,22 +135,6 @@ port is incomplete without it. 🔹 needs-input
 
 ## Backlog
 
-**#00094** — **Clipping is reported as a voxel fraction, which nobody can act on**
-The import check (`importImages.omezarr` → `saturation_qc_findings`) tells you a channel clipped at the
-detector and what fraction of its signal voxels piled at the ceiling. Measured over all 36 channels of
-the nine `kSUFux` movies, the four that clip sit at 3.9-7.2e-5 of signal (0.004-0.007%) — real clipping
-of trivial extent. There is no material case in any data we have, so the level at which a finding fires
-(`_SATURATION_WARN_SIGNAL_FRAC`, 1% of signal) is deliberately a smoke alarm ~140x above anything
-observed, not a calibrated threshold. It says so at the constant.
-
-The quantity a person can answer is not a voxel fraction: it is **how many CELLS have clipped voxels in
-that channel**. One affected cell in ten matters when you are comparing means; 500 voxels spread over a
-377 M-voxel movie may not. That needs labels, so it belongs at `segment.measureLabels` (or
-`tracking.track_measures`) rather than at import — the import pass can only say clipping is present.
-
-Doing this would also give the import threshold something to be calibrated AGAINST, instead of the
-current situation where it can only be set from what would obviously be damage.
-
 **#00090** — **A third of a drift-corrected stack can be empty, and every task still processes it**
 Measured 2026-07-31 on `k3Tx90` (project `kSUFux`… actually `4kS67f`, 201×20×544×548): drift correction
 expands the canvas and pads with zeros, and on that image **z 0–2 and z 16–20 are all-zero across every

--- a/python/cecelia/tests/test_intensity_utils.py
+++ b/python/cecelia/tests/test_intensity_utils.py
@@ -152,6 +152,34 @@ class TestIntensityUtils(unittest.TestCase):
         clean = iu.saturation_stats(self._tail(2000))
         self.assertFalse(clean['saturated'])
 
+    def test_the_signal_denominator_is_not_diluted_by_empty_frame(self):
+        """THE reason `clippedSignalFrac` exists. Padding a channel with background must not change how
+        clipped it is — but it changes `topFrac`, because that divides by every voxel. Measured on the
+        nine kSUFux movies (~95% background) the all-voxel figure lands at 1e-6, which says as much
+        about how much blank frame there is as about the clipping."""
+        h = self._clipped(4000, clip_at=1200)
+        padded = h.copy()
+        padded[0] += 100 * int(h.sum())              # a far emptier frame, same recorded signal
+
+        a, b = iu.saturation_stats(h), iu.saturation_stats(padded)
+        self.assertAlmostEqual(a['clippedSignalFrac'], b['clippedSignalFrac'], places=9)
+        self.assertLess(b['topFrac'], a['topFrac'] / 50)   # the all-voxel figure collapses
+        self.assertEqual(a['signalVoxels'], b['signalVoxels'])
+
+    def test_the_signal_fraction_is_larger_than_the_all_voxel_one(self):
+        """Sanity on direction: signal voxels are a SUBSET, so the same clipping is a bigger fraction
+        of them. On the real movies: 3.9-7.2e-5 of signal against 1.1-1.4e-6 of everything."""
+        s = iu.saturation_stats(self._clipped(4000, clip_at=1200))
+        self.assertGreater(s['clippedSignalFrac'], s['topFrac'])
+        self.assertGreater(s['signalVoxels'], 0)
+
+    def test_saturation_stats_on_a_flat_or_empty_channel(self):
+        """No signal to divide by → 0.0, not a ZeroDivisionError on the import path."""
+        for h in (np.zeros(4096, dtype=np.int64), np.eye(1, 4096, 7, dtype=np.int64)[0]):
+            s = iu.saturation_stats(h)
+            self.assertEqual(s['clippedSignalFrac'], 0.0)
+            self.assertFalse(s['saturated'])
+
     def test_triangle_threshold_degenerate_histograms(self):
         self.assertEqual(iu.triangle_threshold(np.zeros(16, np.int64)), 0.0)
         one = np.zeros(16, np.int64); one[7] = 5

--- a/python/cecelia/utils/intensity_utils.py
+++ b/python/cecelia/utils/intensity_utils.py
@@ -132,21 +132,41 @@ def is_saturated(hist, min_count=None):
     return bool(int(h[top]) > float(np.median(below)))
 
 
-def saturation_stats(hist):
+def saturation_stats(hist, background_method='triangle'):
     """`is_saturated` plus the numbers behind the verdict, JSON-friendly for QC.
 
     `topValue` is where the pile-up sits — the detector's effective ceiling, which is worth reporting
     because it is NOT the dtype maximum on sub-16-bit sensor data.
+
+    **Two denominators, and `clippedSignalFrac` is the one to reason with.** `topFrac` divides by every
+    voxel in the channel, and these images are ~95% background, so it is diluted by empty space: on the
+    nine `kSUFux` movies the clipped channels come out at 1.1-1.4e-6, a number no threshold can be
+    argued about because it says as much about how much blank frame there is as about the clipping.
+    `clippedSignalFrac` divides by the voxels ABOVE the derived background (`background_threshold`), so
+    it answers "how much of what this channel actually recorded got truncated" — 3.9-7.2e-5 for those
+    same channels. Both are kept: `topFrac` because the cohort metric already banks it.
+
+    Measured caveat, so nobody reads more into the change than it earns: the better denominator did NOT
+    separate the flagged channels more cleanly (a 1.5x gap to the highest unflagged one, against 1.9x
+    for `topFrac`). It is a more meaningful quantity, not a sharper discriminator.
     """
     h = np.asarray(hist)
     total = int(h.sum())
     nz = np.nonzero(h)[0]
     top = int(nz[-1]) if nz.size else 0
+    n_top = int(h[top]) if nz.size else 0
+    signal = 0
+    if nz.size > 1:
+        bg = background_threshold(h, method=background_method)
+        lo = int(np.ceil(bg))
+        signal = int(h[lo:].sum()) if lo < h.size else 0
     return {
         'saturated': bool(is_saturated(h)),
         'topValue': top,
-        'topCount': int(h[top]) if nz.size else 0,
-        'topFrac': (int(h[top]) / total) if total else 0.0,
+        'topCount': n_top,
+        'topFrac': (n_top / total) if total else 0.0,
+        'signalVoxels': signal,
+        'clippedSignalFrac': (n_top / signal) if signal else 0.0,
     }
 
 


### PR DESCRIPTION
Follow-up to #456. You asked whether the clipping floor could be re-derived. I tried, and the result splits in two: one part was fixable, one genuinely isn't — and saying which is which is most of the value here.

## Fixable: the denominator was wrong

`topFrac` divides clipped voxels by **every** voxel in the channel. These images are ~95% background, so the figure is diluted by empty frame — it says as much about how much blank space an acquisition contains as about the clipping. That's why any threshold on it read as invented.

`clippedSignalFrac` divides by voxels **above the derived background** (`background_threshold`, already in that module): how much of what the channel actually recorded got truncated.

| | clipped / all voxels | clipped / signal voxels |
|---|---|---|
| flagged (4 of 36) | 1.10–1.41e-6 | 3.9–7.2e-5 |
| not flagged (32) | ≤5.7e-7 | ≤2.55e-5 |

Both are banked. The finding gates on the signal one, and so should cohort comparison, since it doesn't move with frame emptiness.

**Stated in the docstring rather than glossed:** the better denominator did *not* separate the flagged channels more cleanly — a 1.5× gap to the highest unflagged channel, against 1.9× for `topFrac`. It's a more meaningful quantity, not a sharper discriminator.

## Not fixable: there is no material case to calibrate against

Against signal voxels, the worst clipping in that whole session is **0.007%**. So any level between the observed trace and 1% separates "trace" from "nothing", not "material" from "trace". No amount of re-deriving fixes that — the data doesn't contain the case the threshold is meant to catch.

So rather than dress it up: `_SATURATION_WARN_SIGNAL_FRAC` is 1% of signal, ~140× above anything acquired, and the constant says outright that it is a **smoke alarm for unmistakable damage, not a claim about where clipping starts to matter**, and that the first genuinely clipped acquisition should replace it.

## The successor, recorded in `docs/FUTURE.md`

A voxel fraction is not answerable. "**N cells have clipped voxels in channel C**" is — one affected cell in ten matters when you're comparing means, while 500 voxels spread over a 377 M-voxel movie may not. That needs labels, so it belongs at `segment.measureLabels`, and it would give this threshold something real to be calibrated against.

**Deferred until segmentation is reliable on real data.** It was briefly filed as TODO #00094; once gated on that, `docs/TODO.md`'s own routing table puts it in `docs/FUTURE.md` as a known-better approach set aside — a per-cell count from uncertain labels would be as unactionable as the voxel fraction it replaces. The entry carries the trigger, and `_SATURATION_WARN_SIGNAL_FRAC` points at it so the reason it is uncalibrated leads to its successor.

## Testing

Package (QC framework 233 → 237), Python (445), API and frontend suites green.

New tests worth noting: padding a channel with background must not change how clipped it is — `clippedSignalFrac` is invariant while `topFrac` collapses by >50×, which is the entire reason for the change. Plus a case where a large all-voxel fraction with trace signal clipping stays quiet, so the old denominator can't be what decides.

Verified on real data: `kSUFux/PsD5Xc` ch2 now reports **0.0041% of signal** (was "0.0001%" of all voxels), still banks, still raises nothing.

## Reservations

- **The threshold is still uncalibrated.** This PR makes that explicit instead of fixing it, because it can't be fixed from the data available. If you'd rather have no finding at all until #00094 exists, that's a smaller change and a defensible position.
- `background_threshold` (triangle) is now on the import path for every channel. It's computed from the histogram already in hand, so no extra pass — but a channel whose histogram defeats the triangle method gets a wrong `signalVoxels`, and therefore a wrong fraction. Flat/empty channels are handled (0.0, no divide-by-zero); a pathological shape is not something I can rule out.
- `maxClippedFrac` is kept alongside the new metric only because it was already banked. Two near-identical cohort metrics is mild clutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)