### PR TITLE
Pre-release: 0.1.0 notes, correct the phase docs, retire numeric TODO ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: CI
 #
 # Runs the full chain on Linux, Windows and macOS-arm64 so platform-specific breakage is caught
 # before release, not by a tester: missing PyPI wheels forcing a source build (e.g. cvxopt on
-# macOS-arm64, TODO #00062), the platform-gated torch index, and the Windows path/process helpers
+# macOS-arm64), the platform-gated torch index, and the Windows path/process helpers
 # (and it proves the Julia server actually boots + serves on Win/Mac). The repo is public, so
 # GitHub-hosted runners are free on all OSes — no minute metering, hence the full matrix.
 #
@@ -187,7 +187,7 @@ jobs:
         uses: julia-actions/cache@v3
 
       # Instantiate the *server* project (api → pulls Cecelia from ../app). This precompiles
-      # everything the server loads (incl. PythonCall/CondaPkg on first use — see TODO #00056).
+      # everything the server loads (incl. PythonCall/CondaPkg on first use).
       - name: Instantiate Julia (server env)
         run: julia --project=api -e 'using Pkg; Pkg.instantiate()'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,67 @@ stack. Per-tag notes are also on the
 
 _Changes on `main` that have not yet been tagged in a release._
 
+## [0.1.0] — 2026-08-05
+
+**The first plain release.** Everything before this was an `-rcN` snapshot; nine of them never
+converged, and because Julia sorts an `rc10` prerelease *below* `rc9` as a string, no further rc could
+have reached an installed client at all. This tag ends that: it outranks every prerelease, and
+`releases/latest` resolves for the first time.
+
+498 commits since `v0.1.0-rc9`. Highlights:
+
+### Added
+- **Statistics on summary plots** — between-group hypothesis tests (Mann-Whitney / Kruskal-Wallis by
+  default, t/ANOVA opt-in), Prism-parity brackets with p-value labels, Compact Letter Display as
+  hoverable HTML overlays that survive PDF/PNG/SVG export, a Compare-groups toggle, which test `auto`
+  picked, a sibling `{name}.stats.csv` per plot, and raw+stats zipped into one download.
+- **Task preview** — a resident worker (`:7656`) runs a task's *own* compute over the visible region so
+  parameters can be judged before a full run. Previewability is a declared task trait; re-previews are
+  debounced on view change with a visible state, contrast windows survive moving T/Z, corrected
+  channels keep their original's name and colour, and a failure says why somewhere readable.
+- **Branching / skeleton analysis** (`segment.branching`) — skeleton extraction, a `branch` pop type
+  with per-branch-type filter populations, anisotropy via `skimage.feature.structure_tensor` expressed
+  in µm, napari skeleton + branch-type visualisation, and notebook readouts for the orientation field.
+- **Spatial analysis + region clustering** — neighbour graphs, neighbourhood-composition region
+  clustering with a `region` pop type, cell–cell contact statistics, and a CODEX-style contact heatmap.
+- **Structured image delete** — one modal on the Import page with four scopes (whole images, versions
+  with the new active picked, label sets with their companions, all analysis), replacing five deletion
+  entry points spread across four screens. `reset_image_analysis!` drops derived output while keeping
+  the image and never touching gate definitions.
+- **Image file operations on the selection** — Copy / Move / Delete in the Import action bar instead of
+  hidden at the end of each table row, applied to every checked image at once.
+- **Copy an image version into a new image/set** (`editImages.copyImage`) — a re-import shortcut.
+- **Custom cellpose checkpoints are drop-in** — `ccia.fluo` (fluorescence, for dendritic/SHG stroma)
+  is fetched at install time; any checkpoint dropped into the models dir appears in the picker without
+  a restart.
+- **What's New + tip of the day** — a release-notes modal on launch, with feijoa sketches on the cards.
+- **Observer / MCP** — one-click terminal setup for Claude, shadowed-entry detection and repair.
+- **A set reference image**, nominated by the user, plus axis-based task gating (replacing the
+  project-wide static/live distinction).
+- **QC**: clipped-detector channels flagged on every import; AF's derived ceiling banked.
+
+### Changed
+- **The acquired bit depth is kept** — the 16→8-bit import conversion is gone as a non-goal, and the
+  store codec is now an explicit, measured decision surfaced in Settings.
+- **Every Julia↔Python boundary is versioned**, not just the preview worker.
+- **UI unification** — one `.cc-btn` family, one `CcToggle`, one task-status colour map, semantic
+  scenario utilities (`.cc-muted` / `.cc-readout` / `.cc-empty` …) with detectors that fail the build
+  on a hand-rolled variant, and a tooltip *coverage* ratchet on top of the length one.
+- **Storage reporting** — the Settings storage box now accounts for derived analysis, not just images.
+
+### Fixed
+- **`rc10` sorted below `rc9`**, so the updater told every client it was up to date. Prerelease digits
+  now compare numerically.
+- **Staged updates apply on every launch**, not only the first.
+- **A worktree's Python env could resolve `cecelia` into a different checkout** — `PYTHONPATH` is
+  pinned per checkout, and the shutdown path now stops every resident child.
+- **Calibration**: the time scale reaches NGFF metadata and napari; both zarr layouts resolve when
+  syncing; OME-XML is written into staged stores instead of being silently skipped.
+- **Python text I/O declares UTF-8**, so Windows stops decoding sources as cp1252.
+- **A store is identified by structure, not file extension**; the debris sweep finds what is
+  incomplete rather than what is named `.partial`.
+- Numerous AF-correction, import-window, QC-text, tooltip-layout and task-param fixes.
+
 ## [0.1.0-rc9] — 2026-07-21
 
 ### Added
@@ -177,7 +238,8 @@ _Changes on `main` that have not yet been tagged in a release._
 - **Bootstrap installer** + release workflow (`release.yml`); CI smoke-test
   workflow; README + docs.
 
-[Unreleased]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc9...HEAD
+[Unreleased]: https://github.com/schienstockd/cecelia/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc9...v0.1.0
 [0.1.0-rc9]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc8...v0.1.0-rc9
 [0.1.0-rc8]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc7...v0.1.0-rc8
 [0.1.0-rc7]: https://github.com/schienstockd/cecelia/compare/v0.1.0-rc6...v0.1.0-rc7

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,8 +17,8 @@ authors:
 license: GPL-3.0-or-later
 repository-code: "https://github.com/schienstockd/cecelia"
 url: "https://github.com/schienstockd/cecelia"
-version: 0.1.0-rc9
-date-released: 2026-07-21
+version: 0.1.0
+date-released: 2026-08-05
 keywords:
   - microscopy
   - image-analysis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,10 @@ Completed prompt files are kept in a `previous-prompts/` folder in the **workspa
   the loosest edges, so orphans drift into it: a deliberate non-goal, or something conditional on a
   trigger that may never fire, belongs in `docs/FUTURE.md`. There's a routing table at the top of
   `docs/TODO.md` — check it before adding an entry.
-- IDs are stable so code comments can cite them (`# see TODO #00020`) — increment the highest. They
-  are not sacred: renumber to resolve a collision, and note it in the item.
+- Items are keyed by **title**, not a number. Cite one as `docs/TODO.md` → *Title*. Numeric IDs were
+  retired 2026-08-05 (half the code comments citing one pointed at a deleted item — see the note in
+  `docs/TODO.md`). **From code, prefer the permanent reference** — a `docs/<AREA>.md` section or a
+  `docs/todo/X_PLAN.md` path, which cannot dangle when the work ships.
 
 ## Parked plans (`docs/todo/`)
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ data. It is a ground-up reimplementation of the original R/Shiny
 ## Install & run
 
 **Install**, then **run** — Cecelia asks where to keep your projects on first launch, so there's
