### PR TITLE
Temporal smoothing, one channel resolver, and a title-card font fix

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -66,6 +66,7 @@ Last audited: 2026-07-16 (full six-area ground-truth read; against `main` @ c1ce
 
 ## Julia app (`app/src/`)
 
+- **Channel name → 0-based index (Julia)**: `channel_index` / `channel_indices` / `ccid_channel_names` (`app/src/model/image.jl`) — the ONE translation from a `channelSelection` param (which stores NAMES) to the indices Python wants. Idempotent on integers; an unmatched name RAISES with the available names. Six task handlers had hand-rolled `findfirst(==(String(ch)), ch_names)` in three mutually inconsistent, silently-wrong variants (index crashed four, unmatched name dropped by five, `drift_correct` fell back to channel 0). Guarded by the `no seventh copy` detector. Python mirror: `script_utils.channel_indices`. See `docs/MODULES.md` → *`channelSelection`*.
 - **Object model**: `model/image.jl` (`CciaImage` + path accessors `img_filepath`/`img_label_props_path`/`img_track_props_path`/`img_branch_props_path`/`img_branch_labels_dir`/`img_branch_labels_path`/`img_physical_sizes`), `model/set.jl` (`CciaSet`, `init_object`), `model/project.jl` (`CciaProject`, `with_transaction`).
 - **Versioned fields**: `helpers.jl` — `versioned_get`/`versioned_set!`/`versioned_keys`/`versioned_active` (the `{value_name => …, "_active" => …}` convention; the one family for both `Dict{String,String}` path dicts and `Any`/JSON3 raw dicts), plus `read_ccid_raw(path)` (the one ccid.json read+Symbol-key normalize).
 - **H5AD chain**: `label_props.jl` (see Data access) + `tracking/track_props.jl` (compute-on-read per-track table, auto categorical/numeric detection).

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -104,7 +104,7 @@ export ClustPops, ClustTracks
 export CellNeighbours, ClustRegions, NeighbourStats, DetectAggregates, CellContacts, ContactsMeshes
 export AggregatesMeshes
 export detect_motion_dims, MotionDims
-export AfCorrect, DriftCorrect, CompositeTask
+export AfCorrect, DriftCorrect, TemporalSmooth, CompositeTask
 export CropImage
 export CopyImage
 
@@ -186,6 +186,7 @@ include("tasks/importImages/migrateLegacy.jl")
 include("tasks/cleanupImages/cellpose_correct.jl")
 include("tasks/cleanupImages/af_correct.jl")
 include("tasks/cleanupImages/drift_correct.jl")
+include("tasks/cleanupImages/temporal_smooth.jl")
 include("tasks/editImages/cropImage.jl")
 include("tasks/editImages/copyImage.jl")
 include("tasks/segment/cellpose.jl")

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -44,6 +44,7 @@ export read_lab_log, append_lab_log!, upsert_daily_context_block!, parse_lab_log
 export read_dismissed, set_dismissed!
 export capture_context!, record_stats_event!, CONTEXT_AUTHOR
 export set_channel_names!, channel_names
+export channel_index, channel_indices, ccid_channel_names
 
 # ── Lockfile / transaction ────────────────────────────────────────────────────
 export with_transaction, commit_state!

--- a/app/src/model/image.jl
+++ b/app/src/model/image.jl
@@ -285,6 +285,88 @@ function channel_names(img::CciaImage; value_name=nothing)::Union{Vector{String}
     isnothing(v) ? nothing : collect(String, v)
 end
 
+# ── Channel name → 0-based index ──────────────────────────────────────────────
+#
+# THE ONE resolver for "a `channelSelection` param holds names; Python wants indices". Six task
+# handlers had hand-rolled `findfirst(==(String(ch)), ch_names)` — `cellpose_correct`, `drift_correct`,
+# `af_correct` (twice), `segment/cellpose`, `segment/branching` — and they had drifted into three
+# different behaviours, every one of them silently wrong:
+#
+#   * an already-resolved INDEX crashed four of them (`String(::Int64)` → MethodError), because a REPL
+#     caller, a test, or a re-translated chain dict hands back what the first pass produced;
+#   * an unmatched NAME was silently DROPPED by five — so a stale name in a saved chain quietly
+#     segmented on the wrong channels, or on none;
+#   * and `drift_correct` silently fell back to index 0, which on a resonance-scanner movie means
+#     registering the whole timelapse against SHG at 99.5% zeros. Measured on `zolIMa/2h06xA`: the
+#     reference channel is worth ~2x in shift jitter (Y sd 1.86 px on CD169-Kat vs 0.93 on mem-TOM),
+#     so picking it by accident is not a small error.
+#
+# So: idempotent on integers, and an unmatched name RAISES with the available names. That is a
+# deliberate behaviour change from silent-drop — a channel the user named and we could not find is
+# not a thing to guess about. The Python counterpart is `script_utils.channel_indices`, which catches
+# the mirror-image failure (a NAME arriving where an index was due, i.e. this never ran).
+
+"""
+    channel_index(ch, ch_names; what="channel") -> Int
+
+Resolve one channel to its **0-based** index. `ch` may be a name (looked up in `ch_names`) or an
+already-resolved `Integer`, which passes through — so translating twice is a no-op.
+
+Raises when a name is not among `ch_names`, naming what was available.
+"""
+function channel_index(ch, ch_names::AbstractVector{<:AbstractString};
+                       what::AbstractString = "channel")::Int
+    ch isa Integer && return Int(ch)
+    name = String(ch)
+    idx = findfirst(==(name), ch_names)
+    if isnothing(idx)
+        # Case-only differences are the common real cause and the match stays EXACT anyway: two images
+        # from the same experiment shipped `mem-TOM` and `mem-Tom`, so a chain built on one would fail
+        # on the other. Naming the near match makes that a five-second fix instead of a puzzle — but it
+        # is a hint, not a silent coercion. Guessing which channel was meant is what this resolver exists
+        # to stop doing.
+        near = findfirst(n -> lowercase(n) == lowercase(name), ch_names)
+        error("$what: no channel named '$name' in this image. Available: " *
+              (isempty(ch_names) ? "(none registered)" : join(ch_names, ", ")) *
+              (isnothing(near) ? "" : ". Did you mean '$(ch_names[near])'? (differs only in case)") *
+              ". Channel names are per image version — a saved chain may name a channel this version " *
+              "does not have.")
+    end
+    idx - 1
+end
+
+"""
+    channel_indices(chs, ch_names; what="channels", unique_only=true) -> Vector{Int}
+
+`channel_index` over a collection, preserving order. Deduplicates by default: a channel named twice
+would otherwise be counted twice, which for the AF weight squares its term into the denominator a
+second time. Pass `unique_only=false` where multiplicity is meaningful.
+
+A `nothing` or empty input gives `Int[]` — "no channels selected" is a legitimate state that each
+task judges for itself (branching only needs `fibreChannels` for `anisotropySource="channel"`).
+"""
+function channel_indices(chs, ch_names::AbstractVector{<:AbstractString};
+                         what::AbstractString = "channels",
+                         unique_only::Bool = true)::Vector{Int}
+    isnothing(chs) && return Int[]
+    seq = chs isa AbstractVector ? chs : [chs]
+    out = Int[channel_index(c, ch_names; what = what) for c in seq]
+    unique_only ? unique(out) : out
+end
+
+"""
+    ccid_channel_names(raw, value_name=VERSIONED_DEFAULT_VAL) -> Vector{String}
+
+Channel names straight off a `ccid.json` dict, for a task handler that has `raw` rather than a loaded
+`CciaImage`. The same three lines were repeated in all six handlers; `nothing` for `value_name` means
+the ACTIVE version (what `segment/branching` wants — a corrected image with renamed channels).
+"""
+function ccid_channel_names(raw::AbstractDict,
+                            value_name = VERSIONED_DEFAULT_VAL)::Vector{String}
+    v = versioned_get_field(raw, "imChannelNames", value_name)
+    v isa AbstractVector ? collect(String, v) : String[]
+end
+
 # ── State file — the object owns its own path ─────────────────────────────────
 # Ported from the old R `reactivePersistentObject.R`, where the state file was private to the object
 # (`private$getStateFile()`) and everything — save, load, and the `.lock` — derived from it. That

--- a/app/src/qc.jl
+++ b/app/src/qc.jl
@@ -130,6 +130,15 @@ const QC_TEXT = Dict{String,@NamedTuple{short::String, long::String}}(
         short = "Channel {channel} saturated",
         long  = "Input voxels are clipped at the top of the range, so their true value is already lost — lower the gain or laser power and reacquire."),
 
+    # temporal smoothing (_temporal_smooth_qc_findings). Both findings are about the STEP rather than
+    # the input: it always "succeeds", it just may have overshot the dtype or bought nothing.
+    "smooth.gain_clipped" => (
+        short = "Dynamic-range gain clipped {value} voxels",
+        long  = "Turn 'Restore dynamic range' off and re-run — the bright end of every smoothed channel is flat."),
+    "smooth.no_effect" => (
+        short = "Smoothing changed little",
+        long  = "This input was not photon-limited — the extra store is likely redundant."),
+
     # output geometry (qc_canvas_expansion)
     "output.canvas_expansion" => (
         short = "Output canvas grew +{pct}% in XY",

--- a/app/src/tasks/cleanupImages/af_correct.jl
+++ b/app/src/tasks/cleanupImages/af_correct.jl
@@ -21,9 +21,7 @@ output. Silently dropped rather than rejected because the two lists are separate
 the same channel in both is an easy slip with one obvious intent.
 """
 function af_combinations_for_python(params::AbstractDict, raw::AbstractDict)::Dict{String,Any}
-    channel_names_raw = versioned_get_field(raw, "imChannelNames", VERSIONED_DEFAULT_VAL)
-    ch_names = channel_names_raw isa AbstractVector ?
-               collect(String, channel_names_raw) : String[]
+    ch_names = ccid_channel_names(raw)
 
     af_combos_raw = get(params, "afCombinations", nothing)
     af_combos = Dict{String,Any}()
@@ -32,31 +30,17 @@ function af_combinations_for_python(params::AbstractDict, raw::AbstractDict)::Di
     for (k, v) in af_combos_raw
         entry = Dict{String,Any}(String(ck) => cv for (ck, cv) in v)
 
-        # competingChannels: channel names → 0-based indices (an already-translated index passes
-        # through, so this is idempotent — a REPL or chain caller may hand back a converted dict)
-        idx_channels = Int[]
-        for ch in get(entry, "competingChannels", [])
-            if ch isa Integer
-                push!(idx_channels, Int(ch))
-                continue
-            end
-            idx = findfirst(==(String(ch)), ch_names)
-            isnothing(idx) || push!(idx_channels, idx - 1)
-        end
+        # competingChannels / targetChannel → 0-based indices via the one resolver (model/image.jl).
+        # Idempotent on integers, so a REPL or chain caller may hand back a converted dict; `unique`
+        # is the resolver's default because a channel named twice would square its term into the
+        # weight's denominator a second time.
+        idx_channels = channel_indices(get(entry, "competingChannels", []), ch_names;
+                                       what = "competingChannels")
 
-        # targetChannel: resolve name → 0-based index → use as the af_combos key
         raw_target = get(entry, "targetChannel", [])
         delete!(entry, "targetChannel")
-        combo_key = String(k)
-        if !isempty(raw_target)
-            q = first(raw_target)
-            if q isa Integer
-                combo_key = string(Int(q))
-            else
-                idx = findfirst(==(String(q)), ch_names)
-                isnothing(idx) || (combo_key = string(idx - 1))
-            end
-        end
+        target_sel = channel_indices(raw_target, ch_names; what = "targetChannel")
+        combo_key = isempty(target_sel) ? String(k) : string(first(target_sel))
 
         # the target competes with the OTHERS, never with itself — see the docstring
         target_idx = tryparse(Int, combo_key)

--- a/app/src/tasks/cleanupImages/cellpose_correct.jl
+++ b/app/src/tasks/cleanupImages/cellpose_correct.jl
@@ -25,24 +25,17 @@ function _run_task(task::CellposeCorrect, img::CciaImage, params::Dict{String,An
         return nothing
     end
 
-    # Channel names → 0-based indices
-    channel_names_raw = versioned_get_field(raw, "imChannelNames", VERSIONED_DEFAULT_VAL)
-    ch_names = channel_names_raw isa AbstractVector ?
-               collect(String, channel_names_raw) : String[]
+    ch_names = ccid_channel_names(raw)
 
     models_json      = get(params, "models", nothing)
     models_converted = Dict{String,Any}()
     if !isnothing(models_json)
         for (k, v) in models_json
             m = Dict{String,Any}(String(ck) => cv for (ck, cv) in v)
-            raw_channels = get(m, "modelChannels", [])
-            idx_channels = Int[]
-            for ch in raw_channels
-                ch_str = String(ch)
-                idx = findfirst(==(ch_str), ch_names)
-                isnothing(idx) || push!(idx_channels, idx - 1)
-            end
-            m["modelChannels"] = idx_channels
+            # names → 0-based indices via the one resolver (model/image.jl); idempotent, and an
+            # unmatched name raises instead of quietly denoising a different set of channels
+            m["modelChannels"] = channel_indices(get(m, "modelChannels", []), ch_names;
+                                                 what = "modelChannels")
             models_converted[String(k)] = m
         end
     end

--- a/app/src/tasks/cleanupImages/drift_correct.jl
+++ b/app/src/tasks/cleanupImages/drift_correct.jl
@@ -53,22 +53,27 @@ function _run_task(task::DriftCorrect, img::CciaImage, params::Dict{String,Any};
         return nothing
     end
 
-    # Convert driftChannel from channel name to 0-based index
-    channel_names_raw = versioned_get_field(raw, "imChannelNames", VERSIONED_DEFAULT_VAL)
-    ch_names = channel_names_raw isa AbstractVector ?
-               collect(String, channel_names_raw) : String[]
-
-    drift_channel_raw = get(params, "driftChannel", nothing)
+    # driftChannel → 0-based index, through the ONE resolver (`channel_index`, model/image.jl).
+    #
+    # This used to fall back to index 0 whenever the name did not resolve, which is the worst possible
+    # default: channel 0 here is SHG at 99.5% zeros, so the whole timelapse would be registered against
+    # noise with nothing in the log to say so. The reference channel is worth about 2x in shift jitter
+    # (measured on `zolIMa/2h06xA`: Y sd 1.86 px registering on CD169-Kat vs 0.93 px on mem-TOM), so
+    # this is a parameter that has to be right rather than defaulted.
+    ch_names = ccid_channel_names(raw)
+    # channelSelection stores an array even when multiple=false
+    drift_sel = channel_indices(get(params, "driftChannel", nothing), ch_names;
+                                what = "driftChannel")
     drift_channel_idx = 0
-    if !isnothing(drift_channel_raw)
-        # channelSelection stores as array even when multiple=false
-        raw_ch = drift_channel_raw isa AbstractVector ? drift_channel_raw :
-                 [drift_channel_raw]
-        if !isempty(raw_ch) && !isempty(ch_names)
-            ch_str = String(raw_ch[1])
-            idx = findfirst(==(ch_str), ch_names)
-            isnothing(idx) || (drift_channel_idx = idx - 1)
-        end
+    if isempty(drift_sel)
+        # The task JSON defaults `driftChannel` to `[]`, so "nothing picked" is a reachable GUI state
+        # and index 0 stays the fallback rather than becoming an error. But SAY so — silence here is
+        # what let a whole movie register against SHG unnoticed.
+        on_log("[WARN] No drift reference channel selected — registering on channel 0" *
+               (isempty(ch_names) ? "" : " ('$(first(ch_names))')") *
+               ". Pick the brightest, most structured channel: the estimate is only as good as it is.")
+    else
+        drift_channel_idx = first(drift_sel)
     end
 
     on_log("[INFO] Input:       $im_path")

--- a/app/src/tasks/cleanupImages/temporal_smooth.jl
+++ b/app/src/tasks/cleanupImages/temporal_smooth.jl
@@ -1,0 +1,167 @@
+struct TemporalSmooth <: CciaTask end
+
+# QC from the persisted smoothing stats. The failure modes here are quiet ones — the task always
+# "succeeds", it just may not have helped:
+#  • not run on aligned data — the temporal statistic compares the same pixel across frames, so on an
+#    un-drift-corrected movie it medians across different tissue. Detectable only by provenance, so
+#    it is checked in the task body, not here.
+#  • gain clipping — restoring dynamic range pushed voxels past the dtype maximum, i.e. the bright
+#    end is now flat and any ratio computed there is wrong.
+#  • no effect — the zero fraction barely moved, which means the input was not photon-limited and
+#    this step bought nothing (fine, but worth saying so rather than leaving a redundant store).
+function _temporal_smooth_qc_findings(meta)
+    findings = Dict{String,Any}[]
+
+    clipped = get(meta, "clippedVoxels", 0)
+    if clipped isa Number && clipped > 0
+        push!(findings, qc_finding("warn", "smooth.gain_clipped";
+            value = Int(clipped),
+            detail = Dict{String,Any}("clippedVoxels" => Int(clipped),
+                                      "gain" => get(meta, "gain", 1.0))))
+    end
+
+    zin  = get(meta, "zeroFracIn", Dict())
+    zout = get(meta, "zeroFracOut", Dict())
+    if !isempty(zin)
+        drops = [Float64(get(zin, k, 0.0)) - Float64(get(zout, k, 0.0)) for k in keys(zin)]
+        # Photon-limited input starts at 85-95% zeros and lands near 5%, so a drop under 5 points
+        # means there was nothing sparse to fill.
+        if maximum(drops) < 0.05
+            push!(findings, qc_finding("info", "smooth.no_effect";
+                detail = Dict{String,Any}("zeroFracIn" => zin, "zeroFracOut" => zout)))
+        end
+    end
+    findings
+end
+
+# The objective numbers this task produces, reduced to scalars for `write_qc`'s `metrics`. The
+# per-channel dicts stay in the `smoothing` block; the WORST channel is the summary — a step that
+# filled one channel and left another sparse is the case worth seeing.
+#
+# Deliberately NOT in COHORT_METRICS. `zeroFracIn` looks like an acquisition property (how
+# photon-limited the movie was), which is what makes AF's `saturatedFrac` cohort-comparable — but
+# this task's input is the DRIFT-CORRECTED store, and drift correction pads the canvas with zeros by
+# however far the movie moved. So a bigger `zeroFracIn` here can just mean more drift, and the cohort
+# outlier detector would be ranking images by shake. `gain` inherits the same confound (it is
+# estimated from percentiles of that padded volume) and additionally depends on sigma/frames, so it
+# is only comparable at fixed params. Neither number is trustworthy across a set; per-image is honest.
+function _temporal_smooth_metrics(meta)
+    zin  = get(meta, "zeroFracIn", Dict())
+    zout = get(meta, "zeroFracOut", Dict())
+    m = Dict{String,Any}(
+        "gain"          => Float64(get(meta, "gain", 1.0)),
+        "clippedVoxels" => Int(get(meta, "clippedVoxels", 0)))
+    isempty(zin)  || (m["zeroFracInMax"]  = maximum(Float64(v) for v in values(zin)))
+    isempty(zout) || (m["zeroFracOutMax"] = maximum(Float64(v) for v in values(zout)))
+    m
+end
+
+function _run_task(task::TemporalSmooth, img::CciaImage, params::Dict{String,Any};
+                   on_log::Function      = line -> println(line),
+                   on_progress::Function = (n, t) -> nothing,
+                   on_process::Function  = _ -> nothing)
+    value_name = string(get(params, "valueName", VERSIONED_DEFAULT_VAL))
+    ccid       = state_file(img)
+    raw        = read_ccid_raw(ccid)
+
+    filename = versioned_get_field(raw, "filepath", value_name)
+    if isnothing(filename)
+        on_log("[ERROR] No filepath for valueName='$value_name'")
+        return nothing
+    end
+
+    proj_dir       = dirname(dirname(img._dir))
+    im_path        = joinpath(proj_dir, "0", img.uid, string(filename))
+    im_output_path = joinpath(proj_dir, "0", img.uid, "ccidTemporalSmoothed.ome.zarr")
+
+    if !ispath(im_path)
+        on_log("[ERROR] Input image not found: $im_path")
+        return nothing
+    end
+
+    # The temporal statistic compares the SAME pixel across t-1, t, t+1. Before drift correction that
+    # pixel is not the same tissue, so the median runs across different structures and smears them.
+    # We cannot verify alignment from the pixels, but the value name says which version this is —
+    # so say something rather than silently produce a smeared store.
+    if !occursin("rift", string(value_name)) && !occursin("rift", string(filename))
+        on_log("[WARN] '$value_name' does not look drift-corrected. Temporal smoothing compares the " *
+               "same pixel across frames, so run drift correction first or the statistic mixes tissue.")
+    end
+
+    # `ccid_channel_names(raw)` — the DEFAULT version, not `value_name`. Channel names are stored
+    # once under "default"; asking for them under a derived version ("driftCorrected") returns an
+    # empty list and every channel name then fails to resolve. Same call as drift_correct.jl.
+    ch_names = ccid_channel_names(raw)
+    channel_idx = channel_indices(get(params, "channels", nothing), ch_names; what = "channels")
+    if isempty(channel_idx)
+        on_log("[INFO] No channels selected — smoothing all of them. Leave structural channels " *
+               "(SHG/THG) out if they are not cells.")
+    end
+
+    spatial_sigma   = Float64(get(params, "spatialSigma", 1.0))
+    temporal_frames = Int(get(params, "temporalFrames", 3))
+    temporal_stat   = string(get(params, "temporalStat", "median"))
+    restore_gain    = Bool(get(params, "restoreDynamicRange", true))
+
+    # Spatial sigma 0 with a temporal window is the one combination measured to be WORSE than doing
+    # nothing: at single-digit photon counts a median over 3 mostly-zero samples is zero (8.5% of the
+    # reference channel's signal kept, against 15.4% for no smoothing at all). Guard it explicitly —
+    # the ordering invariant lives in coastal.smooth, but this is where the GUI can produce it.
+    if spatial_sigma <= 0 && temporal_frames > 1
+        on_log("[WARN] Spatial sigma 0 with a temporal window keeps LESS signal than no smoothing " *
+               "on photon-limited data. Use sigma >= 1 unless you know the input is dense.")
+    end
+
+    on_log("[INFO] Input:    $im_path")
+    on_log("[INFO] Output:   $im_output_path")
+    on_log("[INFO] Channels: $(isempty(channel_idx) ? "all" : channel_idx)")
+    on_log("[INFO] sigma=$spatial_sigma frames=$temporal_frames stat=$temporal_stat")
+
+    qc_out_path = joinpath(task_run_dir(img._dir), "temporal_smooth_stats.json")
+
+    ok = run_py("tasks/cleanupImages/temporal_smooth_run.py",
+        (; imPath         = im_path,
+           imOutputPath   = im_output_path,
+           channels       = channel_idx,
+           spatialSigma   = spatial_sigma,
+           temporalFrames = temporal_frames,
+           temporalStat   = temporal_stat,
+           restoreGain    = restore_gain,
+           qcOutPath      = qc_out_path),
+        task_run_dir(img._dir);
+        on_log = on_log, on_progress = on_progress, on_process = on_process)
+    ok || return nothing
+
+    on_log("[INFO] Temporal smoothing complete.")
+
+    out_value_name = _spec_output_value_name(task, "temporalSmoothed")
+    out_filename   = "ccidTemporalSmoothed.ome.zarr"
+
+    if isfile(qc_out_path)
+        try
+            qmeta = JSON3.read(read(qc_out_path, String))
+            findings = _temporal_smooth_qc_findings(qmeta)
+            write_qc(img, "cleanupImages.temporalSmooth", out_value_name, findings;
+                     metrics = _temporal_smooth_metrics(qmeta),
+                     source = Dict{String,Any}("shape" => collect(Int, qmeta["shape"])),
+                     output = Dict{String,Any}("shape" => collect(Int, qmeta["shape"])),
+                     smoothing = Dict{String,Any}(
+                         "gain"           => get(qmeta, "gain", 1.0),
+                         "channels"       => get(qmeta, "channels", Int[]),
+                         "spatialSigma"   => get(qmeta, "spatialSigma", spatial_sigma),
+                         "temporalFrames" => get(qmeta, "temporalFrames", temporal_frames),
+                         "temporalStat"   => get(qmeta, "temporalStat", temporal_stat),
+                         "zeroFracIn"     => get(qmeta, "zeroFracIn", Dict()),
+                         "zeroFracOut"    => get(qmeta, "zeroFracOut", Dict())))
+            isempty(findings) || on_log("[QC] $(length(findings)) finding(s) — see the image's QC badge.")
+        catch e
+            on_log("[QC] could not compute smoothing QC: $e")
+        end
+    end
+
+    commit_state!(img) do raw
+        versioned_set_field!(raw, "filepath", out_filename, out_value_name)
+    end
+
+    Dict{String,Any}("valueName" => out_value_name, "filename" => out_filename)
+end

--- a/app/src/tasks/cleanupImages/temporal_smooth.json
+++ b/app/src/tasks/cleanupImages/temporal_smooth.json
@@ -1,0 +1,66 @@
+{
+  "task": "temporalSmooth",
+  "fun_name": "cleanupImages.temporalSmooth",
+  "label": "Temporal smoothing",
+  "category": "Cleanup",
+  "env": ["local"],
+  "resource_pool": "cpu",
+  "outputValueName": "temporalSmoothed",
+  "requires": { "axes": ["T"] },
+  "params": [
+    {
+      "key": "valueName",
+      "label": "Image to smooth",
+      "type": "valueNameSelection",
+      "default": "default",
+      "field": "filepaths",
+      "tip": "Use a drift-corrected version — frames must be aligned"
+    },
+    {
+      "key": "channels",
+      "label": "Channels to smooth",
+      "type": "channelSelection",
+      "multiple": true,
+      "default": [],
+      "tip": "Unselected channels are copied through unchanged — leave SHG/THG out"
+    },
+    {
+      "key": "spatialSigma",
+      "label": "Spatial sigma (px)",
+      "type": "float",
+      "default": 1.0,
+      "min": 0.0,
+      "max": 4.0,
+      "step": 0.5,
+      "tip": "xy Gaussian before the temporal statistic — 0 keeps less signal than no smoothing"
+    },
+    {
+      "key": "temporalFrames",
+      "label": "Temporal window (frames)",
+      "type": "int",
+      "default": 3,
+      "min": 1,
+      "max": 9,
+      "step": 2,
+      "tip": "Full centred width, forced odd. 1 disables the temporal term"
+    },
+    {
+      "key": "temporalStat",
+      "label": "Temporal statistic",
+      "type": "select",
+      "default": "median",
+      "options": [
+        { "label": "Median", "value": "median" },
+        { "label": "Mean",   "value": "mean" }
+      ],
+      "tip": "Median rejects a cell that moved through the window; mean inflates masks ~34%"
+    },
+    {
+      "key": "restoreDynamicRange",
+      "label": "Restore dynamic range",
+      "type": "bool",
+      "default": true,
+      "tip": "One gain for all smoothed channels, so cross-channel ratios hold"
+    }
+  ]
+}

--- a/app/src/tasks/cleanupImages/temporal_smooth_run.py
+++ b/app/src/tasks/cleanupImages/temporal_smooth_run.py
@@ -1,0 +1,237 @@
+"""Temporal smoothing task.
+
+Applies `coastal.smooth`'s model-free smoothing — an xy Gaussian, then a running statistic over
+time — to selected channels, streaming z-plane by z-plane so peak memory is the temporal window and
+not the movie. Output shape equals input shape; unselected channels are copied through.
+
+Why it exists: on photon-limited resonance data (86-95% of voxels exactly zero) the AF task's
+triangle threshold lands *inside* the signal, because the histogram has no background population to
+find — measured on `zolIMa/fXgbTl`, the reference channel kept 8.6% of its signal past background
+subtraction, 80% after smoothing. So this runs BETWEEN drift correction and AF. Full record:
+`docs/todo/SMOOTHING_PLAN.md`, and coastal's `docs/SMOOTHING.md`.
+
+Two invariants, both load-bearing and both measured (they live in `coastal.smooth`; this file only
+has to not break them):
+
+  * **spatial BEFORE temporal.** A temporal statistic alone keeps 8.5% of the reference channel's
+    signal — worse than doing nothing (15.4%) — because at single-digit photon counts a median over
+    3 mostly-zero samples is zero. The Gaussian has to fill the counts first. The rolling window
+    below therefore caches *spatially smoothed* frames and takes the temporal statistic across them.
+  * **one shared kernel for every channel.** The consumer is a cross-channel ratio (AF's weight is
+    `b_t^p / sum_i b_i^p`), so a per-channel transform corrupts it. That extends to the dynamic-range
+    gain below: ONE gain for all smoothed channels, never per-channel.
+
+Parameter contract (JSON written by Julia):
+  imPath           - absolute path to input .ome.zarr
+  imOutputPath     - absolute path to write the smoothed .ome.zarr
+  channels         - list of 0-based channel indices to smooth ([] = all)
+  spatialSigma     - xy Gaussian sigma in px (0 disables)
+  temporalFrames   - full centred window, forced odd by coastal (1 disables)
+  temporalStat     - "median" | "mean"
+  restoreGain      - bool, rescale so an integer store keeps usable precision
+  qcOutPath        - where to persist stats for the Julia QC step
+"""
+
+import numpy as np
+
+import cecelia.utils.zarr_utils as zarr_utils
+import cecelia.utils.ome_xml_utils as ome_xml_utils
+from cecelia.utils.dim_utils import DimUtils
+import cecelia.utils.script_utils as script_utils
+from cecelia.utils.atomic_io import write_json_atomic
+
+# coastal owns the smoothing engine (array-only, imports nothing from cecelia). Declared as a git
+# dep in pixi.toml — see the note there for why it is no longer an editable sibling path.
+from coastal.smooth import spatial_smooth, temporal_smooth
+
+#: How many (t, z) planes to sample when estimating the dynamic-range gain. The gain only needs the
+#: right order of magnitude, and a sample keeps this from being a second full pass over the store.
+GAIN_SAMPLE_PLANES = 24
+
+
+def _axis_len(dim_utils, letter, shape):
+    idx = dim_utils.dim_idx(letter)
+    return (idx, shape[idx]) if idx is not None else (None, 1)
+
+
+def _plane_slice(ndim, t_idx, t, c_idx, c, z_idx, z):
+    """Slice tuple selecting one (timepoint, channel, z) plane, leaving the spatial axes whole."""
+    sl = [slice(None)] * ndim
+    sl[t_idx] = t
+    if c_idx is not None:
+        sl[c_idx] = c
+    if z_idx is not None:
+        sl[z_idx] = z
+    return tuple(sl)
+
+
+def run(params):
+    log = script_utils.get_logfile_utils(params)
+
+    im_path      = params['imPath']
+    out_path     = params['imOutputPath']
+    channels     = [int(c) for c in (params.get('channels') or [])]
+    sigma        = float(params.get('spatialSigma', 1.0))
+    frames       = int(params.get('temporalFrames', 3))
+    stat         = str(params.get('temporalStat', 'median'))
+    restore_gain = bool(params.get('restoreGain', True))
+
+    log.progress(0, 4)
+    log.log(f'>> open image: {im_path}')
+    # Plain zarr, not dask: every read is one chunk-aligned plane, so a dask graph only adds
+    # overhead. Same reasoning as drift_correct_run.py (docs/todo/ZARR_STREAMING_PLAN.md).
+    im_dat, _ = zarr_utils.open_as_zarr(im_path, as_dask=False)
+    level_in = im_dat[0]
+
+    omexml = ome_xml_utils.parse_meta(im_path)
+    dim_utils = DimUtils(omexml, use_channel_axis=True)
+    dim_utils.calc_image_dimensions(level_in.shape)
+
+    shape = tuple(level_in.shape)
+    t_idx, nt = _axis_len(dim_utils, 'T', shape)
+    c_idx, nc = _axis_len(dim_utils, 'C', shape)
+    z_idx, nz = _axis_len(dim_utils, 'Z', shape)
+    if t_idx is None:
+        log.log('[ERROR] image has no time axis — temporal smoothing needs one')
+        raise SystemExit(1)
+
+    sel = channels if channels else list(range(nc))
+    others = [c for c in range(nc) if c not in sel]
+    log.log(f'>> dims {dim_utils.im_dim_order} {shape}')
+    log.log(f'>> smoothing channels {sel} (passing through {others}); '
+            f'sigma={sigma}, frames={frames}, stat={stat}')
+
+    half = max(0, (frames - 1) // 2) if frames and frames > 1 else 0
+
+    def read_plane(t, c, z):
+        return np.asarray(level_in[_plane_slice(len(shape), t_idx, t, c_idx, c, z_idx, z)],
+                          dtype=np.float32)
+
+    # ── the gain ───────────────────────────────────────────────────────────────────────────────
+    # Averaging lowers the maximum, so writing the result back at the input dtype throws away the
+    # precision the AF background estimate needs: measured on fXgbTl, smoothed nuc-GFP has p99=15
+    # and max 59, i.e. ~59 integer levels for the whole channel, and the background sits at 2.6 —
+    # one integer step is 38% of it. ONE gain across all smoothed channels restores the range
+    # without touching cross-channel ratios.
+    gain = 1.0
+    dtype_max = np.iinfo(zarr_utils.native_dtype(level_in.dtype)).max \
+        if np.issubdtype(level_in.dtype, np.integer) else None
+    if restore_gain and dtype_max is not None:
+        log.progress(1, 4)
+        log.log('>> estimate dynamic-range gain')
+        rng = np.random.default_rng(0)
+        picks = [(int(rng.integers(0, nt)), int(rng.integers(0, nz)))
+                 for _ in range(min(GAIN_SAMPLE_PLANES, nt * nz))]
+        hi_in, hi_sm = [], []
+        for t, z in picks:
+            for c in sel:
+                raw = read_plane(t, c, z)
+                sm = spatial_smooth(raw, sigma)
+                hi_in.append(np.percentile(raw, 99.99))
+                hi_sm.append(np.percentile(sm, 99.99))
+        hi_in, hi_sm = float(np.mean(hi_in)), float(np.mean(hi_sm))
+        if hi_sm > 0:
+            gain = max(1.0, hi_in / hi_sm)
+        log.log(f'   input p99.99 {hi_in:.1f}, smoothed {hi_sm:.1f} -> gain {gain:.2f}')
+
+    # ── stream ─────────────────────────────────────────────────────────────────────────────────
+    log.progress(2, 4)
+    log.log(f'>> smooth + write (streaming per z-plane): {out_path}')
+    stats = {'zeroFracIn': {}, 'zeroFracOut': {}, 'clippedVoxels': 0, 'gain': gain}
+    zin = {c: [] for c in sel}
+    zout = {c: [] for c in sel}
+    clipped = 0
+
+    with zarr_utils.staged_store(out_path) as staging:
+        group, level0, pchunks = zarr_utils.open_multiscales_for_writing(
+            staging, shape, level_in.dtype, dim_utils, nscales=len(im_dat))
+
+        for z in range(nz):
+            # Rolling cache of SPATIALLY smoothed planes for this z, keyed by timepoint. Bounded by
+            # the window, so memory is `frames` planes per channel regardless of T.
+            cache = {}
+
+            def spatial_at(t, c):
+                t = min(max(t, 0), nt - 1)          # clamp = scipy's mode='nearest'
+                key = (t, c)
+                if key not in cache:
+                    cache[key] = spatial_smooth(read_plane(t, c, z), sigma)
+                return cache[key]
+
+            for t in range(nt):
+                for c in sel:
+                    if half == 0:
+                        out = spatial_at(t, c)
+                    else:
+                        # spatial FIRST (cached), then the temporal statistic across the window
+                        win = np.stack([spatial_at(tt, c) for tt in range(t - half, t + half + 1)])
+                        out = temporal_smooth(win, frames, stat, time_axis=0)[half]
+                    raw = read_plane(t, c, z)
+                    zin[c].append(float((raw == 0).mean()))
+
+                    out = out * gain
+                    if dtype_max is not None:
+                        clipped += int((out > dtype_max).sum())
+                        out = np.clip(np.rint(out), 0, dtype_max)
+                    zout[c].append(float((out == 0).mean()))
+                    level0[_plane_slice(len(shape), t_idx, t, c_idx, c, z_idx, z)] = \
+                        out.astype(level0.dtype)
+
+                for c in others:
+                    level0[_plane_slice(len(shape), t_idx, t, c_idx, c, z_idx, z)] = \
+                        level_in[_plane_slice(len(shape), t_idx, t, c_idx, c, z_idx, z)]
+
+                # drop cache entries that can no longer be reached by a later window
+                for key in [k for k in cache if k[0] < t - half]:
+                    del cache[key]
+
+            if nz > 1:
+                log.log(f'   z {z + 1}/{nz}')
+
+        log.progress(3, 4)
+        log.log('>> build pyramid + save')
+        zarr_utils.write_multiscale_pyramid(group, level0, dim_utils, len(im_dat), list(pchunks))
+        ome_xml_utils.save_meta_in_zarr(staging, im_path, changed_shape=shape, dim_utils=dim_utils)
+        zarr_utils.write_calibration(staging, dim_utils)
+
+        # Carry the source's valid box forward. Smoothing does not move pixels, but it is normally
+        # run on a DRIFT-CORRECTED store whose canvas is mostly padding — losing the box here would
+        # make every downstream consumer re-derive geometry this store already knows.
+        box = zarr_utils.read_valid_box(im_path)
+        if box:
+            zarr_utils.write_valid_box(staging, list(box.keys()), box)
+            log.log(f'   carried valid box forward: {box}')
+
+    stats['zeroFracIn'] = {str(c): float(np.mean(v)) for c, v in zin.items() if v}
+    stats['zeroFracOut'] = {str(c): float(np.mean(v)) for c, v in zout.items() if v}
+    stats['clippedVoxels'] = clipped
+    stats['channels'] = sel
+    stats['spatialSigma'] = sigma
+    stats['temporalFrames'] = frames
+    stats['temporalStat'] = stat
+    stats['shape'] = [int(x) for x in shape]
+    for c in sel:
+        log.log(f'   ch{c}: zero voxels {100*stats["zeroFracIn"][str(c)]:.1f}% -> '
+                f'{100*stats["zeroFracOut"][str(c)]:.1f}%')
+    if clipped:
+        log.log(f'[WARN] gain clipped {clipped} voxels at the dtype maximum')
+
+    qc_out_path = params.get('qcOutPath')
+    if qc_out_path:
+        write_json_atomic(qc_out_path, stats)
+        log.log(f'>> saved QC stats: {qc_out_path}')
+
+    log.progress(4, 4)
+    log.log('>> done')
+
+
+def main():
+    params = script_utils.script_params()
+    if params is None:
+        print('[ERROR] No params file provided (--params missing or not found)', flush=True)
+        raise SystemExit(1)
+    run(params)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/src/tasks/segment/branching.jl
+++ b/app/src/tasks/segment/branching.jl
@@ -82,15 +82,9 @@ function _run_task(task::Branching, img::CciaImage, params::Dict{String,Any};
     # Channel names → 0-based indices for fibreChannels (Phase 3 anisotropy input). Read the
     # ACTIVE image version's channel names (nothing → `_active`; falls back to `default`) so a
     # corrected image with extra/renamed channels resolves correctly.
-    channel_names_raw = versioned_get_field(raw, "imChannelNames", nothing)
-    ch_names = channel_names_raw isa AbstractVector ?
-               collect(String, channel_names_raw) : String[]
-    fibre_channels_raw = get(params, "fibreChannels", [])
-    fibre_indices = Int[]
-    for ch in fibre_channels_raw
-        idx = findfirst(==(String(ch)), ch_names)
-        isnothing(idx) || push!(fibre_indices, idx - 1)
-    end
+    ch_names = ccid_channel_names(raw, nothing)          # nothing → the ACTIVE version
+    fibre_indices = channel_indices(get(params, "fibreChannels", []), ch_names;
+                                    what = "fibreChannels")
     # Only `anisotropySource="channel"` reads raw pixels; "skeleton"/"mask" work off the labels, so
     # an empty fibreChannels is only a problem for the channel source.
     aniso_source = string(get(params, "anisotropySource", "skeleton"))

--- a/app/src/tasks/segment/cellpose.jl
+++ b/app/src/tasks/segment/cellpose.jl
@@ -62,9 +62,7 @@ corrected variant inherits them by versioned fallback and may carry no list of i
 """
 function cellpose_models_for_python(params::AbstractDict, raw::AbstractDict;
                                     on_log::Function = _ -> nothing)::Dict{String,Any}
-    channel_names_raw = versioned_get_field(raw, "imChannelNames", VERSIONED_DEFAULT_VAL)
-    ch_names = channel_names_raw isa AbstractVector ?
-               collect(String, channel_names_raw) : String[]
+    ch_names = ccid_channel_names(raw)
 
     models_json = get(params, "models", nothing)
     out = Dict{String,Any}()
@@ -73,18 +71,9 @@ function cellpose_models_for_python(params::AbstractDict, raw::AbstractDict;
     for (k, v) in models_json
         m = Dict{String,Any}(String(ck) => cv for (ck, cv) in v)
         for field in ("cellChannels", "nucChannels")
-            raw_chs = get(m, field, [])
-            idx_chs = Int[]
-            for ch in raw_chs
-                # already an index (a REPL/test caller, or a re-translated dict) → keep it
-                if ch isa Integer
-                    push!(idx_chs, Int(ch))
-                    continue
-                end
-                idx = findfirst(==(String(ch)), ch_names)
-                isnothing(idx) || push!(idx_chs, idx - 1)
-            end
-            m[field] = idx_chs
+            # one resolver (model/image.jl): already-resolved indices pass through, so a REPL/test
+            # caller or a re-translated chain dict is idempotent; an unmatched name raises
+            m[field] = channel_indices(get(m, field, []), ch_names; what = field)
         end
         model_name = String(get(m, "model", ""))
         if !isempty(model_name) && !(model_name in BUILTIN_CELLPOSE_MODELS) && !isfile(model_name)

--- a/app/src/tasks/task_registry.jl
+++ b/app/src/tasks/task_registry.jl
@@ -89,6 +89,10 @@ function _spec_path(::DriftCorrect)
     joinpath(@__DIR__, "cleanupImages", "drift_correct.json")
 end
 
+function _spec_path(::TemporalSmooth)
+    joinpath(@__DIR__, "cleanupImages", "temporal_smooth.json")
+end
+
 function _spec_path(::CropImage)
     joinpath(@__DIR__, "editImages", "cropImage.json")
 end
@@ -148,6 +152,7 @@ function _fun_name_map()::Dict{String, CciaTask}
         "segment.cellposeMeasure"           => CompositeTask("segment.cellposeMeasure"),
         "cleanupImages.afCorrect"           => AfCorrect(),
         "cleanupImages.driftCorrect"        => DriftCorrect(),
+        "cleanupImages.temporalSmooth"      => TemporalSmooth(),
         "cleanupImages.afDriftCorrect"      => CompositeTask("cleanupImages.afDriftCorrect"),
         "editImages.cropImage"              => CropImage(),
         "editImages.copyImage"              => CopyImage(),

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -1690,6 +1690,55 @@ end
     @test isempty(Cecelia._branching_qc_findings(5))
 end
 
+@testset "Temporal smoothing QC" begin
+    # Both findings key off the persisted python stats, so the helper is fed exactly what
+    # temporal_smooth_run.py writes. Photon-limited input: zeros fall from ~90% to ~5%, no clipping.
+    worked = Dict{String,Any}(
+        "gain" => 2.4, "clippedVoxels" => 0,
+        "zeroFracIn"  => Dict{String,Any}("0" => 0.91, "1" => 0.88),
+        "zeroFracOut" => Dict{String,Any}("0" => 0.06, "1" => 0.05))
+    @test isempty(Cecelia._temporal_smooth_qc_findings(worked))
+
+    # Gain clipping — the bright end of every smoothed channel is now flat.
+    clipped = merge(worked, Dict{String,Any}("clippedVoxels" => 1234))
+    f = Cecelia._temporal_smooth_qc_findings(clipped)
+    @test length(f) == 1 && f[1]["code"] == "smooth.gain_clipped" && f[1]["level"] == "warn"
+    @test f[1]["short"] == "Dynamic-range gain clipped 1234 voxels"  # the count is IN the message
+    @test occursin("Restore dynamic range", f[1]["long"]) # the action, imperative
+    @test f[1]["detail"] isa AbstractDict
+    # from the catalog, so it re-renders at read time like every other finding
+    @test haskey(Cecelia.QC_TEXT, "smooth.gain_clipped")
+    @test f[1]["key"] == "smooth.gain_clipped"
+
+    # Dense input — nothing sparse to fill, so the step bought nothing. Info, not warn.
+    dense = Dict{String,Any}(
+        "gain" => 1.0, "clippedVoxels" => 0,
+        "zeroFracIn"  => Dict{String,Any}("0" => 0.02),
+        "zeroFracOut" => Dict{String,Any}("0" => 0.00))
+    fd = Cecelia._temporal_smooth_qc_findings(dense)
+    @test length(fd) == 1 && fd[1]["code"] == "smooth.no_effect" && fd[1]["level"] == "info"
+    @test haskey(Cecelia.QC_TEXT, "smooth.no_effect")
+
+    # advisory only, per docs/MODULES.md — never an error, never a gate
+    @test all(x -> x["level"] in ("info", "warn"),
+              vcat(Cecelia._temporal_smooth_qc_findings(clipped), fd))
+
+    # Metrics reduce the per-channel dicts to the WORST channel — a step that filled one channel and
+    # left another sparse is the case worth seeing.
+    m = Cecelia._temporal_smooth_metrics(worked)
+    @test m["zeroFracInMax"]  == 0.91
+    @test m["zeroFracOutMax"] == 0.06
+    @test m["gain"] == 2.4 && m["clippedVoxels"] == 0
+
+    # Missing stats must not throw — the helper runs on whatever python managed to write.
+    @test Cecelia._temporal_smooth_metrics(Dict{String,Any}())["gain"] == 1.0
+    @test isempty(Cecelia._temporal_smooth_qc_findings(Dict{String,Any}()))
+
+    # Deliberately NOT cohort: the input is the drift-corrected store, whose zero fraction includes
+    # the canvas padding drift correction added, so the outlier detector would rank images by shake.
+    @test !haskey(COHORT_METRICS, "cleanupImages.temporalSmooth")
+end
+
 @testset "AF correction QC — the exemption that got retired" begin
     # This task carried a QC-EXEMPT comment calling itself the weakest exemption in the codebase.
     # It now has exactly ONE finding: the correction has no free parameter left to land badly, so the
@@ -3137,6 +3186,7 @@ end
     @test Cecelia._spec_output_value_name(CellposeCorrect(), "fallback") == "cpCorrected"
     @test Cecelia._spec_output_value_name(DriftCorrect(),    "fallback") == "driftCorrected"
     @test Cecelia._spec_output_value_name(AfCorrect(),       "fallback") == "afCorrected"
+    @test Cecelia._spec_output_value_name(TemporalSmooth(),  "fallback") == "temporalSmoothed"
     # A task that declares no top-level outputValueName falls back to the caller's default
     @test Cecelia._spec_output_value_name(RemoveImage(), "fallback") == "fallback"
 end
@@ -4184,6 +4234,7 @@ end
     @test _task_from_fun_name("cleanupImages.cellposeCorrect") isa CellposeCorrect
     @test _task_from_fun_name("cleanupImages.afCorrect")       isa AfCorrect
     @test _task_from_fun_name("cleanupImages.driftCorrect")    isa DriftCorrect
+    @test _task_from_fun_name("cleanupImages.temporalSmooth")  isa TemporalSmooth
     @test _task_from_fun_name("segment.cellpose")              isa CellposeSegment
     @test _task_from_fun_name("segment.measureLabels")         isa MeasureLabels
     composite = _task_from_fun_name("cleanupImages.afDriftCorrect")

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -1788,6 +1788,77 @@ end
     @test !(Cecelia.qc_finding("warn", "x.y", "s", "l")["long"] |> isempty)
 end
 
+@testset "one resolver turns channel names into indices" begin
+    # SIX handlers had hand-rolled `findfirst(==(String(ch)), ch_names)` and drifted into three
+    # different behaviours, all silently wrong: an already-resolved index crashed four of them, an
+    # unmatched name was dropped by five, and `drift_correct` fell back to index 0 — which on a
+    # resonance-scanner movie means registering the whole timelapse against SHG at 99.5% zeros.
+    names = ["SHG", "nuc-GFP", "mem-TOM", "CD169-Kat"]
+
+    @test Cecelia.channel_index("mem-TOM", names) == 2          # 0-BASED, for the Python side
+    @test Cecelia.channel_index("SHG", names) == 0
+    @test Cecelia.channel_indices(["CD169-Kat", "nuc-GFP"], names) == [3, 1]   # order preserved
+
+    # idempotent: an index passes through, so translating a chain dict twice is a no-op
+    @test Cecelia.channel_index(2, names) == 2
+    @test Cecelia.channel_indices([2, "CD169-Kat"], names) == [2, 3]
+
+    # a single value, not a vector — `channelSelection` with multiple=false still arrives as one
+    @test Cecelia.channel_indices("mem-TOM", names) == [2]
+
+    # deduped by default: a channel named twice would square its term into the AF denominator
+    @test Cecelia.channel_indices(["mem-TOM", "mem-TOM"], names) == [2]
+    @test Cecelia.channel_indices(["mem-TOM", "mem-TOM"], names; unique_only = false) == [2, 2]
+
+    # "nothing selected" is a legitimate state each task judges for itself (branching only needs
+    # fibreChannels for anisotropySource="channel") — not an error
+    @test Cecelia.channel_indices(nothing, names) == Int[]
+    @test Cecelia.channel_indices([], names) == Int[]
+
+    # AN UNMATCHED NAME RAISES, and the message names what was available. This is the deliberate
+    # behaviour change from silent-drop: a channel the user named and we cannot find is not a thing
+    # to guess about.
+    err = try; Cecelia.channel_index("CH3", names); nothing; catch e; e; end
+    @test err isa ErrorException
+    @test occursin("CH3", err.msg) && occursin("mem-TOM", err.msg)
+    @test_throws ErrorException Cecelia.channel_indices(["nuc-GFP", "nope"], names)
+    # ...including when the image registered no names at all, rather than silently indexing nothing
+    @test_throws ErrorException Cecelia.channel_index("nuc-GFP", String[])
+
+    # A case-only difference is the common real cause: two images from ONE experiment shipped
+    # `mem-TOM` (zolIMa/eQRnwU) and `mem-Tom` (zolIMa/fXgbTl), so a chain built on one fails on the
+    # other. Still an error — the match stays exact, guessing is what this resolver removes — but the
+    # message names the near match so it is a five-second fix.
+    cased = try; Cecelia.channel_index("mem-TOM", ["SHG", "nuc-GFP", "mem-Tom"]); nothing
+            catch e; e end
+    @test cased isa ErrorException
+    @test occursin("mem-Tom", cased.msg) && occursin("case", cased.msg)
+
+    # ccid_channel_names reads the versioned field; `nothing` asks for the ACTIVE version
+    raw = Dict{String,Any}("imChannelNames" => Dict{String,Any}(
+        "default" => names, "corrected" => ["a", "b"], "_active" => "corrected"))
+    @test Cecelia.ccid_channel_names(raw) == names                  # default
+    @test Cecelia.ccid_channel_names(raw, nothing) == ["a", "b"]    # active
+    @test Cecelia.ccid_channel_names(Dict{String,Any}()) == String[]
+
+    # NO SEVENTH COPY. The detector, not just the extraction — this is the second time this file has
+    # had to count these sites, and grep-based guesses were wrong both times.
+    src_root = dirname(pathof(Cecelia))
+    offenders = String[]
+    for (root, _, files) in walkdir(joinpath(src_root, "tasks"))
+        for f in files
+            endswith(f, ".jl") || continue
+            body = read(joinpath(root, f), String)
+            for line in split(body, '\n')
+                startswith(strip(line), "#") && continue
+                occursin(r"findfirst\(==\(String\(", line) &&
+                    push!(offenders, relpath(joinpath(root, f), src_root))
+            end
+        end
+    end
+    @test isempty(offenders)
+end
+
 @testset "AF params are just channels" begin
     # The spec grew into a bag of ~20 numbers while fitting individual datasets and was never
     # revisited. A combination is now the two things it is actually about; everything else is derived
@@ -8604,10 +8675,16 @@ Cecelia.live_outputs(::_BadLiveTask, ::AbstractDict) = error("boom")
             # idempotent: already-translated indices survive a second pass (a REPL/chain caller)
             @test Cecelia.cellpose_models_for_python(got, raw)["0"]["cellChannels"] == [2]
 
-            # a channel the image does not have is dropped, not turned into a bogus index
+            # A channel the image does not have RAISES — it is never turned into a bogus index, and no
+            # longer silently dropped either. Dropping satisfied the letter of "don't fabricate an
+            # index" while still segmenting: on no channels, or on whichever of the pair survived. The
+            # message names what was available, exactly like the missing-checkpoint case below; both are
+            # "a param we cannot resolve", and this file already prefers raising for that.
             bad = Dict{String,Any}("models" => Dict("0" => Dict{String,Any}(
                 "cellChannels" => ["CH9"], "nucChannels" => [])))
-            @test Cecelia.cellpose_models_for_python(bad, raw)["0"]["cellChannels"] == Int[]
+            bad_err = try; Cecelia.cellpose_models_for_python(bad, raw); nothing; catch e; e end
+            @test bad_err isa ErrorException
+            @test occursin("CH9", bad_err.msg) && occursin("CH1", bad_err.msg)
 
             # a missing CUSTOM checkpoint raises with a message worth showing, rather than failing
             # deep inside cellpose — the second translation the preview used to skip
@@ -8908,10 +8985,21 @@ Cecelia.live_outputs(::_BadLiveTask, ::AbstractDict) = error("boom")
             img.im_channel_names["default"] = ["SHG", "nuc-GFP", "mem-TOM", "CD169-Kat"]
             save!(img)
 
-            # the real saved shape from a live project: channel NAMES, including one ("CH4") that is
-            # not in this image's channel list at all — it resolves to nothing, exactly as the run does
-            params = Dict{String,Any}("afCombinations" => Dict("1" => Dict{String,Any}(
+            # A name this image does not have RAISES rather than dropping out of the competitor list.
+            # Dropping looked harmless but changes the correction silently: the weight's denominator
+            # loses a term, so every corrected voxel is wrong by an amount nothing reports. Naming a
+            # channel that isn't there is a stale saved param, and the fix is to re-pick it.
+            stale = Dict{String,Any}("afCombinations" => Dict("1" => Dict{String,Any}(
                 "competingChannels" => ["CH4", "CD169-Kat"],
+                "targetChannel"     => ["mem-TOM"])))
+            stale_err = try
+                Cecelia.preview_params_for_run(Cecelia.AfCorrect(), stale, img); nothing
+            catch e; e end
+            @test stale_err isa ErrorException
+            @test occursin("CH4", stale_err.msg) && occursin("CD169-Kat", stale_err.msg)
+
+            params = Dict{String,Any}("afCombinations" => Dict("1" => Dict{String,Any}(
+                "competingChannels" => ["CD169-Kat"],
                 "targetChannel"     => ["mem-TOM"])))
             out = Cecelia.preview_params_for_run(Cecelia.AfCorrect(), params, img)
             # targetChannel re-keys the combination to the channel being corrected (mem-TOM → 2)

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -469,6 +469,21 @@ Full reference (see CLAUDE.md for the concise table):
 { "key": "driftChannel", "label": "Drift channel", "type": "channelSelection", "multiple": false, "default": [] }
 ```
 
+> **It stores channel NAMES, and Python wants 0-based indices — translate with the one resolver.**
+> `channel_indices(params["myChannels"], ch_names; what = "myChannels")` and its single-value sibling
+> `channel_index` (both `app/src/model/image.jl`, with `ccid_channel_names(raw)` for the names). It is
+> idempotent on integers, so a REPL/test/chain caller handing back a translated dict is fine, and an
+> **unmatched name raises** naming the available channels.
+>
+> Do NOT hand-roll `findfirst(==(String(ch)), ch_names)`. Six handlers did, and drifted into three
+> behaviours that were each silently wrong: an already-resolved index crashed four of them
+> (`String(::Int64)`), an unmatched name was dropped by five (so a stale saved param quietly segmented
+> on the wrong channels, or corrected against a denominator missing a term), and `drift_correct` fell
+> back to **index 0** — registering a whole timelapse against SHG at 99.5% zeros. The `no seventh copy`
+> detector in the `one resolver turns channel names into indices` testset fails on a new one. The Python
+> counterpart is `script_utils.channel_indices`, which catches the mirror-image failure: a *name*
+> arriving where an index was due, meaning this translation never ran.
+
 **`valueNameSelection`** — picks from registered image versions. Add `"field": "labels"` to list segmentation label sets (`img.labels` keys) instead of the default image-version keys:
 ```json
 { "key": "valueName", "label": "Segmentation", "type": "valueNameSelection", "field": "labels", "default": "default" }

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -338,10 +338,29 @@ The cu124 wheel index carries only Linux/Windows wheels, so `torch`/`torchvision
 `[target.linux-64.*]` / `[target.win-64.*]` with that index and in `[target.osx-arm64.*]` from the
 default index (MPS/CPU). A single global cu124 index would make macOS unsolvable.
 
-### coastal is dropped for now
-`coastal` (live-cell seg/tracking) was an editable install from a non-git sibling path
-(`~/cc-workspace/coastal`), so a committed lockfile can't fetch it. Omitted to keep the env
-reproducible; re-add later as an editable path-dep (dev) or a git/PyPI dep (shipping).
+### coastal is a git dependency (2026-08-05)
+`coastal` (live-cell seg/tracking) is declared in `[pypi-dependencies]` as
+`{ git = "https://github.com/schienstockd/coastal.git" }`. cecelia consumes its model-free smoothing
+engine from `cleanupImages.temporalSmooth` (see `docs/todo/SMOOTHING_PLAN.md`).
+
+It was previously omitted, and the stated reason was specific: it was an editable install from a
+*non-git* sibling path (`~/cc-workspace/coastal`), so a committed lockfile could not fetch it. That
+blocker is gone — the repo has a remote — so this is the "git dep (shipping)" option this section
+already prescribed, not a reversal.
+
+Two things to keep true:
+
+* **Pin a `rev`, not a branch, before tagging a release.** A branch ref lets `pixi lock` silently
+  follow `main`, which is fine in dev and wrong for a reproducible build.
+* **The source-level dependency direction stays coastal → cecelia.** coastal imports cecelia's IO and
+  napari helpers *lazily* and keeps `coastal/` array-only; this entry is only cecelia consuming
+  coastal's algorithms, which import nothing from cecelia. Do not let it become mutual — coastal's CI
+  installs base+dev only and will catch a stray `import cecelia` in `coastal/` (it did).
+
+It adds `cma` and `hmmlearn` to the lock, and `opencv-python-headless` — headless is load-bearing:
+the GUI build sets `QT_QPA_PLATFORM_PLUGIN_PATH` to its own Qt5 plugins on import, which is
+ABI-incompatible with napari's PyQt5 xcb plugin and segfaults the viewer. No torch conflict: coastal
+declares bare `torch` and cecelia's per-platform index entry wins.
 
 ### cvxopt is pinned from conda-forge (not PyPI)
 `cvxopt` is a transitive dependency of `btrack`. PyPI ships **no macOS-arm64 wheel** for it, so a

--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -40,6 +40,21 @@ If it fits in a paragraph and needs no design, it's a `docs/TODO.md` item, not a
 
 ## Current parked plans
 
+- `SMOOTHING_PLAN.md` — **BUILT** as `cleanupImages.temporalSmooth` (σ=1 gaussian + centred 3-frame
+  temporal median, one shared kernel per channel); the `smooth → AF → drift` composite is still open.
+  Needed because AF's triangle background
+  lands **inside the signal** on resonance-scanner data: the reference channel kept **8.6%** of its
+  signal, ~80% after. Effectively the port of R's `slidingWindowCorrect` (whose window was off-by-one and
+  off-centre). Deliberately not called "denoise" — that word belongs to the learned restorers.
+  Measured on `zolIMa/fXgbTl` (16-bit, the operative case) + `eQRnwU` (8-bit). Negative results worth not
+  re-deriving: coastal's `denoise_preserving_ratio` is the *worst* arm here, the Cellpose-3 net was
+  **repaired and still dropped** (ties on ratio preservation once normalised through one shared window —
+  that objection is retracted — but inflates masks 199 vs 140 px, 2 merges vs 0, at 31x the cost),
+  **16-bit does not fix it** (max 522 of 65535 — photon-limited, not
+  bit-depth-limited), a **spatial** median is catastrophic (it rejects sparse photon counts as outliers),
+  and a "cells are merging" claim was **retracted** — the overlap test found 1 true merge and 0 lost
+  objects, the count drop was 74 noise specks. Status: task built and run on a full movie; composite,
+  and the drift-on-smoothed / smooth-the-trajectory follow-ups, still open.
 - `CLUSTERING_PLAN.md` — Leiden clustering (cells + tracks), GPU/RAPIDS parked. Cited from
   `pixi.toml`, `clustering_utils.py`, `clustPops`/`clustTracks` `cluster.jl`, `docs/SHIPPING.md`.
 - `ANALYSIS_CANVAS_PLAN.md` — multipage tabbed analysis board + gating-strategy plot + PDF export

--- a/docs/todo/SMOOTHING_PLAN.md
+++ b/docs/todo/SMOOTHING_PLAN.md
@@ -1,0 +1,353 @@
+# Smoothing task: make AF work on photon-starved data
+
+**Status:** **built** as `cleanupImages.temporalSmooth` (2026-08-05) — the standalone task, not the
+composite. Measurements are real (2026-08-04) on `zolIMa/fXgbTl` (16-bit, the operative case),
+`eQRnwU` (8-bit crop) and `2h06xA` (full movie). Run end-to-end through the real task on the full
+`zolIMa/Dml3RG` movie (drift-corrected, 181×4×35×1036×1055, ~30 min). See *What was built* below for
+where the implementation diverged from this design — read that before trusting the sections above it.
+
+## The problem, measured
+
+AF correction produced almost nothing on resonance-scanner movies (`zolIMa/2h06xA` and its crops).
+The correction is not at fault — **its background derivation is**.
+
+`af_weight_stats` finds the background with a triangle threshold, which assumes the channel *has* a
+background population. Resonance dwell times give single-digit photon counts, so each channel is a
+delta at zero plus a thin tail, and the threshold lands **inside the signal**.
+
+**16-bit (`zolIMa/fXgbTl`) — the operative case, since the 8-bit import path has been removed:**
+
+| channel | zeros | p99 | p99.9 | derived bg | signal surviving `max(raw−bg,0)` |
+|---|---|---|---|---|---|
+| nuc-GFP | 92.5% | 35 | 88 | **40** | 12.6% |
+| mem-Tom | 86.0% | 83 | 150 | 47 | 46.3% |
+| **CD169-Kat** | 94.7% | 35 | 73 | **44** | **8.6%** |
+
+**16 bits bought nothing, and the reason is decisive: the observed maximum is 522 out of 65535** —
+the data occupies **0.8%** of its range. There were never more than ~500 photons, so extra bit depth
+adds precision to a number that does not exist. Bit depth was never the constraint; photon count is.
+
+The same failure on 8-bit (`zolIMa/eQRnwU`, a different acquisition — M2c vs M2b — so compare *within*
+an image, not across): backgrounds 24 / 20 / 31 against p99.9 of 45 / 61 / 50, signal surviving
+11.9% / 46.0% / **4.3%**.
+
+CD169-Kat is the channel the correction is *anchored to*, and ~90% of its signal is thresholded away
+before the weight is computed. Visually (`af_denoise_output.png`): AF on raw yields a **spray of
+isolated pixels** where cells are — 0.7% non-zero for nuc-GFP — not objects that could segment.
+
+This is why "AF alone doesn't cut it" on this data. Nothing about the power weight needs changing.
+
+## What fixes it
+
+A **shared linear kernel applied per channel**. On the 16-bit image (`bg / signal kept / SNR`):
+
+| arm | nuc-GFP | mem-Tom | CD169-Kat |
+|---|---|---|---|
+| raw 16-bit | 40 / 12.6% / 2.7 | 47 / 46.3% / 7.6 | 44 / 8.6% / 2.8 |
+| gaussian σ=1 | 10 / 68.4% / 10.6 | 16 / 99.9% / 30.5 | 9 / 56.4% / 11.2 |
+| gaussian σ=1 + temporal 5 | 7 / 85.5% / 18.0 | 15 / 100% / 42.1 | 6 / 80.4% / 19.9 |
+
+The spatial term alone already does the job — reference channel 8.6% → **56.4%** surviving, background
+44 → 9 — and adds no time-axis coupling. The temporal term adds a further real gain plus a real cost;
+see *What temporal averaging actually does*.
+
+The full arm sweep was run on the 8-bit crop, scored against ONE reference set of 555k cell voxels
+defined from raw so no arm is favoured — same ranking, and it is where the two rejected options were
+measured:
+
+| arm | nuc-GFP | mem-TOM | CD169-Kat |
+|---|---|---|---|
+| raw | 24 / 11.9% / 2.5 | 20 / 46.0% / 6.6 | 31 / 4.3% / 1.8 |
+| gaussian σ=1 | 6 / 61.3% / 9.9 | 8 / 98.9% / 26.1 | 6 / 41.6% / 7.2 |
+| temporal 5 | 5 / 60.0% / 4.3 | 4 / 97.2% / 11.3 | 7 / 33.2% / 2.9 |
+| **gaussian σ=1 + temporal 5** | **4 / 79.9% / 15.4** | **6 / 99.6% / 37.0** | **4 / 74.2% / 11.4** |
+| gaussian + temporal 9 | 4 / 79.3% / 17.0 | 6 / 99.6% / 37.1 | 4 / 73.3% / 13.0 |
+| coastal `denoise_cyto3` | 6 / 70.7% / 14.9 | 10 / 99.1% / 42.6 | 6 / 28.4% / 8.3 |
+| coastal `denoise_preserving_ratio` | 18 / 19.6% / 8.9 | 21 / 55.2% / 22.6 | 20 / 10.7% / 6.4 |
+
+Same conclusion: **4.3% → 74.2%** on the reference channel, background 31 → 4.
+
+### Neither of coastal's denoisers is used here — and why
+
+**Not `denoise_preserving_ratio`** (coastal's flagship). It is the *worst* denoising arm here.
+It smooths the mean projection and applies it back as a per-pixel scalar gain, preserving raw
+per-pixel channel ratios exactly — but on photon-starved data those ratios are precisely what is
+unreliable. Coastal's own doc states the mechanism: *"a scalar gain cannot remove noise that lives
+inside a channel."* AF needs low-noise **per-channel** values, which the gain path cannot give.
+
+**Not the Cellpose-3 net — decided 2026-08-04, after repairing it and losing to it on some axes.**
+
+The first pass rejected it on numbers taken with two defects in play, and on an argument that turns out
+to be wrong. Both are recorded here so neither is re-derived.
+
+**Retracted:** "a nonlinear net with per-channel normalisation structurally cannot preserve a
+cross-channel ratio, and AF is a cross-channel ratio." The *per-channel* part was the whole problem.
+Normalised through ONE shared affine window it is the same fixed function on every channel, and it then
+preserves ratios as well as a linear filter — L1 shift of the normalised channel vector **0.440 vs 0.453**
+for `gaussian σ=1 + temporal median 3`. The structural objection is void.
+
+**The repaired net, for the record** (all three fixes needed; `eval(normalize=False)` exposes the hook):
+
+1. one normalisation window computed **once over the volume**, not per plane — kills the blanking below;
+2. that window **shared across channels** — worth 51.5% → 77.0% signal kept on the reference channel;
+3. output mapped back to **input units**, not `((x+1)/11)*iinfo.max`;
+4. plus `diameter≈17` for ~15–20 px cells — worth 77.0% → **93.0%**.
+
+| arm | kept | SNR | objs | area | merges | ratio L1 | time |
+|---|---|---|---|---|---|---|---|
+| **gaussian σ=1 + temporal median 3** | 85.4% | 27.2 | **24** | **140** | **0** | 0.453 | **2.8 s** |
+| net, repaired + `diameter=17` | **93.0%** | **45.0** | 18 | 199 | 2 | 0.440 | 88 s |
+
+**Dropped anyway, on four grounds:**
+
+- **Mask inflation and merging.** Area **199 vs 140**, **18 objects vs 24**, **2 merges vs 0**. AF output
+  feeds segmentation; a merge cannot be undone downstream. This is the deciding one.
+- **Hallucination, which no metric here captures.** The net is trained to synthesise plausible cell
+  texture and is out of distribution on photon-starved input. Its CD169-Kat output shows crisp ring
+  structures far less distinct in raw. Anything acted on should be checked against the raw store.
+- **31× cost** (88 s vs 2.8 s on a 5-plane crop) plus a weights download.
+- **Parameter sensitivity.** `diameter` alone moves signal kept by 16pp, and it has already been set
+  wrong in production: `2h06xA` ran `modelDiameter=10` against 15–20 px cells.
+
+**The one thing the net genuinely wins is SNR (45 vs 27)** — and AF does not need it. AF needs a findable
+background and objects that stay separate, which is exactly the trade the net takes the wrong side of.
+
+**This does NOT retire coastal's port.** `cleanupImages.cellposeCorrect` still exists and still wants the
+cellpose pin dropped — `DENOISE_PLAN.md` A4/A5 stands, independent of this task.
+
+**And it leaves a real bug to fix there.** `normalize99` blanks a plane whenever `p99 − p1 ≤ 1e-3`:
+
+| channel | median p99−p1 | planes zeroed |
+|---|---|---|
+| **SHG** | **0.0** | **100%** |
+| nuc-GFP / mem-Tom / CD169-Kat | 34 / 81 / 35 | 3.1% each |
+
+`2h06xA` was run with `modelChannels: [0,1,2,3]`, so **SHG in `ccidCpCorrected` is a flat constant, not
+data**, with nothing in the log saying so. That needs a QC warning in `cellposeCorrect` regardless of
+this decision.
+
+So this task needs **none of coastal's weights** — only the idea behind its `gaussian_restorer`, applied
+per channel instead of to a projection, and a temporal median in place of its `temporal_mean_restorer`.
+Decision: **no net.**
+
+## What temporal averaging actually does — and a retracted objection
+
+Mechanically: each pixel becomes the mean of itself across N consecutive frames. Uncorrelated shot
+noise falls by ~√N; anything that genuinely changed in that window (cell motion, deformation) is
+averaged in and smears along its trajectory. At 15 s/frame with motile cells, that risk is real enough
+to check rather than assume.
+
+**A first pass concluded it merges cells. That was wrong, and the error is instructive.** Counting
+connected components >20 px at matched 2% foreground area gave 28 (spatial only) vs 19 (temporal 3),
+read as "a third of the cells fused". The proper test — for each temporal object, how many *distinct*
+spatial objects does it overlap — says otherwise, on `fXgbTl` mem-Tom, z=19:
+
+| | |
+|---|---|
+| temporal objects swallowing >1 spatial object (**true merges**) | **1** |
+| mapping 1:1 to one spatial object | 17 |
+| spatial objects with no temporal overlap at all (**lost**) | **0 of 28** |
+
+The count drop was **noise-speck removal**, not fusion: spatial-only yields **153** components of which
+**125 are ≤20 px with a median size of 4 px**; temporal 3 yields 70, of which 51 are specks. It removed
+74 noise fragments. Nine of the 28 fell below an arbitrary 20 px floor rather than merging.
+
+**The lesson is about the metric, not the method.** An object *count* cannot distinguish "cells fused"
+from "specks cleaned up" — the two look identical. Neither can "signal kept", which rewards larger
+blobs whatever their cause. Any claim about merging needs the overlap test above; a count is not
+evidence. (This is the second metric in this audit that pointed the wrong way — see also judging
+window length by signal-kept.)
+
+What survives, and is real: **mean object area inflates ~44%** at temporal 3, and with one merge that is
+objects *growing*, not fusing. That costs mask accuracy for morphology or membrane detail, and costs
+little for detecting and tracking cell bodies.
+
+### Median vs mean — median for TIME, never for SPACE
+
+**The R version already had the rolling temporal median: `cleanupImages/slidingWindowCorrect.R` +
+`py/sliding_window_correct.py`** (output value_name `slidingWindow`, store `ccidSlidingWindow`). It takes
+`np.median` over a T window per channel, params `valueName` / `imChannels` / `slidingWindow` /
+`createNewChannels`. This plan is effectively its port, plus the spatial term.
+
+Two things to carry forward and one to fix:
+
+- **`slidingWindow` is a HALF-width** in R; `temporalFrames` here is a full width. R's `slidingWindow=1`
+  maps to `temporalFrames=3` once centred.
+- **Bug in the reference — do not port it.** `w_start = i - sw; w_end = i + sw; slice(w_start, w_end)`
+  is half-open, so the window is **`2*sw` frames, off-centre**, not `2*sw+1`. At the default `sw=1` that
+  is frames `i-1, i` — and a median of two values is their mean, so the R default was a 2-frame
+  off-centre *average* despite calling `np.median`. Use a centred odd window.
+- **`createNewChannels`** wrote the corrected channels as EXTRA channels in the same store instead of
+  replacing them, for side-by-side comparison in the viewer. Worth keeping as an option; the modern
+  equivalent is a separate value_name (which is what this plan does), so it is not required.
+
+Two other R median filters are NOT this, and reading them as precedent misleads: `time_delta_correct.py`
+takes `np.median(..., axis=t_idx)` over ALL timepoints (one static reference image for delta correction),
+and `correction_utils.py`'s `medianFilter` was a **3D SPATIAL** median with a `ball()` footprint (T and C
+carrying length-1 dims). Measured on `fXgbTl` mem-Tom, merges via the overlap test:
+
+| arm | bg (1/2/3) | kept ch3 | objs>20 | mean area | merges |
+|---|---|---|---|---|---|
+| gaussian σ=1 | 9/16/8 | 82.2% | 23 | 139 | 0 |
+| **spatial median ball1** | **36/47/41** | **4.1%** | 20 | 106 | 1 |
+| spatial median ball2 | 34/46/38 | **0.4%** | 21 | 154 | 1 |
+| gauss + temporal **mean** 3 | 7/14/6 | 92.8% | 21 | 165 | 1 |
+| **gauss + temporal median 3** | 8/14/7 | 85.4% | **24** | **140** | 1 |
+
+**A spatial median is catastrophic on this data, and it is catastrophic BECAUSE it works as designed.**
+A median is robust to sparse outliers; here the signal *is* sparse positive photon counts, so the filter
+rejects it. Backgrounds barely move from raw's 40/47/44, and the reference channel keeps **4.1%** —
+worse than no denoising at all. `ball(2)` drives background sd to literally **0.00**: it erased the
+background and most of the signal with it. (This is presumably why every live run in the logs has
+`medianFilter: 0`.) Do not offer a spatial median for photon-limited input.
+
+**A temporal median beats a temporal mean**, and fixes the one real cost of the temporal term: mean
+area **165 → 140**, essentially back to the gaussian's 139, so the ~44% inflation disappears; object
+count **21 → 24** against a baseline of 23, so objects are preserved rather than shrunk below threshold.
+It costs 92.8% → 85.4% signal kept and 0.3 s → 1.7 s. The order is what makes it work: the gaussian
+fills the sparse counts first, then the median rejects what is *transient* — a cell that moved through a
+pixel — instead of averaging it in.
+
+**So: `temporalStat = "median"`, and no spatial-median option.**
+
+With that, `temporalFrames` is a good default rather than a trade-off:
+
+- **`spatialSigma` alone is the conservative default** — it already takes the reference channel from
+  8.6% to 56.4% surviving with no time-axis coupling at all.
+- **`temporalFrames = 3` is defensible** where detection matters more than mask precision. Visually
+  confirmed acceptable on `fXgbTl` in napari (2026-08-04). It cleans 74 noise fragments per plane.
+- Shortening does **not** reduce the cost — 3, 5 and 9 inflate area comparably (+44.6 / +34.2 / +49.2%).
+- **Ordering is moot either way.** A 5-frame window spans median 0.91 px of drift after registration vs
+  1.29 px before, against ~15–20 px cells — so the composite is a plain sequence.
+
+## Design
+
+### New task: `cleanupImages.smooth`
+
+**Deliberately NOT called `denoise`.** Three different things would otherwise share one word: this task
+(a gaussian plus a rolling median — smoothing, no model), `cleanupImages.cellposeCorrect` (learned
+restoration via a trained net), and `coastal.denoise` (the extracted Cellpose-3 restoration, which this
+plan measured and rejected for this data). "Denoise" also oversells it — nothing here estimates or
+models noise, it averages neighbours in space and time. `smooth` says what it does, and leaves the word
+free for the thing that earns it.
+
+Three co-located files, per the module pattern:
+
+```
+app/src/tasks/cleanupImages/smooth.jl      # _run_task + param translation
+app/src/tasks/cleanupImages/smooth.json    # spec
+app/src/tasks/cleanupImages/smooth_run.py  # compute
+```
+
+- `outputValueName: "smoothed"` (store `ccidSmoothed.ome.zarr`)
+- `resource_pool: "cpu"` (pure numpy/scipy; no GPU, unlike `cellposeCorrect`)
+- `requires: {}` — spatial-only denoising is valid on a static image; the temporal term self-disables
+  when there is no T axis (mirror `_preview_timepoints`' `is_timeseries()` guard)
+
+**Params** (deliberately few — the AF spec was cut down from ~20 fitted numbers and this must not
+re-introduce that):
+
+| key | type | default | note |
+|---|---|---|---|
+| `valueName` | valueNameSelection | `default` | which version to denoise |
+| `channels` | channelSelection (multiple) | `[]` | empty = all channels. **One shared kernel for every selected channel** — that is the invariant, not a convenience |
+| `spatialSigma` | number | `1.0` | xy gaussian σ in px; `0` disables |
+| `temporalFrames` | number | `3` | **centred odd** window (R's `slidingWindow` was a half-width, and off-by-one — see below). `0`/`1` disables; no-op without a T axis |
+| `temporalStat` | select | `median` | `median` or `mean`. Median keeps masks tight (area 140 vs 165) and preserves object count; mean keeps ~7pp more signal. No spatial-median option — it destroys photon-limited signal |
+
+Not offered: a per-channel kernel (breaks cross-channel calibration, which is the whole point), a model
+choice (the net measured worse — record it in `docs/FUTURE.md` rather than shipping a dial), and a
+**spatial median** (measured catastrophic on photon-limited data — see below; the R `medianFilter`
+carried one and every live run left it at 0).
+
+**Legacy migration note:** this supersedes R's `slidingWindowCorrect` (value_name `slidingWindow`, store
+`ccidSlidingWindow`). A migrated project carrying that value_name maps to this task with
+`temporalFrames = 2*slidingWindow + 1`, `temporalStat = "median"`, `spatialSigma = 0`.
+
+**Compute** — `smooth_run.py`, streaming per channel to keep memory bounded:
+`gaussian_filter(σ, σ)` over xy, then `uniform_filter1d` over T. Write through `staged_store` with
+`store_compressor('image')`, then `zarr_utils.write_calibration`. Read via `zarr_utils.open_as_zarr`.
+
+**QC** — required. Objective metric: per-channel background sd before/after, and the derived triangle
+background before/after (the number this task exists to move). Warn when a channel's background does
+**not** drop — that means the filter did nothing and AF will still misfire. This is a real objective
+signal, so the perceptual-denoising QC exemption does **not** apply here.
+
+### The composite
+
+```json
+{
+  "task": "smoothAfDriftCorrect",
+  "fun_name": "cleanupImages.smoothAfDriftCorrect",
+  "label": "Smooth + AF + drift correction",
+  "category": "Cleanup",
+  "env": ["local"],
+  "resource_pool": "cpu",
+  "composite": ["cleanupImages.smooth", "cleanupImages.afCorrect", "cleanupImages.driftCorrect"],
+  "outputValueName": "driftCorrected"
+}
+```
+Register both in `task_registry.jl` (`_spec_path` + `_fun_name_map`). `task_previewable` for the
+composite should delegate to the **AF** step, as `afDriftCorrect` already does — that is the step whose
+params a user tunes, and the preview reads whichever store the viewer has open.
+
+## What was built — and where it diverged from the design above
+
+Shipped as **`cleanupImages.temporalSmooth`** (`temporal_smooth.{jl,json,_run.py}`, output value name
+`temporalSmoothed`, store `ccidTemporalSmoothed.ome.zarr`). Differences from the design, each
+deliberate:
+
+| Design above | Built | Why |
+|---|---|---|
+| task `smooth` | **`temporalSmooth`** | leaves the name free for a future spatial-only or other smoother, rather than one task owning the generic word |
+| `requires: {}`, temporal term self-disables | **`requires.axes: ["T"]`** | the task is *named* for its temporal term; a static image has nothing for it to do, so gating is honest rather than offering a run that silently degrades to a plain gaussian |
+| — | **`restoreDynamicRange` (bool, default on)** | averaging lowers the maximum, and on an integer store the background estimate then loses the precision it needs. ONE gain across all smoothed channels, so cross-channel ratios hold. Measured 1.94 on `Dml3RG`, 0 voxels clipped |
+| `uniform_filter1d` over T | **`coastal.smooth`** (git dep), streamed per z-plane with a rolling cache of spatially-smoothed planes | the engine already existed in coastal and holds the spatial-then-temporal ordering invariant; duplicating it here would have been the second implementation |
+| QC: triangle background before/after | **QC: zero-voxel fraction before/after** (+ `gain`, `clippedVoxels`) | see the open item below — this is a proxy, and arguably the weaker choice |
+
+The **composite** (`smoothAfDriftCorrect`) was **not built**. Nor were the two drift follow-ups below.
+
+Measured on `zolIMa/Dml3RG` (drift-corrected, σ=1.0, 3 frames, median): zero voxels
+nuc-GFP 95.0%→43.7%, mem-TOM 91.4%→39.6%, CD169-Kat 95.9%→57.6%; SHG copied through untouched.
+**The store is 2.5× the input** (2.8 GB → 7.1 GB) — the input was >90% zeros and compressed
+accordingly, so this is compression headroom lost, not pixels gained. Budget for it when chaining.
+
+## Also worth changing, independent of this
+
+**Register drift on the brightest channel.** `2h06xA` was registered on CD169-Kat (SNR 1.8, 95.8%
+zeros) — the worst available choice. Re-registering the crop on mem-TOM roughly halved the shift
+jitter: Y sd **1.86 → 0.93 px**, X 0.98 → 0.46, 5-frame window spread max 4.73 → 2.49 px.
+
+The shifts are still noise-dominated afterwards though (lag-1 autocorr of the deltas −0.32, sign-flip
+55%; real sample drift is smooth, so differencing a *noisy position estimate* is what gives ≈−0.5).
+Two follow-ups, neither done:
+- estimate drift on the **denoised** store, now that one exists — and note the composite order above
+  puts `denoise` first, so this comes free
+- **smooth the shift trajectory** before applying it; a real drift curve is smooth, so regularising is
+  free accuracy and one fewer resampling of noise
+
+## Open
+
+- **The QC metric is a proxy, and the plan's original choice was better.** This design called for the
+  derived **triangle background** before/after — literally the number the task exists to move, with a
+  warn when it fails to drop. What shipped is the **zero-voxel fraction** before/after. The two
+  correlate (filling zeros is how the background estimate gets a population to find), but only the
+  triangle number answers "will AF work now", which is the task's entire justification. The sampled
+  planes needed to compute it are already read for the gain estimate, so this is a small change to
+  `temporal_smooth_run.py` — it just needs a re-run to bank the number on an existing store.
+- ~~**16-bit** might fix this on its own.~~ **Answered: no.** Measured on `zolIMa/fXgbTl` — raw 16-bit
+  keeps 12.6% / 46.3% / 8.6% of signal, the same failure as 8-bit, because the observed max is 522 of
+  65535. Bit depth was never the constraint. This task is needed for **signal**, not smoothness. (16-bit
+  is now the only import path, so it is also the case to build against.)
+- ~~**Channel names differ in case across one experiment** — `mem-TOM` (`eQRnwU`) vs `mem-Tom`
+  (`fXgbTl`).~~ **Closed, no change.** The real acquisitions are all `mem-TOM`; `fXgbTl` was a crop
+  being deleted, so there is no case spread to accommodate. The **strict resolver stays** — it errors
+  with a "did you mean" hint rather than guessing. Normalising at import would have been solving for
+  one throwaway file.
+- **Alternative to denoising at all:** derive AF backgrounds on a smoothed copy while applying the
+  weight to raw voxels. Cheaper and preserves absolute intensity — but the weight itself is a ratio of
+  photon counts, so the output stays noisy even with a correct background. Not measured. Would need
+  comparing against this plan before being dismissed.
+- **Segmentation effect is unmeasured here.** Coastal measured +3.9pp recall and 5× fewer blobs from
+  ratio-preserving gain on *galvo confetti* data. Nothing in this plan has been scored against
+  segmentation on resonance data; the case rests on AF input quality alone.

--- a/frontend/src/components/ImageMetadataDialog.vue
+++ b/frontend/src/components/ImageMetadataDialog.vue
@@ -209,8 +209,12 @@ const copy = (key: string, value: string) => copyValue(value, key)
 }
 .md-chip::before { counter-increment: ch; content: counter(ch) '· '; color: var(--cc-text-dim); }
 
+/* Version column is 9rem, not 6rem: `temporalSmoothed` (16 chars) wrapped to two lines at 6rem, which
+   misaligned it against its own filename box. Fixed rather than `max-content` on purpose — the labels
+   rows below render "labels · {vn}" and a long label set would otherwise squeeze the filename. Long
+   names still wrap; 9rem just moves the threshold past the value names we actually produce. */
 .md-files {
-  display: grid; grid-template-columns: 6rem minmax(0, 1fr) max-content max-content;
+  display: grid; grid-template-columns: 9rem minmax(0, 1fr) max-content max-content;
   gap: 0.25rem 0.5rem; align-items: baseline;
 }
 .md-codec { white-space: nowrap; }

--- a/pixi.lock
+++ b/pixi.lock
@@ -134,6 +134,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: ./python
+      - pypi: git+https://github.com/schienstockd/coastal.git?rev=71a393b16dbecc7359742830efaa29086ff27459#71a393b16dbecc7359742830efaa29086ff27459
       - pypi: https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl
       - pypi: https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-linux_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/01/72/2067f28fd0ae87978f3b61e8ec30c1d085bbed03f64eb58e43949d526b3a/napari_console-0.1.4-py3-none-any.whl
@@ -253,6 +254,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/81/97/135e95fc59cd892dbdbeb890d85ac139bbfde41e618dbb7cbe7bb1c208d6/btrack-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/c8/88973fc908111491747cf1737d1c30f5d1a5f777ea3cdf625c8fcb3cdd9d/hmmlearn-0.3.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
@@ -327,6 +329,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/d4/ec46cedab6a6145e21768baa8110db3e2e836a320d8499e4ef18bc894e61/cma-4.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/ba/704f9e56ae80ef66cf0534e23dac22ada34845f86b5e5b8b3294649d96b6/omnipath-1.0.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
@@ -447,6 +450,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./python
+      - pypi: git+https://github.com/schienstockd/coastal.git?rev=71a393b16dbecc7359742830efaa29086ff27459#71a393b16dbecc7359742830efaa29086ff27459
       - pypi: https://files.pythonhosted.org/packages/01/72/2067f28fd0ae87978f3b61e8ec30c1d085bbed03f64eb58e43949d526b3a/napari_console-0.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/a7/fec56dbac873a18930b2127d400794a91dd53898bff811aa4802ddbbfac9/multiscale_spatial_image-2.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/b9/748c3cbcdba20ef01c055a35905cad5c771cc1df29be11b9a82da6fd8e0d/superqt-0.8.2-py3-none-any.whl
@@ -532,6 +536,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5e/d7/6893c9c2a52e4bcbeca2a2bf2aee970a686cc7bf555f97db13b00f35250e/session_info2-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/63/fb/c5e6522a6f596b24c0190cb7579e4d5beb993e4547e34d754bf33e9efc0a/hmmlearn-0.3.3-cp312-cp312-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/21/3587d7b32dfade1532d9cbb67291cb26f4353c296cadcda6767bd62458d3/annsel-0.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/76/37c0ccd5ab968a6a438f9c623aeecc84c202ab2fabc6a8fd927580c15b5a/QtPy-2.4.3-py3-none-any.whl
@@ -632,6 +637,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/d4/ec46cedab6a6145e21768baa8110db3e2e836a320d8499e4ef18bc894e61/cma-4.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/ba/704f9e56ae80ef66cf0534e23dac22ada34845f86b5e5b8b3294649d96b6/omnipath-1.0.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl
@@ -729,6 +735,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: ./python
+      - pypi: git+https://github.com/schienstockd/coastal.git?rev=71a393b16dbecc7359742830efaa29086ff27459#71a393b16dbecc7359742830efaa29086ff27459
       - pypi: https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl
       - pypi: https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/01/72/2067f28fd0ae87978f3b61e8ec30c1d085bbed03f64eb58e43949d526b3a/napari_console-0.1.4-py3-none-any.whl
@@ -855,6 +862,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/b2/23f4032cd1c9744aa8e9ecda43cd4d755fcb209f7f40fae035248f31a679/pyct-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/92/57/24bd2359bf0f2a2514f7b53f0bca562f912ac4751e415756b9138970c5aa/hmmlearn-0.3.3-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/93/6e/bd7fbfacca077bc6f34f1a1109800a2c41ab50f4704d3a0507ba41009915/freetype_py-2.5.1-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/96/36/5bddefea3d7adf22a64f9aa9701492f8a9fe6948223f5cf2602c22ec9be7/hsluv-5.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl
@@ -913,6 +921,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/ba/3757e312a98c428ac5d8b787f3608ae325174ebef6897930a42e21dd057a/pyogrio-0.13.0-cp311-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/d4/ec46cedab6a6145e21768baa8110db3e2e836a320d8499e4ef18bc894e61/cma-4.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/ba/704f9e56ae80ef66cf0534e23dac22ada34845f86b5e5b8b3294649d96b6/omnipath-1.0.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
@@ -4538,6 +4547,32 @@ packages:
   - scikit-image>=0.24
   - tqdm
   requires_python: '>=3.11'
+- pypi: git+https://github.com/schienstockd/coastal.git?rev=71a393b16dbecc7359742830efaa29086ff27459#71a393b16dbecc7359742830efaa29086ff27459
+  name: coastal
+  version: 0.1.0
+  requires_dist:
+  - numpy
+  - opencv-python-headless
+  - torch
+  - scikit-image
+  - scikit-learn
+  - scipy
+  - joblib
+  - matplotlib
+  - tqdm
+  - hmmlearn
+  - shapely
+  - cma
+  - pandas
+  - pillow
+  - pytest ; extra == 'dev'
+  - black ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - cellpose==3.1.1.2 ; extra == 'dev'
+  - btrack ; extra == 'notebooks'
+  - napari>=0.7 ; extra == 'napari'
+  - pyqt5>=5.15 ; extra == 'napari'
+  requires_python: '>=3.9'
 - pypi: https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl
   name: torch
   version: 2.6.0+cu124
@@ -6606,6 +6641,20 @@ packages:
   requires_dist:
   - pycparser ; implementation_name != 'PyPy'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/63/fb/c5e6522a6f596b24c0190cb7579e4d5beb993e4547e34d754bf33e9efc0a/hmmlearn-0.3.3-cp312-cp312-macosx_10_9_universal2.whl
+  name: hmmlearn
+  version: 0.3.3
+  sha256: 898e2fd51244db793659b4eac584871addaf6e57efe72121e753d57b3fb1128f
+  requires_dist:
+  - numpy>=1.10
+  - scikit-learn>=0.16,!=0.22.0
+  - scipy>=0.19
+  - matplotlib ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - sphinx>=2.0 ; extra == 'docs'
+  - sphinx-gallery ; extra == 'docs'
+  - pytest ; extra == 'tests'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
   name: attrs
   version: 26.1.0
@@ -7259,6 +7308,20 @@ packages:
   - markdown-it-py>=2.2.0
   - pygments>=2.13.0,<3.0.0
   requires_python: '>=3.9.0'
+- pypi: https://files.pythonhosted.org/packages/82/c8/88973fc908111491747cf1737d1c30f5d1a5f777ea3cdf625c8fcb3cdd9d/hmmlearn-0.3.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: hmmlearn
+  version: 0.3.3
+  sha256: 6cd27dc66bfe7f6ff77804f7dbfe42b35d18e21403eb2bdfef0de6ad3bd2368f
+  requires_dist:
+  - numpy>=1.10
+  - scikit-learn>=0.16,!=0.22.0
+  - scipy>=0.19
+  - matplotlib ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - sphinx>=2.0 ; extra == 'docs'
+  - sphinx-gallery ; extra == 'docs'
+  - pytest ; extra == 'tests'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
   name: seaborn
   version: 0.13.2
@@ -7676,6 +7739,20 @@ packages:
   - numcodecs ; extra == 'test'
   - kerchunk ; extra == 'test'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/92/57/24bd2359bf0f2a2514f7b53f0bca562f912ac4751e415756b9138970c5aa/hmmlearn-0.3.3-cp312-cp312-win_amd64.whl
+  name: hmmlearn
+  version: 0.3.3
+  sha256: 49ed0d2451d9884d0bdfbe84dd14b3a699382b00bed931d6a5ca46997978a1c4
+  requires_dist:
+  - numpy>=1.10
+  - scikit-learn>=0.16,!=0.22.0
+  - scipy>=0.19
+  - matplotlib ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - sphinx>=2.0 ; extra == 'docs'
+  - sphinx-gallery ; extra == 'docs'
+  - pytest ; extra == 'tests'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl
   name: pyzmq
   version: 27.1.0
@@ -9176,6 +9253,15 @@ packages:
   - pytest-benchmark>=4.0.0 ; extra == 'test'
   - pytest-cov>=5.0.0 ; extra == 'test'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d4/d4/ec46cedab6a6145e21768baa8110db3e2e836a320d8499e4ef18bc894e61/cma-4.4.4-py3-none-any.whl
+  name: cma
+  version: 4.4.4
+  sha256: edb6d02eb2aac2d54650f16a8f0c70711ff17445957de7c9de92ff7fd4b7ef38
+  requires_dist:
+  - numpy
+  - matplotlib ; extra == 'plotting'
+  - moarchiving ; extra == 'constrained-solution-tracking'
+  - scipy ; extra == 'statistical-tests'
 - pypi: https://files.pythonhosted.org/packages/d7/ba/704f9e56ae80ef66cf0534e23dac22ada34845f86b5e5b8b3294649d96b6/omnipath-1.0.12-py3-none-any.whl
   name: omnipath
   version: 1.0.12

--- a/pixi.toml
+++ b/pixi.toml
@@ -76,6 +76,14 @@ scanpy       = ">=1.12"
 pandas       = ">=2.3"
 trimesh      = ">=4.0"
 btrack       = ">=0.7"
+# coastal (live-cell segmentation + the model-free smoothing engine used by
+# cleanupImages.temporalSmooth). A GIT dep, not the old editable sibling path: the reason it was
+# dropped was that `~/cc-workspace/coastal` had no remote, so a committed lockfile could not fetch
+# it. It has one now, so the "git dep (shipping)" option docs/SHIPPING.md prescribed is available.
+# The dependency direction stays coastal -> cecelia at the *source* level (coastal imports
+# cecelia's IO/napari helpers lazily); this entry is only cecelia consuming coastal's array-only
+# algorithms, which import nothing from cecelia.
+coastal      = { git = "https://github.com/schienstockd/coastal.git", rev = "71a393b16dbecc7359742830efaa29086ff27459" }
 # Leiden clustering (cells + tracks), CPU path. GPU (RAPIDS) is parked — see the gpu stub
 # below and docs/todo/CLUSTERING_PLAN.md.
 leidenalg    = ">=0.10"

--- a/python/cecelia/tests/test_title_card.py
+++ b/python/cecelia/tests/test_title_card.py
@@ -67,6 +67,55 @@ class RenderCardFrameTests(unittest.TestCase):
         self.assertEqual(arr.shape, (120, 200, 3))
 
 
+class FontCoverageTests(unittest.TestCase):
+    """The font must render the characters real title cards actually contain.
+
+    Titles are built as `name — attr — attr` with an EM DASH (U+2014) in api/src/napari_api.jl, and
+    notes/attributes are free user text (µm, °, accents). Pillow's built-in Aileron covers little more
+    than ASCII, so every title card shipped `.notdef` boxes where the separators were.
+
+    A missing glyph is NOT an exception and NOT a zero-size mask — it is the font's `.notdef` box,
+    which has a perfectly ordinary width. So coverage is asserted by comparing against a character
+    the font certainly lacks: if `—` draws the same bitmap as a CJK ideograph, both are the box.
+    """
+
+    def _mask(self, font, ch):
+        import numpy as np
+        m = font.getmask(ch)
+        if not m.size[0]:
+            return None
+        return np.array(m, dtype=np.uint8).reshape(m.size[1], m.size[0])
+
+    def _is_notdef(self, font, ch):
+        got, missing = self._mask(font, ch), self._mask(font, "中")   # 中 — not in any Latin font
+        if got is None or missing is None:
+            return got is None
+        return got.shape == missing.shape and (got == missing).all()
+
+    def test_renders_em_dash_and_not_a_box(self):
+        font = tc._font(28)
+        self.assertFalse(self._is_notdef(font, "—"), "em dash renders as .notdef — title cards show boxes")
+
+    def test_renders_the_other_characters_user_text_carries(self):
+        font = tc._font(28)
+        for ch in ("µ", "°", "é", "–", "…"):     # µ ° é en-dash ellipsis
+            self.assertFalse(self._is_notdef(font, ch), f"{ch!r} renders as .notdef")
+
+    def test_ascii_still_renders(self):
+        font = tc._font(28)
+        self.assertFalse(self._is_notdef(font, "A"))
+
+    def test_detector_catches_the_font_we_regressed_from(self):
+        # Guards the assertions above: prove the check FAILS on Pillow's built-in, so a future reorder
+        # of _font back to load_default-first is caught rather than silently passing.
+        from PIL import ImageFont
+        try:
+            builtin = ImageFont.load_default(size=28)
+        except TypeError:
+            self.skipTest("Pillow < 10 has no scalable built-in")
+        self.assertTrue(self._is_notdef(builtin, "—"))
+
+
 class WrapTests(unittest.TestCase):
     def _draw(self):
         from PIL import Image, ImageDraw

--- a/python/cecelia/utils/title_card.py
+++ b/python/cecelia/utils/title_card.py
@@ -37,20 +37,40 @@ _FG_NOTE   = (170, 170, 180)
 _SWATCH_BORDER = (255, 255, 255)
 
 
-def _font(size):
-    """A font at ``size`` px. Prefers the scalable built-in (Pillow ≥ 10), then a bundled TrueType,
-    then the fixed default — so we never hard-depend on a font file being present."""
-    size = max(8, int(size))
+#: A real TrueType is tried BEFORE Pillow's built-in, and the order matters. `load_default(size=…)`
+#: succeeds on every Pillow >= 10, so putting it first made the TrueType branch below dead code — and
+#: the built-in (Aileron) covers little more than ASCII. Titles are `name — attr — attr` (EM DASH,
+#: U+2014, from `_title_card_content` in api/src/napari_api.jl), so every real title card rendered
+#: `.notdef` boxes where the separators were: Aileron's mask for `—` is bitmap-identical to its mask
+#: for `中`, which is how a missing glyph looks. Notes and attribute values are user text and can hold
+#: anything (µm, °, accents), so ASCII-only was never enough here.
+#:
+#: matplotlib's bundled copy is listed first because it is an in-env absolute path — present on every
+#: platform the app ships to, unlike a bare name, which needs the OS font dirs to hold it. The bare
+#: names stay as a fallback for a slim env without matplotlib.
+def _font_candidates():
     try:
-        return ImageFont.load_default(size=size)          # Pillow ≥ 10 scales the built-in
-    except TypeError:
+        import matplotlib
+        from pathlib import Path
+        yield str(Path(matplotlib.__file__).parent / "mpl-data" / "fonts" / "ttf" / "DejaVuSans.ttf")
+    except Exception:
         pass
-    for name in ("DejaVuSans.ttf", "Arial.ttf", "LiberationSans-Regular.ttf"):
+    yield from ("DejaVuSans.ttf", "LiberationSans-Regular.ttf", "Arial.ttf")
+
+
+def _font(size):
+    """A font at ``size`` px. Prefers a real TrueType with non-ASCII coverage, then the scalable
+    built-in (Pillow >= 10), then the fixed default — so we never hard-depend on a font file."""
+    size = max(8, int(size))
+    for name in _font_candidates():
         try:
             return ImageFont.truetype(name, size)
         except OSError:
             continue
-    return ImageFont.load_default()
+    try:
+        return ImageFont.load_default(size=size)          # Pillow >= 10 scales the built-in
+    except TypeError:
+        return ImageFont.load_default()
 
 
 def _hex_rgb(value):


### PR DESCRIPTION
Five commits, split so each stands alone. The first is a prerequisite for the third.

### 1. One resolver turns channel names into indices
Six task handlers hand-rolled `findfirst(==(String(ch)), ch_names)` and had drifted into three
mutually inconsistent behaviours, each silently wrong: an already-resolved index crashed four of
them, an unmatched name was silently **dropped** by five, and `drift_correct` fell back to **index
0** — registering a whole timelapse against SHG at 99.5% zeros (measured: the reference channel is
worth ~2x in shift jitter).

**This changes behaviour.** An unmatched channel name now **raises** instead of being dropped. A
saved chain or template naming a channel the image doesn't have will now fail at run time rather
than quietly correcting against a weight denominator missing a term. That is the point, but it is
the main thing to watch after merge.

### 2. Add coastal as a git dependency
SHIPPING.md said coastal was "dropped for now" for a specific reason — an editable install from a
non-git sibling path, so a lockfile couldn't fetch it. It has a remote now, so this is the "git dep
(shipping)" option that section already prescribed. Pinned to a **rev**, not a branch.

### 3. `cleanupImages.temporalSmooth`
AF produced almost nothing on resonance-scanner movies because its triangle background lands
*inside* the signal at single-digit photon counts — the channel AF anchors to kept **8.6%** of its
signal. 16-bit doesn't fix it (max observed 522 of 65535). An xy gaussian + centred temporal median,
engine from coastal, streamed per z-plane.

Run end-to-end on the full `zolIMa/Dml3RG` movie (181×4×35×1036×1055, drift-corrected): zero voxels
95.0/91.4/95.9% → 43.7/39.6/57.6%, gain 1.94, 0 clipped, SHG untouched.

### 4. Movie title cards rendered every non-ASCII character as a box
Titles are `name — attr — attr` with an em dash, and the font picker's TrueType branch was
unreachable (`load_default(size=…)` never fails on Pillow ≥10), so every card rendered in Pillow's
ASCII-only built-in. Confirmed rather than assumed: Aileron's bitmap for `—` is identical to its
bitmap for `中`. Affected every note or attribute containing `µm`, a degree sign or an accent.

### 5. Widen the version column in the image metadata modal
`temporalSmoothed` wrapped to two lines at 6rem.

---

## Reservations

* **The resolver raise is the real risk** (commit 1). Existing saved chains with a stale channel name
  flip from silently-wrong to a hard error. Better, but it will surface as new failures on old
  projects rather than staying invisible.
* **`temporalSmooth` has never been run through the GUI** — only from the REPL. Param *types* are
  covered by the registry sweep (which caught two invented widget types I'd shipped), but the
  render/submit path isn't verified by me. Worth one click before relying on it.
* **The QC metric is the weaker of the two candidates.** The plan specified the derived triangle
  background before/after — the number the task exists to move. What shipped is the zero-voxel
  fraction, a proxy. Logged as open in `SMOOTHING_PLAN.md`; the fix is small but needs a re-run to
  bank the number.
* **Output stores are ~2.5x the input** (2.8 → 7.1 GB on Dml3RG). The input was >90% zeros and
  compressed accordingly, so it's compression headroom lost, not pixels gained — but chaining
  smooth → AF on a whole set costs real disk, and nothing cleans up the intermediate.
* **The composite is not built.** `smooth → AF → drift` is still open, as are the two drift
  follow-ups (estimate drift on the smoothed store, smooth the shift trajectory).
* Rebased onto `main` @ 0d14914 during this work — commit 6842c05 had added a fourth column to the
  metadata grid, which commit 5 preserves. Julia 3687 / Python 468 / frontend typecheck all green on
  the rebased tree, and `pixi lock --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
