### PR TITLE
docs(releasing): an rc is not the quiet option — both channels ship it

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,13 +43,49 @@ conceptual split:
 |---|---|---|
 | **release** `v0.1.0` | **the default.** A version a user installs and can name | the heartbeat, and any fix a user is waiting on (bump the patch) |
 | **rc tag** `v0.1.0-rcN` | a build you intend to **soak before promoting** | bracketing a risky refactor; a candidate you will re-cut as a release |
+| **milestone** (M-entry) | a coarse "shippable state" note in MILESTONES.md | only at big boundaries (a capability lands, v1.0 freeze) — **not** every tag |
 
 **Prefer a plain release.** The rc ladder was the default for nine tags and never converged, because
 none of them were candidates *for* anything — they were snapshots wearing a candidate's label, while
 being the only thing users could install. A prerelease also flags "don't rely on this" to the exact
 people relying on it, and GitHub's `releases/latest` never resolves while every tag is a prerelease.
 If a user hits a bug you have already fixed, that is a **patch release** (`v0.1.1`), not an rc.
-| **milestone** (M-entry) | a coarse "shippable state" note in MILESTONES.md | only at big boundaries (a capability lands, v1.0 freeze) — **not** every tag |
+
+### An rc is not the quiet option — both channels ship it
+
+The distinction is **intent, not size**. Nothing mechanical makes a prerelease safer, and it is worth
+knowing exactly what `-rcN` does and does not change before reaching for it.
+
+| Tag | in-app updater | `install.sh` one-liner |
+|---|---|---|
+| `v0.1.1` | offered | installed |
+| `v0.1.1-rc1` | **offered** | **installed** |
+
+- **The updater does not filter prereleases.** `api_update_check` (`api/src/update_api.jl`) skips only
+  *drafts* and takes the max by `VersionNumber`. A prerelease sorts below its own release but *above* the
+  previous one, so `v"0.1.1-rc1" > v"0.1.0"` — every install already on 0.1.0 is offered the rc.
+- **Neither does the installer.** `install.sh` deliberately does **not** use `releases/latest` (that
+  404s while every tag is a prerelease, which was true for nine tags). It calls `/repos/…/releases` and
+  takes the first `tag_name` — the newest *published* release, prereleases included.
+
+So `-rcN` buys you the GitHub prerelease label and a "don't rely on this" signal, and nothing else: the
+build still goes to everyone, both to existing installs and to the next person who runs the one-liner.
+Two consequences:
+
+1. **An rc is not a safety valve.** If the hesitation is "this might break someone", a prerelease does
+   not achieve that. Cut nothing, or cut a release you are willing to stand behind.
+2. **An rc must actually be promoted.** It only earns the label if re-cutting it as `vX.Y.Z` is a real
+   plan with an end — otherwise it is another snapshot wearing a candidate's label, which is exactly how
+   the nine-tag ladder happened.
+
+**Wanting a rollback anchor before a risky change is a plain release cut *before* the merge** — already
+one of the event triggers below — not a candidate published after it.
+
+> **Latent inconsistency, if you ever backport.** The two paths order releases differently: the updater
+> takes the max **by version**, the installer takes the newest **by date**. Publish `v0.2.0` and then a
+> `v0.1.2` patch off an older line, and a new install gets `v0.1.2` while an existing one is offered
+> `v0.2.0`. Nothing today does this — pre-1.0 the heartbeat only ever moves forward — but the two are not
+> the same rule, and only one of them is version-aware.
 
 ## The semi-schedule (heartbeat)
 

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -162,8 +162,11 @@ Users bootstrap the installer from `raw.githubusercontent.com/…/main/install.{
 404s; the raw path on `main` is always available. `install.{sh,ps1}` then resolve the newest
 published release themselves via the GitHub API (`/repos/…/releases`, newest first — *includes*
 prereleases) and download that tag's `cecelia.tar.gz`. `CECELIA_VERSION=v0.1.0-rcN` pins a specific
-tag. Once a stable (non-prerelease) release is cut, `releases/latest` also starts working, but the
-API-resolve path keeps working for RC-only states — so no installer change is needed at that point.
+tag. Since `v0.1.0` (2026-08-05) `releases/latest` resolves, but the installers keep the API-resolve path —
+it also works in an RC-only state, so no installer change was needed. **One consequence worth knowing:
+the installer therefore installs a prerelease** (newest by date), and so does the in-app updater (max by
+version, and a prerelease outranks the release before it). `-rcN` is a label, not a quieter channel —
+see `docs/RELEASING.md` → *An rc is not the quiet option*.
 They then install Pixi + Juliaup if missing, run `pixi install` (which resolves the GPU variant
 per-OS from `pixi.toml`'s platform-gated torch) + `julia --project=api instantiate`, and create the
 launcher.


### PR DESCRIPTION
`RELEASING.md` stated the rc-vs-patch policy but not the mechanics that make it hold, so the reason gets rediscovered by cutting one.

**Both delivery paths ship a prerelease:**

| Tag | in-app updater | `install.sh` one-liner |
|---|---|---|
| `v0.1.1` | offered | installed |
| `v0.1.1-rc1` | **offered** | **installed** |

- `api_update_check` (`api/src/update_api.jl`) skips only **drafts** and takes the max by `VersionNumber`. A prerelease sorts below its own release but *above* the previous one, so `v"0.1.1-rc1" > v"0.1.0"` — every install already on 0.1.0 is offered the rc.
- `install.sh` deliberately does **not** use `releases/latest` (that 404s while every tag is a prerelease, which was true for nine tags). It calls `/repos/…/releases` and takes the first `tag_name` — the newest *published* release, prereleases included.

So `-rcN` buys the GitHub prerelease label and a "don't rely on this" signal, and nothing else. Two consequences, now written down: an rc **is not a safety valve** (if the worry is "this might break someone", a prerelease doesn't achieve it), and an rc **must actually be promoted** or it's another snapshot wearing a candidate's label — which is how the nine-tag ladder happened.

**Also records a latent inconsistency.** The updater orders by **version**; the installer orders by **date**. Publish `v0.2.0` and then a `v0.1.2` backport off an older line, and a new install gets `v0.1.2` while an existing one is offered `v0.2.0`. Nothing does this today (pre-1.0 the heartbeat only moves forward), but the two are not the same rule and only one is version-aware.

**Two smaller fixes while here:** the `milestone` table row was stranded *below* the table it belongs to, and `SHIPPING.md` still described `releases/latest` as not-yet-working ("once a stable release is cut") — it resolves as of v0.1.0.

## Reservations

- I got this wrong on the first pass and had to correct it mid-change: I grepped `releases/latest` in `install.sh`, hit the comment explaining why the installer **avoids** it, and wrote a table claiming an rc reaches existing users but not new ones. The committed version is from reading the resolution block (lines 91-99). Worth a second look precisely because I asserted the opposite an hour ago.
- Docs only — no test covers whether these claims stay true. If the updater ever learns to filter prereleases, or the installer switches to `releases/latest`, this section silently goes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)