### PR TITLE
ci(release): move the release action onto the Node 24 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,10 @@ jobs:
           ls -lh out/
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        # v3 = the same action on the Node 24 runtime (v3.0.0 was runtime-only; `v2` is pinned to
+        # the 2.x line and still declares node20, which GitHub now force-runs on 24 with a
+        # deprecation warning). Inputs below are unchanged between the two majors.
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             out/cecelia.tar.gz


### PR DESCRIPTION
`softprops/action-gh-release@v2` declares `node20`, which GitHub now force-runs on Node 24 with a deprecation warning — it annotated the **v0.1.0** release build:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `softprops/action-gh-release@v2`

The `v2` tag stays pinned to the 2.x line, so bumping within it doesn't help. `v3` is the fix, and per [its release notes](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0) 3.0.0 is **runtime-only**:

> `3.0.0` is a major release that moves the action runtime from Node 24… If you still need the last Node 20-compatible line, stay on `v2.6.2`.

The inputs we pass — `files`, `generate_release_notes`, `fail_on_unmatched_files`, `prerelease` — are identical across the two majors. Verified `v3`'s `action.yml` declares `using: "node24"`.

**Audited the rest while here.** `prefix-dev/setup-pixi@v0` and `actions/checkout@v5` already declare `node24`; the `julia-actions/*` ones are composite; both workflows already set `node-version: 24`. This was the only `node20` left, so the next release should build annotation-free.

## Reservations

- **Untestable until the next tag.** `release.yml` only runs on `v*`, and `ci.yml` doesn't use this action — so CI passing here proves the YAML parses, nothing more. If `v3` misbehaves we find out when cutting `v0.1.1`.
- Blast radius is contained: `fail_on_unmatched_files: true` means a broken upload fails the job loudly rather than publishing a release with missing assets.
- Floating `@v3` rather than a pinned `@v3.0.2`, matching the other actions in these workflows (`@v5`, `@v3`, `@v0`). Consistent, but it does mean a future 3.x can change under us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)