### PR TITLE
fix(import): follow bioformats2raw's blosc shuffle spelling per version

### DIFF
--- a/app/src/config.jl
+++ b/app/src/config.jl
@@ -432,6 +432,42 @@ function set_image_compressor!(name::AbstractString)::String
 end
 
 """
+    bf2raw_shuffle_values(lib_dir) -> (on, off)
+
+How THIS bioformats2raw spells the blosc `shuffle` property. Returns the value for byte-shuffle-on and
+for shuffle-off.
+
+bioformats2raw 0.12.0 swapped its zarr library (jzarr → zarr-java, upstream PR #302) and with it the
+spelling of this one property. The two are mutually exclusive — each version **hard-fails** on the
+other's, so the flag has to follow the binary:
+
+| passed              | 0.11.x (jzarr) | 0.12.x (zarr-java)   |
+|---------------------|----------------|----------------------|
+| `shuffle=1`         | byte shuffle   | NullPointerException |
+| `shuffle=0`         | no shuffle     | NullPointerException |
+| `shuffle=shuffle`   | invalid option | byte shuffle         |
+| `shuffle=noshuffle` | invalid option | no shuffle           |
+
+**`byteshuffle` — the alias 0.12's README documents for byte shuffle — is BROKEN upstream.** It
+reaches blosc-java as a null enum (`NullPointerException: Cannot read field "shuffle" because "x0" is
+null`, in `Blosc.Shuffle.access\$000`) and every chunk write throws `ZarrException: Error in encoding
+blosc`. `shuffle` is the spelling that works; measured against 0.12.1 for cname ∈
+{lz4, zstd, zlib, blosclz} and both NGFF 0.4 and 0.5.
+
+Detected from the BUNDLED ZARR LIBRARY, not by parsing `--version`: the library *is* the cause, and a
+directory listing costs nothing where `--version` pays a JVM start on every import. An unrecognised
+install gets the current spelling — a wrong guess fails loudly (non-zero exit, which `_run_task`
+already checks), it cannot silently write the wrong codec.
+"""
+function bf2raw_shuffle_values(lib_dir::AbstractString)
+    legacy = isdir(lib_dir) && any(startswith(f, "jzarr-") for f in readdir(lib_dir))
+    legacy ? ("1", "0") : ("shuffle", "noshuffle")
+end
+
+# lib/ sits next to bin/ in every bioformats2raw distribution: <install>/bin/bioformats2raw + <install>/lib
+_bf2raw_lib_dir(bin::AbstractString = bioformats2raw_bin()) = joinpath(dirname(dirname(bin)), "lib")
+
+"""
     bf2raw_compression_flags([name]) -> Vector{String}
 
 bioformats2raw CLI flags that make it write the SAME compressor our own Python writers use.
@@ -440,12 +476,15 @@ bioformats2raw defaults to `blosc/lz4-5`, which on real 16-bit acquisition data 
 default choice for no read-speed benefit that survives measurement. The import is the one store we do
 NOT write through `zarr_utils`, so it is the one that has to be told explicitly — otherwise an
 imported original and every correction derived from it are encoded differently.
+
+The `shuffle` value's spelling depends on the installed version — see `bf2raw_shuffle_values`.
 """
 function bf2raw_compression_flags(name::AbstractString = image_compressor())::Vector{String}
     i = findfirst(c -> c.name == name, IMAGE_COMPRESSOR_CHOICES)
     c = IMAGE_COMPRESSOR_CHOICES[isnothing(i) ? 1 : i]
+    shuf_on, shuf_off = bf2raw_shuffle_values(_bf2raw_lib_dir())
     ["--compression", "blosc",
      "--compression-properties", "cname=$(c.cname)",
      "--compression-properties", "clevel=$(c.clevel)",
-     "--compression-properties", "shuffle=$(c.shuffle ? 1 : 0)"]
+     "--compression-properties", "shuffle=$(c.shuffle ? shuf_on : shuf_off)"]
 end

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -7793,13 +7793,36 @@ end
         @test occursin("IMAGE_COMPRESSOR_DEFAULT = '$(Cecelia.IMAGE_COMPRESSOR_DEFAULT)'", py)
         @test Cecelia.image_compressor() in [c.name for c in Cecelia.IMAGE_COMPRESSOR_CHOICES]
 
-        # bioformats2raw is handed the numeric blosc shuffle; numcodecs names it
+        # The blosc `shuffle` property is spelled DIFFERENTLY per bioformats2raw version, and each
+        # version hard-fails on the other's spelling (0.12.0 swapped jzarr → zarr-java). Detected from
+        # the bundled jar; asserted here against synthetic lib dirs so this is hermetic — CI has no
+        # bioformats2raw install at all, and that must resolve to the current spelling, not error.
+        mktempdir() do d
+            legacy = joinpath(d, "legacy"); mkpath(legacy)
+            touch(joinpath(legacy, "jzarr-0.4.2.jar"))
+            @test Cecelia.bf2raw_shuffle_values(legacy) == ("1", "0")
+
+            modern = joinpath(d, "modern"); mkpath(modern)
+            touch(joinpath(modern, "zarr-java-0.1.3.jar"))
+            @test Cecelia.bf2raw_shuffle_values(modern) == ("shuffle", "noshuffle")
+
+            # neither jar, and a missing dir → the current spelling (a wrong guess fails loudly)
+            empty_dir = joinpath(d, "empty"); mkpath(empty_dir)
+            @test Cecelia.bf2raw_shuffle_values(empty_dir) == ("shuffle", "noshuffle")
+            @test Cecelia.bf2raw_shuffle_values(joinpath(d, "absent")) == ("shuffle", "noshuffle")
+        end
+        # NOT the literal "1"/"0": that is the legacy spelling, and hardcoding it here is what would
+        # hide the incompatibility. Assert against whatever THIS install wants.
+        shuf_on, shuf_off = Cecelia.bf2raw_shuffle_values(Cecelia._bf2raw_lib_dir())
         flags = Cecelia.bf2raw_compression_flags("zstd-shuffle")
         @test flags[1:2] == ["--compression", "blosc"]
         props = Dict(split(flags[i], "=")[1] => split(flags[i], "=")[2] for i in 4:2:length(flags))
