### PR TITLE
fix(preview): a corrected layer keeps its channel's name and colour

### DIFF
--- a/api/src/preview_api.jl
+++ b/api/src/preview_api.jl
@@ -91,10 +91,20 @@ function _ensure_preview!()::Bool
                 return true
             elseif ok
                 @warn "Replacing preview worker: it speaks protocol $protocol, this backend needs " *
-                      "$PREVIEW_PROTOCOL (its code predates a change to the reply shape or the " *
-                      "previewable tasks)"
-                try; close!(probe); catch e
-                    @warn "Could not stop the stale preview worker" exception = e
+                      "$PREVIEW_PROTOCOL (its code predates a change to what a preview answers — " *
+                      "the reply shape, the previewable tasks, or a bug fixed since)"
+                # Kill by PORT, not `close!(probe)` — the probe was only ever pinged, so its `proc` is
+                # nothing and `close!` is a silent no-op. The stale worker then keeps the port, the
+                # replacement cannot bind, and its readiness ping is answered by the very process we
+                # meant to remove: a relaunch loop that serves the old code. Same reason and same
+                # helper as the napari bridge in `_ensure_viewer!`.
+                Cecelia._kill_listeners_on_port(PREVIEW_PORT)
+                # …and WAIT for it to let go. The kill is asynchronous, so launching straight away races
+                # the old process's exit: the replacement loses the bind and dies, which `launch!` reports
+                # as an error the user sees once before the next attempt succeeds. Cheap to just wait.
+                for _ in 1:20
+                    first(_preview_ping(probe)) || break
+                    sleep(0.25)
                 end
             end
         end
@@ -238,12 +248,15 @@ function api_preview_run(body_bytes::Vector{UInt8})
     catch
         nothing
     end
+    # Loaded unconditionally: the params translation needs it, and so do the channel DISPLAY names,
+    # which only `ccid.json` knows (see `preview_request` — deriving them in the worker instead is what
+    # made every corrected layer render grey).
+    img_for_params = try
+        init_object(project_uid, image_uid)      # already validated against the open image above
+    catch e
+        return 500, JSON3.write((; error = "could not load image metadata: " * sprint(showerror, e)))
+    end
     if task !== nothing
-        img_for_params = try
-            init_object(project_uid, image_uid)      # already validated against the open image above
-        catch e
-            return 500, JSON3.write((; error = "could not load image metadata: " * sprint(showerror, e)))
-        end
         params = try
             preview_params_for_run(task, params, img_for_params)
         catch e
@@ -252,6 +265,7 @@ function api_preview_run(body_bytes::Vector{UInt8})
                 code = "params-not-previewable"))
         end
     end
+    chan_names = something(channel_names(img_for_params; value_name = in_value_name), String[])
 
     reply = try
         _with_preview() do
@@ -259,7 +273,8 @@ function api_preview_run(body_bytes::Vector{UInt8})
             w === nothing && error("preview worker is not running")
             send(w, preview_request(open_image.zarrPath, open_image.taskDir, params, region;
                                     value_name = value_name,
-                                    fun_name = String(get(data, "funName", ""))))
+                                    fun_name = String(get(data, "funName", "")),
+                                    channel_names = chan_names))
         end
     catch e
         return 500, JSON3.write((; error = sprint(showerror, e)))

--- a/app/src/preview.jl
+++ b/app/src/preview.jl
@@ -28,14 +28,15 @@ const PREVIEW_PORT   = 7656
 #
 # Stale code presented as a bare "Preview failed": a worker predating the AF backend ignored
 # `funName`, fell through to the segmentation path and raised "no models in preview params", with
-# nothing anywhere reporting that the process was old. Bump BOTH sides together whenever the reply shape
-# or the set of previewable tasks changes.
+# nothing anywhere reporting that the process was old.
 #
