### PR TITLE
fix(import): a re-import no longer reverts renamed channels

### DIFF
--- a/app/src/tasks/importImages/omezarr.jl
+++ b/app/src/tasks/importImages/omezarr.jl
@@ -398,10 +398,39 @@ const _OME_DERIVED_META_KEYS = (
     "TimeIncrement", "TimeIncrementUnit",
 )
 
+"""
+Reconcile the channel names a fresh store read produced with the ones already in `ccid.json`.
+
+Channel names are the one "authoritative re-read" value a human routinely edits, and the edit lives
+ONLY in ccid.json: bioformats2raw writes the vendor's own labels (`CH1`…`CHn`) into the store's
+`omero.channels[].label`, so re-reading a store ALWAYS yields placeholders — never the names the
+user typed. Taking the fresh read verbatim on a *re*-import therefore silently reverts every rename,
+which is the same failure the fill-only merge guards against for a human calibration correction
+(see `resync_ome_meta!`), with a nastier tail: saved task params reference channels BY NAME
+(`af_combinations_for_python`, `cellpose_models_for_python`), so a reset turns a live `"CD169-Kat"`
+into a name that is no longer in the list and resolves to nothing instead of erroring.
+
+So the fresh names are taken only when there is nothing to preserve (first import, or an image
+un-imported by `remove_image_version!`), or when the count no longer matches — stored names cannot
+describe a store with a different channel count, and the fresh ones are then the only valid list.
+Deliberate renaming stays the API's job (`set_channel_names!`).
+
+Returns `:set` (fresh names written) or `:kept` (existing names preserved).
+"""
+function _merge_channel_names!(raw::Dict{String,Any}, fresh)::Symbol
+    fresh_names = collect(String, fresh)
+    stored      = versioned_get_field(raw, "imChannelNames", VERSIONED_DEFAULT_VAL)
+    if stored isa AbstractVector && !isempty(stored) && length(stored) == length(fresh_names)
+        return :kept
+    end
+    versioned_set_field!(raw, "imChannelNames", fresh_names)
+    :set
+end
+
 # `overwrite`:
-#   true  (import) — re-read is authoritative: clear the derived keys first (see
+#   true  (import) — re-read is authoritative for the DERIVED keys: clear them first (see
 #          `_OME_DERIVED_META_KEYS`) so a value THIS read no longer produces can't linger as a
-#          zombie, and take the fresh channel names.
+#          zombie. Channel names are the documented exception — see `_merge_channel_names!`.
 #   false (backfill / `resync_ome_meta!`) — fill-only: set a key ONLY when it's genuinely absent,
 #          never clobber a value already on disk. That value may be a human correction, or the
 #          ImageJ-TIFF Z auto-fix, both of which live only in ccid.json and are NOT reproducible by
@@ -414,9 +443,11 @@ const _OME_DERIVED_META_KEYS = (
 function _merge_zarr_meta_into_ccid!(img::CciaImage, zarr_meta::Dict;
                                       zarr_filename::Union{String,Nothing} = nothing,
                                       value_name::String = VERSIONED_DEFAULT_VAL,
-                                      overwrite::Bool = true)::Dict{String,Any}
+                                      overwrite::Bool = true,
+                                      on_log::Function = _ -> nothing)::Dict{String,Any}
     merged = Dict{String,Any}()
     isempty(zarr_meta) && isnothing(zarr_filename) && return merged
+    ch_action = :none
     try
         commit_state!(img) do raw
             m = Dict{String,Any}(String(k) => v for (k, v) in get(raw, "meta", Dict()))
