### PR TITLE
fix(deps): bump Reseau to 1.3.5 — 1.3.1's precompile cert expired

### DIFF
--- a/api/Manifest.toml
+++ b/api/Manifest.toml
@@ -803,9 +803,9 @@ version = "1.3.1"
 
 [[deps.Reseau]]
 deps = ["NetworkOptions", "OpenSSL_jll", "PrecompileTools", "Random", "SHA"]
-git-tree-sha1 = "0eab6d95ed40c2ef3992255c1c71e4f9748932b5"
+git-tree-sha1 = "6bb4e276780eaba7c5a61af85c6d537a245d8150"
 uuid = "802f3686-a58f-41ce-bb0c-3c43c75bba36"
-version = "1.3.1"
+version = "1.3.5"
 
 [[deps.Rmath]]
 deps = ["Random", "Rmath_jll"]

--- a/app/Manifest.toml
+++ b/app/Manifest.toml
@@ -627,9 +627,9 @@ version = "1.3.1"
 
 [[deps.Reseau]]
 deps = ["NetworkOptions", "OpenSSL_jll", "PrecompileTools", "Random", "SHA"]
-git-tree-sha1 = "0eab6d95ed40c2ef3992255c1c71e4f9748932b5"
+git-tree-sha1 = "6bb4e276780eaba7c5a61af85c6d537a245d8150"
 uuid = "802f3686-a58f-41ce-bb0c-3c43c75bba36"
-version = "1.3.1"
+version = "1.3.5"
 
 [[deps.Rmath]]
 deps = ["Random", "Rmath_jll"]


### PR DESCRIPTION
CI on `main` is red and none of it is ours.

Reseau 1.3.1 bakes a test certificate into its **precompile workload** and runs a TLS handshake against it. That certificate expired at **2026-08-06 17:07:04 UTC**:

```
tls handshake failed: tls: certificate has expired or is not yet valid
(valid unix range 1714842424-1786036024)
```

So `Reseau` fails to precompile, and `HTTP` and `Cecelia` fail behind it — every Julia suite dies before the first assertion. Upstream fixed exactly this in **v1.3.5** ([Reseau.jl#140](https://github.com/JuliaServices/Reseau.jl/pull/140), released four hours before the failing run); the replacement cert is valid to 2036.

### Why it looked Windows-only

It isn't. ubuntu and macOS restored a Julia depot cache that already held a precompiled 1.3.1, so they never re-ran the workload. Windows had a cache miss and hit the clock. The next cache miss on either of the others would have done the same thing.

### Scope

Two manifests, not three — `pluto/` is still on the HTTP 1.x/MbedTLS line and has no Reseau dependency at all. Nothing else moved in either manifest.

### Verified

`pixi run test-pkg` and `pixi run test-api` both green on the bump (Linux). Windows is CI's to confirm — the cause is platform-independent and the fix is upstream's own, but I can't run it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