-# 4 is also the first bump where a stale worker would NOT fail loudly: it carries the old ratio
-# `af_correct_frame`, so it would keep returning well-formed ratio previews — hollowed-out overlapping
-# cells and all — while the backend believes the power weight is being shown. A preview that silently
-# disagrees with the run is the one outcome this feature must never produce.
-const PREVIEW_PROTOCOL = 4
+# So the rule is BEHAVIOURAL, not structural: bump BOTH sides together whenever an adopted older worker
+# would answer differently — a changed reply shape, a changed set of previewable tasks, OR a bug fixed
+# inside the worker. The version is the only thing that can refuse a process we did not start, so
+# anything we would not want served from the old code has to move it. 5 is that case with nothing else
+# attached: the reply shape is identical to 4, and the fix (a preview crashing on every AF request) is
+# invisible to any check but this one.
+const PREVIEW_PROTOCOL = 5
 const PREVIEW_WORKER = joinpath(@__DIR__, "..", "..", "preview", "preview_worker.py")
 
 mutable struct PreviewWorker
@@ -65,9 +66,16 @@ end
 """
     launch!(w::PreviewWorker) -> PreviewWorker
 
-Start the worker and wait until it answers a ping. The wait is generous on purpose: the process
-imports torch and cellpose before it can serve anything (~18 s measured), which is the cost being
-amortised — a short timeout would just make the first toggle look broken.
+Start the worker and wait until it answers a ping **with our own protocol**. The wait is generous on
+purpose: the process imports torch and cellpose before it can serve anything (~18 s measured), which is
+the cost being amortised — a short timeout would just make the first toggle look broken.
+
+Readiness is the protocol, not merely a reply, because the port may already be held by a worker running
+older code. That process answers a ping perfectly, so a reply-only check reports "connected" for a
+process we did not start and cannot use — while the one we just spawned has already died unable to bind.
+The result is a relaunch loop that keeps serving the stale worker, which is strictly worse than the
+mismatch it was meant to repair. A dead child is also detected directly, so a bind failure surfaces in a
+second rather than after the full 90.
 """
 function launch!(w::PreviewWorker)::PreviewWorker
     # PYTHONPATH pins `import cecelia.*` to THIS checkout's `python/`, exactly as `run_py` does for
@@ -79,16 +87,32 @@ function launch!(w::PreviewWorker)::PreviewWorker
     w.proc = run(addenv(`$(python_bin_path()) $PREVIEW_WORKER`, "PYTHONPATH" => _python_dir()),
                  wait=false)
     deadline = time() + 90
+    squatter = nothing
     while time() < deadline
         try
-            send(w, Dict("type" => "ping"))
-            @info "Preview worker connected" port=w.port
-            return w
+            reply = send(w, Dict("type" => "ping"))
+            protocol = Int(get(reply, "protocol", 1))
+            if protocol == PREVIEW_PROTOCOL
+                @info "Preview worker connected" port=w.port
+                return w
+            end
+            # Someone else holds the port. Keep waiting — it may be on its way out (a kill is async, and
+            # the process we just spawned cannot bind until it goes) — but remember what answered so the
+            # timeout can name the cause instead of blaming the launch.
+            squatter = protocol
         catch
-            sleep(0.5)
         end
+        if !process_running(w.proc)
+            error("Preview worker exited immediately" *
+                  (squatter === nothing ? "" :
+                   " — port $(w.port) is held by a worker speaking protocol $squatter, which is why it " *
+                   "could not bind. Stop that process (Settings → Restart stops it with the backend)."))
+        end
+        sleep(0.5)
     end
-    error("Preview worker did not start within 90 seconds")
+    error("Preview worker did not start within 90 seconds" *
+          (squatter === nothing ? "" :
+           " — port $(w.port) is answering with protocol $squatter, not $PREVIEW_PROTOCOL"))
 end
 
 """
@@ -129,7 +153,8 @@ function preview_request(img::CciaImage, params::AbstractDict, region::AbstractD
     im_path = img_filepath(img, in_value_name)
     isnothing(im_path) && error("no image filepath for valueName='$in_value_name'")
     preview_request(im_path, img._dir, params, region;
-                    value_name = value_name, fun_name = fun_name)
+                    value_name = value_name, fun_name = fun_name,
+                    channel_names = something(channel_names(img; value_name = in_value_name), String[]))
 end
 
 """
@@ -143,11 +168,22 @@ store supplies both, or neither.
 
 The API separately refuses to preview at all when the open version isn't the one the task would read —
 see `api/src/preview_api.jl`. That check is what makes this pairing safe rather than merely consistent.
