### PR TITLE
fix(preview): a failed preview says why, in a place you can read

### DIFF
--- a/frontend/src/stores/taskPreview.ts
+++ b/frontend/src/stores/taskPreview.ts
@@ -22,9 +22,9 @@ import {
   previewBlocker, previewNotice, previewSummary, baseOnlyWarning, tilingWarning,
   compositeWarning, warmPollAction,
   PREVIEW_DEBOUNCE_MS, WORKER_WARM_POLL_MS,
-  type PreviewContext, type PreviewStatus, type PreviewBlocker,
-} from '../utils/taskPreview'
+  type PreviewContext, type PreviewStatus, type PreviewBlocker, previewFailureLog } from '../utils/taskPreview'
 import { useWsStore } from './ws'
+import { useLogStore } from './log'
 
 export const useTaskPreviewStore = defineStore('taskPreview', () => {
   // SESSION-ONLY, and a deliberate exception to "persist every user-settable option"
@@ -59,6 +59,24 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
   const errorCode = ref('')
   /** true between toggle-on and the worker answering — its imports take ~18 s, so this is visible */
   const starting = ref(false)
+
+  const log = useLogStore()
+
+  /**
+   * Record a failure: the readout AND the error console.
+   *
+   * One helper because three paths set `error` and every one of them was readout-only. The notice shows
+   * ≤4 words with the specifics in a tooltip, which is how an `AttributeError` from the worker reached
+   * the user as a bare "Preview failed" — the text was there, one hover away, with nothing saying so.
+   * `previewFailureLog` (pure, unit-tested) decides the level and the headline so the console and the
+   * button cannot disagree.
+   */
+  function fail(message: string, code = '') {
+    error.value = message
+    errorCode.value = code
+    const entry = previewFailureLog({ message, code })
+    if (entry) log[entry.level](entry.message, { detail: entry.detail, source: entry.source })
+  }
 
   /** Forget the last result. Called whenever it stops describing what is on screen. */
   function clearResult() {
@@ -133,8 +151,7 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
     // result must go with it. "12 cells" beside "Wrong version open" reads as twelve cells in THIS
     // version; the count no longer describes anything we accepted.
     onError: e => {
-      error.value = e instanceof Error ? e.message : String(e)
-      errorCode.value = (e as SvcError)?.code ?? ''
+      fail(e instanceof Error ? e.message : String(e), (e as SvcError)?.code ?? '')
       starting.value = false
       clearResult()
     },
@@ -188,8 +205,7 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
           return
         case 'abandon':
           starting.value = false
-          error.value = 'The preview worker did not start.'
-          errorCode.value = 'timeout'
+          fail('The preview worker did not start.', 'timeout')
           return
         default:
           warmTimer = setTimeout(tick, WORKER_WARM_POLL_MS)
@@ -215,7 +231,7 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
       // toggle-on rather than making the user's first parameter change look like a 10 s hang
       await previewApi.start()
     } catch (e) {
-      error.value = e instanceof Error ? e.message : String(e)
+      fail(e instanceof Error ? e.message : String(e))
     }
     await refreshStatus()
     request()
@@ -233,7 +249,7 @@ export const useTaskPreviewStore = defineStore('taskPreview', () => {
       // removes the layer AND stops the worker — the only thing that releases the model's VRAM
       await previewApi.stop(context.value?.valueName)
     } catch (e) {
-      error.value = e instanceof Error ? e.message : String(e)
+      fail(e instanceof Error ? e.message : String(e))
     }
     await refreshStatus()
   }

--- a/frontend/src/utils/taskPreview.test.ts
+++ b/frontend/src/utils/taskPreview.test.ts
@@ -4,8 +4,7 @@ import {
   FALLBACK_2D_WARN, baseOnlyWarning, tilingWarning, compositeWarning,
   paramsBlocker, hasAfCombination,
   warmPollAction, WORKER_WARM_POLL_MS, WORKER_WARM_TIMEOUT_MS,
-  type PreviewContext, type PreviewStatus,
-} from './taskPreview'
+  type PreviewContext, type PreviewStatus, previewFailureLog } from './taskPreview'
 
 const ctx = (over: Partial<PreviewContext> = {}): PreviewContext => ({
   projectUid: 'p', imageUid: 'img1', valueName: 'A', funName: 'segment.cellpose',
@@ -464,5 +463,47 @@ describe('warmPollAction', () => {
   it('the poll interval is well under the timeout, or the wait would never retry', () => {
     expect(WORKER_WARM_POLL_MS).toBeGreaterThan(0)
     expect(WORKER_WARM_POLL_MS).toBeLessThan(WORKER_WARM_TIMEOUT_MS / 10)
+  })
+})
+
+
+describe('previewFailureLog — a failure has to be readable, not hover-only', () => {
+  // The bug: AF preview died with an AttributeError from the worker. The message travelled intact
+  // through Julia, the API and the store, and stopped one `v-tooltip` short of being readable — the
+  // user saw "Preview failed" and had no hint there was anything to hover.
+  const ATTR = "preview worker: AttributeError: module 'cecelia.utils.correction_utils' " +
+               "has no attribute 'af_channel_indices'"
+
+  it('sends a real failure to the console at error level, with the full text as detail', () => {
+    const e = previewFailureLog({ message: ATTR })
+    expect(e).not.toBeNull()
+    expect(e!.level).toBe('error')          // error, not warn — this is what raises the unread badge
+    expect(e!.message).toBe('Preview failed')
+    expect(e!.detail).toBe(ATTR)            // the whole thing, not a truncation
+    expect(e!.source).toBe('preview')
+  })
+
+  it('a timeout is a warn — a slow machine as often as a fault, and it has its own readout', () => {
+    const e = previewFailureLog({ message: 'The preview worker did not start.', code: 'timeout' })
+    expect(e!.level).toBe('warn')
+  })
+
+  it('the headline matches what the control says, so console and button agree', () => {
+    // same ERROR_SHORT lookup previewNotice uses
+    const code = 'params-not-previewable'
+    expect(previewFailureLog({ message: 'x', code })!.message)
+      .toBe(previewNotice(null, { message: 'x', code }).short)
+  })
+
+  it('logs nothing when there is no failure', () => {
+    expect(previewFailureLog(null)).toBeNull()
+    expect(previewFailureLog({ message: '' })).toBeNull()
+    expect(previewFailureLog({ message: '   ' })).toBeNull()   // a cleared error must not log
+  })
+
+  it('a blocker is NOT a failure — logging "no image open" would train users to ignore the console', () => {
+    // blockers never reach this function; the store only calls it from a catch. Pinned so a future
+    // refactor that starts routing blockers here has to make the decision deliberately.
+    expect(previewFailureLog({ message: '', code: 'image-mismatch' })).toBeNull()
   })
 })

--- a/frontend/src/utils/taskPreview.ts
+++ b/frontend/src/utils/taskPreview.ts
@@ -157,6 +157,49 @@ export interface PreviewNotice {
   warn: boolean
 }
 
+/** A log-store entry for a preview failure, or `null` when there is nothing worth logging. */
+export interface PreviewLogEntry {
+  level: 'warn' | 'error'
+  message: string
+  detail: string
+  source: 'preview'
+}
+
+/**
+ * Should this preview failure also go to the error console, and how loudly?
+ *
+ * **Because the notice alone was not enough.** `previewNotice` puts the problem in ≤4 words and the
+ * specifics in `detail`, which the control renders as a TOOLTIP — so when AF preview died with
+ * `AttributeError: module 'cecelia.utils.correction_utils' has no attribute 'af_channel_indices'`, the
+ * user saw "Preview failed" and nothing else, with no hint there was anything to hover. The message had
+ * travelled intact from the worker through Julia through the API into the store, and stopped one
+ * `v-tooltip` short of being readable. (The store's own comment already said "a failed preview must be
+ * visible, not a console-only unhandled rejection" — the intent was right, the volume was not.)
+ *
+ * `error` rather than `warn` for a genuine failure, because that is what raises the console's unread
+ * badge — the thing that says "something is written down". A **timeout** is a warn: the worker not
+ * starting in 180 s is worth recording but it is a slow machine as often as a fault, and it already has
+ * its own readout.
+ *
+ * Returns `null` for anything that is not a failure at all, so a cleared error never logs. Blockers are
+ * deliberately absent: "no image open" is visible in the viewer, and logging it would teach the user to
+ * ignore the console.
+ */
+export function previewFailureLog(
+  error: { message?: string; code?: string } | null,
+): PreviewLogEntry | null {
+  const message = error?.message?.trim()
+  if (!error || !message) return null
+  const code = error.code ?? ''
+  return {
+    level: code === 'timeout' ? 'warn' : 'error',
+    // the headline matches what the control says, so the console and the button agree
+    message: ERROR_SHORT[code] ?? 'Preview failed',
+    detail: message,
+    source: 'preview',
+  }
+}
+
 export function previewNotice(
   blocker: PreviewBlocker | null,
   error: { message?: string; code?: string } | null,


### PR DESCRIPTION
Follow-up to #463 (which fixed the crash). This is about **why you couldn't read the error**.

## The message was never lost

It travelled intact the whole way and stopped one `v-tooltip` short of being visible:

```
worker      raises AttributeError
  → handle  {"type":"error","msg":"AttributeError: …no attribute 'af_channel_indices'"}
  → Julia   send() raises  →  API returns 500 {"error": "preview worker: AttributeError: …"}
  → store   error.value = that message                    ← the text IS here
  → notice  { short: "Preview failed", detail: <the AttributeError>, warn: true }
  → render  short as text, detail ONLY as v-tooltip.left  ← and here it stops
```

`previewNotice` is designed to put the problem in ≤4 words with the specifics in `detail` — good for *"Wrong image open"*, wrong for a crash. Nothing indicated there was anything to hover.

The store's own comment already said **"a failed preview must be visible, not a console-only unhandled rejection"**. The intent was right; the volume wasn't.

## The fix

A failure now also goes to the **error console**, where `ErrorConsole` renders `detail` with click-to-expand and the unread badge says something was written down. That's where `BatchMoviesPanel` already sends *its* preview failures — the task preview was the outlier, not the precedent.

Levels are deliberate:

| case | level | why |
|---|---|---|
| genuine failure | `error` | raises the unread badge — the thing that says "this is recorded" |
| `timeout` | `warn` | a worker not starting in 180 s is a slow machine as often as a fault, and it already has its own readout |
| blockers | **nothing** | "no image open" is visible in the viewer; logging it would teach you to ignore the console |

## Shape

The decision is a **pure function** (`previewFailureLog`) rather than logic buried in the store, so it's unit-testable per `docs/DEV.md`. Its headline reuses the same `ERROR_SHORT` lookup `previewNotice` uses, so the console and the button can't drift — there's a test pinning exactly that.

One `fail()` helper in the store, because all four paths that set `error` were readout-only.

## Tests

766 frontend (6 new) + typecheck. `ui-copy` clean on every enforced surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