-        @test props == Dict("cname" => "zstd", "clevel" => "3", "shuffle" => "1")
+        @test props == Dict("cname" => "zstd", "clevel" => "3", "shuffle" => shuf_on)
         @test Dict(split(f, "=")[1] => split(f, "=")[2]
-                   for f in Cecelia.bf2raw_compression_flags("zstd")[4:2:end])["shuffle"] == "0"
+                   for f in Cecelia.bf2raw_compression_flags("zstd")[4:2:end])["shuffle"] == shuf_off
+        # `byteshuffle` is the alias 0.12's README documents for byte shuffle, and it is BROKEN
+        # upstream (null enum → NPE → every chunk write fails). It must never be emitted.
+        @test !any(occursin("byteshuffle", f) for f in flags)
 
         # an unknown name falls back rather than erroring - a typo in custom.toml must not fail a
         # multi-hour import


### PR DESCRIPTION
bioformats2raw 0.12.0 swapped its underlying zarr library (jzarr → zarr-java, upstream [PR #302](https://github.com/glencoesoftware/bioformats2raw/pull/302)) and with it the spelling of the blosc `shuffle` property. The two spellings are **mutually exclusive** — each version hard-fails on the other's:

| passed | 0.11.x (jzarr) | 0.12.x (zarr-java) |
|---|---|---|
| `shuffle=1` | byte shuffle | `NullPointerException` |
| `shuffle=0` | no shuffle | `NullPointerException` |
| `shuffle=shuffle` | invalid option | byte shuffle |
| `shuffle=noshuffle` | invalid option | no shuffle |

So `bf2raw_compression_flags` now takes the spelling from the install, via `bf2raw_shuffle_values`. It's detected from the **bundled jar** (`jzarr-*` vs `zarr-java-*`) rather than by parsing `--version`: the library *is* the cause, and a directory listing costs nothing where `--version` pays a JVM start on every import. Verified against both real installs — `0.11.0 → ("1","0")`, `0.12.1 → ("shuffle","noshuffle")`.

### `byteshuffle` is broken upstream

The value 0.12's README documents as the byte-shuffle alias does not work. It reaches blosc-java as a null enum:

```
java.lang.NullPointerException: Cannot read field "shuffle" because "x0" is null
    at com.scalableminds.bloscjava.Blosc$Shuffle.access$000(Blosc.java:251)
Caused by: dev.zarr.zarrjava.ZarrException: Error in encoding blosc.
    at dev.zarr.zarrjava.v2.codec.core.BloscCodec.encode(BloscCodec.java:70)
```

Every chunk write throws. Reproduced for `cname` ∈ {lz4, zstd, zlib, blosclz} and for **both** NGFF 0.4 and 0.5, on synthetic and real data. Plain `shuffle` is the spelling that works. A test asserts we never emit `byteshuffle`.

### Verification

Ran the **real import task** (not the bare CLI) over `M3c-CD8-GFP-CD20-Tom_MAX.tif` (199 MB) on 0.12.1 against an isolated config dir:

- task ok in **11.3 s**, 95×4×1×512×512
- output store **structurally identical** to a 0.11.0 one — same `.zgroup`/`.zattrs`, same `0/` series wrapper with multiscales + omero in the same place, `zarr_format 2`
- same codec: `{'id': 'blosc', 'cname': 'zstd', 'shuffle': 1, 'clevel': 3, 'typesize': 2}`
- **dtype `<u2` instead of `>u2`** — new imports are little-endian, which retires the byte-order class of bug (#483) for anything imported from here on
- Python (`series_base`/`read_axes`/`read_scale`/`open_as_zarr`), Julia (`open_level0`/`image_geometry`/`store_compression`) and the crop preview all read it **unchanged**

0.12.1 still defaults to NGFF 0.4 (zarr v2), so this is not a v3 switch — v3 and sharding become *available*, and consuming them is separate work.

`pixi run test-pkg` green. The existing testset hardcoded `shuffle="1"`, which would have failed CI (no bioformats2raw installed there); it now asserts `bf2raw_shuffle_values` against synthetic lib dirs and derives the expected spelling from the install.

### Known limitations

- **Bio-Formats 8.3.0 → 8.5.0 is unassessed.** One MAX TIFF was verified; vendor reader behaviour for `.oir`/`.czi`/`.lif` could differ. That's the untested half of the upgrade.
- **Jar-glob detection is indirect.** A future release that renames the bundled lib falls through to the current spelling. A wrong guess fails loudly (non-zero exit, already checked by `_run_task`) — it cannot silently write the wrong codec.
- Verified on Linux only; the `bin/`+`lib/` layout is the same in the Windows/macOS distributions but unverified there.
- **This changes nothing until the install is repointed.** There is no documented bioformats2raw version pin in `docs/INSTALL.md`, so nothing here selects 0.12.1 — it only makes both versions work correctly.
- `PhysicalSizeZ` came out `2.35e-05` µm on that MAX projection (`SizeZ=1`). Not verified against 0.11.0, so not claimed as a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