+
+`channel_names` is the DISPLAY name per channel index, and Julia has to supply it: `ccid.json` is
+authoritative for channel names (they are user-editable), so it is the only half of this conversation
+that knows them. The worker used to read them from the store's OME-XML instead, which is a different copy
+— on a real image that copy still said `CH1..CH4` while the viewer, named from `ccid.json`, showed
+`SHG`/`nuc-GFP`/`mem-TOM`/`CD169-Kat`. The corrected layer was therefore called `CH3 AF`, and its
+`source` pointed at a layer named `CH3` that does not exist, so the colormap mirror silently found
+nothing and every corrected channel rendered GREY — the one thing that makes it useless to compare
+against its original. Same shape as the calibration rule: several copies exist, exactly one is
+authoritative, and nobody re-derives it.
 """
 function preview_request(im_path::AbstractString, task_dir::AbstractString,
                          params::AbstractDict, region::AbstractDict;
                          value_name::AbstractString = VERSIONED_DEFAULT_VAL,
-                         fun_name::AbstractString = "")::Dict{String,Any}
+                         fun_name::AbstractString = "",
+                         channel_names::AbstractVector{<:AbstractString} = String[])::Dict{String,Any}
     req = Dict{String,Any}(
         "type"            => "preview",
         "imPath"          => String(im_path),
@@ -156,6 +192,7 @@ function preview_request(im_path::AbstractString, task_dir::AbstractString,
         "region"          => Dict{String,Any}(String(k) => v for (k, v) in region),
         "params"          => Dict{String,Any}(String(k) => v for (k, v) in params),
     )
+    isempty(channel_names) || (req["channelNames"] = String[String(n) for n in channel_names])
     # which compute to run. The worker dispatches on it (`preview_worker._BACKENDS`) because the params
     # alone cannot say: a `models` bag means cellpose and an `afCombinations` bag means AF correction,
     # and inferring the task from the shape of its params is exactly the guess `task_previewable`

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -8669,6 +8669,21 @@ Cecelia.live_outputs(::_BadLiveTask, ::AbstractDict) = error("boom")
             @test direct["taskDir"] == "/somewhere/meta"
             @test direct["outputValueName"] == "B"
             @test direct["region"]["z"] == 8
+
+            # Channel DISPLAY names travel with the request, because `ccid.json` is the only
+            # authoritative copy — the worker deriving them from the store's OME-XML instead is what
+            # made every corrected AF layer render grey (its `source` named a layer that did not
+            # exist). Sent only when known: an empty list would overwrite the fallback with nothing.
+            @test !haskey(direct, "channelNames")
+            named = Cecelia.preview_request(
+                "/somewhere/open.ome.zarr", "/somewhere/meta",
+                Dict("models" => Dict()), region; channel_names = ["SHG", "mem-TOM"])
+            @test named["channelNames"] == ["SHG", "mem-TOM"]
+
+            # and the image form fills them in from ccid, per the version being previewed
+            img.im_channel_names["default"] = ["SHG", "nuc-GFP", "mem-TOM", "CD169-Kat"]
+            from_img = Cecelia.preview_request(img, Dict("models" => Dict()), region)
+            @test from_img["channelNames"] == ["SHG", "nuc-GFP", "mem-TOM", "CD169-Kat"]
         end
     end
 
@@ -8804,6 +8819,34 @@ Cecelia.live_outputs(::_BadLiveTask, ::AbstractDict) = error("boom")
         @test Cecelia.PREVIEW_PORT ∉ (7655, 7660, 8080, 5173)
         # not alive until launched — `preview_alive` must never report true for a null process
         @test !Cecelia.preview_alive(Cecelia.PreviewWorker())
+    end
+
+    @testset "a stale preview worker is stopped by port, not by handle" begin
+        # THE BUG THIS PINS. On a protocol mismatch the backend must remove the worker holding :7656.
+        # It only ever PINGED that process, so the handle it has is a bare `PreviewWorker()` with no
+        # `proc` — and `close!` on that is a silent no-op. Kill-by-handle therefore left the stale
+        # worker listening, the replacement could not bind, and the replacement's readiness ping was
+        # answered by the process being replaced: a relaunch loop serving the old code, strictly worse
+        # than the mismatch. So the adoption path must kill by PORT, like `_ensure_viewer!` does.
+        adopted = Cecelia.PreviewWorker()          # exactly what `_ensure_preview!` probes with
+        @test adopted.proc === nothing
+        Cecelia.close!(adopted)                    # no-op, and must not throw pretending otherwise
+        @test adopted.proc === nothing
+
+        # `_kill_listeners_on_port` is the one helper for this (never inline kill/lsof/taskkill), and
+        # the mismatch branch in the API layer has to use it. Source-level because that branch needs a
+        # live stale worker to exercise.
+        api_src = read(joinpath(dirname(dirname(pathof(Cecelia))), "..", "api", "src",
+                                "preview_api.jl"), String)
+        @test occursin("_kill_listeners_on_port(PREVIEW_PORT)", api_src)
+        # CODE only — the comment above that call names `close!(probe)` to say why it is wrong, and a
+        # naive text search cannot tell an explanation from the thing it warns about.
+        api_code = filter(l -> !startswith(strip(l), "#"), split(api_src, '\n'))
+        @test !any(l -> occursin("close!(probe)", l), api_code)
+
+        # And readiness is the protocol, not merely a reply — the other half of the same loop.
+        preview_src = read(joinpath(dirname(pathof(Cecelia)), "preview.jl"), String)
+        @test occursin("protocol == PREVIEW_PROTOCOL", preview_src)
     end
 
     @testset "language boundaries agree on their protocol" begin

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,6 +45,14 @@ live server does not always reload it.
 the `language boundaries agree on their protocol` testset — before it existed the preview pair had been
 bumped by hand three times and the fourth was nearly missed.
 
+**When to bump is BEHAVIOURAL, not structural: whenever an adopted older peer would answer
+differently.** A changed message shape is the obvious case; a bug fixed *inside* an adopted process is
+the one that gets missed, and it is the worse of the two. `PREVIEW_PROTOCOL` 5 is exactly that — the
+reply shape is byte-identical to 4, and the only change is that AF preview no longer dies on an
+`AttributeError`. Left unbumped, a backend carrying the fix adopts the broken worker and serves the bug,
+which is how the fix appeared not to work at all. The version is the only thing that can refuse a
+process we did not start, so anything we would not want served from the old code has to move it.
+
 Why versions at all, rather than trusting the processes to match: a mismatch is **never a clean
 failure**. A stale peer answers the handshake perfectly and then misreads the actual work. The three
 real occurrences read as `unexpected keyword argument 'mask'`, a bare `Preview failed`, and

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -125,7 +125,8 @@ Errors are returned as `{"type": "error", "msg": "..."}` — `send()` raises on 
 
 `ping` reports `protocol`, and `_ensure_viewer!` **only adopts a bridge whose value matches**
 `NAPARI_PROTOCOL` (`app/src/napari.jl`); a mismatch kills the port listener and relaunches. Bump both
-whenever the surface changes shape — a new or renamed command, a changed argument, a changed reply.
+whenever an adopted older bridge would answer differently — a new or renamed command, a changed
+argument, a changed reply, or a bug fixed in the bridge itself.
 
 This exists because adoption is deliberate: the bridge outlives a backend crash or Ctrl-C so the user
 keeps their viewer window, which also means it can be running code from before a branch switch. That is

--- a/preview/preview_worker.py
+++ b/preview/preview_worker.py
@@ -74,7 +74,14 @@ AF_PREVIEW_STRIDE = (2, 4)
 #:    `af_correct_frame`, so it would keep serving RATIO previews — hollowed-out overlapping cells and
 #:    all — against a backend that believes it is showing the new method. Silently, and the preview's
 #:    entire purpose is to agree with the run.
-PROTOCOL = 4
+#: 5: two fixes, one of which has no shape at all. (a) `af_channel_indices` had moved to `script_utils`
+#:    and the call here still used the old name, so every AF preview died on `AttributeError` — a fix
+#:    INSIDE the worker is exactly the case adoption gets wrong and nothing else can catch, so it earns
+#:    a bump on its own; see `PREVIEW_PROTOCOL` in `app/src/preview.jl` for the behavioural rule.
+#:    (b) the REQUEST now carries `channelNames` from `ccid.json`, the only authoritative copy — an
+#:    adopted protocol-4 worker ignores the field and falls back to the store's stale OME-XML, which
+#:    renders every corrected channel grey.
+PROTOCOL = 5
 
 #: Named in the error a channel NAME raises, so the message points at the Julia function that should
 #: have resolved it — see `script_utils.channel_indices`.
@@ -300,13 +307,14 @@ class PreviewContext:
     """
 
     __slots__ = ('im_path', 'task_dir', 'value_name', 'params', 'levels', 'dim_utils',
-                 'axis_len', 'bounds', 'fallback2d')
+                 'axis_len', 'bounds', 'fallback2d', 'given_names')
 
     def __init__(self, im_path, task_dir, value_name, params, levels, dim_utils,
-                 axis_len, bounds, fallback2d):
+                 axis_len, bounds, fallback2d, given_names=None):
         self.im_path, self.task_dir, self.value_name = im_path, task_dir, value_name
         self.params, self.levels, self.dim_utils = params, levels, dim_utils
         self.axis_len, self.bounds, self.fallback2d = axis_len, bounds, fallback2d