-nothing to configure by hand. Image import works out of the box too — **bioformats2raw and Java are
-bundled** in the release.
+nothing to configure by hand. Image import works out of the box too — Java ships in the
+environment and the installer fetches **bioformats2raw** for you.
 
 The installer sets up [Pixi](https://pixi.sh) + [Julia](https://julialang.org) if they're missing,
 downloads the latest release, and provisions the environment (a few GB on first run; later launches

--- a/api/src/notebooks_api.jl
+++ b/api/src/notebooks_api.jl
@@ -123,7 +123,7 @@ end
 # use we build it here in the BACKGROUND while notebooks stay usable (slow first plot until it lands).
 # The freshly-built image is picked up by launch.jl on the NEXT server launch — we don't restart a
 # running server out from under an open session. Mirrors the server lifecycle above (one tracked proc,
-# atexit cleanup). See docs/NOTEBOOKS.md and TODO #00070.
+# atexit cleanup). See docs/NOTEBOOKS.md.
 # The stamp format has ONE implementation — pluto/sysimage_stamp.jl — and this file uses it rather
 # than keeping a parallel copy (paths, Manifest fingerprint and both stamp readers used to be
 # duplicated here, "kept trivially in sync" by hand). It is deliberately dependency-free so it can be

--- a/app/src/config.jl
+++ b/app/src/config.jl
@@ -122,7 +122,7 @@ custom_toml_path(dev_dir::Union{String,Nothing} = nothing)::String =
 # custom fluorescence model that segments dendritic / SHG stroma (upstream of the branching task).
 # The Julia handler resolves a user-selected model NAME to its FILE PATH before calling the
 # Python runner, so cellpose's own `os.path.isfile(model_type)` branch (`cellpose_utils.py`) picks
-# the custom path up automatically. See TODO #00087.
+# the custom path up automatically. See docs/SEGMENTATION.md → *Custom cellpose checkpoints*.
 
 """Absolute directory for user cellpose checkpoints. Just a path — no I/O, no side-effects."""
 cellpose_models_dir(dev_dir::Union{String,Nothing} = nothing)::String =

--- a/app/src/tasks/segment/cellpose.jl
+++ b/app/src/tasks/segment/cellpose.jl
@@ -38,7 +38,7 @@ task_previewable(::CellposeSegment) = true
 # Cellpose's built-in model names. Anything outside this set is treated as a *custom* checkpoint name
 # and resolved via `cellpose_model_path` into a file path the Python runner loads with
 # `CellposeModel(pretrained_model=<path>)` — see `cellpose_utils.py::_get_model` (its
-# `os.path.isfile(model_type)` branch is the pickup point). See TODO #00087.
+# `os.path.isfile(model_type)` branch is the pickup point). See docs/SEGMENTATION.md → *Custom cellpose checkpoints*.
 const BUILTIN_CELLPOSE_MODELS = ("cyto3", "cyto2", "cyto", "nuclei")
 
 """

--- a/app/src/tracking/track_props.jl
+++ b/app/src/tracking/track_props.jl
@@ -1,6 +1,6 @@
 # ── track_props — per-track property table (compute-on-read) ─────────────────────
 #
-# Ports R `cciaImage$tracksInfo` (docs/TRACKING.md, TODO #00029). A track's properties are its
+# Ports R `cciaImage$tracksInfo` (docs/TRACKING.md). A track's properties are its
 # motility measures (precomputed in {vn}__tracks.h5ad) PLUS on-read aggregates of any per-CELL
 # column (intensity, morphology, hmm.state, …) over the track's cells. Compute-on-read — nothing
 # extra is stored, so track properties never go stale and need no re-run when new cell measures

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -191,7 +191,7 @@ end
     end
 end
 
-# ── Custom cellpose model resolver (TODO #00087) ─────────────────────────────
+# ── Custom cellpose model resolver ───────────────────────────────────────────
 # A user-placed checkpoint under `<config_dir>/models/cellposeModels/{name}` is picked up
 # by the cellpose Julia handler and passed to Python as an absolute file path (which
 # `cellpose_utils.py::_get_model` loads via `pretrained_model=…`). No shell-outs, no
@@ -881,7 +881,7 @@ end
 end
 
 # ── commit_state!: registering an output is atomic against a concurrent registration ────────
-# THE lost-update bug (was TODO #00003). Every task used to hand-roll re-read → poke → write, so
+# THE lost-update bug. Every task used to hand-roll re-read → poke → write, so
 # two tasks finishing on one image both read the old dict and the second write dropped the first's
 # field. `write_json_atomic` alone does NOT fix this — each write is individually intact; the
 # second is simply built on stale data.
@@ -5075,7 +5075,7 @@ end
 # ── Summary-canvas population picker (plot_pop_types / plot_population_groups) ──
 # The logic the /api/plots/populations route delegates to — pure, so tested here (the route is a
 # thin wrapper). Covers granularity→pop_type selection, cross-image + cross-pop_type union/dedup,
-# derived-pop injection, and pop_type tagging (the track-pops-in-the-picker fix, docs/TODO #00043).
+# derived-pop injection, and pop_type tagging (the track-pops-in-the-picker fix; docs/POPULATION.md).
 @testset "plot population picker" begin
     # pop_type selection by granularity
     @test plot_pop_types("live", "cell") == ["live"]
@@ -6809,7 +6809,7 @@ end
     @test length(st) == nrow(df)
 
     # regression: an EMPTY measure selection from the GUI arrives as `Vector{Union{}}` (not
-    # Vector{String}); fit must not MethodError on the normalise/scale step. (#00051)
+    # Vector{String}); fit must not MethodError on the normalise/scale step.
     let stu = hmm_fit_states(df, ["live.cell.speed", "live.cell.angle"]; num_states=2, time_col="t",
                              scale_measures=Union{}[], normalise=Dict{String,String}())
         @test count(!ismissing, stu) == count(!ismissing, st)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -270,7 +270,7 @@ Clients tracked in `_ws_clients::Set` guarded by `_ws_clients_lock`.
 | C→S | `task:run` | `taskId`, `projectUid`, `imageUid`, `module`, `task`, `params`, `poolName` | `sockets.jl` → `handle_task_run`; `poolName` (string) overrides the task-spec `resource_pool` when non-empty — set by the pool dropdown in `TaskRunner.vue` |
 | C→S | `task:cancel` | `taskId` | `sockets.jl` → `kill_task` — kills the individual task subprocess |
 | C→S | `chain:run` | `projectUid`, `chain`, `imageUids` | `sockets.jl` → `handle_chain_run` — starts a chain run in a `Threads.@spawn`; does not block the WS thread |
-| C→S | `chain:cancel` | `runId` | `sockets.jl` → `cancel_chain_run!(runId)` — sets the cancelled flag; nodes check it between steps (does **not** kill currently-executing subprocesses — see TODO #00016) |
+| C→S | `chain:cancel` | `runId` | `sockets.jl` → `cancel_chain_run!(runId)` — sets the cancelled flag; nodes check it between steps (does **not** kill currently-executing subprocesses — see `docs/TODO.md` → *Set-scope / incremental node subprocesses not killed on chain cancel*) |
 | S→C | `chain:run:started` | `runId`, `projectUid` | broadcast when a chain run begins |
 | S→C | `chain:run:done` | `runId`, `projectUid` | broadcast when `run_chain` returns successfully |
 | S→C | `chain:run:failed` | `runId`, `projectUid`, `error` | broadcast on unhandled error in `run_chain` |

--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -296,7 +296,7 @@ LabelPropsView(path).add_obs(df).save()       # df has a `label` column + value 
 - **`drop_obs(lp, names)`** stages obs columns to delete (idempotent — names absent from the file
   are ignored). Use to invalidate derived columns whose source changed — the tracking task drops
   stale `live.cell.*` / `live.track.*` measures when it writes new `track_id`s, so a re-track
-  doesn't leave measures computed against the previous tracking (`docs/TODO.md` #00028). Combine
+  doesn't leave measures computed against the previous tracking. Combine
   with `add_obs` in one chain; `save!` applies drops and adds together.
 - **`save!(lp)`** (Julia) / **`save()`** (Python) is the terminal write — flush staged columns in
   one open/write/close. Julia writes each as a `/obs/<name>` float64 dataset with
@@ -315,7 +315,7 @@ matrix is a full rewrite, not a cheap append). Building a new `.h5ad` from measu
 (`X` + `var` + `obsm`) is the producing task's job and is done in Python via `anndata`
 (`python/cecelia/utils/measure_utils.py`) — the "Python owns the files it produces" boundary. Gating
 needs only `:vars` columns to be gateable today, so measures that must be gateable are deferred to
-the phase that settles per-track storage (`docs/TODO.md` #00021), not force-written to `X` here.
+the phase that settles per-track storage, not force-written to `X` here.
 
 This is also a hard rule in `CLAUDE.md` (*H5AD / cell-data access*).
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -115,7 +115,7 @@ parallel jobs per OS**, split by what each needs installed:
 Jobs run concurrently, so wall-clock is the longest job, not the sum. It runs as a
 **matrix on Linux, Windows and macOS-arm64** (`fail-fast: false`), so a
 platform-specific install/build/boot failure is caught in CI rather than by a tester — e.g. a PyPI
-dep with no macOS wheel falling back to a source build (TODO #00062). The repo is public, so
+dep with no macOS wheel falling back to a source build. The repo is public, so
 GitHub-hosted runners are free on all OSes (no minute metering — the multipliers only bill private
 repos). All steps run under `bash` (Git Bash on the Windows runner). Keep it green before requesting
 a merge. See `docs/SHIPPING.md` for the release pipeline.

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -137,9 +137,9 @@ data→px through the same `viewExtents`, and every layer already redraws when i
 `viewExtents` — not a matrix-replication job. Hit-testing needs no change (`GateOverlay` already maps
 through the same extents).
 
-**Reference:** `docs/POPULATION.md` → *Gating plot — rendering & UX hacks*. (Was `docs/TODO.md`
-`#00087`, and before that a duplicate `#00003`; moved here because a deliberate non-goal is not open
-work.)
+**Reference:** `docs/POPULATION.md` → *Gating plot — rendering & UX hacks*. (Was a `docs/TODO.md`
+item; moved here because a deliberate non-goal is not open work. It carried a numeric ID that had
+already been issued twice — one of the collisions that got numeric IDs retired, see `docs/TODO.md`.)
 
 ---
 
@@ -158,7 +158,7 @@ structure the observer needs in order to spot outliers (Dominik).
 **Revisit when:** the payload trim proves insufficient in practice. Then add it as an explicit opt-in
 for the "compare T vs B across the set" question only — per-image stays the default.
 
-**Reference:** `docs/ai-assist/OBSERVER.md`. (Was `docs/TODO.md` `#00084`; moved here because it is
+**Reference:** `docs/ai-assist/OBSERVER.md`. (Was a `docs/TODO.md` item; moved here because it is
 conditional on something that may never happen.)
 
 ---

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -17,6 +17,36 @@ git-tag, and attach the built artifacts to a GitHub release (see ROADMAP Phases 
 
 ---
 
+## M2 — Distribution + analysis breadth (2026-08-05)
+
+- **Version:** `0.1.0` — the first **plain** release. Every prior tag was an `-rcN`; nine of them never
+  converged, and since Julia sorts an `rc10` prerelease *below* `rc9` as a string, no further rc could
+  have reached an installed client. This tag outranks every prerelease and makes `releases/latest`
+  resolve for the first time.
+- **Packaging:** git tag `v0.1.0` → `release.yml` publishes a ~6 MB portable bundle (prebuilt frontend,
+  `VERSION`, `pixi.toml`/`pixi.lock`) + a SHA-256. `install.sh` / `install.ps1` provision Pixi + Julia
+  and fetch bioformats2raw (~190 MB) and the `ceceliaModels` cellpose checkpoints (~26 MB) at install
+  time. In-app update check + staged apply on launch.
+- **Landed** since M1 (498 commits):
+  - **Distribution end-to-end** — installers, desktop launcher, `pixi run app`, checksum-verified
+    self-update. ROADMAP Phases 4 and 5.
+  - **Clustering** — cells, tracks and spatial regions as first-class populations in the one
+    population manager (ROADMAP Phase 2), with heatmap + UMAP canvas plots.
+  - **Spatial analysis** — neighbour graphs, region clustering, cell–cell contact statistics.
+  - **Statistics on plots** — hypothesis tests, Prism-parity brackets, Compact Letter Display, CSV
+    export; all surviving PDF/PNG/SVG export.
+  - **Branching / skeleton analysis** with anisotropy in µm, and the custom-checkpoint path
+    (`ccia.fluo`) that makes its real fibrous-tissue workflow reachable on a fresh install.
+  - **Task preview** — a resident worker running a task's own compute over the visible region.
+  - **Notebooks** (Pluto) and the **MCP observer** for read-only assistant access.
+  - **Import correctness** — the acquired bit depth is kept, the store codec is an explicit decision,
+    detector clipping is flagged, and calibration reaches NGFF + OME-XML + ccid consistently.
+  - **UI unification with enforcement** — one button/toggle/status vocabulary, semantic scenario
+    utilities, and build-failing detectors for copy length, copy style and tooltip coverage.
+- **Known limitations at this milestone:** written almost entirely by AI and not yet independently
+  tested by another user; native constructor/menuinst installers not built (the shell installers cover
+  all three OSes); system-scope install unverified on a second machine.
+
 ## M1 — Analysis spine (2026-06-27)
 
 - **Version:** `0.0.0` (pre-release dev)

--- a/docs/NOTEBOOKS.md
+++ b/docs/NOTEBOOKS.md
@@ -232,7 +232,7 @@ ignores a stale image (falls back to slow-first-plot rather than handing workers
 and the status endpoint reports `stale` so the page shows a **Rebuild** button — same flow as first-run.
 `_classify_sysimage` (in `notebooks_api.jl`) is the pure, tested classifier: `ready` / `stale` /
 `building` / `error` / `absent`. Release packaging (ship a prebuilt image per platform vs. build on
-first run): see `docs/SHIPPING.md` and TODO #00070.
+first run): see `docs/SHIPPING.md` and `docs/TODO.md` → *Ship a prebuilt Notebooks sysimage in the bundle*.
 
 **Which recipe built it (`variant`).** Both builds write the same `deps.so`, but the deps-only one
 excludes `Cecelia` so workers load it from source, while `-full` bakes it in. That made them

--- a/docs/POPULATION.md
+++ b/docs/POPULATION.md
@@ -598,8 +598,8 @@ WebGL/regl layer these notes originally described was removed; see `docs/PLOTS.m
   there, but no wheel/drag handler is wired to change the extents (the canvas-level zoom in
   `useCanvasZoom` is a CSS transform over the whole panel, a different thing). Tracked in
   `docs/FUTURE.md` → *Interactive pan/zoom on the gating plots* — re-scope before picking it up, as the
-  original write-up still described the removed regl camera. (It cited `docs/TODO.md` #00003, which was
-  a duplicate id; the real #00003 was per-image commit locking, now done.)
+  original write-up still described the removed regl camera. (It cited a `docs/TODO.md` ID that had been
+  issued twice — one of the collisions behind retiring numeric IDs.)
 - **Active panel + manager link.** `GatingPlots` tracks an `activePanel` index (orange border
   via `.panel.active`); clicking a panel activates it; the active panel watches `selectedPop`
   and sets its parent so the manager selection "shows up on the plot".

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -91,8 +91,8 @@ cycle if nothing changed). This is the whole schedule. It gives you:
 > on its own merits.
 
 **Hard blocker before *any* external handoff:** a root `LICENSE` (GPL-3-or-later) + third-party
-acknowledgements (celltrackR GPL-2) — TODO #00060. Fine to skip for personal rc's; required the moment
-someone else installs it.
+acknowledgements (celltrackR GPL-2). **Satisfied** — `LICENSE`, `THIRD_PARTY.md`, and the
+`license` key in `app/Project.toml` are all in place.
 
 ### One-time constraint: everything shipped so far is stuck behind `v0.1.0-rc9`
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,7 +43,7 @@ smoothing). States written as **numeric integer codes** (fast to gate/filter, au
 categorical); transitions as **categorical strings**. Set-scope wiring (`task_scope`,
 `run_task(imgs)`, `task:run` `imageUids`, `BehaviourModule` TaskRunner + `labelPropsColsSelection`
 widget) landed too and is reused by Phase 2. **Dropped** (no-ops): `skipTimesteps`/`subtrackOverlap`
-+ `seed` → TODO #00047. **Not yet:** `hmmHybrid` standalone (transitions already does cross-model
++ `seed` → `docs/TODO.md` → *Temporal downsampling / overlapping tracklets for behaviour*. **Not yet:** `hmmHybrid` standalone (transitions already does cross-model
 hybrid), `createPseudotime` (stretch), interpretive state relabelling (deferred to clustering).
 
 Original design notes (kept for reference):
@@ -62,10 +62,13 @@ Original design notes (kept for reference):
 Module page `BehaviourModule.vue` follows `GatingModule.vue` (ModuleLayout + TaskRunner +
 useTaskDefs + persisted view state); states surface in the existing summary-plot canvas.
 
-## Phase 2 — Cell & track clustering (akin to gating)
+## Phase 2 — Cell & track clustering (akin to gating) — **LANDED**
 
 "Akin to gating" = clusters become **populations in the same population manager**, not a parallel
-UI.
+UI. Shipped: `clustPops.cluster` (cells) and `clustTracks.cluster` (tracks) with `clust`/`trackclust`
+pop types, a shared scanpy engine, heatmap + UMAP canvas plots, and `clustRegions.cluster` on top
+(spatial regions, a `region` pop type — beyond the original scope). See `docs/todo/CLUSTERING_PLAN.md`
+and `docs/POPULATION.md`.
 
 - **Cell clustering — `clustPopulations.leiden`** (Python/scanpy; port `leidenClustering.R`):
   normalise → optional batch correction → Leiden → UMAP/PCA. Clusters land as populations; UMAP in
@@ -74,13 +77,18 @@ UI.
   `clusterTracks.R`): k-means/hierarchical on the per-track table — one point per track, cluster
   members expand to their cells. Track clusters become track populations.
 
-## Phase 3 — Freeze v1.0
+## Phase 3 — Freeze v1.0 — **the only phase still ahead**
 
-Hardening only. Version bump `0.0.0 → 1.0.0`, `CHANGELOG.md`, per-task smoke/validation tests,
-docs pass, root `LICENSE`. Record the freeze as a milestone (below). Scope-freeze the post-v1
-backlog.
+Hardening only. Per-task smoke/validation tests, docs pass, scope-freeze the post-v1 backlog, record
+the freeze as a milestone (below). `CHANGELOG.md` and the root `LICENSE` (GPL-3-or-later) + third-party
+acknowledgements are DONE. The 1.0 bar is **fitness for the science being done with it**, not R-parity
+— see `docs/RELEASING.md` → *Versioning*.
 
-## Phase 4 — Packaging & distribution (Linux/macOS/Windows)
+> Phases 4 and 5 below shipped ahead of this one: packaging and self-update were needed to get the tool
+> onto other machines, which the freeze does not gate. The phase numbers are historical order, not
+> dependency order.
+
+## Phase 4 — Packaging & distribution (Linux/macOS/Windows) — **LANDED**
 
 Ship Cecelia as a **primary Julia package that carries a GUI and bootstraps its own Python env** —
 the same model as the old R `cecelia` (a package that provisions its heavy Python deps). Frontend
@@ -95,13 +103,21 @@ Detailed plan + current state: **`docs/SHIPPING.md`**.
   at same-origin `:8080` (DONE) and a small `app.py` launcher opens the default browser. **No Tauri**
   (rejected: Rust + webkit build pain), **no Electron** (rejected: bundled Chromium). Native installer
   + desktop icon come from conda `constructor` + menuinst (Phase 2, per-OS/CI build).
-- **CI**: GitHub Actions matrix building per-platform release artifacts.
+- **CI**: GitHub Actions matrix building per-platform release artifacts — DONE (`ci.yml` on three
+  OSes, `release.yml` publishes the bundle + a SHA-256 on every `v*` tag).
+- **Installers — DONE**: `install.sh` / `install.ps1` provision Pixi + Julia, fetch bioformats2raw and
+  the `ceceliaModels` cellpose checkpoints, and register a desktop launcher; `pixi run app` opens the
+  browser at `:8080`. Constructor/menuinst native installers remain the only unbuilt piece.
 
-## Phase 5 — Self-update via GitHub
+## Phase 5 — Self-update via GitHub — **LANDED**
 
 Releases tagged with semver; app checks the GitHub Releases API, pulls a newer release, re-syncs
 the Julia Manifest + Python lockfile, uses the prebuilt frontend asset. Update-on-launch with
 confirmation, not silent. (Adapts the old `updateCecelia.R` intent to a GitHub-release source.)
+
+**Shipped**: `api/src/update_api.jl` + the header update badge + Settings install button; the staged
+update applies on launch, and the downloaded bundle is checksum-verified. `VERSION` is written into
+the bundle by `release.yml` so an installed app knows what it is running.
 
 ---
 
@@ -122,4 +138,4 @@ more segmentation (StarDist/Mesmer/donblo/watershed/blob/iLEE/branching), more c
 (drift/AF/N2V/stripe/registration/filters), spatial analysis (neighbours/contacts/regions/meshes/
 distances), classifiers (object + pixel), signal peaks, flow (FCS) import, model training (N2V),
 region clustering, infra (HPC offload, mflux backup, launchpad), more import (Xenium/cellToLocation,
-normalise/rescale/crop/split). See `docs/TODO.md` #00036–#00038 and `docs/FUTURE.md`.
+normalise/rescale/crop/split). See `docs/TODO.md` and `docs/FUTURE.md`.

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -217,7 +217,8 @@ registered `run_task(task, imgs, …)` overload, so it has a `TaskRecord` and ca
 
 Impact is currently nil — no real set-scope subprocess task exists (only mock/plot tasks). When the
 first one lands (e.g. HMM training), give the chain's multi-image path a `TaskRecord` + `chain_run_id`
-like the per-image path: **TODO #00020**.
+like the per-image path: `docs/TODO.md` → *Set-scope / incremental node subprocesses not killed on
+chain cancel*.
 
 ---
 

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -418,7 +418,8 @@ overloads it beside its struct, and there is a `CompositeTask` overload because 
   matching *deletes* base labels that found no nucleus, so the run finds **fewer** cells than the
   preview shows — the warning says which case you're in. Not run because `_compute_iou_matrix` is
   quadratic: 1.8 s at 100×100 labels, **26.9 s at 400×400**, against a 0.14–0.38 s preview (see
-  `docs/TODO.md` #00093 — the real pipeline pays this per timepoint too).
+  `docs/TODO.md` → *`_compute_iou_matrix` is quadratic in cell count* — the real pipeline pays this per
+  timepoint too).
 - **Not tiled like the run.** `SegmentationUtils` tiles at `blockSize` and re-stitches labels split
   across each seam; the preview segments the visible region as ONE tile. Where a seam would cross the
   region the run's mask is two inferences plus an IoU re-join and the preview's is one, so counts and

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -381,7 +381,8 @@ artifact: it's native code tied to the exact **platform/arch + Julia + package v
 build stamps `deps.so.stamp` (`{julia, hash(Manifest.toml)}`, `pluto/sysimage_stamp.jl`); after an
 update the image is detected **stale** and rebuilt automatically, and `launch.jl` refuses to hand a
 stale image to workers (a Julia-version mismatch would break them). *Optional* release optimisation
-(TODO #00070): build the `-full` image per platform in CI and ship it in the bundle so even the first
+(`docs/TODO.md` → *Ship a prebuilt Notebooks sysimage in the bundle*): build the `-full` image per
+platform in CI and ship it in the bundle so even the first
 open is instant — it falls through to the on-first-run build wherever no prebuilt image is present.
 Because the image is stamped, a shipped one that predates the user's Julia/deps still self-heals.
 
@@ -419,7 +420,7 @@ alongside the fast paths, which is how official Julia binaries ship.
 so every user's precompiled code is compiled on the CPU that will run it — which is why a Windows
 user pays precompilation once at install and never again. Nothing currently ships prebuilt.
 
-**The trigger to watch is TODO #00070** (build the `-full` sysimage per platform in CI and ship it
+**The trigger to watch is** `docs/TODO.md` → *Ship a prebuilt Notebooks sysimage in the bundle* (build the `-full` sysimage per platform in CI and ship it
 in the bundle). The moment that lands, or the constructor bundle carries a warmed depot, a
 `native`-compiled artifact would be rejected on any user whose CPU differs from the build
 machine's — recompiling on first run, or on *every* launch if the bundle is read-only, with nothing

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -18,8 +18,23 @@ adding, check the others:
 A fact you want recorded but that nobody should act on is **not** a TODO item. That is the drift this
 table exists to stop: something worth knowing turns up, has no obvious home, and lands in the backlog.
 
-**IDs** are stable so code comments can cite them (`# see TODO #00020`); increment the highest. They
-are not sacred — renumber to resolve a collision, and say so in the item.
+**Referencing an item.** Items are keyed by their **title** — there are no numeric IDs. Cite one as
+`docs/TODO.md` → *Title*.
+
+> Numeric IDs (`#00042`) were retired on 2026-08-05. They existed so code could cite an item, and they
+> failed at exactly that: of the eight code comments citing an ID, **four pointed at an item that no
+> longer existed**. The cause was structural — completion *deletes* an item, so "increment the highest"
+> was evaluated against a shrinking set and reissued numbers that plans, comments and git history still
+> referenced. `#00087` ended up meaning two different things; `#00003` was a known duplicate. Meanwhile
+> `docs/FUTURE.md` (keyed by title) and `docs/todo/*_PLAN.md` (cited by path) never collided once.
+>
+> Every citation in the docs and the code was repointed at the same time. `docs/prompts/` is left as
+> written — those are frozen records of finished work, so a retired number there is history, not a
+> broken pointer.
+
+**From code, prefer the permanent reference.** A `docs/<AREA>.md` section or a `docs/todo/X_PLAN.md`
+path cannot dangle when the work ships, which is what a TODO citation does by construction. Cite the
+tracker only for work that is genuinely still open, and by title.
 
 Items marked **🔹 needs-input** need something only Dominik can provide — a test asset, a
 domain-specific expected value, or a decision an agent shouldn't make alone. Grep `needs-input`.
@@ -28,7 +43,7 @@ domain-specific expected value, or a decision an agent shouldn't make alone. Gre
 
 ## Next up
 
-**#00088** — **Per-notebook reset (re-run a notebook on new data without killing the Pluto server)**
+### Per-notebook reset (re-run a notebook on new data without killing the Pluto server)
 Pluto has no filesystem watcher, so a notebook keeps rendering **stale data with no visible sign**
 after a pipeline task rewrites its inputs. The `DATA_STAMP` convention
 (`docs/NOTEBOOKS.md` → *Refreshing after a pipeline re-run*) is the working answer today, but it is
@@ -60,14 +75,7 @@ Related, and a bigger decision: **`PlutoUI` is not in `pluto/Project.toml`**. Ad
 `Button` (an in-notebook refresh) *and* sliders for a timepoint, but costs a re-resolve of all three
 manifests. Decide that separately.
 
-**#00057** — **Update README for the install / run / update flow (and switch to versioned releases)**
-Once the shipping functions are all in — the installer (constructor/pixi-pack), the `pixi run app`
-launcher (done), and the update path (`pixi run update` done; in-app button pending) — rewrite
-`README.md` for the end-user install → run → update story (it currently predates Pixi). Tie in with
-the move from commit-as-we-go to **versioned GitHub Releases** (SHIPPING.md Phase 3): once releases
-exist, the README's install section should point at the release installers, not a source checkout.
-
-**#00070** — **Ship a prebuilt Notebooks sysimage in the bundle** (release optimisation)
+### Ship a prebuilt Notebooks sysimage in the bundle (release optimisation)
 (1) **DONE** — build-on-demand: an **Enable fast plots** button on the Notebooks page builds
 `pluto/deps.so` in a background process, notebooks stay usable (slow-first-plot until it lands), and
 it's stamped so a package/Julia update marks it stale and surfaces a **Rebuild** button
@@ -79,7 +87,7 @@ instant. It falls through to (1) wherever no prebuilt image is present, and the 
 image that predates the user's Julia/deps self-heals. Belongs with the packaging phase; not urgent —
 the on-first-run path already gives every user a fast cache after one build.
 
-**#00085** — **Zarr/dask processing rework (read-frame-once + cellpose batching)**
+### Zarr/dask processing rework (read-frame-once + cellpose batching)
 The whole-image RAM fix landed (drift/AF/cellpose/segmentation stream per timepoint/channel via the
 `zarr_utils` streaming writers). The follow-up perf/consolidation work is parked in
 `docs/todo/ZARR_STREAMING_PLAN.md`: Phase 1 = read each timepoint once into a bounded frame and tile
@@ -89,7 +97,7 @@ Phase 2 = batch cellpose `dn.eval` (GPU throughput, measure first); Phase 3 = ch
 real measured benefit — the plan explicitly rejects a grand `map_over_zarr`, an `as_dask` sweep, and
 intra-task thread pools (Julia resource pools already parallelize across images).
 
-**#00047** — **Temporal downsampling / overlapping tracklets for behaviour** (deferred)
+### Temporal downsampling / overlapping tracklets for behaviour (deferred)
 The old framework computed track measures on the fly, so HMM could push `skipTimesteps` /
 `subtrackOverlap` into celltrackR: a way to **downsample** tracks (e.g. treat 10s/frame data like
 30s/frame to compare across acquisition rates) and to generate **overlapping tracklets**. The new
@@ -101,8 +109,8 @@ select; (b) a resampling step that emits overlapping sub-tracks as first-class r
 per-image frame-interval normalisation so cross-rate comparison needs no manual skip. Settle the
 storage/UX before building. Not urgent.
 
-**#00020** — **Set-scope / incremental node subprocesses not killed on chain cancel**
-The per-image cancel path (#00016) kills running subprocesses. Set-scope (`_run_set_scope_node!`)
+### Set-scope / incremental node subprocesses not killed on chain cancel
+The per-image cancel path kills running subprocesses. Set-scope (`_run_set_scope_node!`)
 and incremental (`_run_incremental_node!`) runners call the multi-image `_run_task` directly with
 `on_process = _ -> nothing` and are **not** registered in `_TASKS`, so `cancel_chain_run!` can't
 reach their subprocesses mid-run (the between-node flag still stops not-yet-started ones). No real
@@ -110,7 +118,7 @@ set-scope subprocess task exists yet (only mock/plot tasks), so impact is curren
 first real set-scope subprocess task lands (e.g. HMM training), give the multi-image `_run_task`
 path a `TaskRecord` + `chain_run_id` so it's cancellable like the per-image path. Low priority.
 
-**#00086** — **Port `createBranching` (skeleton/branch analysis) from the old R version**
+### Port `createBranching` (skeleton/branch analysis) from the old R version
 Skeletonise a segmentation into a branch/path network for fibrous non-cell structures (collagen/SHG,
 nerves, FRC reticular networks). Full plan is parked in `docs/todo/BRANCHING_PLAN.md` (audited
 2026-07-27: ILEE_CSK vendoring dropped in favour of `skimage.feature.structure_tensor`; Decision 6
@@ -118,24 +126,7 @@ resolved via a dedicated `branch_labels` field; Decision 2 cost re-measured agai
 `ACCEPT_TOKENS`/`POP_MAP_SUFFIX` dispatch as ~10 code sites + ~10 test assertions). In progress on
 `feat/branching-port`.
 
-**#00087** — **Ship custom Cellpose models (starting with `ccia.fluo`)**
-The old R version bundled a custom Cellpose model `ccia.fluo` (~26 MiB, trained for fluorescence —
-the model that actually segments dendritic and SHG branches in `mxIBEX.Rmd`, upstream of
-`createBranching`). The current `segment/cellpose.json` hardcodes cellpose's four built-in models
-(`cyto3`/`cyto2`/`cyto`/`nuclei`) in a `select` — no path for custom checkpoints. Needs (a) a
-custom-model slot in the cellpose task JSON + Julia handler + Python runner (accept a model name
-or file path, resolve to a Cellpose checkpoint), (b) a delivery mechanism for the packaged
-`ccia.fluo` + other custom checkpoints (equivalent of the old `cciaModels()` downloader from
-`github.com/schienstockd/ceceliaModels`, or bundled in the release). Load-bearing for branching's
-real-world use case (fibrous / SHG segmentation), so schedule before v0.1.0 or note the branching
-port is incomplete without it. 🔹 needs-input
-
-
----
-
-## Backlog
-
-**#00090** — **A third of a drift-corrected stack can be empty, and every task still processes it**
+### A third of a drift-corrected stack can be empty, and every task still processes it
 Measured 2026-07-31 on `k3Tx90` (project `kSUFux`… actually `4kS67f`, 201×20×544×548): drift correction
 expands the canvas and pads with zeros, and on that image **z 0–2 and z 16–20 are all-zero across every
 channel** — 8 of 21 planes. `EaMaVq` is the same (z 0–6 empty at t=0). The padding also MOVES per
@@ -163,7 +154,7 @@ What is left is the consuming decision, which the box does not make for you:
   skipping known-empty work, not for cropping.
 - **Does the win generalise**, or is it specific to how much drift a movie has?
 
-**#00093** — **`_compute_iou_matrix` is quadratic in cell count, and every nuc+cyto run pays it per frame**
+### `_compute_iou_matrix` is quadratic in cell count, and every nuc+cyto run pays it per frame
 `SegmentationUtils._compute_iou_matrix` (`python/cecelia/utils/segmentation_utils.py`) compares every
 cyto label against every nuc label with a **full-plane boolean op per pair** — `len(a) × len(b)` array
 comparisons. Measured 2026-07-31 on one 590×590 plane: **1.8 s at 100×100 labels, 26.9 s at 400×400**.
@@ -181,7 +172,7 @@ numbers, so the existing `match_threshold`/`removeUnmatched` behaviour is unchan
 be pinned by asserting the new implementation matches the current one on a fixture before swapping it
 (the same oracle trick #435 used for the drift refactor).
 
-**#00092** — **Export an image version as OME-TIFF**
+### Export an image version as OME-TIFF
 Nothing in the codebase writes a TIFF today (no `tifffile.imwrite` anywhere). The need is figures:
 people render in **Imaris** rather than napari, and Imaris reads OME-TIFF, not our zarr stores. The
 `.ccbundle` export is a different thing entirely (whole-project archive, tar-per-store, for moving a
@@ -199,17 +190,17 @@ Worth settling when it's built:
 - **Where it lands**: not inside the project tree (it's an artefact, not data), so it wants a
   destination picker like `default_export_dir()`. Task rail + progress, staged output.
 
-**#00002** — **Auto-follow in task manager**
+### Auto-follow in task manager
 Selecting the newest running task in `TasksModule.vue` (`/tasks`) when a task starts does not
 work. Approaches tried: `watch`, `watchEffect`, `computed+watch`, WS event listener
 (`ws.on('task:status', ...)`). Likely a Pinia/Vue 3 deep reactivity edge case with array
 element property tracking.
 
-**#00027** — **`testTasks.*` task fun_names/files are still camelCase**
+### `testTasks.*` task fun_names/files are still camelCase
 The test tasks `testTasks.imageTask`/`testTasks.setTask`/`testTasks.incrementalPlotTask` (files
 `tasks/testTasks/{imageTask,setTask,incrementalPlotTask}.{jl,json}`, structs `TestImageTask`/
-`TestSetTask`/`IncrementalPlotTask`) predate the snake_case convention (see `#00026`,
-`feedback_julia_naming`). Rename to snake_case `fun_name`s + files (e.g. `testTasks.image_task`,
+`TestSetTask`/`IncrementalPlotTask`) predate the snake_case convention (see
+`docs/DEV.md` and the Julia naming rule in `CLAUDE.md`). Rename to snake_case `fun_name`s + files (e.g. `testTasks.image_task`,
 `tasks/test_tasks/image_task.{jl,json}`) — structs stay PascalCase. Touches `_spec_path`/
 `_fun_name_map` in `task_registry.jl`, the `Cecelia.jl` includes, and any test references. Not
 important (test-only scaffolding, no user-facing impact) but should be fixed for consistency;

--- a/docs/TRACKING.md
+++ b/docs/TRACKING.md
@@ -231,7 +231,7 @@ is `live.cell.speed` present in the cell `obs` **and** the `{value_name}__tracks
 existing. A cached run is skipped; `forceRecompute=true` overrides. **The tracking task owns
 invalidation** — when btrack writes new `track_id`s it drops any stale `live.cell.*` /
 `live.track.*` obs columns (`tracking_utils.py._write_back` via the `drop_obs` chain verb, see
-`docs/DATAMODEL.md` and TODO #00028); `track_measures` likewise drops any leftover broadcast
+`docs/DATAMODEL.md`); `track_measures` likewise drops any leftover broadcast
 `live.track.*` from the cell obs when it runs. Re-running the composite recomputes against the
 fresh tracking and rewrites the track table.
 
@@ -275,5 +275,5 @@ Still deferred:
 3. **Track-gating canvas in the Tracking module (3e)** — the gating scatter + population manager
    with `popType="track"`, reusing the extracted canvas shell; conditional manager option-groups.
 
-Tracked as TODO #00021. All of it builds on the `track_id` + measures already written — nothing
+Tracked in `docs/TODO.md`. All of it builds on the `track_id` + measures already written — nothing
 above needs to change.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -1774,7 +1774,7 @@ Chain events flow: `_update_node_state!` (Julia) → `subscribe_chain_events!` s
 The synthetic task ID is `runId::nodeId::imageUid` — stable across updates so the same entry is updated in place. Chain tasks appear in `TaskList` with a purple `pi-sitemap` badge. The rerun button is suppressed for chain tasks (they're driven by `run_chain`, not the task queue).
 
 `addFromChainEvent` stores `label` from `opts.label` (which may be empty — the backend events
-don't include a `label` field yet; see TODO #00018). Fallback is `fn.split('.').pop()`.
+don't include a `label` field yet). Fallback is `fn.split('.').pop()`.
 
 **Cancel from TaskList**: when `t.chainRunId` is set, the cancel button sends `chain:cancel {runId}`
 over WS and calls `cancelChainRun(runId)` in the task store (which marks all tasks with that
@@ -1997,7 +1997,7 @@ factored out of the gating page so every module canvas reuses them unchanged:
   that key, so open plots **persist across navigation** (re-binds the same panels instead of starting
   empty). Cleared on project open/close. ⚠️ **Seed default panels only when the canvas is empty**
   (`if (panels.value.length === 0) add()`) — an unconditional `add()` in `onMounted` stacks duplicates
-  every remount (the Gate↔Tracking 2→4→6 bug, #00044).
+  every remount (the Gate↔Tracking 2→4→6 bug).
 
 ---
 

--- a/docs/todo/ANALYSIS_CANVAS_PLAN.md
+++ b/docs/todo/ANALYSIS_CANVAS_PLAN.md
@@ -5,7 +5,7 @@ Status: **planning** (branch `feat/multipage-analysis-canvas`). This is a parked
 
 ## Goal
 
-Turn the universal Analysis page (`/analysis`, TODO #00036, already built as a thin `SummaryCanvas`
+Turn the universal Analysis page (`/analysis`, already built as a thin `SummaryCanvas`
 with `module=null`) into a **tabbed, multipage analysis workspace**:
 
 - **One interface to every plot** — summary plots (all module specs) *and* interactive plots (UMAP,
@@ -209,7 +209,7 @@ labelled child name+%, arranged via `ggarrange(nrow, ncol)` (user-set grid).
   (inputs, the R lineage), the napari-screenshot slot, and PDF export. Cross-reference from `CLAUDE.md`
   doc table, `docs/UI.md` (§ Analysis-plot canvas), `docs/PLOTS.md`, `docs/POPULATION.md`, `docs/NAPARI.md`.
 - Update `docs/UI.md` (tabs + interactive-in-universal), `docs/API.md` (if `/api/gating/hierarchy`
-  lands), `docs/TODO.md` (close #00036 follow-ups; the interactive-family routing note).
+  lands), `docs/TODO.md` (the Analysis-board follow-ups; the interactive-family routing note).
 
 ## Open questions / risks
 
@@ -226,7 +226,7 @@ labelled child name+%, arranged via `ggarrange(nrow, ncol)` (user-set grid).
 ## Third-party / license
 
 `pdf-lib` (MIT) — add to the third-party acknowledgements list at the shipping/cleanup pass
-(see `project_license` / TODO #00060).
+(see `LICENSE` + `THIRD_PARTY.md`, both in place).
 
 ## Phase G — Include the clustering plots (UMAP + cluster heatmap)
 

--- a/docs/todo/ANIMATION_PLAN.md
+++ b/docs/todo/ANIMATION_PLAN.md
@@ -2,7 +2,7 @@
 
 Status (updated 2026-07-24): A–G + F1/F2 **done/merged**. **Phase H (movie title card) DONE** across
 all three entry points (H1 primitive, H2 batch, H3 single record, H4 animation) — see the H section
-below. Supersedes the ad-hoc parts of the image-strip tasks (#00032 legend, #00036 zoom-to-source) —
+below. Supersedes the ad-hoc parts of the image-strip tasks (strip legend, zoom-to-source) —
 both now live on the shared snapshot foundation.
 
 ## Goal
@@ -123,13 +123,13 @@ matches how figures are actually made; F2 is the advanced follow-on.
 - **~~A. Snapshot atom~~ — DONE** — `capture_view_state()` + `apply_view_state(json)` in the bridge
   (whitelist + sanitise + only-present-layers filter); capture folded into the screenshot reply;
   round-trip tested (incl. colormap change). Camera + T/Z + contrast + colormap restore.
-- **~~B. Zoom-to-source (#00036)~~ — DONE** — each strip frame stores `{imageUid, valueName, snapshot,
+- **~~B. Zoom-to-source~~ — DONE** — each strip frame stores `{imageUid, valueName, snapshot,
   colourBy}`; `ImageStripView.zoomToSource` reopens the image + `POST /api/napari/apply-view-state`
   restores the exact view, then **re-pushes the tracks/pops** the frame had — derived from the snapshot's
   overlay layer names (`utils/overlayLayers`) + the captured colour-by, via `utils/napariOverlays`
   (show-tracks/show-populations/colour-labels). (Fixes: overlays weren't restored because the board's
   ViewerPanel may be closed, so open alone only recreated channel layers.) Durable across sessions.
-- **~~C. Strip legend (#00032)~~ — DONE** *(needs A, G)* — channel + population + colour-by colour swatches
+- **~~C. Strip legend~~ — DONE** *(needs A, G)* — channel + population + colour-by colour swatches
   below each frame, from the snapshot + a read-only legend, toggled in the ⚙.
   - **~~Backbone (S1)~~ + ~~channel section~~:** the shared model `utils/viewLegend.ts` + `ViewLegend.vue`.
   - **~~Populations + colour-by sections~~:** captured with the screenshot via `POST /api/napari/overlay-legend`

--- a/docs/todo/BRANCHING_PLAN.md
+++ b/docs/todo/BRANCHING_PLAN.md
@@ -54,11 +54,12 @@ scikit-image 0.26.0, numba 0.65.1). Audited 2026-07-27 for cohesion.
 **Upstream dependency (NOT in this PR, but load-bearing for real use):** the segmentation input to
 branching, on real fibrous images (dendritic cells, SHG collagen, FRC networks), was produced by
 the custom Cellpose model **`ccia.fluo`** in the old R version (`inst/models/cellposeModels/ccia.fluo`,
-~26 MiB). The current `segment/cellpose.json` hardcodes cellpose's four built-in models; no path for
-custom checkpoints. Tracked as **TODO #00087** — needs a custom-model slot in the cellpose task and a
-delivery mechanism for `ccia.fluo` (and any other bundled checkpoints). Branching is technically
-usable without it (any binary label set skeletonises fine), but the real workflow — "segment SHG →
-branch it" — is blocked on #00087. Schedule before advertising branching for its intended use case.
+~26 MiB). **RESOLVED** (2026-08-05): custom checkpoints are drop-in. The model picker is populated at serve time
+from `list_cellpose_models()`, any name outside cellpose's built-ins resolves through
+`cellpose_model_path` (user dir → bundled dir) and is loaded by the Python runner as
+`CellposeModel(pretrained_model=<path>)`; `install.sh`/`install.ps1` fetch `ceceliaModels` at install
+time and `pixi run models-fetch` does the same for a clone. So the real workflow — "segment SHG →
+branch it" — is available to a new user. See `docs/SEGMENTATION.md` → *Custom cellpose checkpoints*.
 
 ---
 

--- a/docs/todo/CLUSTERING_PLAN.md
+++ b/docs/todo/CLUSTERING_PLAN.md
@@ -36,7 +36,7 @@ canvas is mostly assembly.
 3. **jFWePN e2e spot-check** — tick→membership set-wide, trackclust expand-to-cells (backend verified
    this session via the `_expand_tracks_to_cells` fix), napari colour-by-`clusters.{suffix}`.
 
-**Done since (2026-07-01):** Canvas export/theme cleanup (**#00061**) — DPR-aware export scale,
+**Done since (2026-07-01):** Canvas export/theme cleanup — DPR-aware export scale,
 UMAP now composites into its PNG (ancestor-background clear), UMAP + heatmap honour the dark-theme
 knob, gate-plot x-axis label no longer clipped by the footer. Installer 404 fix (prerelease-aware
 bootstrap) also merged.
@@ -111,7 +111,7 @@ CPU↔GPU ARI, pooled set-wide pop counts in the manager.
   toggles (clust points / trackclust ribbons); HMM behaviour plots (states / transitions) on the
   canvas; styling generalised (`PlotOptions` + `PopulationPanelShell` + `plots/export.ts`/`overlays.ts`),
   duplicate/export on every cluster + gate plot. **See "Current state & remaining (2026-07-01)" at the
-  top for the live status + the short remaining list** (sub-clustering, #00061 cleanup, umap-learn pin,
+  top for the live status + the short remaining list** (sub-clustering, the canvas-export cleanup, umap-learn pin,
   e2e spot-check).
 
 ## Goal

--- a/docs/todo/CROP_PANEL_PLAN.md
+++ b/docs/todo/CROP_PANEL_PLAN.md
@@ -1,6 +1,6 @@
 # In-app crop panel — replace the napari 3D crop
 
-**Status:** planned (2026-07-22). Supersedes TODO #00079 ("improve the 3D-crop UX"). Decision by Dominik:
+**Status:** planned (2026-07-22). Supersedes the "improve the 3D-crop UX" TODO item. Decision by Dominik:
 the napari-driven crop has a low ceiling (napari only edits shapes in 2-D, the projection collapses all
 channels to one grayscale MIP, and the 2D↔3D dance is clunky). **Remove the napari crop path entirely**
 and do the crop **in the app**.
@@ -107,9 +107,9 @@ Python bridge and the Julia renderer read the same file. Unblocks the colour req
   `CROP_LAYER`/`CROP_MIP_LAYER` consts and `_crop_*` state + the `crop_*` command dispatch.
 - Delete the `/api/napari/crop-*` routes (`server.jl`) and their `napari_api.jl` handlers.
 - Delete the ViewerPanel "3D crop" section + its `crop*` refs/functions (the interim polish added while
-  scoping #00079 is throwaway — superseded here).
+  scoping that item is throwaway — superseded here).
 - Docs: replace `docs/NAPARI.md` → "3D crop" with a pointer to the new panel; add the panel to
-  `docs/UI.md`/`INVENTORY.md`; delete TODO #00079.
+  `docs/UI.md`/`INVENTORY.md`; delete the superseded TODO item.
 - Done when: no `crop` references remain in the napari bridge/api, and the in-app panel is the only crop.
 
 ## Open questions (settle before the phase that hits them)

--- a/docs/todo/IMAGE_DELETE_PLAN.md
+++ b/docs/todo/IMAGE_DELETE_PLAN.md
@@ -3,7 +3,7 @@
 Status: **BUILT** — all four phases landed in one change (2026-08-04). Kept as the record of *why* the
 shape is what it is; the durable "how it works" now lives in `docs/UI.md` → *Deleting is one modal with
 four scopes*, `docs/OBJECTMODEL.md` → *Dropping the analysis*, `docs/MODULES.md` → *`hidden`*, and
-`docs/API.md`. Supersedes `docs/TODO.md` **#00094**. Dominik, 2026-08-04.
+`docs/API.md`. Grew out of a `docs/TODO.md` item, deleted when this shipped. Dominik, 2026-08-04.
 
 **What shipped, against the phases below:** `DeleteImagesDialog.vue` (four scopes) + the plan/execute
 split with `ImageFileActions`; `utils/imageDelete.ts` (union + per-image active resolution,

--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -75,7 +75,7 @@ If it fits in a paragraph and needs no design, it's a `docs/TODO.md` item, not a
   delete modal on the Import page (whole images / versions + new active / label sets / all analysis)
   and Settings for automatic whole-project reclaim. Unlists the `importImages.remove` task rather than
   deleting it (the chain suite's real-task workhorse) and scraps the ViewerPanel label delete. New core
-  `reset_image_analysis!` (keep-list, not delete-list). Supersedes `docs/TODO.md` #00094.
+  `reset_image_analysis!` (keep-list, not delete-list). Grew out of a since-deleted `docs/TODO.md` item.
 - `SKETCH_ENGINE_PLAN.md` — the **feijoa** play repo
   (`github.com/schienstockd/feijoa`, `~/cc-workspace/feijoa`) where sketches are authored for
   cecelia's tip cards. Not yet wired into cecelia — the plan documents the git-dep + conditional

--- a/docs/todo/SPATIAL_ANISOTROPY_PLAN.md
+++ b/docs/todo/SPATIAL_ANISOTROPY_PLAN.md
@@ -373,9 +373,9 @@ observer is read-only summary-first by design.
 3. **The `uns` key rename is breaking** for anything already banked. Nothing in-tree reads the old
    names, and no notebook exists yet, so the blast radius is Dominik's own EaMaVq run — which
    needs re-running anyway (item 1).
-4. **`ccia.fluo` still blocks the workflow for a new user** (TODO #00087, BRANCHING_PLAN). EaMaVq
-   has a usable `SHG` segmentation so this is testable today, but "segment SHG → branch → quiver"
-   from scratch is still gated on the custom-model slot.
+4. **`ccia.fluo` reaches a new user** (resolved 2026-08-05): the installers fetch `ceceliaModels` and
+   the picker lists any checkpoint in the models dir, so "segment SHG → branch → quiver" from scratch
+   is available. Verified by reading the chain end-to-end, not yet by running it on a fresh install.
 5. **`segmentation_qc.json` declares `groupByOptions: ["t"]`** while the columns API reports
    `["centroid_t"]`, so its LOESS trend chart is unreachable. A one-word fix, deliberately NOT
    applied here — it would enable a chart nobody asked for. Its own change if the trend is wanted.

--- a/docs/todo/TASK_PREVIEW_PLAN.md
+++ b/docs/todo/TASK_PREVIEW_PLAN.md
@@ -2,7 +2,7 @@
 
 **Status: BUILT** — shipped in #437 (2026-08-01) with two consumers, `segment.cellpose` and
 `cleanupImages.afCorrect`. Denoise is deliberately not a consumer; see *Denoise waits for coastal*.
-`docs/TODO.md` #00089 is retired accordingly, and the durable half is promoted into
+The originating `docs/TODO.md` item is retired accordingly, and the durable half is promoted into
 `docs/SEGMENTATION.md` → *Previewing params BEFORE a run (the task preview)*.
 
 **This file is kept for the measurements, not the plan.** Everything below that reads as a decision was
@@ -269,7 +269,7 @@ knowing.
 - **Is a 25 s first preview acceptable?** → **Yes, warmed at toggle-on** so the wait is attributable.
   `normaliseToWhole=false` was rejected: a faster preview that disagrees with the run is what Decision 5
   exists to prevent. AF pays a comparable cold cost for its own globals (~11 s measured).
-- **An empty region reads as "0 cells", which is misleading.** → **Split out as `docs/TODO.md` #00090**,
+- **An empty region reads as "0 cells", which is misleading.** → **Split out as `docs/TODO.md` → *A third of a drift-corrected stack can be empty***,
   which is the wider bug (every task processes the padding, ~38% of GPU time on one image). `#435` landed
   `zarr_utils.read_valid_box` as the mechanism.
 - **Model load latency** → **not a factor (0.2 s).** The worker holds one model at a time.
@@ -296,7 +296,7 @@ because side notes in a conversation do not survive it:
 | A preview's scratch store accumulated with nothing owning it | **removed the store entirely** (Decision 3) |
 | `store_sweep` matches NAMES, so it only sees writers that opted into `staged_store` — import writes straight to the final name and slips through | its own item: detect incompleteness structurally (unregistered store, or declared-but-absent pyramid levels), not by name |
 | The Settings cleanup needs to announce itself, not be knowledge | report leftover bytes in the existing storage box |
-| 8 of 21 planes on a drift-corrected image are empty and every task processes them | `docs/TODO.md` **#00090** — pipeline-wide, not preview-specific |
+| 8 of 21 planes on a drift-corrected image are empty and every task processes them | `docs/TODO.md` → *A third of a drift-corrected stack can be empty* — pipeline-wide, not preview-specific |
 | The preview only handles the `base` model type, so a nuc+cyto run is not what the run produces | stated limitation, to fix or surface |
 | Nothing exposes which image the viewer has open, so out-of-band callers guess (I guessed wrong three times) | the API status route |
 | The worker is a fourth resident process with no pixi task, service-panel entry, or `stop` wiring | operational surface |

--- a/docs/todo/plotting-canvas-and-track-df.md
+++ b/docs/todo/plotting-canvas-and-track-df.md
@@ -99,7 +99,7 @@ Old-R reference: `plotCharsServer.R`, `plotFlowGatingServer.R`, `clustPopulation
   track h5ad's `var` measures (speed × meanTurningAngle etc.).
 - Membership: selected gate → `track_id`s → expand to all member cells → napari highlight
   (reuse the Phase-1 linked-brushing path). Show tracks in napari (Tracks layer) — design here.
-- Docs: `docs/TRACKING.md`, `docs/POPULATION.md` (close out TODO #00021).
+- Docs: `docs/TRACKING.md`, `docs/POPULATION.md` (close out the per-track storage item).
 - **CHECK-IN:** gate a track pop on speed/angle; napari highlights exactly those tracks' cells.
 
 ### Phase 4 — Universal canvas

--- a/frontend/src/components/plots/GateScatterCell.vue
+++ b/frontend/src/components/plots/GateScatterCell.vue
@@ -263,7 +263,7 @@ defineExpose({ exportImage, exportSvg, hiRes, getHost: () => hostEl.value,
 <style scoped>
 /* capture host for PNG export: the axis labels/ticks live in this padding (relative to .panel-plot,
    at negative offsets), so exporting THIS element — not .panel-plot — includes the x/y axis names
-   instead of clipping them at the edge (#00061). */
+   instead of clipping them at the edge. */
 .plot-capture { position: relative; flex: 1; min-height: 218px; min-width: 0; display: flex; box-sizing: border-box;
   padding: 18px 22px 50px 84px; }
 /* light theme for PDF export (dark theme is on-screen only): dark ink/border on the white ground */

--- a/frontend/src/modules/AnalysisModule.vue
+++ b/frontend/src/modules/AnalysisModule.vue
@@ -1,5 +1,5 @@
 <!--
-  Universal, multipage "Analysis board" page (TODO #00036 + docs/todo/ANALYSIS_CANVAS_PLAN.md). The
+  Universal, multipage "Analysis board" page (docs/todo/ANALYSIS_CANVAS_PLAN.md). The
   SAME summary-plot canvas as the per-module pages, but with the MODULE FILTER OFF: each board is a
   `SummaryCanvas` mounted with no `module` prop, so it offers EVERY plot spec — plots can be combined
   across modules / images / segmentations. `TabbedCanvas` wraps N independent boards (Phase A). Pick

--- a/frontend/src/utils/taskPreview.ts
+++ b/frontend/src/utils/taskPreview.ts
@@ -246,7 +246,7 @@ export const FALLBACK_2D_WARN = {
  * takes **1.8 s at 100×100 labels and 26.9 s at 400×400** — it is quadratic in cell count. A warm
  * preview is 0.14–0.38 s, so matching would cost 5×–100× the entire preview and get worse the more
  * cells there are. Honest and fast beats complete and unusable. (That cost is also paid per timepoint
- * by every real nuc+cyto RUN — see TODO #00093.)
+ * by every real nuc+cyto RUN — see docs/TODO.md → `_compute_iou_matrix` is quadratic in cell count.)
  *
  * `removeUnmatched` changes the advice, so it changes the text: with it on, matching DELETES base labels
  * that found no nucleus, so the run genuinely finds fewer cells than the preview shows. With it off the
@@ -332,7 +332,8 @@ export function previewSummary(
 
   // A zero that means "there is nothing here" must never read as "your parameters found nothing" —
   // on a drift-corrected stack a padded plane returns 0 cells and looks exactly like too large a
-  // diameter, so the user retunes against a region that could never produce a mask (TODO #00090).
+  // diameter, so the user retunes against a region that could never produce a mask (docs/TODO.md →
+  // A third of a drift-corrected stack can be empty).
   // The 2D-fallback warning yields to this one: no point explaining z-stitching for an empty region.
   if (cells === 0 && signal && signal.hasSignal === false) {
     warn = signal.noSignalWhy === 'padding' ? 'No image data here' : 'Region is blank'

--- a/pixi.toml
+++ b/pixi.toml
@@ -181,7 +181,7 @@ app = "python app.py"
 # Fetch custom cellpose checkpoints (schienstockd/ceceliaModels → <repo>/models/cellposeModels/).
 # Mirrors the install.sh/.ps1 fetch (bioformats2raw pattern; not in git — see .gitignore /models/).
 # `--ref` and `--dest` override the branch + target dir. See docs/SEGMENTATION.md → Custom
-# cellpose checkpoints, TODO #00087.
+# cellpose checkpoints.
 models-fetch = "python scripts/models_fetch.py"
 
 # Dump every front-facing string (SFCs + task specs + Julia QC text) to UI_COPY_INVENTORY.md, with

--- a/preview/preview_worker.py
+++ b/preview/preview_worker.py
@@ -326,7 +326,8 @@ def _region_signal(im_path, bounds, tile):
 
     "0 cells" is ambiguous and the ambiguity is expensive: on a drift-corrected stack, aiming at a
     padded plane returns 0 cells and looks EXACTLY like a diameter that is too large, so the user
-    retunes parameters against a region that could never produce a mask (see TODO #00090, which this
+    retunes parameters against a region that could never produce a mask (see docs/TODO.md → A third of a
+    drift-corrected stack can be empty, which this
     was measured on).
 
     Two checks, authoritative first:

--- a/python/cecelia/utils/tracking_utils.py
+++ b/python/cecelia/utils/tracking_utils.py
@@ -193,7 +193,7 @@ class BayesianTrackingUtils:
 
         # invalidate stale track measures: new tracks make any cached live.cell.* / live.track.*
         # columns (written by tracking.track_measures against the *previous* tracking) wrong.
-        # The tracking task owns this invalidation (docs/TODO.md #00028, porting spec Step 5).
+        # The tracking task owns this invalidation (docs/TRACKING.md, porting spec Step 5).
         stale = [c for c in view.adata.obs.columns
                  if c.startswith("live.cell.") or c.startswith("live.track.")]
         if stale:


### PR DESCRIPTION
Everything the release checklist asks for before tagging **v0.1.0**, plus what a full release audit turned up.

## The audit verdict

**No blockers.** CI green on `main` across all three OSes; `test-pkg` / `test-api` / `test-py` / frontend all clean locally; `npm run build` (the exact release step) works; `LICENSE` + `THIRD_PARTY.md` + the `license` key are in place; `pixi.lock` is valid (the newer `pixi.toml` edit was `[activation.env]` only, no dependency change).

**Coastal is already absent from the shipping path** — checked because it isn't ready to ship. No runtime import anywhere in `app/ api/ python/ napari/ preview/ mcp/ pluto/`; the only traces are a "dropped for now" note in `pixi.toml` and `docs/SHIPPING.md`, plus future-seam comments (`SegmentationUtils.predict_slice`). So **cellpose 3 ships as the denoise + segmentation engine**, pinned `==3.1.1.2`, which is exactly what `SHIPPING.md` already documents. Nothing to change.

## Release mechanics

- **`CHANGELOG.md`** — `[Unreleased]` becomes `[0.1.0]` with grouped notes synthesised from the **498 commits (302 non-merge)** since `v0.1.0-rc9`, and a fresh `[Unreleased]` above it.
- **The tag must be a plain release, not `rc10`.** Julia parses an `rc10` prerelease as the string `"rc10"`, which sorts *below* `"rc9"` — so no further rc could reach an installed client, and `releases/latest` has never resolved. `v0.1.0` fixes both.
- **`CITATION.cff`** — `0.1.0-rc9` → `0.1.0`, `date-released: 2026-08-05`.
- **`docs/MILESTONES.md`** — **M2**, the first coarse boundary since M1: distribution end-to-end, clustering, spatial analysis, stats on plots, branching, task preview, notebooks, the observer. Records the known limitations too.

## Doc accuracy — three things misrepresented the present

- **`docs/ROADMAP.md`** listed Phases 4 (packaging) and 5 (self-update) as *future*; both shipped, as did Phase 2 (clustering). Now marked LANDED, with a note that 4 and 5 shipped ahead of the v1.0 freeze — the phase numbers are historical order, not dependency order. Phase 3 is the only one still ahead.
- **`README.md`** said bioformats2raw is "bundled in the release". Java ships in the env, but `release.yml` deliberately keeps bf2raw out (~190 MB, bundle stays ~6 MB) and the installers fetch it.
- **`docs/RELEASING.md`** still called `LICENSE` + third-party acknowledgements a *hard blocker*; they're satisfied.

## Two shipped items deleted

The README install/run/update rewrite, and **custom cellpose models** — the second verified end to end before deleting: the picker is populated at serve time from `list_cellpose_models()` (`routes.jl` calls `_inject_dynamic_options!`), a non-builtin name resolves through `cellpose_model_path` (user dir → bundled dir), the Python runner loads it as `CellposeModel(pretrained_model=<path>)` (`cellpose_utils.py:33`), and `install.sh` / `install.ps1` both fetch `ceceliaModels` asserting `ccia.fluo` landed. So `ccia.fluo` reaches a fresh install and branching's real fibrous-tissue workflow is available.

## Numeric TODO ids are retired — the substantive part

They existed so code could cite an item, and they failed at exactly that: of the eight code comments citing an id, **four pointed at an item that no longer existed**.

The cause is structural, not carelessness. Completion *deletes* an item, so "increment the highest" was evaluated against a shrinking set and reissued numbers that plans, comments and git history still referenced. `#00087` came to mean two different things (a gating pan/zoom non-goal, then custom cellpose models); `#00003` was a known duplicate; `#00094` was one new item away from being reissued into two live citations.

Meanwhile `docs/FUTURE.md` (keyed by title) and `docs/todo/*_PLAN.md` (cited by path) have **never collided once** — the repo already contained the working pattern, twice.

So: items are keyed by **title** and cited as `docs/TODO.md` → *Title*; from code the **permanent reference** is preferred (a `docs/<AREA>.md` section, a plan path) because it cannot dangle when the work ships. `CLAUDE.md`'s rule is rewritten, ~30 citations are repointed across the docs and the code — live items cite the title, dangling ones lose the number and keep the prose — and `docs/prompts/` is left as written, since those are frozen records of finished work where a retired number is history rather than a broken pointer.

## Reservations

- **`0.1.0` and `2026-08-05` are written as fact** in `CITATION.cff`, the CHANGELOG heading and the M2 entry. Tag on another day and those three need touching.
- **The CHANGELOG notes are my synthesis** of 302 commits into ~40 lines, and they become the GitHub Release text. Something you care about may be under-weighted.
- **M2 asserts what shipped** from the commit log and the phase docs, not from testing each capability — and `MILESTONES.md` is append-only.
- **The ROADMAP phase verdicts are my reading** of the evidence, not a decision you made.
- **Nothing here is code** beyond comment text, so the suites passing says little; the value is whether the claims are *true*, which is a read-through rather than a test.

## Tests

`test-pkg` 0 failures · `test-api` 0 · `test-py` 464 OK · frontend 841/841 · `vue-tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