@@ -427,7 +458,7 @@ function _merge_zarr_meta_into_ccid!(img::CciaImage, zarr_meta::Dict;
             end
             for (k, v) in zarr_meta
                 if k == "channel_names"
-                    overwrite && versioned_set_field!(raw, "imChannelNames", collect(String, v))
+                    overwrite && (ch_action = _merge_channel_names!(raw, v))
                 elseif overwrite || !haskey(m, k)
                     m[k] = v
                 end
@@ -439,6 +470,12 @@ function _merge_zarr_meta_into_ccid!(img::CciaImage, zarr_meta::Dict;
         end
     catch e
         @warn "Could not update image metadata" exception = e
+    end
+    # A re-import keeping the user's names is invisible otherwise — the store and ccid.json now
+    # disagree by design, so say which list won and what the other one was.
+    if ch_action === :kept
+        on_log("[INFO] Kept the existing channel names; the store labels its channels " *
+               join(collect(String, zarr_meta["channel_names"]), ", "))
     end
     merged
 end
@@ -730,7 +767,8 @@ function _run_task(task::ImportOmezarr, img::CciaImage, params::Dict{String,Any}
     _update_image_status!(img, "done")
     _merge_zarr_meta_into_ccid!(img, zarr_meta;
                                 zarr_filename = basename(zarr_out),
-                                value_name    = value_name)
+                                value_name    = value_name,
+                                on_log        = on_log)
     # bank calibration QC (missing/untrustworthy physical sizes) — the single source the image-table
     # indicator, whiteboard, lab log and MCP all read (replaces the frontend's own re-derivation).
     write_metadata_qc!(img)

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -7189,6 +7189,54 @@ zu.write_calibration(sys.argv[1], du)     # the PYTHON stamp, on the first store
         rm(proj.root; recursive = true)
     end
 
+    # ── A re-import must NOT revert renamed channels ────────────────────────────────────────────
+    # bioformats2raw always writes the vendor's own CH1..CHn into the store's omero labels, so the
+    # fresh read never reproduces a rename — and saved task params reference channels by name.
+    @testset "import keeps renamed channel names" begin
+        proj = create_project!(name = "meta-chan-$(rand(1000:9999))")
+        s    = add_set!(proj; name = "set")
+        img  = add_image!(s; name = "img")
+
+        # First import: nothing stored yet → take the fresh read.
+        Cecelia._merge_zarr_meta_into_ccid!(img,
+            Dict{String,Any}("SizeC" => 4,
+                             "channel_names" => ["CH1", "CH2", "CH3", "CH4"]); overwrite = true)
+        r = init_object(proj.uid, img.uid)
+        @test channel_names(r) == ["CH1", "CH2", "CH3", "CH4"]
+
+        # The user renames them (the API path).
+        set_channel_names!(r, ["SHG", "nuc-GFP", "mem-TOM", "CD169-Kat"]; check_length = false)
+        save!(r)
+
+        # Re-import of the same source: same channel count → the renames survive, and the task
+        # says so rather than reverting silently.
+        logged = String[]
+        Cecelia._merge_zarr_meta_into_ccid!(init_object(proj.uid, img.uid),
+            Dict{String,Any}("SizeC" => 4,
+                             "channel_names" => ["CH1", "CH2", "CH3", "CH4"]);
+            overwrite = true, on_log = l -> push!(logged, l))
+        r2 = init_object(proj.uid, img.uid)
+        @test channel_names(r2) == ["SHG", "nuc-GFP", "mem-TOM", "CD169-Kat"]
+        @test any(l -> occursin("Kept the existing channel names", l), logged)
+
+        # A source whose channel count changed: the stored list cannot describe it → take the fresh
+        # names (and stay silent, nothing was preserved).
+        logged2 = String[]
+        Cecelia._merge_zarr_meta_into_ccid!(r2,
+            Dict{String,Any}("SizeC" => 2, "channel_names" => ["CH1", "CH2"]);
+            overwrite = true, on_log = l -> push!(logged2, l))
+        r3 = init_object(proj.uid, img.uid)
+        @test channel_names(r3) == ["CH1", "CH2"]
+        @test isempty(logged2)
+
+        # Fill-only (resync) never touches channel names at all, whatever the count.
+        Cecelia._merge_zarr_meta_into_ccid!(r3,
+            Dict{String,Any}("channel_names" => ["nope", "nope2"]); overwrite = false)
+        @test channel_names(init_object(proj.uid, img.uid)) == ["CH1", "CH2"]
+
+        rm(proj.root; recursive = true)
+    end
+
     # ── resync_ome_meta! end-to-end: fill-only into ccid, then push the merge back to the zarr ──
     @testset "resync_ome_meta! fill-only" begin
         proj = create_project!(name = "meta-resync-$(rand(1000:9999))")

--- a/docs/OBJECTMODEL.md
+++ b/docs/OBJECTMODEL.md
@@ -135,7 +135,7 @@ This is what lets a project be imported under a new uid, copied, or renamed (`re
 | `kind` | String | Always `"static"` for now |
 | `status` | String | `pending` → `converting` → `done` \| `failed` |
 | `filepath` | versioned dict | Relative filenames inside `0/{uid}/` |
-| `imChannelNames` | versioned dict | Lists of channel name strings |
+| `imChannelNames` | versioned dict | Lists of channel name strings. A rename lives **only** here and survives a re-import — see *Channel names are not re-read* below |
 | `labels` | versioned dict | Paths to label zarrs inside `1/{uid}/data/` |
 | `label_props` | versioned dict | Paths to label property files |
 | `attr` | flat dict | User-defined string metadata (used for filtering) |
@@ -184,6 +184,19 @@ Several fields (`filepath`, `imChannelNames`, `labels`, `label_props`) follow th
 other version remains**. Removing `default` while a corrected variant is still present keeps the
 channel names/dims that variant inherits from `default` via versioned fallback — this is what makes
 "reclaim the original to free space, keep the corrected one" safe.
+
+**Channel names are not re-read** — `_merge_channel_names!`
+(`app/src/tasks/importImages/omezarr.jl`) is the one place that decides. An import's metadata merge is
+otherwise authoritative, but bioformats2raw always writes the *vendor's* labels (`CH1`…`CHn`) into the
+store's `omero.channels[].label`, so re-reading a store can never reproduce a rename. Taking the fresh
+read verbatim on a **re**-import therefore reverted every renamed channel — silently, and worse than
+cosmetically: saved task params reference channels **by name**
+(`af_combinations_for_python`, `cellpose_models_for_python`), so a reset turned a live `"CD169-Kat"`
+into a name no longer in the list, which resolves to nothing instead of erroring. The rule: take the
+fresh names only when there is nothing to preserve (first import, or an image un-imported by
+`remove_image_version!`) or when the channel **count** changed — stored names cannot describe a store
+with a different count. Keeping the stored list is logged, since the store and `ccid.json` then
+disagree by design. Renaming stays `set_channel_names!`/`POST /api/images/channelnames`.
 
 **Dropping the analysis instead** — `reset_image_analysis!` (`storage.jl`) is the mirror operation and
 the two are strictly orthogonal: it deletes every child of `1/{uid}` **except `ANALYSIS_KEEP`**


### PR DESCRIPTION
## The bug

Re-importing an image silently reset its channel names.

`_merge_zarr_meta_into_ccid!` treats an import's re-read as authoritative and took the fresh channel names along with the OME-derived keys. But bioformats2raw always writes the *vendor's* labels (`CH1`…`CHn`) into the store's `omero.channels[].label`, so re-reading a store can never reproduce a rename — the fresh read is always placeholders.

It isn't cosmetic. Saved task params reference channels **by name**, resolved positionally with `findfirst` (`af_combinations_for_python:43,56`, `cellpose_models_for_python:84`), so a reset turns a live `"CD169-Kat"` into a name that is no longer in the list and resolves to nothing instead of erroring. `af_correct.jl` already documented the symptom — real saved params carrying `competingChannels = ["CH4", "CD169-Kat"]` where `"CH4"` isn't in that image's `imChannelNames` at all — without naming the cause.

This is the same case the fill-only merge path already guards for a human calibration correction: it lives only in `ccid.json` and is not reproducible by re-reading the zarr. The function's own comment even claimed channel names were "likewise left untouched" while the `overwrite=true` branch did the opposite.

Found while re-importing a project's images at 16-bit: every image came back as `CH1..CH4`.

## The change

`_merge_channel_names!` takes the fresh names only when there is nothing to preserve — first import, or an image un-imported by `remove_image_version!` — or when the channel **count** changed, since stored names cannot describe a store with a different count. Keeping the stored list is logged, because the store and `ccid.json` then disagree by design. Deliberate renaming stays `set_channel_names!` / `POST /api/images/channelnames`.

## Why kept names can't drift out of sync

Channel order is deterministic for a given file. Three images imported in July as 8-bit and again in August as 16-bit — two independent bioformats2raw reads weeks apart — report identical per-channel maxima index-by-index (`meta.rescale8bit.trueMax` vs `meta.saturation.topValue`):

```
Dml3RG   july [196, 661, 570, 441]   aug [196, 661, 570, 441]
VJy1Nx   july [230, 1302, 913, 471]  aug [230, 1302, 913, 471]
WHkik3   july [193, 602, 637, 360]   aug [193, 602, 637, 360]
```

Reordering would need the bytes at a fixed path replaced by a different acquisition: `ori_path` is written once at registration (`routes.jl:968`) with no route to repoint it, and `src_path` isn't a declared param in `omezarr.json`. A new file registers as a new image with no stored names.

## Tests

New `import keeps renamed channel names` testset covering first import, rename, re-import (kept + logged), a changed channel count (fresh names taken), and fill-only resync (never touches names). Full package suite green — 3617 pass. I inverted one assertion and confirmed it fails, so the testset demonstrably executes rather than silently skipping.

## Reservations

- Not exercised through a real bioformats2raw import — the test drives the merge function directly.
- Re-import is no longer a way to reset names to the file's own labels, and there's no other reset action; recovery is retyping in the metadata editor.
- Scope is the import path only — `migrateLegacy.jl` and the `copyImage`/`cropImage` name propagation are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