+        self.given_names = list(given_names or ())
 
     def crop(self):
         """The visible region of the image, all channels, as `[C, Y, X]`."""
@@ -325,7 +333,20 @@ class PreviewContext:
         return axes, [int(x) for x in full], shape
 
     def channel_names(self):
-        """Channel names from the OME-XML, so a layer can be named after the channel it corrects."""
+        """Display name per channel index, for naming a layer after the channel it corrects.
+
+        The request's `channelNames` WINS. `ccid.json` is authoritative for channel names — they are
+        user-editable — so only Julia knows them, and the store's OME-XML is a different copy that is
+        routinely out of date: on a real image it still read `CH1..CH4` while the viewer showed
+        `SHG`/`nuc-GFP`/`mem-TOM`/`CD169-Kat`, which named the corrected layer `CH3 AF` and pointed its
+        `source` at a layer that does not exist — so the colormap mirror found nothing and every
+        corrected channel came out grey.
+
+        OME-XML remains the fallback for a caller that sends no names (a REPL or test driving the worker
+        directly). It is a fallback, not a second source of truth.
+        """
+        if self.given_names:
+            return list(self.given_names)
         try:
             px = ome_xml_utils.parse_meta(self.im_path).images[0].pixels
             return [c.name or f'ch{i}' for i, c in enumerate(px.channels)]
@@ -484,7 +505,8 @@ def preview(msg):
         raise ValueError(f'empty preview region: {region.get("xy")!r}')
 
     ctx = PreviewContext(im_path, task_dir, value_name, params, levels, dim_utils,
-                         axis_len, bounds, fallback2d)
+                         axis_len, bounds, fallback2d,
+                         given_names=msg.get('channelNames'))
     out = backend(ctx)
     out.setdefault('hasSignal', True)
     out.setdefault('noSignalWhy', '')

--- a/python/cecelia/tests/test_preview_worker.py
+++ b/python/cecelia/tests/test_preview_worker.py
@@ -123,6 +123,30 @@ class PreviewWorkerAfTest(unittest.TestCase):
         self.assertEqual(out['region']['T'], [0, 1])
         self.assertEqual(out['region']['X'], [2, 18])
 
+    def test_the_request_channel_names_win_over_the_stores_ome_xml(self):
+        """THE GREY-LAYER BUG. napari names its layers from `ccid.json`, the authoritative copy; the
+        worker was naming `source` from the store's OME-XML, a copy that is routinely stale. On a real
+        image the store still said CH1..CH4 while the viewer showed SHG/nuc-GFP/mem-TOM/CD169-Kat, so
+        `source` pointed at a layer that does not exist, the colormap mirror silently found nothing, and
+        every corrected channel rendered grey against a magenta original.
+
+        The fixture reproduces exactly that: its OME-XML is CH1..CH4.
+        """
+        names = ['SHG', 'nuc-GFP', 'mem-TOM', 'CD169-Kat']
+        out = self._request({'2': {'competingChannels': [3]}}, channelNames=names)
+        self.assertNotEqual(out.get('type'), 'error', out.get('msg'))
+        layer, = out['layers']
+        self.assertEqual(layer['source'], 'mem-TOM')      # the layer napari actually has
+        self.assertEqual(layer['name'], 'mem-TOM AF')     # and the corrected layer says which channel
+        self.assertNotIn('CH3', layer['name'])
+
+    def test_without_given_names_the_ome_xml_is_the_fallback(self):
+        """A REPL or test driving the worker directly sends no names — that must still work, and must
+        still be a FALLBACK rather than a second source of truth."""
+        out = self._request({'2': {'competingChannels': [3]}})
+        layer, = out['layers']
+        self.assertEqual(layer['source'], 'CH3')
+
     def test_a_combination_with_no_competitor_is_skipped(self):
         out = self._request({'1': {'competingChannels': [2]}, '3': {'competingChannels': []}})
         self.assertEqual(len(out['layers']), 1)


### PR DESCRIPTION
Two bugs behind one report: *"preview timed out, then the layers came up — but they're all grey."*

## Grey layers — two sources of truth for channel names

`ccid.json` is authoritative for channel names (they are user-editable), and napari names its layers from it. The preview worker derived them from the store's OME-XML instead — a different copy, and on a real image a stale one:

| | Channel 2 |
|---|---|
| napari layer (from `ccid.json`) | `mem-TOM` |
| worker `source` (from OME-XML) | `CH3` |

So the corrected layer was named `CH3 AF`, and its `source` pointed at a layer that does not exist. `_mirror_source_colormap` is best-effort by design, so it silently fell back to napari's default and **every corrected channel rendered grey against a magenta original** — which is exactly the comparison a side-by-side preview exists to support.

Julia now sends `channelNames` with the request. OME-XML stays as a fallback for a caller that sends none (a REPL or a test driving the worker directly) — a fallback, not a second source of truth. Same shape as the calibration rule: several copies exist, exactly one is authoritative, nobody re-derives it.

## Timeout — the adoption path could not replace a stale worker

On a protocol mismatch, `close!(probe)` is a **no-op**: the probe was only ever *pinged*, so its `proc` is `nothing`. The consequence chain:

1. the stale worker keeps `:7656`
2. the replacement spawns and cannot bind
3. the replacement's readiness ping is answered **by the process being replaced** → `launch!` logs "connected"
4. `_preview_worker_alive` still says no (protocol mismatch), so `alive` never goes true
5. the frontend waits out its full 180 s → **"Preview timed out"**

Three fixes: kill by **port** (the same `_kill_listeners_on_port` the napari bridge uses in `_ensure_viewer!`), wait for the port to actually free (the kill is async, so launching immediately races the exit), and make readiness mean **our** protocol answered rather than *something* answered.

## `PREVIEW_PROTOCOL` → 5, and the rule restated

The previous fix to this worker (#463) changed no message shape, so it shipped unbumped — and a backend carrying the fix then **adopted the broken worker and served the bug**, which is why the fix appeared not to work at all.

So the bump rule is now stated as **behavioural, not structural**: bump whenever an adopted older peer would answer differently — a changed reply shape, a changed set of previewable tasks, *or a bug fixed inside it*. That last case has no shape to detect, and the version is the only thing that can refuse a process we did not start.

## Tests

- `the request channel names win over the stores ome xml` — the fixture's OME-XML is `CH1..CH4`, reproducing the real mismatch. **Mutation-verified**: fails if the fix is removed.
- `without given names the ome xml is the fallback` — the REPL path still works.
- `a stale preview worker is stopped by port, not by handle` — asserts `close!` on an adopted handle is a no-op, that the API kills by port, and that readiness checks the protocol.
- `preview_request` carries the names, and fills them from `ccid.json` per version.

3570/3570 Julia · 454 Python OK · API green.

## Reservations

- **The timeout diagnosis is inferred, not confirmed from logs** — `dev.jl` logs to the terminal, so the "Replacing preview worker" warning could not be read back. The mechanism is definitely broken and definitely produces that exact symptom, but if the timeout recurs after this, it is a different cause.
- **A stale worker is now killed automatically** on mismatch — intended, but it will take out a worker deliberately left running from another worktree.
- **A channel that isn't currently a layer** in napari still renders grey. The mirror is best-effort by design; unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
