### PR TITLE
feat(opticalFlow): choose what training sees — Z planes, frame cap, held-out split

### DIFF
--- a/api/src/optical_flow_api.jl
+++ b/api/src/optical_flow_api.jl
@@ -145,8 +145,10 @@ function api_optical_flow_inspect(body_bytes::Vector{UInt8})
     # ONE z plane, resolved here rather than passed through as `nothing`. `preview_region_bounds`
     # skips an axis it is given nothing for, so a null z hands the worker the WHOLE stack — which
     # then fails in `_as_cyx` with a reshape error about a size nothing in the request mentions.
-    # The default is the middle plane because that is what training reads (`_training_sequence`:
-    # `n_z // 2`), so the sheet shows the planes the model was actually fed.
+    # The default is the middle plane, which is where a single-plane training run reads
+    # (`train_run.z_planes(n_z, 1)` == `n_z // 2`). With `zPlanes > 1` a run spreads over the stack,
+    # so there is no one plane to default to — but this sheet is asked BEFORE a model exists and its
+    # question is "do these metrics look like cells here", which the slider answers by being moved.
     z_req = get(data, "z", nothing)
     z_idx = if haskey(d, "z")
         n_z = size(arr, d["z"])

--- a/api/src/optical_flow_api.jl
+++ b/api/src/optical_flow_api.jl
@@ -76,13 +76,21 @@ function api_optical_flow_delete(body_bytes::Vector{UInt8})
 end
 
 # ── Flow metric planes for the canvas panel ─────────────────────────────────────
-# "What goes INTO a model": every flow metric plane for one timepoint, as PNGs the browser can show,
-# so the user can see which look like cells before choosing what to train on. NO MODEL is involved —
-# the metrics are a property of the movie, the channels and the temporal scales, and the question is
-# asked before a model exists. The empty model group below is only what `CoastalUtils` needs to carry
-# the channels and the scales.
+# TWO VIEWS, one route, chosen by whether a `model` is given.
 #
-# No instances either: those are segmentation output and the Segment page previews them already.
+# Without one — "what goes INTO a model": every flow metric plane for one timepoint, as PNGs the
+# browser can show, so the user can see which look like cells before choosing what to train on. NO
+# MODEL is involved, deliberately: the metrics are a property of the movie, the channels and the
+# temporal scales, and the question is asked before a model exists. The empty model group below is
+# only what `CoastalUtils` needs to carry the channels and the scales.
+#
+# With one — "did it learn": the projected input beside that model's probability map. Same window,
+# same projection, same metric build, one forward pass on the end. It shares this route because
+# everything except that pass is identical, and a second route would be a second chance for the
+# geometry or the normalisation to drift from what a run is fed — which is the whole reason these
+# views are worth showing.
+#
+# No instances either way: those are segmentation output and the Segment page previews them already.
 # These are CANVAS PLOTS — nothing here touches napari.
 #
 # Deliberately NOT `api_preview_run`. That route exists to keep the viewer honest: it refuses unless
@@ -107,8 +115,15 @@ function api_optical_flow_inspect(body_bytes::Vector{UInt8})
     err === nothing || return 404, JSON3.write((; error = err))
 
     raw = read_ccid_raw(state_file(joinpath(projects_dir(), project_uid), image_uid))
+    # A MODEL turns this route into the probability view. Same window, same projection, same metric
+    # build — the only difference is one forward pass and two planes instead of fifteen, so it shares
+    # the route rather than duplicating the geometry and the worker plumbing. With no model the
+    # question is pre-training ("which of these look like cells") and no checkpoint may be involved;
+    # with one it is post-training ("did it learn"), and a checkpoint is the whole point.
+    model = String(get(data, "model", ""))
+    want_prob = !isempty(model)
     models = Dict{String,Any}("0" => Dict{String,Any}(
-        "model"        => "",
+        "model"        => model,
         "matchAs"      => "base",
         "cellChannels" => get(data, "cellChannels", Any[])))
     # These ARE the feature set: with no model, `CoastalUtils._manifest` falls back to the group's own
@@ -126,7 +141,8 @@ function api_optical_flow_inspect(body_bytes::Vector{UInt8})
     prepared = try
         Dict{String,Any}("valueName" => value_name, "normaliseToWhole" => true,
                          "colormap" => params["colormap"],
-                         "models" => coastal_models_for_python(params, raw; require_model = false))
+                         "models" => coastal_models_for_python(params, raw;
+                                                               require_model = want_prob))
     catch e
         return 400, JSON3.write((; error = e isa ErrorException ? e.msg : sprint(showerror, e),
                                    code = "params-not-previewable"))
@@ -170,7 +186,9 @@ function api_optical_flow_inspect(body_bytes::Vector{UInt8})
             w = _preview()
             w === nothing && error("preview worker is not running")
             send(w, preview_request(String(zp), String(task_dir), prepared, region;
-                                    value_name = value_name, fun_name = "opticalFlow.inspect",
+                                    value_name = value_name,
+                                    fun_name = want_prob ? "opticalFlow.probability"
+                                                         : "opticalFlow.inspect",
                                     channel_names = ccid_channel_names(raw)))
         end
     catch e

--- a/api/src/preview_api.jl
+++ b/api/src/preview_api.jl
@@ -277,7 +277,15 @@ function api_preview_run(body_bytes::Vector{UInt8})
                                     channel_names = chan_names))
         end
     catch e
-        return 500, JSON3.write((; error = sprint(showerror, e)))
+        raw = sprint(showerror, e)
+        # The worker dispatches on `funName` and raises naming every backend it knows. That message
+        # is for whoever debugs the registry, not for the person who pressed Preview — uncoded, it
+        # reached the tooltip as a repr'd Python list. Code it so the UI can say something true and
+        # short; the raw text still goes to the log.
+        occursin("no preview backend", raw) &&
+            return 500, JSON3.write((; error = "This task has no preview — run it to see the result",
+                                       code = "no-preview-backend", detail = raw))
+        return 500, JSON3.write((; error = raw))
     end
 
     try

--- a/app/src/jobs.jl
+++ b/app/src/jobs.jl
@@ -43,7 +43,13 @@ function _kill_tree(pid::Int)
                 isnothing(child) || _kill_tree(child)
             end
         catch; end
-        try; run(ignorestatus(`kill -9 $pid`)); catch; end
+        # stderr to devnull, not just `ignorestatus`. A process tree is enumerated and then killed,
+        # and killing one member routinely takes its siblings with it — a torch DataLoader's workers
+        # all exit when their parent does. Every already-gone pid then makes `kill` print
+        # "No such process", so cancelling one training run wrote seventeen error lines for what is
+        # the SUCCESS case: the point of this function is that the process is dead, and it is.
+        # `ignorestatus` only stops Julia raising on the exit code; the message is on stderr.
+        try; run(pipeline(ignorestatus(`kill -9 $pid`); stderr = devnull)); catch; end
     end
 end
 

--- a/app/src/preview.jl
+++ b/app/src/preview.jl
@@ -36,7 +36,7 @@ const PREVIEW_PORT   = 7656
 # anything we would not want served from the old code has to move it. 5 is that case with nothing else
 # attached: the reply shape is identical to 4, and the fix (a preview crashing on every AF request) is
 # invisible to any check but this one.
-const PREVIEW_PROTOCOL = 9
+const PREVIEW_PROTOCOL = 10
 const PREVIEW_WORKER = joinpath(@__DIR__, "..", "..", "preview", "preview_worker.py")
 
 mutable struct PreviewWorker

--- a/app/src/qc_cohort.jl
+++ b/app/src/qc_cohort.jl
@@ -38,7 +38,10 @@ const COHORT_METRICS = Dict{String,Vector{String}}(
     # like its peers. `finalLoss` is only comparable within a set trained at the same weights and
     # epochs — which is the normal case, since one parameter set per set is the rule — and
     # `lossDrop` (start/end ratio) is the scale-free companion for when it is not.
-    "opticalFlow.train"          => ["finalLoss", "lossDrop", "epochs"],
+    # valLossDrop is the cohort-comparable one: `lossDrop` is measured on the training frames, so it
+    # can be high across a whole cohort of models that all memorised.
+    "opticalFlow.train"          => ["finalLoss", "lossDrop", "valFinalLoss", "valLossDrop",
+                                     "epochs"],
     # skeleton branching per image (docs/todo/BRANCHING_PLAN.md): nBranches is the primary count;
     # meanBranchLength flags an image whose skeleton is far more/less fragmented than its peers.
     # `anisotropy` (0 = uniform, 1 = non-uniform) is only banked when the anisotropy pass ran, so

--- a/app/src/tasks/opticalFlow/train.jl
+++ b/app/src/tasks/opticalFlow/train.jl
@@ -171,6 +171,7 @@ function _run_task(task::TrainFlowModel, imgs::Vector{CciaImage}, params::Dict{S
            channelName      = join([string(ch_names[c + 1]) for c in channels
                                     if 0 <= c < length(ch_names)], "+"),
            zPlanes          = Int(get(params, "zPlanes", 1)),
+           maxFrames        = Int(get(params, "maxFrames", 0)),
            temporalScales   = scales,
            cumulativeWindow = Int(get(params, "cumulativeWindow", 5)),
            droppedMetrics   = dropped,

--- a/app/src/tasks/opticalFlow/train.jl
+++ b/app/src/tasks/opticalFlow/train.jl
@@ -172,6 +172,7 @@ function _run_task(task::TrainFlowModel, imgs::Vector{CciaImage}, params::Dict{S
                                     if 0 <= c < length(ch_names)], "+"),
            zPlanes          = Int(get(params, "zPlanes", 1)),
            maxFrames        = Int(get(params, "maxFrames", 0)),
+           trainRatio       = Float64(get(params, "trainRatio", 1.0)),
            temporalScales   = scales,
            cumulativeWindow = Int(get(params, "cumulativeWindow", 5)),
            droppedMetrics   = dropped,
@@ -225,18 +226,38 @@ end
 """
     flow_training_qc_findings(metrics) -> Vector
 
-The unambiguous bad case for a training run: the loss did not come down. A model whose loss ended at
-or above where it started has learned nothing, and it will still segment — producing a confidently
-wrong mask — so this is worth a warning rather than being left to the log.
+Two unambiguous bad cases.
+
+**The loss did not come down.** A model whose loss ended at or above where it started has learned
+nothing, and it will still segment — producing a confidently wrong mask — so this is worth a warning
+rather than being left to the log.
+
+**The held-out loss did not follow the training loss.** Only checkable when the run had a
+`trainRatio` split, and it is the one thing the training curve cannot tell you: a loss that drops
+nicely while the held-out loss sits flat or climbs is a model fitting these frames rather than
+learning what a cell looks like. Both curves descending is not evidence on its own — the gap is.
 
 Pure, so it is unit-tested without running a training job.
 """
 function flow_training_qc_findings(metrics::AbstractDict)
+    out = Dict{String,Any}[]
     drop = get(metrics, "lossDrop", NaN)
-    (drop isa Real && !isnan(drop) && drop <= 1.0) || return Dict{String,Any}[]
-    [qc_finding("warn", "opticalFlow.loss_flat", "Loss did not decrease",
-        "Check the channel has visible motion, then retrain";
-        detail = Dict{String,Any}("finalLoss" => get(metrics, "finalLoss", nothing),
-                                  "lossDrop"  => drop,
-                                  "epochs"    => get(metrics, "epochs", 0)))]
+    if drop isa Real && !isnan(drop) && drop <= 1.0
+        push!(out, qc_finding("warn", "opticalFlow.loss_flat", "Loss did not decrease",
+            "Check the channel has visible motion, then retrain";
+            detail = Dict{String,Any}("finalLoss" => get(metrics, "finalLoss", nothing),
+                                      "lossDrop"  => drop,
+                                      "epochs"    => get(metrics, "epochs", 0))))
+    end
+    val_drop = get(metrics, "valLossDrop", NaN)
+    if val_drop isa Real && !isnan(val_drop) && val_drop <= 1.0
+        push!(out, qc_finding("warn", "opticalFlow.val_loss_flat",
+            "Held-out loss did not decrease",
+            "Train on more images or fewer epochs — this fits the frames, not the cells";
+            detail = Dict{String,Any}("valFinalLoss" => get(metrics, "valFinalLoss", nothing),
+                                      "valLossDrop"  => val_drop,
+                                      "finalLoss"    => get(metrics, "finalLoss", nothing),
+                                      "epochs"       => get(metrics, "epochs", 0))))
+    end
+    out
 end

--- a/app/src/tasks/opticalFlow/train.jl
+++ b/app/src/tasks/opticalFlow/train.jl
@@ -170,7 +170,7 @@ function _run_task(task::TrainFlowModel, imgs::Vector{CciaImage}, params::Dict{S
            trainChannels    = channels,
            channelName      = join([string(ch_names[c + 1]) for c in channels
                                     if 0 <= c < length(ch_names)], "+"),
-           zSlice           = Int(get(params, "zSlice", -1)),
+           zPlanes          = Int(get(params, "zPlanes", 1)),
            temporalScales   = scales,
            cumulativeWindow = Int(get(params, "cumulativeWindow", 5)),
            droppedMetrics   = dropped,

--- a/app/src/tasks/opticalFlow/train.json
+++ b/app/src/tasks/opticalFlow/train.json
@@ -46,7 +46,7 @@
       "label": "Max frames per movie",
       "type": "int",
       "min": 0,
-      "max": 2000,
+      "max": 500,
       "step": 10,
       "default": 0,
       "tip": "Contiguous frames each movie contributes; 0 = all, so long movies dominate"

--- a/app/src/tasks/opticalFlow/train.json
+++ b/app/src/tasks/opticalFlow/train.json
@@ -32,14 +32,14 @@
       "tip": "Channels carrying the cell signal; merged by maximum"
     },
     {
-      "key": "zSlice",
-      "label": "Z plane",
+      "key": "zPlanes",
+      "label": "Z planes",
       "type": "int",
-      "min": -1,
-      "max": 500,
+      "min": 1,
+      "max": 25,
       "step": 1,
-      "default": -1,
-      "tip": "Which plane to train on; -1 = middle"
+      "default": 1,
+      "tip": "Evenly-spaced planes per movie; each multiplies the frames pooled"
     },
     {
       "key": "temporalScales",

--- a/app/src/tasks/opticalFlow/train.json
+++ b/app/src/tasks/opticalFlow/train.json
@@ -52,6 +52,16 @@
       "tip": "Contiguous frames each movie contributes; 0 = all, so long movies dominate"
     },
     {
+      "key": "trainRatio",
+      "label": "Train fraction",
+      "type": "float",
+      "min": 0.1,
+      "max": 1.0,
+      "step": 0.05,
+      "default": 0.8,
+      "tip": "Rest of each movie is held out to tell convergence from memorising; 1 = none"
+    },
+    {
       "key": "temporalScales",
       "label": "Temporal scales",
       "type": "chipSelect",

--- a/app/src/tasks/opticalFlow/train.json
+++ b/app/src/tasks/opticalFlow/train.json
@@ -42,6 +42,16 @@
       "tip": "Evenly-spaced planes per movie; each multiplies the frames pooled"
     },
     {
+      "key": "maxFrames",
+      "label": "Max frames per movie",
+      "type": "int",
+      "min": 0,
+      "max": 2000,
+      "step": 10,
+      "default": 0,
+      "tip": "Contiguous frames each movie contributes; 0 = all, so long movies dominate"
+    },
+    {
       "key": "temporalScales",
       "label": "Temporal scales",
       "type": "chipSelect",

--- a/app/src/tasks/opticalFlow/train_run.py
+++ b/app/src/tasks/opticalFlow/train_run.py
@@ -29,6 +29,7 @@ Parameter contract (JSON written by Julia):
   trainChannels            - 0-based indices, merged by maximum
   channelName              - display name(s) for the manifest and the picker label
   zPlanes                  - how many evenly-spaced Z planes per movie (1 = the middle)
+  maxFrames                - cap on the contiguous frames each movie contributes; 0 = all
   temporalScales           - already parsed + validated by Julia
   cumulativeWindow, droppedMetrics, epochs, embeddingDim, seed, normalise
   foregroundWeight, intensityWeight, temporalWeight
@@ -81,12 +82,41 @@ def z_planes(n_z, n):
     return sorted({int((i + 0.5) * n_z / n) for i in range(n)})
 
 
-def _training_sequence(im_dat, dim_utils, params, z):
+def frame_window(n_t, max_frames, seed, movie_idx):
+    """`(start, stop)` — the contiguous run of frames one movie contributes.
+
+    CONTIGUOUS because the metrics are temporal: `mag_8` is the flow between frame *t* and *t+8*, so
+    a random subset of frames is not a shorter movie, it is a movie with the motion taken out.
+
+    The start is SEED-DERIVED rather than 0. Always taking the head of every movie samples one part
+    of the experiment — before the interesting event as often as not, and at whatever bleaching level
+    the start happens to have — and no amount of pooling fixes a window that is always in the same
+    place. Deriving it from the seed and the movie index makes it reproducible (the seed is in the
+    manifest) while giving different runs different views.
+
+    `max_frames <= 0` means no cap.
+    """
+    n_t = int(n_t)
+    if max_frames is None or int(max_frames) <= 0 or int(max_frames) >= n_t:
+        return 0, n_t
+    n_use = int(max_frames)
+    # Seeded per movie, so adding or reordering images does not reshuffle the others' windows.
+    rng = np.random.default_rng([int(seed), int(movie_idx)])
+    start = int(rng.integers(0, n_t - n_use + 1))
+    return start, start + n_use
+
+
+def _training_sequence(im_dat, dim_utils, params, z, window=None):
     """`[T, H, W]` float32 in 0–255 for ONE Z plane — the same projection inference builds per tile.
 
-    Percentiles are taken over the WHOLE plane sequence, which is what makes this the global
-    statistic `normaliseToWhole` reproduces at inference from the image pyramid. If the two ever
-    diverge, the model sees a different photometric range than it was trained on.
+    Percentiles are taken over the WHOLE plane sequence — every timepoint, including those outside
+    `window` — which is what makes this the global statistic `normaliseToWhole` reproduces at
+    inference from the image pyramid. If the two ever diverge, the model sees a different photometric
+    range than it was trained on.
+
+    That ordering is the whole subtlety of the frame cap: normalise over the movie, THEN cut. Cutting
+    first would scale a 50-frame window by its own percentiles while inference scales the 200-frame
+    movie by the movie's, and the mismatch is silent — the same structure at a different brightness.
 
     Per plane, deliberately: each plane is normalised on its own statistics, the way inference
     normalises the plane it is given. Sharing one range across planes would push the dim deep planes
@@ -118,6 +148,9 @@ def _training_sequence(im_dat, dim_utils, params, z):
         projected = arr if projected is None else np.maximum(projected, arr)
 
     assert projected.shape[0] == n_t, f'expected {n_t} frames, got {projected.shape[0]}'
+    # Cut only now — after every percentile has seen the whole movie (see the docstring).
+    if window is not None:
+        projected = projected[window[0]:window[1]]
     return (projected * coastal_utils.PROJECTION_MAX).astype(np.float32)
 
 
@@ -139,7 +172,13 @@ def run(params):
     log.log(f'>> {len(movies)} movie(s) to prepare')
 
     n_planes = int(params.get('zPlanes', 1))
-    sequences, used, planes_used = [], [], {}
+    seed = int(params.get('seed', 42))
+    # A cap per movie, not a total. Without one, pooling is weighted by how long each recording
+    # happened to run: a 200-frame movie contributes ~7x what a 30-frame one does, so the model is
+    # mostly fitted to whichever image the microscope was left on longest. Nothing in the run or the
+    # manifest showed that — the frame count is a single pooled number.
+    max_frames = int(params.get('maxFrames', 0))
+    sequences, used, planes_used, windows = [], [], {}, {}
     for i, m in enumerate(movies):
         im_path = m['imPath']
         uid = m.get('uID', '')
@@ -150,13 +189,21 @@ def run(params):
             log.log(f'>> [WARN] {uid} has no T axis — skipped')
             continue
         n_t = int(dim_utils.dim_val('T'))
-        if n_t < max(scales) + 1:
+        start, stop = frame_window(n_t, max_frames, seed, i)
+        n_use = stop - start
+        # Checked against the CAPPED length, not the movie's. A 200-frame movie capped to 5 produces
+        # no `mag_8` plane, which is the same silent corruption as a genuinely short movie — the
+        # guard has to see what the run will actually feed coastal.
+        if n_use < max(scales) + 1:
             # The same guard CoastalUtils applies. Below this the largest scale produces no plane,
             # so this movie would contribute a DIFFERENT channel layout than the rest — which is a
             # silent corruption of the pooled training set, not just a short movie.
-            log.log(f'>> [WARN] {uid} has {n_t} timepoints, needs '
+            of = f'{n_use} of {n_t}' if n_use < n_t else f'{n_t}'
+            log.log(f'>> [WARN] {uid} has {of} timepoints, needs '
                     f'{max(scales) + 1} for scale {max(scales)} — skipped')
             continue
+        if n_use < n_t:
+            windows[uid] = [start, stop]
 
         # Planes are resolved PER MOVIE because depth is: asking for 3 of a 31-plane stack and 3 of
         # a 9-plane one are different indices, and a single global list would read past the end of
@@ -173,10 +220,11 @@ def run(params):
             planes = [None]
 
         for z in planes:
-            sequences.append(_training_sequence(im_dat, dim_utils, params, z))
+            sequences.append(_training_sequence(im_dat, dim_utils, params, z, (start, stop)))
         used.append(uid)
         where = f'Z {planes}' if planes != [None] else '2D'
-        log.log(f'>>   {where}: {len(planes)} × {n_t} frames of {sequences[-1].shape[1:]}')
+        span = f'{n_use} frames' if n_use == n_t else f'frames {start}–{stop - 1} of {n_t}'
+        log.log(f'>>   {where}: {len(planes)} × {span} of {sequences[-1].shape[1:]}')
 
     if not sequences:
         raise ValueError('no usable movies — every image was skipped (see the warnings above)')
@@ -284,6 +332,10 @@ def run(params):
         'foregroundWeight': float(params.get('foregroundWeight', 1.0)),
         'intensityWeight': float(params.get('intensityWeight', 1.0)),
         'temporalWeight': float(params.get('temporalWeight', 2.0)),
+        'maxFrames': max_frames,
+        # Only the movies that were actually cut. The window is seed-derived, so this is what makes
+        # "which frames did it see" answerable without re-deriving it from the seed by hand.
+        'frameWindows': windows,
         'zPlanes': n_planes,
         # The indices, not just the count: "3 planes" of a 31-deep stack and of a 9-deep one are
         # different depths, and which ones a model saw is the question you ask when it does badly on

--- a/app/src/tasks/opticalFlow/train_run.py
+++ b/app/src/tasks/opticalFlow/train_run.py
@@ -30,6 +30,7 @@ Parameter contract (JSON written by Julia):
   channelName              - display name(s) for the manifest and the picker label
   zPlanes                  - how many evenly-spaced Z planes per movie (1 = the middle)
   maxFrames                - cap on the contiguous frames each movie contributes; 0 = all
+  trainRatio               - fraction of each sequence to train on; 1.0 = no held-out split
   temporalScales           - already parsed + validated by Julia
   cumulativeWindow, droppedMetrics, epochs, embeddingDim, seed, normalise
   foregroundWeight, intensityWeight, temporalWeight
@@ -159,7 +160,8 @@ def run(params):
 
     # All three live in coastal.train — `prepare_data_for_unet_batch` reads as a flow helper and is
     # not one, which cost an end-to-end run to find (unit tests stub coastal, so nothing caught it).
-    from coastal.train import prepare_data_for_unet_batch, train_with_metrics, save_model
+    from coastal.train import (prepare_data_for_unet_batch, train_test_split_per_movie,
+                               train_with_metrics, save_model)
 
     movies = list(params['movies'])
     scales = [int(s) for s in params['temporalScales']]
@@ -251,11 +253,37 @@ def run(params):
     # Pool AFTER the per-sequence metrics: concatenating frames first would make flow cross a
     # boundary between two recordings — or between two Z planes of one timepoint — which is not
     # motion either way.
-    frames_prep = np.concatenate(all_frames, axis=0)
-    metrics = [{k: v for k, v in mm.items() if k not in dropped}
-               for per_movie in all_metrics for mm in per_movie]
+    #
+    # `train_test_split_per_movie` splits WITHIN each sequence and then concatenates, so every movie
+    # and every Z plane appears on both sides — a split that held whole movies out would measure
+    # "does this transfer to another recording", which is a different (and much harder) question
+    # than "has this converged or memorised". It takes the tail of each sequence, which for temporal
+    # data is the right cut: the held-out frames are a stretch the optimiser never saw.
+    #
+    # The metrics were computed over the FULL sequence before the split, so a val frame's flow
+    # metrics were derived partly from frames that ended up in training — about `max(scales)` frames
+    # of overlap at the seam. That is not label leakage (coastal is unsupervised; there are no
+    # labels), and the val frames themselves were never fed to the optimiser, which is what the
+    # comparison rests on. Computing metrics per side instead would change the metrics themselves at
+    # both seams, which is worse.
+    train_ratio = float(params.get('trainRatio', 1.0))
+    split = 0.0 < train_ratio < 1.0
+    if split:
+        frames_prep, val_frames_arr, metrics_raw, val_metrics_raw = train_test_split_per_movie(
+            all_frames, all_metrics, train_ratio=train_ratio, shuffle=False)
+    else:
+        frames_prep = np.concatenate(all_frames, axis=0)
+        metrics_raw = [mm for per_sequence in all_metrics for mm in per_sequence]
+        val_frames_arr, val_metrics_raw = None, None
 
-    key_sets = {tuple(sorted(mm.keys())) for mm in metrics}
+    def _keep(ms):
+        return [{k: v for k, v in mm.items() if k not in dropped} for mm in ms]
+
+    metrics = _keep(metrics_raw)
+    val_metrics = _keep(val_metrics_raw) if val_metrics_raw else None
+
+    # Both sides, or the model trains on one channel layout and is scored on another.
+    key_sets = {tuple(sorted(mm.keys())) for mm in metrics + (val_metrics or [])}
     if len(key_sets) > 1:
         # Would train the model on inconsistent channel layouts — the silent failure this whole
         # contract exists to prevent, so it stops the run.
@@ -263,6 +291,9 @@ def run(params):
     metric_keys = sorted(metrics[0].keys())
     log.log(f'>> {frames_prep.shape[0]} pooled frames, {len(metric_keys)} metrics: '
             f'{", ".join(metric_keys)}')
+    if split:
+        log.log(f'>> holding out {len(val_metrics)} frames ({(1 - train_ratio) * 100:.0f}%) '
+                f'for validation')
 
     # The real figure, from the metrics that exist. Still worth logging after the fact: training is
     # the long part and it holds all of this, so a run that is going to die of memory says so here
@@ -289,6 +320,10 @@ def run(params):
 
     model = train_with_metrics(
         frames_prep, metrics, variance_metrics_norm=None,
+        # No `val_flow_pairs` — the warp term is at weight 0 here (see `loss_weights`), so the
+        # missing flow pairs cost nothing and `val_total` stays comparable with `total`. If warp is
+        # ever given a weight, this needs the pairs or the two curves stop meaning the same thing.
+        val_frames=val_frames_arr, val_temporal_metrics_norm=val_metrics,
         num_epochs=epochs,
         intensity_weight=loss_weights['intensity'],
         foreground_weight=loss_weights['foreground'],
@@ -333,6 +368,7 @@ def run(params):
         'intensityWeight': float(params.get('intensityWeight', 1.0)),
         'temporalWeight': float(params.get('temporalWeight', 2.0)),
         'maxFrames': max_frames,
+        'trainRatio': train_ratio,
         # Only the movies that were actually cut. The window is seed-derived, so this is what makes
         # "which frames did it see" answerable without re-deriving it from the seed by hand.
         'frameWindows': windows,
@@ -358,6 +394,14 @@ def run(params):
         if losses:
             qc['finalLoss'] = float(losses[-1])
             qc['lossDrop'] = float(losses[0] / losses[-1]) if losses[-1] > 0 else float('inf')
+        # The held-out curve, same shape. `lossDrop` alone cannot tell converging from memorising —
+        # it is measured on the frames the weights were fitted to — so where there is a split, the
+        # same ratio on the held-out set is the finding worth banking.
+        val_losses = curves.get('val_total', [])
+        if val_losses:
+            qc['valFinalLoss'] = float(val_losses[-1])
+            qc['valLossDrop'] = (float(val_losses[0] / val_losses[-1]) if val_losses[-1] > 0
+                                 else float('inf'))
         write_json_atomic(qc_out_path, qc)
         log.log(f'>> saved training QC: {qc}')
 

--- a/app/src/tasks/opticalFlow/train_run.py
+++ b/app/src/tasks/opticalFlow/train_run.py
@@ -173,8 +173,19 @@ def run(params):
     log.log(f'>> GPU: {gpu_device if use_gpu else "none (CPU)"}')
     log.log(f'>> {len(movies)} movie(s) to prepare')
 
+    # ── progress ────────────────────────────────────────────────────────────────────────────────
+    # One monotonic scale over the whole run: a tick per movie prepared, one for the flow metrics,
+    # then one per epoch. Without this the task reported NOTHING for its entire duration — `run_py`
+    # routes `[PROGRESS] n/total` to `on_progress` and this runner never printed one, so a training
+    # job that takes tens of minutes was indistinguishable from a wedged one.
+    #
+    # The phases are wildly unequal in wall-clock (metrics is one tick and minutes long) so the bar
+    # does not move smoothly. That is the honest shape: the alternative is inventing weights per
+    # phase, which would be a guess dressed up as measurement.
     n_planes = int(params.get('zPlanes', 1))
     seed = int(params.get('seed', 42))
+    total_steps = len(movies) + 1 + epochs
+    log.progress(0, total_steps)
     # A cap per movie, not a total. Without one, pooling is weighted by how long each recording
     # happened to run: a 200-frame movie contributes ~7x what a 30-frame one does, so the model is
     # mostly fitted to whichever image the microscope was left on longest. Nothing in the run or the
@@ -227,6 +238,9 @@ def run(params):
         where = f'Z {planes}' if planes != [None] else '2D'
         span = f'{n_use} frames' if n_use == n_t else f'frames {start}–{stop - 1} of {n_t}'
         log.log(f'>>   {where}: {len(planes)} × {span} of {sequences[-1].shape[1:]}')
+        # `i + 1`, not `len(used)`: the scale is over the movies ATTEMPTED, so a skipped movie still
+        # advances the bar rather than leaving it short by however many were unusable.
+        log.progress(i + 1, total_steps)
 
     if not sequences:
         raise ValueError('no usable movies — every image was skipped (see the warnings above)')
@@ -249,6 +263,7 @@ def run(params):
             f'(scales {scales}, cumulative {cumulative})')
     all_frames, all_metrics = prepare_data_for_unet_batch(
         sequences, temporal_scales=scales, cumulative_window=cumulative)
+    log.progress(len(movies) + 1, total_steps)
 
     # Pool AFTER the per-sequence metrics: concatenating frames first would make flow cross a
     # boundary between two recordings — or between two Z planes of one timepoint — which is not
@@ -324,6 +339,11 @@ def run(params):
         # missing flow pairs cost nothing and `val_total` stays comparable with `total`. If warp is
         # ever given a weight, this needs the pairs or the two curves stop meaning the same thing.
         val_frames=val_frames_arr, val_temporal_metrics_norm=val_metrics,
+        # The long phase, and the only one that can report from inside itself. coastal's own prints
+        # fire every tenth epoch and are written for a notebook reader, so the callback is what an
+        # application can drive a bar from.
+        on_epoch=lambda epoch, n_epochs, losses: log.progress(
+            len(movies) + 1 + epoch, total_steps),
         num_epochs=epochs,
         intensity_weight=loss_weights['intensity'],
         foreground_weight=loss_weights['foreground'],

--- a/app/src/tasks/opticalFlow/train_run.py
+++ b/app/src/tasks/opticalFlow/train_run.py
@@ -1,19 +1,26 @@
 """
 Optical-flow model training.
 
-Trains a coastal flow-metric UNet on one Z plane of EVERY image in an experimental set and saves it
-to the model vault as a PAIR: `<name>.pt` plus a `<name>.json` manifest. The manifest is not
+Trains a coastal flow-metric UNet on Z planes of EVERY image in an experimental set and saves it to
+the model vault as a PAIR: `<name>.pt` plus a `<name>.json` manifest. The manifest is not
 documentation — it is what `CoastalUtils` configures inference from, because the flow metric set is a
 silent train/inference contract: `predict_frame` stacks metrics in sorted-key order and zero-fills
 the remainder, so a set that does not match shifts every later channel with no error.
 
-Metrics are computed PER MOVIE and the frames pooled afterwards. Motion only exists within a movie —
-flow across a boundary between two recordings is meaningless — which is what
-`prepare_data_for_unet_batch` and `train_test_split_per_movie` encode, so the pooling goes through
-them rather than through a concatenated array.
+Metrics are computed PER SEQUENCE and the frames pooled afterwards. Motion only exists within one
+recording of one plane — flow across a boundary between two movies is meaningless, and so is flow
+between plane k and plane k+1 of the same timepoint — which is what `prepare_data_for_unet_batch`
+encodes, so the pooling goes through it rather than through a concatenated array.
 
-One Z plane per movie: `train_with_metrics` consumes a `[T, H, W]` sequence, and a model trained on
-the middle plane segments the whole stack acceptably (the 3D path runs it per plane).
+A sequence is therefore (movie × plane), not (movie): `zPlanes` planes per movie, each its own
+`[T, H, W]`. Inference runs the model per plane over the whole stack, so training on one plane makes
+the model's whole experience of the data one depth — which for an intravital stack is one slice
+through the tissue, at one signal level. `zPlanes = 1` reproduces the old single-middle-plane
+behaviour exactly.
+
+Note what this multiplies: pooled frames = movies × planes × timepoints, and the metric stack is
+~11-15 float32 planes per frame. Five Z planes is five times the memory of one, which is what the
+per-movie frame cap exists to bound.
 
 Parameter contract (JSON written by Julia):
   movies                   - [{uID, imPath}, …]; every image of the set that resolved
@@ -21,7 +28,7 @@ Parameter contract (JSON written by Julia):
   valueName                - provenance for the manifest
   trainChannels            - 0-based indices, merged by maximum
   channelName              - display name(s) for the manifest and the picker label
-  zSlice                   - plane to train on; -1 = middle
+  zPlanes                  - how many evenly-spaced Z planes per movie (1 = the middle)
   temporalScales           - already parsed + validated by Julia
   cumulativeWindow, droppedMetrics, epochs, embeddingDim, seed, normalise
   foregroundWeight, intensityWeight, temporalWeight
@@ -41,6 +48,12 @@ from cecelia.utils.atomic_io import write_json_atomic
 from cecelia.utils import coastal_utils
 
 
+# Advisory only, and deliberately not a limit: what is too much depends on the box, and refusing to
+# run would be worse than a run the user chose knowing the size. The threshold is "more than a
+# workstation comfortably holds alongside torch".
+MEMORY_WARN_GB = 16.0
+
+
 def _open(im_path):
     im_dat, _ = zarr_utils.open_as_zarr(im_path, as_dask=True)
     dim_utils = DimUtils(ome_xml_utils.parse_meta(im_path), use_channel_axis=True)
@@ -48,27 +61,43 @@ def _open(im_path):
     return im_dat, dim_utils
 
 
-def _training_sequence(im_dat, dim_utils, params, log):
-    """`[T, H, W]` float32 in 0–255 — the same projection inference builds per tile.
+def z_planes(n_z, n):
+    """`n` evenly-spaced plane indices through a stack of `n_z` — the centres of `n` equal bins.
+
+    Bin centres, not `linspace(0, n_z - 1, n)`, and the difference matters at both ends of `n`:
+
+    - `n = 1` lands on `n_z // 2`, which is exactly the single-middle-plane rule this replaced. An
+      existing config keeps training on the same data, so the parameter can be introduced without
+      silently retraining every model on something else.
+    - No `n` picks plane 0 or `n_z - 1` until `n` approaches `n_z`. The top and bottom of an
+      intravital stack are usually outside the tissue, and `linspace` would spend two of five planes
+      on them — the model would learn from noise, and nothing in the run would say so.
+
+    Clamped to `n_z`: asking for more planes than exist yields each plane once, not duplicates
+    (which would silently weight those frames twice in the pool).
+    """
+    n_z = int(n_z)
+    n = max(1, min(int(n), n_z))
+    return sorted({int((i + 0.5) * n_z / n) for i in range(n)})
+
+
+def _training_sequence(im_dat, dim_utils, params, z):
+    """`[T, H, W]` float32 in 0–255 for ONE Z plane — the same projection inference builds per tile.
 
     Percentiles are taken over the WHOLE plane sequence, which is what makes this the global
     statistic `normaliseToWhole` reproduces at inference from the image pyramid. If the two ever
     diverge, the model sees a different photometric range than it was trained on.
+
+    Per plane, deliberately: each plane is normalised on its own statistics, the way inference
+    normalises the plane it is given. Sharing one range across planes would push the dim deep planes
+    toward zero and make them contribute nothing.
     """
     channels = list(params['trainChannels'])
-    z_slice = int(params.get('zSlice', -1))
     percentile_hi = float(params.get('normalise', 99.99))
 
     level = im_dat[0]
     ia = {ax: i for i, ax in enumerate(dim_utils.im_dim_order)}
     n_t = dim_utils.dim_val('T')
-
-    if 'Z' in ia:
-        n_z = dim_utils.dim_val('Z')
-        z = n_z // 2 if z_slice < 0 else min(z_slice, n_z - 1)
-        log.log(f'>> training on Z {z} of {n_z}')
-    else:
-        z = None
 
     projected = None
     for ch in channels:
@@ -109,37 +138,71 @@ def run(params):
     log.log(f'>> GPU: {gpu_device if use_gpu else "none (CPU)"}')
     log.log(f'>> {len(movies)} movie(s) to prepare')
 
-    sequences, used = [], []
+    n_planes = int(params.get('zPlanes', 1))
+    sequences, used, planes_used = [], [], {}
     for i, m in enumerate(movies):
         im_path = m['imPath']
-        log.log(f'>> [{i + 1}/{len(movies)}] {m.get("uID", "")}: {im_path}')
+        uid = m.get('uID', '')
+        log.log(f'>> [{i + 1}/{len(movies)}] {uid}: {im_path}')
         im_dat, dim_utils = _open(im_path)
 
         if not dim_utils.is_timeseries():
-            log.log(f'>> [WARN] {m.get("uID", "")} has no T axis — skipped')
+            log.log(f'>> [WARN] {uid} has no T axis — skipped')
             continue
         n_t = int(dim_utils.dim_val('T'))
         if n_t < max(scales) + 1:
             # The same guard CoastalUtils applies. Below this the largest scale produces no plane,
             # so this movie would contribute a DIFFERENT channel layout than the rest — which is a
             # silent corruption of the pooled training set, not just a short movie.
-            log.log(f'>> [WARN] {m.get("uID", "")} has {n_t} timepoints, needs '
+            log.log(f'>> [WARN] {uid} has {n_t} timepoints, needs '
                     f'{max(scales) + 1} for scale {max(scales)} — skipped')
             continue
 
-        sequences.append(_training_sequence(im_dat, dim_utils, params, log))
-        used.append(m.get('uID', ''))
-        log.log(f'>>   {sequences[-1].shape[0]} frames of {sequences[-1].shape[1:]}')
+        # Planes are resolved PER MOVIE because depth is: asking for 3 of a 31-plane stack and 3 of
+        # a 9-plane one are different indices, and a single global list would read past the end of
+        # the shallow one.
+        axes = set(dim_utils.im_dim_order)
+        if 'Z' in axes:
+            n_z = int(dim_utils.dim_val('Z'))
+            planes = z_planes(n_z, n_planes)
+            planes_used[uid] = planes
+            if len(planes) < n_planes:
+                log.log(f'>> [WARN] {uid} has {n_z} Z planes — training on {len(planes)}, '
+                        f'not the {n_planes} requested')
+        else:
+            planes = [None]
+
+        for z in planes:
+            sequences.append(_training_sequence(im_dat, dim_utils, params, z))
+        used.append(uid)
+        where = f'Z {planes}' if planes != [None] else '2D'
+        log.log(f'>>   {where}: {len(planes)} × {n_t} frames of {sequences[-1].shape[1:]}')
 
     if not sequences:
         raise ValueError('no usable movies — every image was skipped (see the warnings above)')
 
-    log.log(f'>> computing flow metrics per movie (scales {scales}, cumulative {cumulative})')
+    # Say how big this is BEFORE the expensive step. Every metric plane is held at once, so the
+    # pooled frame count — movies × Z planes × timepoints — is the number that decides whether the
+    # machine survives, and `zPlanes` multiplies it directly. Nothing on the form hints at that, and
+    # the failure mode is the run being killed tens of minutes in.
+    #
+    # Frames and megapixels, not an estimated GB: the metric count is only known once coastal has
+    # produced them, and the alternative — a copy of the metric list here — would be a second
+    # spelling of `train.jl`'s `FIXED_FLOW_METRICS` free to disagree with it. The real total is
+    # logged below, from the metrics that actually exist.
+    n_frames_pooled = sum(int(s.shape[0]) for s in sequences)
+    mpx = float(np.prod(sequences[0].shape[1:])) / 1e6
+    log.log(f'>> pooling {n_frames_pooled} frames from {len(sequences)} sequence(s) '
+            f'at {mpx:.2f} MP')
+
+    log.log(f'>> computing flow metrics for {len(sequences)} sequence(s) '
+            f'(scales {scales}, cumulative {cumulative})')
     all_frames, all_metrics = prepare_data_for_unet_batch(
         sequences, temporal_scales=scales, cumulative_window=cumulative)
 
-    # Pool AFTER the per-movie metrics: concatenating frames first would make flow cross a boundary
-    # between two recordings, which is not motion.
+    # Pool AFTER the per-sequence metrics: concatenating frames first would make flow cross a
+    # boundary between two recordings — or between two Z planes of one timepoint — which is not
+    # motion either way.
     frames_prep = np.concatenate(all_frames, axis=0)
     metrics = [{k: v for k, v in mm.items() if k not in dropped}
                for per_movie in all_metrics for mm in per_movie]
@@ -152,6 +215,17 @@ def run(params):
     metric_keys = sorted(metrics[0].keys())
     log.log(f'>> {frames_prep.shape[0]} pooled frames, {len(metric_keys)} metrics: '
             f'{", ".join(metric_keys)}')
+
+    # The real figure, from the metrics that exist. Still worth logging after the fact: training is
+    # the long part and it holds all of this, so a run that is going to die of memory says so here
+    # rather than at an arbitrary epoch — and the number tells you WHICH knob to turn, since it is
+    # linear in Z planes, images and timepoints alike.
+    metrics_gb = (frames_prep.shape[0] * float(np.prod(frames_prep.shape[1:]))
+                  * len(metric_keys) * 4 / 1024 ** 3)
+    log.log(f'>> ~{metrics_gb:.1f} GB of flow metrics held in memory')
+    if metrics_gb > MEMORY_WARN_GB:
+        log.log(f'>> [WARN] ~{metrics_gb:.0f} GB of metrics — if the run is killed, reduce '
+                f'Z planes, images or timepoints')
 
     # Keyed the way coastal keys its loss history, so the manifest can pair each curve with the
     # weight that scales it. `history` records the RAW term; the total is the weighted sum, so a term
@@ -210,7 +284,11 @@ def run(params):
         'foregroundWeight': float(params.get('foregroundWeight', 1.0)),
         'intensityWeight': float(params.get('intensityWeight', 1.0)),
         'temporalWeight': float(params.get('temporalWeight', 2.0)),
-        'zSlice': int(params.get('zSlice', -1)),
+        'zPlanes': n_planes,
+        # The indices, not just the count: "3 planes" of a 31-deep stack and of a 9-deep one are
+        # different depths, and which ones a model saw is the question you ask when it does badly on
+        # a stack of a different thickness. Empty for 2D movies.
+        'zPlanesUsed': planes_used,
         'lossCurves': curves,
         'lossWeights': loss_weights,
         'trainedAt': _now_iso(),

--- a/app/src/tasks/segment/coastal.json
+++ b/app/src/tasks/segment/coastal.json
@@ -98,16 +98,6 @@
           "tip": "How close two cells may be and still get separate seeds"
         },
         {
-          "key": "seedBlurSigma",
-          "label": "Seed blur (µm)",
-          "type": "float",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "default": 2.5,
-          "tip": "Raise to merge fragments of one cell; does not move the outline"
-        },
-        {
           "key": "probThreshold",
           "label": "Foreground threshold",
           "type": "float",
@@ -118,41 +108,51 @@
           "tip": "Cutoff on the probability map; raise to ignore dim regions"
         },
         {
-          "key": "affinityThreshold",
-          "label": "Growing threshold",
-          "type": "float",
-          "min": 0.1,
-          "max": 0.9,
-          "step": 0.05,
-          "default": 0.5,
-          "tip": "Embedding similarity needed to grow into a pixel"
-        },
-        {
-          "key": "minComponentSize",
-          "label": "Min fragment (µm²)",
-          "type": "int",
-          "min": 0.0,
-          "max": 100.0,
-          "step": 0.5,
-          "default": 2.0,
-          "tip": "Remove grown fragments below this area"
-        },
-        {
-          "key": "normalise",
-          "label": "Normalise percentile",
-          "type": "float",
-          "min": 50.0,
-          "max": 100.0,
-          "step": 0.01,
-          "default": 99.99,
-          "tip": "Upper percentile for intensity normalisation"
-        },
-        {
           "key": "advanced",
           "label": "Advanced",
           "type": "section",
           "collapsed": true,
           "params": [
+            {
+              "key": "seedBlurSigma",
+              "label": "Seed blur (µm)",
+              "type": "float",
+              "min": 0.0,
+              "max": 10.0,
+              "step": 0.25,
+              "default": 2.5,
+              "tip": "Raise to merge fragments of one cell; does not move the outline"
+            },
+            {
+              "key": "affinityThreshold",
+              "label": "Growing threshold",
+              "type": "float",
+              "min": 0.1,
+              "max": 0.9,
+              "step": 0.05,
+              "default": 0.5,
+              "tip": "Embedding similarity needed to grow into a pixel"
+            },
+            {
+              "key": "minComponentSize",
+              "label": "Min fragment (µm²)",
+              "type": "int",
+              "min": 0.0,
+              "max": 100.0,
+              "step": 0.5,
+              "default": 2.0,
+              "tip": "Remove grown fragments below this area"
+            },
+            {
+              "key": "normalise",
+              "label": "Normalise percentile",
+              "type": "float",
+              "min": 50.0,
+              "max": 100.0,
+              "step": 0.01,
+              "default": 99.99,
+              "tip": "Upper percentile for intensity normalisation"
+            },
             {
               "key": "stitchThreshold",
               "label": "Z-stitch threshold",
@@ -160,8 +160,8 @@
               "min": 0.0,
               "max": 1.0,
               "step": 0.05,
-              "default": 0.0,
-              "tip": "IoU for matching labels across Z (3D only)"
+              "default": 0.2,
+              "tip": "IoU for matching labels across Z (3D only); 0 leaves every plane independent"
             },
             {
               "key": "probBlurSigma",

--- a/app/src/tasks/segment/coastal.json
+++ b/app/src/tasks/segment/coastal.json
@@ -228,6 +228,16 @@
       ]
     },
     {
+      "key": "labelSmoothing",
+      "label": "Smooth outlines (µm)",
+      "type": "float",
+      "min": 0.0,
+      "max": 3.0,
+      "step": 0.25,
+      "default": 0.5,
+      "tip": "Round the growing frontier's coastline; 0 = raw"
+    },
+    {
       "key": "labelModifications",
       "label": "Label modifications",
       "type": "section",
@@ -269,16 +279,6 @@
           "step": 10.0,
           "default": 0.0,
           "tip": "Remove objects larger than this area (0 = off)"
-        },
-        {
-          "key": "labelSmoothing",
-          "label": "Smooth outlines (µm)",
-          "type": "float",
-          "min": 0.0,
-          "max": 3.0,
-          "step": 0.25,
-          "default": 0.5,
-          "tip": "Round the growing frontier's coastline; 0 = raw"
         },
         {
           "key": "labelExpansion",

--- a/app/src/tasks/segment/coastal.json
+++ b/app/src/tasks/segment/coastal.json
@@ -180,8 +180,8 @@
               "min": 0.0,
               "max": 3.0,
               "step": 0.25,
-              "default": 0.5,
-              "tip": "Larger merges more, and shrinks cells onto their bright cores"
+              "default": 1.5,
+              "tip": "Calibrated at 1.5; larger merges more and shrinks cells onto their bright cores"
             },
             {
               "key": "mergeAffinityThreshold",

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -483,6 +483,29 @@ end
     # no history parsed → no claim either way
     @test isempty(flow_training_qc_findings(Dict{String,Any}("epochs" => 30)))
     @test isempty(flow_training_qc_findings(Dict{String,Any}("lossDrop" => NaN)))
+
+    # The held-out arm. This is the case the training curve CANNOT see: the loss drops 3.4x on the
+    # frames the weights were fitted to while the held-out loss goes nowhere — a model fitting these
+    # frames rather than learning what a cell looks like.
+    memorised = flow_training_qc_findings(Dict{String,Any}(
+        "finalLoss" => 0.2, "lossDrop" => 3.4, "valLossDrop" => 0.99,
+        "valFinalLoss" => 0.9, "epochs" => 30))
+    @test length(memorised) == 1
+    @test memorised[1]["code"] == "opticalFlow.val_loss_flat"
+    @test memorised[1]["level"] == "warn"
+    @test memorised[1]["detail"]["valLossDrop"] == 0.99
+    @test !occursin("0.99", memorised[1]["long"])
+
+    # both flat = both findings, in order
+    @test [f["code"] for f in flow_training_qc_findings(
+        Dict{String,Any}("lossDrop" => 0.9, "valLossDrop" => 0.9))] ==
+        ["opticalFlow.loss_flat", "opticalFlow.val_loss_flat"]
+
+    # a run with no split says nothing about generalising, rather than passing it silently
+    @test isempty(flow_training_qc_findings(
+        Dict{String,Any}("finalLoss" => 0.2, "lossDrop" => 3.4)))
+    @test isempty(flow_training_qc_findings(
+        Dict{String,Any}("lossDrop" => 3.4, "valLossDrop" => 2.1)))
 end
 
 # `_task_spec` runs `_inject_dynamic_options!` for CellposeSegment on every call, so a

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -360,6 +360,27 @@ and the actual indices per image as `zPlanesUsed`, because "3 planes" of a 31-de
 Pooled frames are movies × planes × timepoints and the metric stack is ~11–15 float32 planes per
 frame, so the plane count is a straight memory multiplier.
 
+**`maxFrames` caps what each movie contributes, because pooling is otherwise weighted by recording
+length.** A 200-frame movie contributes ~7× what a 30-frame one does, so without a cap the model is
+mostly fitted to whichever image the microscope was left on longest — and nothing showed it, since
+the frame count is a single pooled number. The window is **contiguous** (the metrics are temporal;
+a random subset of frames is not a shorter movie, it is a movie with the motion taken out) and its
+start is **derived from the seed and the movie index** — reproducible from the manifest, different
+across runs, and stable when images are added or reordered. Always starting at frame 0 would sample
+one part of every experiment, as often as not before the interesting event.
+
+Two ordering constraints, both silent when broken:
+
+- **Normalise over the whole movie, then cut.** The percentiles are the global statistic
+  `normaliseToWhole` reproduces at inference. Cutting first would scale a 50-frame window by its own
+  percentiles while inference scales the 200-frame movie by the movie's — the same structure at a
+  different brightness.
+- **Check `max(scales) + 1` against the CAPPED length.** A 200-frame movie capped to 5 produces no
+  `mag_8` plane, which corrupts the pooled channel layout exactly as a genuinely short movie would.
+
+The manifest records `maxFrames` and `frameWindows` (uID → `[start, stop)`, only for the movies
+actually cut).
+
 **The vault.** `<config_dir>/models/coastalModels/`, same drop-in convention as `cellposeModels/`
 above and the same live enumeration, with two differences: there is nothing built in and nothing
 bundled (an empty vault means a picker with only "None"), and only `.pt` files are entries — the

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -347,6 +347,19 @@ min/max. `normaliseToWhole` supplies that statistic; the projection then pins co
 to the same range. With it off, every tile gets its own scale — the patchiness the option exists to
 prevent, plus a train/inference mismatch on the structure-tensor planes.
 
+**Training reads `zPlanes` planes per movie, and each is its own sequence.** Motion exists within one
+recording of one plane; flow between plane *k* and plane *k+1* of the same timepoint is not motion,
+so a (movie × plane) pair is a sequence and metrics are computed per sequence before pooling. The
+planes are the centres of `zPlanes` equal bins, which puts `zPlanes = 1` on `n_z // 2` (the old
+single-plane rule, unchanged) and keeps larger counts off plane 0 and `n_z - 1` — the top and bottom
+of an intravital stack are usually outside the tissue, and `linspace` would spend two of five planes
+there. Indices are resolved per movie, since depth is: the manifest records the count as `zPlanes`
+and the actual indices per image as `zPlanesUsed`, because "3 planes" of a 31-deep stack and of a
+9-deep one are different tissue.
+
+Pooled frames are movies × planes × timepoints and the metric stack is ~11–15 float32 planes per
+frame, so the plane count is a straight memory multiplier.
+
 **The vault.** `<config_dir>/models/coastalModels/`, same drop-in convention as `cellposeModels/`
 above and the same live enumeration, with two differences: there is nothing built in and nothing
 bundled (an empty vault means a picker with only "None"), and only `.pt` files are entries — the

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -433,7 +433,10 @@ evidence:
   border on the right one. Confirmed by eye in napari across four label versions.
 
 So coastal defaults to `labelSmoothing` **1.5** — cosmetic, honest about being cosmetic, and it keeps
-the size. Cellpose keeps 0.0: it has no growing frontier and therefore not this failure mode, and
+the size. `embeddingBlurSigma` defaults to the calibrated **1.5** (2026-08-07) — the lowest σ in that
+table and the one that holds cell size closest to the expected ~11 µm, and independently coastal's own
+tuned `embedding_blur_sigma` for both passes. `probBlurSigma` stays at **0**: the same measurement
+shows it makes the border *worse*, so its calibrated value is off. Cellpose keeps 0.0: it has no growing frontier and therefore not this failure mode, and
 changing a shipped task's default would alter existing pipelines.
 
 **Coastal's spatial params are in MICRONS, not pixels.** A seed window or a blur radius describes a

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -432,11 +432,14 @@ evidence:
   area roughly halves. A clean border on a cell too small to be a cell is a worse answer than an ugly
   border on the right one. Confirmed by eye in napari across four label versions.
 
-So coastal defaults to `labelSmoothing` **1.5** — cosmetic, honest about being cosmetic, and it keeps
-the size. `embeddingBlurSigma` defaults to the calibrated **1.5** (2026-08-07) — the lowest σ in that
-table and the one that holds cell size closest to the expected ~11 µm, and independently coastal's own
-tuned `embedding_blur_sigma` for both passes. `probBlurSigma` stays at **0**: the same measurement
-shows it makes the border *worse*, so its calibrated value is off. Cellpose keeps 0.0: it has no growing frontier and therefore not this failure mode, and
+So coastal defaults to `labelSmoothing` **0.5** — cosmetic, honest about being cosmetic, and it keeps
+the size. (This paragraph read 1.5 until 2026-08-07. The shipped spec has always been 0.5 and 0.5 is
+the intended value: the doc was wrong, not the spec.)
+
+`embeddingBlurSigma` defaults to the calibrated **1.5** (2026-08-07) — the lowest σ in the table above
+and the one holding cell size closest to the expected ~11 µm, and independently coastal's own tuned
+`embedding_blur_sigma` for both passes. `probBlurSigma` stays at **0**: the same measurement shows it
+makes the border *worse*, so its calibrated value is off. Cellpose keeps 0.0: it has no growing frontier and therefore not this failure mode, and
 changing a shipped task's default would alter existing pipelines.
 
 **Coastal's spatial params are in MICRONS, not pixels.** A seed window or a blur radius describes a

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -439,8 +439,10 @@ the intended value: the doc was wrong, not the spec.)
 `embeddingBlurSigma` defaults to the calibrated **1.5** (2026-08-07) — the lowest σ in the table above
 and the one holding cell size closest to the expected ~11 µm, and independently coastal's own tuned
 `embedding_blur_sigma` for both passes. `probBlurSigma` stays at **0**: the same measurement shows it
-makes the border *worse*, so its calibrated value is off. Cellpose keeps 0.0: it has no growing frontier and therefore not this failure mode, and
-changing a shipped task's default would alter existing pipelines.
+makes the border *worse*, so its calibrated value is off.
+
+Cellpose keeps `labelSmoothing` 0.0: it has no growing frontier and therefore not this failure mode,
+and changing a shipped task's default would alter existing pipelines.
 
 **Coastal's spatial params are in MICRONS, not pixels.** A seed window or a blur radius describes a
 CELL, so the same number has to mean the same biology on every image of a set — a px value silently

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -399,6 +399,23 @@ labels) and the held-out frames themselves never reach the optimiser, which is w
 rests on. Computing the metrics per side instead would change the metrics at *both* seams, which is
 worse.
 
+**Two canvas plots, one route.** `POST /api/optical-flow/inspect` answers with the metric planes
+when no model is given and with the model's probability map when one is. Same window, same
+projection, same metric build — one forward pass is the only difference — so they share the route and
+the request machinery (`useFlowPlanes`) rather than getting a second copy of the geometry that could
+drift from what a run is fed.
+
+| Plot | Question | Model |
+|---|---|---|
+| **Flow metrics** | which of these look like cells, i.e. what should I train on | none, deliberately — the question predates any checkpoint |
+| **Model probability** | did it learn to tell cell from background | the vault's selection, honouring global/local scope |
+
+Neither shows instances: those are segmentation output, the Segment page previews them through the
+normal path, and a threshold plus a growing step hides exactly what the probability map is for.
+`predict_frame` returns `(prob_map, instances, props)` and a run discards the first
+(`CoastalUtils._predict_plane`), so the worker's `opticalFlow.probability` backend is the only place
+that value is looked at.
+
 Progress is reported over one monotonic scale — a tick per movie prepared, one for the flow metrics,
 then one per epoch through coastal's `on_epoch`. The phases are wildly unequal in wall-clock (metrics
 is a single tick and minutes long) so the bar does not move smoothly; weighting them would be a guess

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -381,6 +381,29 @@ Two ordering constraints, both silent when broken:
 The manifest records `maxFrames` and `frameWindows` (uID → `[start, stop)`, only for the movies
 actually cut).
 
+**`trainRatio` holds part of every sequence back, and without it the loss curve cannot be read.** A
+training loss is measured on the frames the weights were just fitted to, so it goes down whether the
+model learned what a cell looks like or memorised these frames. With a split, coastal evaluates every
+term on the held-out frames each epoch (no grad, no augmentation) and the manifest's `lossCurves`
+gains a `val_<term>` beside each one; the **gap** between the pair is the reading.
+
+The split is `train_test_split_per_movie`, which cuts *within* each sequence — so every movie and
+every Z plane appears on both sides. Holding whole movies out would ask "does this transfer to
+another recording", a different and much harder question. The held-out frames are the tail of each
+sequence, a stretch the optimiser never saw.
+
+One honest caveat: the metrics are computed over the full sequence *before* the split, so a held-out
+frame's flow metrics derive partly from frames that ended up in training — roughly `max(scales)`
+frames of overlap at the seam. That is not label leakage (coastal is unsupervised; there are no
+labels) and the held-out frames themselves never reach the optimiser, which is what the comparison
+rests on. Computing the metrics per side instead would change the metrics at *both* seams, which is
+worse.
+
+The convergence plot draws each `val_` curve dashed in the same colour as its term — the only thing
+read off a validation curve is its distance from its own training line, and a second colour would
+make that a legend lookup. QC banks `valFinalLoss`/`valLossDrop` and warns when the held-out loss
+does not come down even though the training loss did.
+
 **The vault.** `<config_dir>/models/coastalModels/`, same drop-in convention as `cellposeModels/`
 above and the same live enumeration, with two differences: there is nothing built in and nothing
 bundled (an empty vault means a picker with only "None"), and only `.pt` files are entries — the

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -399,6 +399,12 @@ labels) and the held-out frames themselves never reach the optimiser, which is w
 rests on. Computing the metrics per side instead would change the metrics at *both* seams, which is
 worse.
 
+Progress is reported over one monotonic scale — a tick per movie prepared, one for the flow metrics,
+then one per epoch through coastal's `on_epoch`. The phases are wildly unequal in wall-clock (metrics
+is a single tick and minutes long) so the bar does not move smoothly; weighting them would be a guess
+dressed up as a measurement. Before this the task emitted no `[PROGRESS]` at all, so a run of tens of
+minutes was indistinguishable from a wedged one.
+
 The convergence plot draws each `val_` curve dashed in the same colour as its term — the only thing
 read off a validation curve is its distance from its own training line, and a second colour would
 make that a legend lookup. QC banks `valFinalLoss`/`valLossDrop` and warns when the held-out loss

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -410,6 +410,13 @@ drift from what a run is fed.
 | **Flow metrics** | which of these look like cells, i.e. what should I train on | none, deliberately — the question predates any checkpoint |
 | **Model probability** | did it learn to tell cell from background | the vault's selection, honouring global/local scope |
 
+Both carry an **image-version selector**, and its default differs on purpose. The metric sheet has no
+model, so it defaults to the image's ACTIVE version — what a task form resolves to and what the viewer
+shows. The probability plot defaults to the version the MODEL was trained on, read from its manifest's
+`sourceValueName`, because that is by definition the right input; pick another and the panel says
+"not trained input". Both hardcoded `default` until 2026-08-07, which fed a model trained on a denoised
+movie the raw import — a different photometric world, with nothing on screen saying so.
+
 Neither shows instances: those are segmentation output, the Segment page previews them through the
 normal path, and a threshold plus a growing step hides exactly what the probability map is for.
 `predict_frame` returns `(prob_map, instances, props)` and a run discards the first

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -1361,9 +1361,15 @@ panel reads as "frozen". But a spinner that flashes on every quick plot is worse
 
 Do **not** hand-roll per-plot "…" text or an immediate spinner. **Small/embedded plots stay out**: the
 gate montage tiles (compact `GateScatterCell`, rendered by `GateMontage`) keep an unobtrusive dot, not a
-wheel per tile — gate the overlay on `!compact` (or equivalent). Wired today in `SummaryPanel` and the
-full-size `GateScatterCell` (Gate page); `UmapView` has its own empty-state wheel. New heavy plots: reuse
+wheel per tile — gate the overlay on `!compact` (or equivalent). Wired today in `SummaryPanel`, the
+full-size `GateScatterCell` (Gate page), and both flow plots (via `useFlowPlanes`, which owns the
+decision so the two cannot disagree); `UmapView` has its own empty-state wheel. New heavy plots: reuse
 these two primitives.
+
+**A slow plot should also say its content is STALE.** The flow plots dim the planes while a render is
+queued or running (`.planes-stale`, tied to the same delayed flag as the wheel). Without it a slow
+render is indistinguishable from a control that did nothing — which is how a debounced slider reads as
+broken. Gate it on the delayed flag, never on raw loading, or it flickers on every drag.
 
 **Gate scatters — one renderer, three hosts.** `components/plots/GateScatterCell.vue` is the ONE
 scatter+gate body (2D-canvas dots + contour/pop-colour layer + gate overlay). The interactive Gate page

--- a/frontend/src/components/canvas/interactiveViews.test.ts
+++ b/frontend/src/components/canvas/interactiveViews.test.ts
@@ -28,8 +28,9 @@ describe('interactive view surface flags', () => {
   })
 
   it('the flow views are offered on their module page AND the board', () => {
-    expect(pageViews('opticalFlowPage').map(v => v.key)).toEqual(['flowMetrics', 'flowTraining'])
-    for (const k of ['flowMetrics', 'flowTraining'])
+    expect(pageViews('opticalFlowPage').map(v => v.key))
+      .toEqual(['flowMetrics', 'flowTraining', 'flowProbability'])
+    for (const k of ['flowMetrics', 'flowTraining', 'flowProbability'])
       expect(boardViews('interactive').map(v => v.key)).toContain(k)
   })
 

--- a/frontend/src/components/canvas/interactiveViews.ts
+++ b/frontend/src/components/canvas/interactiveViews.ts
@@ -4,6 +4,7 @@ import GatingStrategyView from '../plots/GatingStrategyView.vue'
 import ImageStripView from '../plots/ImageStripView.vue'
 import FlowMetricsView from '../plots/FlowMetricsView.vue'
 import FlowTrainingView from '../plots/FlowTrainingView.vue'
+import FlowProbabilityView from '../plots/FlowProbabilityView.vue'
 
 // Registry of INTERACTIVE plot views (client/WebGL point clouds with per-point interaction, e.g.
 // 2D-canvas dot plots), keyed by a stable view id. This is the counterpart to SUMMARY plots — those are
@@ -49,6 +50,10 @@ export const INTERACTIVE_VIEWS: Record<string, InteractiveView> = {
   // Training convergence per loss TERM. A plot, not a chart in the vault's details modal, so it gets
   // the canvas chrome and the CSV/PNG/SVG + board-PDF export for free.
   flowTraining: { label: 'Training convergence', component: FlowTrainingView, opticalFlowPage: true, analysisBoard: true },
+  // What the trained model SEES: the projected input beside its probability map. Separate from
+  // `flowMetrics` on purpose — that one is asked before a model exists and must not take one, this
+  // one is meaningless without a checkpoint. Model comes from the vault's selection, not a picker.
+  flowProbability: { label: 'Model probability', component: FlowProbabilityView, opticalFlowPage: true, analysisBoard: true },
 }
 
 export const isInteractiveView = (key: string): boolean => key in INTERACTIVE_VIEWS

--- a/frontend/src/components/plots/FlowMetricsView.vue
+++ b/frontend/src/components/plots/FlowMetricsView.vue
@@ -29,19 +29,14 @@
   data is. Nothing here touches napari.
 -->
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { computed, watch } from 'vue'
 import ChipSelect, { type ChipOption } from '../ChipSelect.vue'
 import { useProjectStore } from '../../stores/project'
-import { debouncedLatest, type RunState } from '../../utils/debouncedLatest'
-import { PREVIEW_DEBOUNCE_MS } from '../../utils/taskPreview'
+import { useFlowPlanes, type FlowPlaneState, type FlowRequest } from '../../composables/useFlowPlanes'
 
-interface Plane { name: string; png: string }
-interface FlowState {
-  imageUid?: string; valueName?: string
-  channels?: string[]; t?: number; z?: number | null
-  scales?: string[]                     // temporal scales — only used when no model is picked
+interface FlowState extends FlowPlaneState {
+  scales?: string[]                     // temporal scales — this sheet's own choice
   show?: string[]                       // which planes are visible, by name
-  colormap?: string
 }
 
 const props = defineProps<{ projectUid: string; imageUids?: string[]; state: FlowState }>()
@@ -53,13 +48,6 @@ const SCALE_OPTIONS: ChipOption[] = ['1', '2', '3', '4', '6', '8', '12', '16']
   .map(v => ({ value: v, label: v }))
 
 const COLORMAPS = ['viridis', 'magma', 'grey']
-
-const planes = ref<Plane[]>([])
-const extent = ref({ t: 1, z: 1 })       // slider bounds, from the image's own geometry
-const runState = ref<RunState>('idle')
-const loading = computed(() => runState.value !== 'idle')
-const starting = ref(false)
-const error = ref('')
 
 const state = computed(() => props.state)
 const t = computed({ get: () => state.value.t ?? 0, set: v => (state.value.t = v) })
@@ -111,102 +99,22 @@ watch(imageChannels, avail => {
   if (!cur.length || !cur.every(c => avail.includes(c))) state.value.channels = [...avail]
 }, { immediate: true })
 
-// The whole request, as of the moment it is built. Every control feeds this ONE object, and it is
-// what gets scheduled — so the run that eventually fires carries the settings the user had when they
-// stopped moving, not whatever the refs happen to hold when the timer expires.
-interface InspectRequest {
-  projectUid: string; imageUid: string; valueName: string
-  cellChannels: string[]; t: number; z: number | null
-  temporalScales: number[]; colormap: string
-}
-const inspectRequest = computed<InspectRequest | null>(() => state.value.imageUid ? {
+// The request. `temporalScales` is this sheet's own control — the metric planes depend on it, and
+// no model is involved to carry them (see the header).
+const request = computed<FlowRequest | null>(() => state.value.imageUid ? {
   projectUid: props.projectUid, imageUid: state.value.imageUid,
   valueName: state.value.valueName ?? 'default',
   cellChannels: state.value.channels ?? [], t: t.value, z: state.value.z ?? null,
-  temporalScales: scales.value.map(Number), colormap: colormap.value,
+  colormap: colormap.value, temporalScales: scales.value.map(Number),
 } : null)
 
-// The worker pays ~18 s of torch imports on first use and answers 202 `starting` until it is up.
-// Telling the user to "try again in a moment" and stopping made the panel look broken for a minute,
-// so we wait for it — bounded, and with the wait visible rather than a frozen spinner.
-const RETRY_MS = 1500
-const MAX_WAIT_MS = 120_000
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+const { planes, extent, runState, loading, starting, error, load } = useFlowPlanes(state, request)
 
-// Debounced, latest-wins — the same scheduler the task preview uses, for the same reason. A slider
-// drag emits an event per pixel and each one is a real flow computation in the worker, so firing per
-// event queued a dozen runs whose results then LANDED ONE BY ONE: the sheet visibly flipped through
-// every timepoint the user had scrubbed past, seconds after they stopped. Two rules fix it and both
-// are needed — the debounce collapses the burst, and `isCurrent()` stops a run that was already in
-// flight from painting its (now stale) planes over the one the user is waiting for. Without the
-// guard, whichever request happened to finish last would win, which is not the same as the latest.
-const scheduler = debouncedLatest<InspectRequest>(async (req, isCurrent) => {
-  error.value = ''
-  for (let waited = 0; ; waited += RETRY_MS) {
-    const r = await fetch('/api/optical-flow/inspect', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(req),
-    })
-    const d = await r.json()
-    // superseded while the worker computed — neither the planes NOR an error belong to the current
-    // settings any more, so nothing here is applied
-    if (!isCurrent()) return
-    if (!r.ok) throw new Error(d.error ?? `HTTP ${r.status}`)
-    if (!d.starting) {
-      starting.value = false
-      planes.value = d.planes ?? []
-      // Show everything by default — a contact sheet you have to unhide plane by plane answers
-      // nothing. The chips are for narrowing once you know what you're looking at.
-      if (!state.value.show) state.value.show = planes.value.map(p => p.name)
-      return
-    }
-    if (waited >= MAX_WAIT_MS) throw new Error('Preview worker did not start.')
-    starting.value = true
-    await sleep(RETRY_MS)
-    if (!isCurrent()) return
-  }
-}, {
-  wait: PREVIEW_DEBOUNCE_MS,
-  onState: s => { runState.value = s },
-  onError: e => {
-    starting.value = false
-    error.value = e instanceof Error ? e.message : String(e)
-  },
+// Show everything by default — a contact sheet you have to unhide plane by plane answers nothing.
+// The chips are for narrowing once you know what you are looking at.
+watch(planes, ps => {
+  if (ps.length && !state.value.show) state.value.show = ps.map(p => p.name)
 })
-onBeforeUnmount(() => scheduler.cancel())
-
-/** Run now, skipping the debounce — the refresh button and the first paint. */
-function load() {
-  if (!inspectRequest.value) return
-  scheduler.schedule(inspectRequest.value)
-  scheduler.flush()
-}
-
-// Slider bounds come from the ONE geometry route (`api/src/image_geometry.jl`), per VERSION — the
-// active version can be a different shape from `default`, so the valueName has to travel with the
-// question or the sliders end past the end of the store being read.
-async function loadExtent() {
-  if (!state.value.imageUid) return
-  try {
-    const q = new URLSearchParams({ projectUid: props.projectUid, imageUid: state.value.imageUid,
-                                    valueName: state.value.valueName ?? 'default' })
-    const r = await fetch(`/api/images/geometry?${q}`)
-    if (!r.ok) return
-    const g = await r.json()
-    extent.value = { t: Math.max(1, g.sizeT ?? 1), z: Math.max(1, g.sizeZ ?? 1) }
-  } catch { /* the sliders just keep their previous bounds */ }
-}
-
-// The extent is NOT awaited before the first load: it only sets the slider bounds, and the request
-// sends `z: null` for "the middle plane" (the server resolves it), so the two are independent. When
-// they were sequential, a slow geometry call let the debounce timer expire first and the panel made
-// two requests on mount for the same picture.
-onMounted(() => { void loadExtent(); load() })
-watch(() => state.value.imageUid, loadExtent)
-// One watch over the whole request object: any control that changes it schedules a run, and the
-// scheduler decides when. A new object identity per change is exactly the trigger we want.
-watch(inspectRequest, req => { if (req) scheduler.schedule(req) })
-
 
 // Follow the host: seed the first image, and drop a pick that has left the selection (else the panel
 // keeps rendering an image the page no longer shows).

--- a/frontend/src/components/plots/FlowMetricsView.vue
+++ b/frontend/src/components/plots/FlowMetricsView.vue
@@ -51,6 +51,26 @@ const SCALE_OPTIONS: ChipOption[] = ['1', '2', '3', '4', '6', '8', '12', '16']
 const COLORMAPS = ['viridis', 'magma', 'grey']
 
 const state = computed(() => props.state)
+
+// Which image version the metrics are computed on. Same bug as the probability plot had: this was
+// hardcoded to `default`, so the sheet showed flow over the RAW import while a model is trained on the
+// denoised one — a different photometric world, and nothing said so. No model here to name the right
+// version, so the default is the image's ACTIVE one, matching what a task form resolves to
+// (`preferredValueName`) and what the viewer shows.
+const image = computed(() =>
+  project.sets.flatMap(s => s.images).find(i => i.uid === state.value.imageUid))
+const versionOptions = computed<string[]>(() => Object.keys(image.value?.filepaths ?? {}))
+const valueName = computed({
+  get: () => state.value.valueName ?? '',
+  set: v => (state.value.valueName = v),
+})
+watch(versionOptions, opts => {
+  if (!opts.length) return
+  if (state.value.valueName && opts.includes(state.value.valueName)) return
+  state.value.valueName = image.value?.activeValueName && opts.includes(image.value.activeValueName)
+    ? image.value.activeValueName : opts[0]
+}, { immediate: true })
+
 const t = computed({ get: () => state.value.t ?? 0, set: v => (state.value.t = v) })
 // z is nullable — empty means "the middle plane", which is what training reads. The slider needs a
 // number, so it shows the middle until the user moves it.
@@ -104,7 +124,7 @@ watch(imageChannels, avail => {
 // no model is involved to carry them (see the header).
 const request = computed<FlowRequest | null>(() => state.value.imageUid ? {
   projectUid: props.projectUid, imageUid: state.value.imageUid,
-  valueName: state.value.valueName ?? 'default',
+  valueName: state.value.valueName || 'default',
   cellChannels: state.value.channels ?? [], t: t.value, z: state.value.z ?? null,
   colormap: colormap.value, temporalScales: scales.value.map(Number),
 } : null)
@@ -141,6 +161,10 @@ const shown = computed(() => planes.value.filter(p => (state.value.show ?? []).i
                 @change="state.imageUid = ($event.target as HTMLSelectElement).value">
           <option value="" disabled>Image…</option>
           <option v-for="o in imageOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+        </select>
+        <select v-if="versionOptions.length > 1" class="select-input fmv-ver" v-model="valueName"
+                v-tooltip.top="'Image version the metrics are computed on'">
+          <option v-for="v in versionOptions" :key="v" :value="v">{{ v }}</option>
         </select>
         <select class="select-input fmv-cmap" v-model="colormap"
                 v-tooltip.top="'Colour map for every plane'">
@@ -220,6 +244,7 @@ const shown = computed(() => planes.value.filter(p => (state.value.show ?? []).i
 .fmv-bar { flex-wrap: wrap; }
 .fmv-scales { flex-wrap: wrap; gap: 0.4rem; }
 .fmv-cmap { max-width: 8rem; }
+.fmv-ver { max-width: 10rem; }
 .fmv-sliders { gap: 0.8rem; }
 .fmv-terms { flex-wrap: wrap; gap: 0.4rem; }
 /* each slider is a row-GROUP so a label never splits from its track when the strip wraps */

--- a/frontend/src/components/plots/FlowMetricsView.vue
+++ b/frontend/src/components/plots/FlowMetricsView.vue
@@ -31,6 +31,7 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import ChipSelect, { type ChipOption } from '../ChipSelect.vue'
+import PlotSpinner from './PlotSpinner.vue'
 import { useProjectStore } from '../../stores/project'
 import { useFlowPlanes, type FlowPlaneState, type FlowRequest } from '../../composables/useFlowPlanes'
 
@@ -108,7 +109,8 @@ const request = computed<FlowRequest | null>(() => state.value.imageUid ? {
   colormap: colormap.value, temporalScales: scales.value.map(Number),
 } : null)
 
-const { planes, extent, runState, loading, starting, error, load } = useFlowPlanes(state, request)
+const { planes, extent, runState, loading, showSpinner, starting, error, load } =
+  useFlowPlanes(state, request)
 
 // Show everything by default — a contact sheet you have to unhide plane by plane answers nothing.
 // The chips are for narrowing once you know what you are looking at.
@@ -197,12 +199,16 @@ const shown = computed(() => planes.value.filter(p => (state.value.show ?? []).i
       Pick an image and a channel to see the flow metrics.
     </p>
 
-    <div class="fmv-grid">
+    <div class="fmv-grid" :class="{ 'planes-stale': showSpinner }">
       <figure v-for="p in shown" :key="p.name">
         <img :src="`data:image/png;base64,${p.png}`" :alt="p.name" />
         <figcaption class="cc-muted">{{ p.name }}</figcaption>
       </figure>
     </div>
+
+    <!-- Delayed, so it never flashes on a fast render (docs/UI.md → Plot loading state). The panel is
+         `position: relative`, which is what this overlay fills. -->
+    <PlotSpinner v-if="showSpinner" label="Rendering…" />
   </div>
 </template>
 
@@ -223,6 +229,10 @@ const shown = computed(() => planes.value.filter(p => (state.value.show ?? []).i
 .fmv-val { width: 5ch; text-align: right; }   /* + .cc-readout (tabular nums, dim) */
 .fmv-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
             gap: 0.5rem; padding: 0.5rem; }
+/* While a render is queued or running, the planes on screen are the PREVIOUS settings. Dimming says
+   so — without it a slow render is indistinguishable from a control that did nothing. Tied to the
+   same delayed flag as the wheel, so a quick render never flickers. */
+.fmv-grid.planes-stale { opacity: 0.45; transition: opacity 120ms ease; }
 .fmv-grid figure { margin: 0; }
 .fmv-grid img { width: 100%; display: block; image-rendering: pixelated;
                 border-radius: var(--cc-radius-sm); }

--- a/frontend/src/components/plots/FlowMetricsView.vue
+++ b/frontend/src/components/plots/FlowMetricsView.vue
@@ -255,7 +255,7 @@ const shown = computed(() => planes.value.filter(p => (state.value.show ?? []).i
           <span class="cc-readout cc-fs-xs fmv-val">{{ t }}/{{ extent.t - 1 }}</span>
         </label>
         <label v-if="extent.z > 1" class="cc-row-group fmv-slider"
-               v-tooltip.top="'Z plane — the middle is what training reads'">
+               v-tooltip.top="'Z plane'">
           <span class="cc-muted cc-fs-xs fmv-axis">z</span>
           <input type="range" class="slider" min="0" :max="extent.z - 1" step="1" :value="z"
                  @input="z = Number(($event.target as HTMLInputElement).value)" />

--- a/frontend/src/components/plots/FlowProbabilityView.vue
+++ b/frontend/src/components/plots/FlowProbabilityView.vue
@@ -1,0 +1,181 @@
+<!--
+  "Did this model learn anything" — the projected input beside the model's probability map.
+
+  The POST-training counterpart to FlowMetricsView, and deliberately a separate plot rather than a
+  toggle on that one. The metric sheet is asked BEFORE a model exists and must not take one: an
+  earlier version offered a model picker there and it quietly turned "what should I train on" into
+  "what did I train". This plot is meaningless without a checkpoint, so it is the other question with
+  its own panel.
+
+  Two planes, not instances. Instances are segmentation output — the Segment page previews them
+  through the normal preview path — and they hide the thing you want to see behind a threshold and a
+  region-growing step. Whether the model can tell cell from background at all is exactly what the
+  probability map shows and what a label mask cannot.
+
+  The MODEL COMES FROM THE VAULT, like the convergence plot: the vault owns the selection and its
+  global/local scope, the way the population manager owns which pops the plots highlight. No picker
+  here — two pickers for one thing is how a canvas ends up with panels that disagree about what they
+  are showing.
+
+  `predict_frame` returns `(prob_map, instances, props)` and a real run throws the first away
+  (`CoastalUtils._predict_plane`), so the worker's `opticalFlow.probability` backend is the one place
+  that value is looked at. Same window, same projection, same metric build as the run — the request
+  machinery is shared with the metric sheet (`useFlowPlanes`) precisely so the two cannot drift.
+-->
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import ChipSelect, { type ChipOption } from '../ChipSelect.vue'
+import { useProjectStore } from '../../stores/project'
+import { useFlowPlanes, type FlowPlaneState, type FlowRequest } from '../../composables/useFlowPlanes'
+
+const COLORMAPS = ['viridis', 'magma', 'grey']
+
+const props = defineProps<{
+  projectUid: string
+  imageUids?: string[]
+  state: FlowPlaneState
+  /** The vault's selection, resolved by the canvas for the current scope. */
+  model?: string
+}>()
+const project = useProjectStore()
+
+const state = computed(() => props.state)
+const t = computed({ get: () => state.value.t ?? 0, set: v => (state.value.t = v) })
+const z = computed({
+  get: () => state.value.z ?? Math.floor(extent.value.z / 2),
+  set: v => (state.value.z = v),
+})
+const colormap = computed({
+  get: () => state.value.colormap ?? 'viridis',
+  set: v => (state.value.colormap = v),
+})
+
+// Declared BEFORE the watches that name them: a watch source runs immediately at setup, and a `const`
+// below it is still in the temporal dead zone — which throws, takes the panel's setup with it, and
+// aborts the canvas patch so every sibling panel vanishes too. Enforced by `utils/setupOrder.ts`.
+const nameOf = (uid: string) =>
+  project.sets.flatMap(s => s.images).find(i => i.uid === uid)?.name ?? uid
+const imageOptions = computed<ChipOption[]>(() =>
+  (props.imageUids ?? []).map(uid => ({ value: uid, label: nameOf(uid) })))
+
+const imageChannels = computed<string[]>(() =>
+  project.sets.flatMap(s => s.images).find(i => i.uid === state.value.imageUid)?.channelNames ?? [])
+const channelOptions = computed<ChipOption[]>(() =>
+  imageChannels.value.map(c => ({ value: c, label: c })))
+const channels = computed({
+  get: () => state.value.channels ?? [],
+  set: v => (state.value.channels = v),
+})
+
+// Every channel by default, max-merged the way the segmenter merges them. Defaulting to the first is
+// what made the metric sheet open on SHG and look broken; all-channels is never empty.
+watch(imageChannels, avail => {
+  if (!avail.length) return
+  const cur = state.value.channels ?? []
+  if (!cur.length || !cur.every(c => avail.includes(c))) state.value.channels = [...avail]
+}, { immediate: true })
+
+// `model` is what makes this the probability view — the route dispatches on its presence. No model
+// means no request at all rather than a metric sheet nobody asked for.
+const request = computed<FlowRequest | null>(() =>
+  state.value.imageUid && props.model
+    ? {
+        projectUid: props.projectUid, imageUid: state.value.imageUid,
+        valueName: state.value.valueName ?? 'default',
+        cellChannels: state.value.channels ?? [], t: t.value, z: state.value.z ?? null,
+        colormap: colormap.value, model: props.model,
+      }
+    : null)
+
+const { planes, extent, runState, loading, starting, error, load } = useFlowPlanes(state, request)
+
+// Follow the host: seed the first image, and drop a pick that has left the selection.
+watch(imageOptions, opts => {
+  const uids = opts.map(o => o.value)
+  if (uids.length && (!state.value.imageUid || !uids.includes(state.value.imageUid)))
+    state.value.imageUid = uids[0]
+}, { immediate: true })
+</script>
+
+<template>
+  <div class="fpv">
+    <div class="fpv-ctrl cc-panel-controls">
+      <div class="cc-row fpv-bar">
+        <select class="select-input" :value="state.imageUid ?? ''"
+                v-tooltip.top="'Image to run the model on'"
+                @change="state.imageUid = ($event.target as HTMLSelectElement).value">
+          <option value="" disabled>Image…</option>
+          <option v-for="o in imageOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+        </select>
+        <select class="select-input fpv-cmap" v-model="colormap"
+                v-tooltip.top="'Colour map for both planes'">
+          <option v-for="c in COLORMAPS" :key="c" :value="c">{{ c }}</option>
+        </select>
+        <!-- disabled only while a run is IN FLIGHT, not while one is merely queued: during the
+             debounce window this button is how you skip the wait -->
+        <button class="cc-btn cc-btn-bare cc-btn-icon" v-tooltip.left="'Reload'"
+                :disabled="runState === 'running'" @click="load()">
+          <i class="pi pi-refresh" :class="{ 'pi-spin': loading }" />
+        </button>
+      </div>
+
+      <div class="cc-row fpv-sliders">
+        <label class="cc-row-group fpv-slider" v-tooltip.top="'Timepoint'">
+          <span class="cc-muted cc-fs-xs fpv-axis">t</span>
+          <input type="range" class="slider" min="0" :max="extent.t - 1" step="1" :value="t"
+                 @input="t = Number(($event.target as HTMLInputElement).value)" />
+          <span class="cc-readout cc-fs-xs fpv-val">{{ t }}/{{ extent.t - 1 }}</span>
+        </label>
+        <label v-if="extent.z > 1" class="cc-row-group fpv-slider" v-tooltip.top="'Z plane'">
+          <span class="cc-muted cc-fs-xs fpv-axis">z</span>
+          <input type="range" class="slider" min="0" :max="extent.z - 1" step="1" :value="z"
+                 @input="z = Number(($event.target as HTMLInputElement).value)" />
+          <span class="cc-readout cc-fs-xs fpv-val">{{ z }}/{{ extent.z - 1 }}</span>
+        </label>
+      </div>
+
+      <label v-if="channelOptions.length" class="cc-row fpv-terms">
+        <span class="cc-muted cc-fs-xs"
+              v-tooltip.top="'Channel the flow is computed on'">channel</span>
+        <ChipSelect :options="channelOptions" :model-value="channels" multiple aria-label="Channels"
+                    @update:model-value="v => channels = v as string[]" />
+      </label>
+    </div>
+
+    <p v-if="error" class="cc-muted-warn">{{ error }}</p>
+    <p v-else-if="starting" class="cc-muted">Starting the preview worker…</p>
+    <p v-else-if="!model" class="cc-muted">Select a model in the vault.</p>
+    <p v-else-if="!planes.length && !loading" class="cc-muted">
+      Pick an image to see what the model predicts.
+    </p>
+
+    <div class="fpv-grid">
+      <figure v-for="p in planes" :key="p.name">
+        <img :src="`data:image/png;base64,${p.png}`" :alt="p.name" />
+        <figcaption class="cc-muted">{{ p.name }}</figcaption>
+      </figure>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* position: relative so the overlaid .fpv-ctrl (.cc-panel-controls) anchors to the plane grid */
+.fpv { position: relative; display: flex; flex-direction: column; gap: 0.4rem; height: 100%;
+       overflow: auto; }
+.fpv-ctrl { display: flex; flex-direction: column; gap: 0.4rem; padding: 4px 6px; }
+.fpv-bar { flex-wrap: wrap; }
+.fpv-cmap { max-width: 8rem; }
+.fpv-sliders { gap: 0.8rem; }
+.fpv-terms { flex-wrap: wrap; gap: 0.4rem; }
+/* each slider is a row-GROUP so a label never splits from its track when the strip wraps */
+.fpv-slider { flex: 1; min-width: 9rem; align-items: center; gap: 0.4rem; }
+.fpv-axis { width: 1ch; }
+.fpv-slider .slider { flex: 1; min-width: 5rem; }
+.fpv-val { width: 5ch; text-align: right; }   /* + .cc-readout (tabular nums, dim) */
+/* Two planes side by side — the comparison IS the plot, so they must not stack until it is narrow. */
+.fpv-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 0.5rem; padding: 0.5rem; }
+.fpv-grid figure { margin: 0; }
+.fpv-grid img { width: 100%; display: block; image-rendering: pixelated;
+                border-radius: var(--cc-radius-sm); }
+</style>

--- a/frontend/src/components/plots/FlowProbabilityView.vue
+++ b/frontend/src/components/plots/FlowProbabilityView.vue
@@ -25,6 +25,7 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import ChipSelect, { type ChipOption } from '../ChipSelect.vue'
+import PlotSpinner from './PlotSpinner.vue'
 import { useProjectStore } from '../../stores/project'
 import { useFlowPlanes, type FlowPlaneState, type FlowRequest } from '../../composables/useFlowPlanes'
 
@@ -87,7 +88,8 @@ const request = computed<FlowRequest | null>(() =>
       }
     : null)
 
-const { planes, extent, runState, loading, starting, error, load } = useFlowPlanes(state, request)
+const { planes, extent, runState, loading, showSpinner, starting, error, load } =
+  useFlowPlanes(state, request)
 
 // Follow the host: seed the first image, and drop a pick that has left the selection.
 watch(imageOptions, opts => {
@@ -149,12 +151,16 @@ watch(imageOptions, opts => {
       Pick an image to see what the model predicts.
     </p>
 
-    <div class="fpv-grid">
+    <div class="fpv-grid" :class="{ 'planes-stale': showSpinner }">
       <figure v-for="p in planes" :key="p.name">
         <img :src="`data:image/png;base64,${p.png}`" :alt="p.name" />
         <figcaption class="cc-muted">{{ p.name }}</figcaption>
       </figure>
     </div>
+
+    <!-- Delayed, so it never flashes on a fast render (docs/UI.md → Plot loading state). The panel is
+         `position: relative`, which is what this overlay fills. -->
+    <PlotSpinner v-if="showSpinner" label="Rendering…" />
   </div>
 </template>
 
@@ -175,6 +181,10 @@ watch(imageOptions, opts => {
 /* Two planes side by side — the comparison IS the plot, so they must not stack until it is narrow. */
 .fpv-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
             gap: 0.5rem; padding: 0.5rem; }
+/* While a render is queued or running, the planes on screen are the PREVIOUS settings. Dimming says
+   so — without it a slow render is indistinguishable from a control that did nothing. Tied to the
+   same delayed flag as the wheel, so a quick render never flickers. */
+.fpv-grid.planes-stale { opacity: 0.45; transition: opacity 120ms ease; }
 .fpv-grid figure { margin: 0; }
 .fpv-grid img { width: 100%; display: block; image-rendering: pixelated;
                 border-radius: var(--cc-radius-sm); }

--- a/frontend/src/components/plots/FlowProbabilityView.vue
+++ b/frontend/src/components/plots/FlowProbabilityView.vue
@@ -23,7 +23,7 @@
   machinery is shared with the metric sheet (`useFlowPlanes`) precisely so the two cannot drift.
 -->
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed, ref, watch, onMounted } from 'vue'
 import ChipSelect, { type ChipOption } from '../ChipSelect.vue'
 import PlotSpinner from './PlotSpinner.vue'
 import { useProjectStore } from '../../stores/project'
@@ -41,6 +41,52 @@ const props = defineProps<{
 const project = useProjectStore()
 
 const state = computed(() => props.state)
+
+// ── which image version the model is run ON ──────────────────────────────────────────────────────
+// This is not cosmetic. A flow model is trained on a DENOISED movie (the page hint says so) and
+// reading the raw import instead feeds it a different photometric world than it ever saw — the
+// probability map then looks bad for a reason that has nothing to do with the model. Both flow plots
+// used to hardcode `default`, silently.
+//
+// The default here comes from the MODEL, not from the image: its manifest records
+// `sourceValueName`, the version it was trained on, and that is by definition the right input. The
+// same `/api/optical-flow/models` route the vault and the picker use, so there is no second listing
+// that can disagree with them.
+const trainedOn = ref<Record<string, string>>({})
+async function loadTrainedOn() {
+  try {
+    const r = await fetch('/api/optical-flow/models')
+    if (!r.ok) return
+    const models = (await r.json()).models ?? []
+    trainedOn.value = Object.fromEntries(
+      models.map((m: { name: string; manifest?: { sourceValueName?: string } }) =>
+        [m.name, m.manifest?.sourceValueName ?? '']).filter(([, v]: [string, string]) => v))
+  } catch { /* fall back to the image's active version */ }
+}
+onMounted(loadTrainedOn)
+watch(() => props.model, loadTrainedOn)
+
+const image = computed(() =>
+  project.sets.flatMap(s => s.images).find(i => i.uid === state.value.imageUid))
+const versionOptions = computed<string[]>(() => Object.keys(image.value?.filepaths ?? {}))
+const valueName = computed({
+  get: () => state.value.valueName ?? '',
+  set: v => (state.value.valueName = v),
+})
+
+// Seed once per (model, image): the model's own version if the image has it, else the active one.
+// An explicit pick is never overridden — the whole point of the control is to look at another one.
+watch([() => props.model, versionOptions], () => {
+  const opts = versionOptions.value
+  if (!opts.length) return
+  if (state.value.valueName && opts.includes(state.value.valueName)) return
+  const wanted = trainedOn.value[props.model ?? '']
+  state.value.valueName = wanted && opts.includes(wanted)
+    ? wanted
+    : (image.value?.activeValueName && opts.includes(image.value.activeValueName)
+        ? image.value.activeValueName : opts[0])
+}, { immediate: true })
+
 const t = computed({ get: () => state.value.t ?? 0, set: v => (state.value.t = v) })
 const z = computed({
   get: () => state.value.z ?? Math.floor(extent.value.z / 2),
@@ -82,7 +128,7 @@ const request = computed<FlowRequest | null>(() =>
   state.value.imageUid && props.model
     ? {
         projectUid: props.projectUid, imageUid: state.value.imageUid,
-        valueName: state.value.valueName ?? 'default',
+        valueName: state.value.valueName || 'default',
         cellChannels: state.value.channels ?? [], t: t.value, z: state.value.z ?? null,
         colormap: colormap.value, model: props.model,
       }
@@ -109,6 +155,15 @@ watch(imageOptions, opts => {
           <option value="" disabled>Image…</option>
           <option v-for="o in imageOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
+        <select v-if="versionOptions.length > 1" class="select-input fpv-ver" v-model="valueName"
+                v-tooltip.top="'Image version fed to the model — normally the one it was trained on'">
+          <option v-for="v in versionOptions" :key="v" :value="v">{{ v }}</option>
+        </select>
+        <!-- says so when you are NOT looking at what the model was trained on: the map then looks bad
+             for a reason that is not the model -->
+        <span v-if="trainedOn[model ?? ''] && valueName && trainedOn[model ?? ''] !== valueName"
+              class="cc-muted-warn cc-fs-2xs"
+              v-tooltip.top="'This model was trained on ' + trainedOn[model ?? '']">not trained input</span>
         <select class="select-input fpv-cmap" v-model="colormap"
                 v-tooltip.top="'Colour map for both planes'">
           <option v-for="c in COLORMAPS" :key="c" :value="c">{{ c }}</option>
@@ -171,6 +226,7 @@ watch(imageOptions, opts => {
 .fpv-ctrl { display: flex; flex-direction: column; gap: 0.4rem; padding: 4px 6px; }
 .fpv-bar { flex-wrap: wrap; }
 .fpv-cmap { max-width: 8rem; }
+.fpv-ver { max-width: 10rem; }
 .fpv-sliders { gap: 0.8rem; }
 .fpv-terms { flex-wrap: wrap; gap: 0.4rem; }
 /* each slider is a row-GROUP so a label never splits from its track when the strip wraps */

--- a/frontend/src/components/plots/FlowTrainingView.vue
+++ b/frontend/src/components/plots/FlowTrainingView.vue
@@ -92,6 +92,10 @@ const rows = computed(() => shown.value.flatMap(s =>
 const valRows = computed(() => shown.value.flatMap(s =>
   (s.val ?? []).map((loss, i) => ({ epoch: i + 1, term: s.term, loss }))))
 const hasVal = computed(() => shown.value.some(s => s.val?.length))
+// Log only when every plotted value is positive — val included. Zero is a legitimate loss, and
+// log(0) would drop the point silently rather than fail.
+const isLog = computed(() =>
+  logY.value && [...rows.value, ...valRows.value].every(r => r.loss > 0))
 
 async function load() {
   loading.value = true
@@ -140,11 +144,15 @@ async function render() {
     x: { label: 'epoch', grid: true },
     // Log only when every plotted value is positive. Zero is a legitimate loss and log(0) would drop
     // the point silently rather than fail.
+    // Anchored at zero on the linear scale. Plot's default domain starts at the data minimum, which
+    // for a converged run means the flat tail fills the panel and every curve looks like it stopped
+    // just short of the axis — a loss settling at 0.2 and one settling at 0.02 draw identically.
+    // "How close to zero did it actually get" is the question, so zero has to be on screen.
+    // Never on a log scale: log(0) is undefined and Plot would drop the axis.
     y: { label: raw.value ? 'loss (raw)' : 'loss (weighted)', grid: true,
          // Every plotted value, val included — a log axis chosen on the training rows alone would
          // silently drop a val point that touched zero.
-         type: logY.value && [...rows.value, ...valRows.value].every(r => r.loss > 0)
-           ? 'log' : 'linear' },
+         ...(isLog.value ? { type: 'log' as const } : { type: 'linear' as const, zero: true }) },
     color: { domain, range: distinctColors(domain.length), legend: false },
     marks: [
       Plot.line(rows.value, { x: 'epoch', y: 'loss', stroke: 'term', strokeWidth: 1.5, tip: true }),

--- a/frontend/src/components/plots/FlowTrainingView.vue
+++ b/frontend/src/components/plots/FlowTrainingView.vue
@@ -17,6 +17,12 @@
   view: it lands on the canvas with the panel chrome, the zoom, CSV/PNG/SVG export and the board's
   PDF export already attached. A chart in a modal would need every one of those written again, worse.
 
+  **The held-out curve is the one that answers the question.** A training loss only ever says the
+  number went down, measured on the frames the weights were just fitted to. When the run had a
+  `trainRatio` split, each term also carries a `val_` curve — drawn dashed in the SAME colour as its
+  term, because the only thing you read off it is the GAP to its own training line, and a second
+  colour would make that a legend lookup instead of a picture.
+
   Data is the model's own manifest, read through `GET /api/optical-flow/models` — the route the
   picker and the vault already use, so there is no second listing that can disagree with them. Models
   trained before the curves were recorded say so rather than drawing an empty box; the run kept only
@@ -80,6 +86,12 @@ const terms = computed<string[]>(() =>
 const shown = computed(() => series.value.filter(s => terms.value.includes(s.term)))
 const rows = computed(() => shown.value.flatMap(s =>
   s.values.map((loss, i) => ({ epoch: i + 1, term: s.term, loss }))))
+// Held-out curves, drawn dashed in the SAME colour as their term. The only thing anyone reads off a
+// validation curve is the gap to its own training curve, so a second colour would turn the
+// comparison into a legend lookup.
+const valRows = computed(() => shown.value.flatMap(s =>
+  (s.val ?? []).map((loss, i) => ({ epoch: i + 1, term: s.term, loss }))))
+const hasVal = computed(() => shown.value.some(s => s.val?.length))
 
 async function load() {
   loading.value = true
@@ -113,6 +125,9 @@ async function render() {
   if (!Plot) Plot = await import('@observablehq/plot')
   node?.remove(); node = null
   if (!rows.value.length) return
+  // Only the training rows get a tip. Two `tip: true` marks stacked on one x means both pointers
+  // fire and the boxes overlap; the training curve is the one you hover to read a value, and the
+  // val line's meaning is its distance from it, not its number.
   const w = Math.max(200, host.value.clientWidth || 360)
   const h = Math.max(160, host.value.clientHeight || 240)
   const dark = !forceLight.value
@@ -126,10 +141,15 @@ async function render() {
     // Log only when every plotted value is positive. Zero is a legitimate loss and log(0) would drop
     // the point silently rather than fail.
     y: { label: raw.value ? 'loss (raw)' : 'loss (weighted)', grid: true,
-         type: logY.value && rows.value.every(r => r.loss > 0) ? 'log' : 'linear' },
+         // Every plotted value, val included — a log axis chosen on the training rows alone would
+         // silently drop a val point that touched zero.
+         type: logY.value && [...rows.value, ...valRows.value].every(r => r.loss > 0)
+           ? 'log' : 'linear' },
     color: { domain, range: distinctColors(domain.length), legend: false },
     marks: [
       Plot.line(rows.value, { x: 'epoch', y: 'loss', stroke: 'term', strokeWidth: 1.5, tip: true }),
+      Plot.line(valRows.value, { x: 'epoch', y: 'loss', stroke: 'term', strokeWidth: 1.5,
+                                 strokeDasharray: '3,3' }),
     ],
   }) as SVGElement
   host.value.append(node)
@@ -142,7 +162,7 @@ onMounted(() => {
   }
 })
 onBeforeUnmount(() => { ro?.disconnect(); ro = null; node?.remove(); node = null })
-watch([chosen, logY, raw, () => terms.value.join(',')], render)
+watch([chosen, logY, raw, () => terms.value.join(','), hasVal], render)
 
 // ── export (the generic panel contract — plots/export.ts, same helpers as the cluster panels) ──
 const exportFormats = ['png', 'svg', 'csv']
@@ -194,6 +214,8 @@ defineExpose({ exportFormats, exportAs, exportImage, exportSvg, getCsv: csv })
         <label class="cc-muted cc-fs-xs ftv-opt" v-tooltip.top="'Log scale on the loss axis'">
           <input type="checkbox" v-model="logY" /> log
         </label>
+        <!-- A dashed line with nothing naming it is a puzzle. Only shown when there is one. -->
+        <span v-if="hasVal" class="cc-muted cc-fs-2xs">dashed = held out</span>
         <button class="cc-btn cc-btn-bare cc-btn-icon" v-tooltip.left="'Reload'"
                 :disabled="loading" @click="load">
           <i class="pi pi-refresh" :class="{ 'pi-spin': loading }" />

--- a/frontend/src/composables/useFlowPlanes.ts
+++ b/frontend/src/composables/useFlowPlanes.ts
@@ -1,0 +1,139 @@
+/**
+ * The shared half of the two flow canvas plots: ask `/api/optical-flow/inspect` for a set of planes
+ * and hold the answer.
+ *
+ * Extracted because there are two callers and they must not drift. `FlowMetricsView` shows the metric
+ * planes a model would be TRAINED on; `FlowProbabilityView` shows one model's probability map. Both
+ * are the same request against the same route — the model is the only difference — and both exist to
+ * claim "this is what a run is actually fed". Two copies of the request building, the debounce and
+ * the stale-response guard would be two chances for one of those claims to stop being true.
+ *
+ * What lives here: the request, the scheduling, and the geometry the sliders need. What does not: the
+ * controls and which planes get rendered, because that is exactly what differs.
+ */
+import { ref, computed, watch, onMounted, onBeforeUnmount, type Ref } from 'vue'
+import { debouncedLatest, type RunState } from '../utils/debouncedLatest'
+import { PREVIEW_DEBOUNCE_MS } from '../utils/taskPreview'
+
+export interface Plane { name: string; png: string }
+
+/** The panel state these plots persist. Callers add their own keys. */
+export interface FlowPlaneState {
+  [key: string]: unknown
+  imageUid?: string
+  valueName?: string
+  channels?: string[]
+  t?: number
+  z?: number | null
+  colormap?: string
+}
+
+export interface FlowRequest {
+  projectUid: string
+  imageUid: string
+  valueName: string
+  cellChannels: string[]
+  t: number
+  z: number | null
+  colormap: string
+  /** Temporal scales — the metric sheet's own choice; omitted for a model, which carries its own. */
+  temporalScales?: number[]
+  /** A vault `.pt` name. Present ⇒ the route answers with the probability map instead. */
+  model?: string
+}
+
+// The worker pays ~18 s of torch imports on first use and answers 202 `starting` until it is up.
+// Telling the user to "try again in a moment" and stopping made the panel look broken for a minute,
+// so we wait for it — bounded, and with the wait visible rather than a frozen spinner.
+const RETRY_MS = 1500
+const MAX_WAIT_MS = 120_000
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+export function useFlowPlanes(
+  state: Ref<FlowPlaneState>,
+  /** The request, or `null` when there is nothing to ask for yet. Rebuilt by the caller's computed. */
+  request: Ref<FlowRequest | null>,
+) {
+  const planes = ref<Plane[]>([])
+  const extent = ref({ t: 1, z: 1 })     // slider bounds, from the image's own geometry
+  const runState = ref<RunState>('idle')
+  const loading = computed(() => runState.value !== 'idle')
+  const starting = ref(false)
+  const error = ref('')
+
+  // Debounced, latest-wins — the same scheduler the task preview uses, for the same reason. A slider
+  // drag emits an event per pixel and each one is real compute in the worker, so firing per event
+  // queued a dozen runs whose results then LANDED ONE BY ONE: the sheet visibly flipped through
+  // every timepoint the user had scrubbed past, seconds after they stopped. Two rules fix it and
+  // both are needed — the debounce collapses the burst, and `isCurrent()` stops a run that was
+  // already in flight from painting its (now stale) planes over the one the user is waiting for.
+  // Without the guard, whichever request finished last would win, which is not the same as latest.
+  const scheduler = debouncedLatest<FlowRequest>(async (req, isCurrent) => {
+    error.value = ''
+    for (let waited = 0; ; waited += RETRY_MS) {
+      const r = await fetch('/api/optical-flow/inspect', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req),
+      })
+      const d = await r.json()
+      // superseded while the worker computed — neither the planes NOR an error belong to the current
+      // settings any more, so nothing here is applied
+      if (!isCurrent()) return
+      if (!r.ok) throw new Error(d.error ?? `HTTP ${r.status}`)
+      if (!d.starting) {
+        starting.value = false
+        planes.value = d.planes ?? []
+        return
+      }
+      if (waited >= MAX_WAIT_MS) throw new Error('Preview worker did not start.')
+      starting.value = true
+      await sleep(RETRY_MS)
+      if (!isCurrent()) return
+    }
+  }, {
+    wait: PREVIEW_DEBOUNCE_MS,
+    onState: s => { runState.value = s },
+    onError: e => {
+      starting.value = false
+      error.value = e instanceof Error ? e.message : String(e)
+    },
+  })
+  onBeforeUnmount(() => scheduler.cancel())
+
+  /** Run now, skipping the debounce — the refresh button and the first paint. */
+  function load() {
+    if (!request.value) return
+    scheduler.schedule(request.value)
+    scheduler.flush()
+  }
+
+  // Slider bounds come from the ONE geometry route (`api/src/image_geometry.jl`), per VERSION — the
+  // active version can be a different shape from `default`, so the valueName has to travel with the
+  // question or the sliders end past the end of the store being read.
+  async function loadExtent() {
+    if (!state.value.imageUid) return
+    try {
+      const q = new URLSearchParams({
+        projectUid: request.value?.projectUid ?? '',
+        imageUid: state.value.imageUid,
+        valueName: state.value.valueName ?? 'default',
+      })
+      const r = await fetch(`/api/images/geometry?${q}`)
+      if (!r.ok) return
+      const g = await r.json()
+      extent.value = { t: Math.max(1, g.sizeT ?? 1), z: Math.max(1, g.sizeZ ?? 1) }
+    } catch { /* the sliders just keep their previous bounds */ }
+  }
+
+  // The extent is NOT awaited before the first load: it only sets the slider bounds, and the request
+  // sends `z: null` for "the middle plane" (the server resolves it), so the two are independent. When
+  // they were sequential, a slow geometry call let the debounce timer expire first and the panel made
+  // two requests on mount for the same picture.
+  onMounted(() => { void loadExtent(); load() })
+  watch(() => state.value.imageUid, loadExtent)
+  // One watch over the whole request object: any control that changes it schedules a run, and the
+  // scheduler decides when. A new object identity per change is exactly the trigger we want.
+  watch(request, req => { if (req) scheduler.schedule(req) })
+
+  return { planes, extent, runState, loading, starting, error, load }
+}

--- a/frontend/src/composables/useFlowPlanes.ts
+++ b/frontend/src/composables/useFlowPlanes.ts
@@ -14,6 +14,7 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount, type Ref } from 'vue'
 import { debouncedLatest, type RunState } from '../utils/debouncedLatest'
 import { PREVIEW_DEBOUNCE_MS } from '../utils/taskPreview'
+import { useDelayedLoading } from './useDelayedLoading'
 
 export interface Plane { name: string; png: string }
 
@@ -135,5 +136,16 @@ export function useFlowPlanes(
   // scheduler decides when. A new object identity per change is exactly the trigger we want.
   watch(request, req => { if (req) scheduler.schedule(req) })
 
-  return { planes, extent, runState, loading, starting, error, load }
+  // The spinner, decided HERE rather than per view, so both plots answer "is it doing anything?" the
+  // same way. `loading` covers the debounce window too (state `pending`), which is the point: the
+  // gap the user actually notices is between letting go of a slider and the picture changing, and
+  // most of that gap is a request that has not been sent yet.
+  //
+  // Delayed, per docs/UI.md — but the threshold matters less here than usual, because neither of
+  // these plots is ever fast: both are a worker round-trip and the probability map is a forward pass
+  // on top. Nothing to protect against a flash on a cheap render, everything to gain from the wheel
+  // appearing before the user concludes the control is dead.
+  const showSpinner = useDelayedLoading(loading)
+
+  return { planes, extent, runState, loading, showSpinner, starting, error, load }
 }

--- a/frontend/src/plots/lossCurves.test.ts
+++ b/frontend/src/plots/lossCurves.test.ts
@@ -40,6 +40,39 @@ describe('lossSeries', () => {
     expect(lossSeries(undefined, undefined)).toEqual([])
     expect(lossSeries(null, null)).toEqual([])
   })
+
+  // A run with a held-out split writes `val_<term>` beside every term. Listing those as their own
+  // series would double the chip list AND give the pair two colours — when the only thing anyone
+  // reads off a validation curve is the gap to its OWN training curve.
+  it('attaches val_<term> to its term instead of listing it separately', () => {
+    const s = lossSeries({ total: [3, 2], val_total: [3.2, 2.4] }, {})
+    expect(s.map(x => x.term)).toEqual(['total'])
+    expect(s[0]!.val).toEqual([3.2, 2.4])
+  })
+
+  it('scales the val curve by the same weight — they are only comparable as one quantity', () => {
+    const s = lossSeries({ temporal: [1, 2], val_temporal: [1.5, 2.5] }, { temporal: 2 })
+    expect(s[0]!.values).toEqual([2, 4])
+    expect(s[0]!.val).toEqual([3, 5])
+  })
+
+  it('never rescales val_total, for the same reason it never rescales total', () => {
+    const s = lossSeries({ total: [3], val_total: [4] }, { total: 5 })
+    expect(s[0]!.values).toEqual([3])
+    expect(s[0]!.val).toEqual([4])
+  })
+
+  it('leaves val undefined when the run had no split', () => {
+    expect(lossSeries({ total: [3, 2] }, {})[0]!.val).toBeUndefined()
+    // ...and an empty val curve is the same as none, not an empty dashed line
+    expect(lossSeries({ total: [3, 2], val_total: [] }, {})[0]!.val).toBeUndefined()
+  })
+
+  it('does not invent a term from an orphan val curve', () => {
+    // `val_warp` with no `warp` means the manifest is inconsistent; drawing a lone dashed line
+    // labelled "warp" would claim a training curve that does not exist.
+    expect(lossSeries({ total: [1], val_warp: [2] }, {}).map(x => x.term)).toEqual(['total'])
+  })
 })
 
 describe('lossTable', () => {
@@ -54,6 +87,17 @@ describe('lossTable', () => {
     expect(lossTable([{ term: 'total', weight: 1, values: [3, 2] },
                       { term: 'warp', weight: 1, values: [1] }]))
       .toEqual([{ epoch: 1, total: 3, warp: 1 }, { epoch: 2, total: 2 }])
+  })
+
+  it('gives the val curve its own column beside its term', () => {
+    // The export exists so the train/val gap can be worked out in a spreadsheet, and that is a
+    // subtraction between two columns.
+    expect(lossTable([{ term: 'total', weight: 1, values: [3, 2], val: [3.5, 2.5] }]))
+      .toEqual([{ epoch: 1, total: 3, val_total: 3.5 }, { epoch: 2, total: 2, val_total: 2.5 }])
+  })
+
+  it('counts val epochs when sizing the table', () => {
+    expect(lossTable([{ term: 'total', weight: 1, values: [3], val: [3.5, 2.5] }]).length).toBe(2)
   })
 
   it('is empty for no series', () => {

--- a/frontend/src/plots/lossCurves.ts
+++ b/frontend/src/plots/lossCurves.ts
@@ -17,7 +17,13 @@ export interface LossSeries {
   values: number[]
   /** The weight this term was trained with. `1` when the manifest records none. */
   weight: number
+  /** Same term on the held-out set, when the run had one. Absent otherwise. */
+  val?: number[]
 }
+
+/** `val_temporal` → `temporal`; anything else → `null`. */
+const valTermOf = (key: string): string | null =>
+  key.startsWith('val_') ? key.slice(4) : null
 
 /**
  * The curves to draw, ordered `total` first and then alphabetically.
@@ -26,14 +32,30 @@ export interface LossSeries {
  * the weighted sum — so it is never scaled again, whichever mode is on. `weight` defaults to 1 for a
  * term the manifest has no weight for: a model trained before `lossWeights` existed should show its
  * curves unscaled rather than vanish at zero.
+ *
+ * **`val_<term>` is attached to its term, not listed beside it.** A run with a held-out split writes
+ * both, and treating them as sixteen independent series would be wrong twice over: the chip list
+ * would double, and — the part that matters — the pair would get two different colours, when the
+ * only thing anyone reads off a validation curve is the GAP between it and its own training curve.
+ * Two colours make that comparison a lookup; one colour and a dashed line make it the picture.
+ *
+ * The val curve is scaled by the same weight, because it has to be: the two are only comparable if
+ * they are the same quantity, and `val_total` is already coastal's weighted sum for the same reason
+ * `total` is.
  */
 export function lossSeries(curves?: LossCurves | null, weights?: Record<string, number> | null,
                            raw = false): LossSeries[] {
+  const all = curves ?? {}
   const out: LossSeries[] = []
-  for (const [term, values] of Object.entries(curves ?? {})) {
-    if (!values?.length) continue
+  for (const [term, values] of Object.entries(all)) {
+    if (!values?.length || valTermOf(term)) continue
     const weight = term === 'total' ? 1 : (weights?.[term] ?? 1)
-    out.push({ term, weight, values: raw || weight === 1 ? values : values.map(v => v * weight) })
+    const scale = (vs: number[]) => raw || weight === 1 ? vs : vs.map(v => v * weight)
+    const val = all[`val_${term}`]
+    out.push({
+      term, weight, values: scale(values),
+      ...(val?.length ? { val: scale(val) } : {}),
+    })
   }
   return out.sort((a, b) =>
     a.term === 'total' ? -1 : b.term === 'total' ? 1 : a.term.localeCompare(b.term))
@@ -46,12 +68,17 @@ export function lossSeries(curves?: LossCurves | null, weights?: Record<string, 
  * each other — a pivot first. Epoch is 1-based, matching the axis.
  */
 export function lossTable(series: LossSeries[]): Record<string, number>[] {
-  const n = series.reduce((m, s) => Math.max(m, s.values.length), 0)
+  const n = series.reduce((m, s) => Math.max(m, s.values.length, s.val?.length ?? 0), 0)
   return Array.from({ length: n }, (_, i) => {
     const row: Record<string, number> = { epoch: i + 1 }
     // A shorter series (a term coastal stopped recording mid-run) leaves the cell out rather than
     // writing a 0, which would read as "this term reached zero".
-    for (const s of series) if (i < s.values.length) row[s.term] = s.values[i]!
+    for (const s of series) {
+      if (i < s.values.length) row[s.term] = s.values[i]!
+      // Its own column, next to its term — the export exists so the train/val gap can be worked
+      // out in a spreadsheet, and that is a subtraction between two columns.
+      if (s.val && i < s.val.length) row[`val_${s.term}`] = s.val[i]!
+    }
     return row
   })
 }

--- a/frontend/src/tasks/ParamRenderer.vue
+++ b/frontend/src/tasks/ParamRenderer.vue
@@ -9,7 +9,7 @@ import type { ParamDef, ParamValues } from './types'
 import type { CciaImage } from '../stores/project'
 import { SEVERITY } from '../lib/severity'
 import { paramAdvisor, type ParamAdvisory, type AdvisorContext } from './paramAdvisors'
-import { preferredValueName } from './paramValues'
+import { isChosenValueName, preferredValueName } from './paramValues'
 import { groupPopulations, type PopGroupDef, type RawGroup } from '../utils/popGroups'
 import ChipSelect, { type ChipOption } from '../components/ChipSelect.vue'
 import CcToggle from '../components/CcToggle.vue'
@@ -81,7 +81,11 @@ watch(() => props.context?.images, (images) => {
   if (!images || images.length === 0) return
   // Keep an already-valid selection — notably an edge-propagated chain value like
   // "cpCorrected" — rather than resetting it to the active/first name on every image change.
-  if (props.modelValue && availableValueNames.value.includes(props.modelValue as string)) return
+  // `isChosenValueName` excludes the spec's OWN default: it is what the form started with, not a
+  // pick, and since every task JSON declares `"default": "default"` this guard used to fire on
+  // first render everywhere and the prefer-the-active-version line below never ran at all.
+  if (isChosenValueName(props.modelValue, props.param.default)
+      && availableValueNames.value.includes(props.modelValue as string)) return
   emit('update:modelValue', preferredValueName(
     availableValueNames.value, props.param.field, images[0].activeValueName))
 }, { immediate: true })

--- a/frontend/src/tasks/paramValues.test.ts
+++ b/frontend/src/tasks/paramValues.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   buildParamValues, flattenParams, missingParamKeys,
-  preferredValueName, isKnownValueNameField, VALUE_NAME_FIELDS,
-} from './paramValues'
+  preferredValueName, isKnownValueNameField, VALUE_NAME_FIELDS, isChosenValueName } from './paramValues'
 import type { TaskDef, ParamValues } from './types'
 
 // the clustRegions.cluster spec AFTER the neighbour-graph refactor
@@ -250,5 +249,27 @@ describe('buildParamValues — repeatable group entries', () => {
     const flat = flattenParams(AF_DEF, buildParamValues(AF_DEF, saved))
     expect(flat.afCombinations).toEqual(saved.afCombinations)
     expect(missingParamKeys(AF_DEF, flat)).toEqual([])
+  })
+})
+
+describe('isChosenValueName', () => {
+  // The bug this exists for: every task JSON declares `"default": "default"`, and "default" is a
+  // valid version on essentially every image — so ParamRenderer's "keep an already-valid selection"
+  // guard fired on FIRST RENDER for every task, and prefer-the-active-version never ran anywhere.
+  it('does not count the spec default as a choice', () => {
+    expect(isChosenValueName('default', 'default')).toBe(false)
+  })
+
+  it('counts anything else the user or a chain edge put there', () => {
+    expect(isChosenValueName('cpCorrected', 'default')).toBe(true)
+    // a spec with no default at all: any value is a choice
+    expect(isChosenValueName('default', undefined)).toBe(true)
+  })
+
+  it('treats empty and non-strings as unset', () => {
+    expect(isChosenValueName('', 'default')).toBe(false)
+    expect(isChosenValueName(undefined, 'default')).toBe(false)
+    expect(isChosenValueName(null, 'default')).toBe(false)
+    expect(isChosenValueName(3, 'default')).toBe(false)
   })
 })

--- a/frontend/src/tasks/paramValues.ts
+++ b/frontend/src/tasks/paramValues.ts
@@ -157,3 +157,21 @@ export function preferredValueName(
   const preferred = wantsActive ? (activeValueName ?? first) : first
   return available.includes(preferred) ? preferred : first
 }
+
+/**
+ * Has the user actually CHOSEN this value name, or is it just what the form started with?
+ *
+ * The distinction is the whole reason `preferredValueName` above reaches anything. Its caller keeps
+ * an already-valid selection — right, for a chain-propagated name like `cpCorrected` — but every
+ * task JSON declares `"default": "default"`, and `"default"` is a valid version on essentially every
+ * image. So the guard fired on first render for all of them and prefer-the-active-version never ran:
+ * the docstring above described behaviour the app did not have, on every page, and the four tasks
+ * recorded there as fixed were still opening on the raw import.
+ *
+ * A value equal to the spec's own default therefore does not count as a choice. The cost is that
+ * deliberately picking `default` while the active version is something else does not survive a
+ * change of image selection — a re-pick, against a version silently reading the wrong pixels.
+ */
+export function isChosenValueName(value: unknown, specDefault: unknown): boolean {
+  return typeof value === 'string' && value !== '' && value !== specDefault
+}

--- a/frontend/src/utils/flowManifest.test.ts
+++ b/frontend/src/utils/flowManifest.test.ts
@@ -51,6 +51,23 @@ describe('modelDetailGroups', () => {
     expect(fieldsOf({ zPlanes: 1, zPlanesUsed: {} }, 'Input')).toEqual({ 'Z planes': '1 (middle)' })
   })
 
+  // The frame cap is invisible in `nFrames` — a pooled total cannot say whether a movie was cut or
+  // simply short, and the window is seed-derived so it is not recoverable by inspection either.
+  it('reports the frame cap, spelling out an uncapped run rather than showing 0', () => {
+    expect(fieldsOf({ maxFrames: 0 }, 'Source')['Max frames/movie']).toBe('all')
+    expect(fieldsOf({ maxFrames: 50 }, 'Source')['Max frames/movie']).toBe('50')
+  })
+
+  it('names the movies that were actually cut, and their windows', () => {
+    expect(fieldsOf({ maxFrames: 50, frameWindows: { long: [40, 90] } }, 'Source')['Windows (1)'])
+      .toBe('long: 40–89')
+  })
+
+  it('shows no window row when nothing was cut', () => {
+    expect(fieldsOf({ maxFrames: 50, frameWindows: {} }, 'Source'))
+      .toEqual({ 'Max frames/movie': '50' })
+  })
+
   it('says "none" when a model kept every metric, and lists them when it did not', () => {
     expect(fieldsOf({ metricKeys: ['mag_1', 'strain'] }, 'Flow metrics')).toEqual({
       'Planes read': '2', Set: 'mag_1, strain', Excluded: 'none',

--- a/frontend/src/utils/flowManifest.test.ts
+++ b/frontend/src/utils/flowManifest.test.ts
@@ -27,9 +27,28 @@ describe('modelDetailGroups', () => {
     expect(groupNames({ lossCurves: { total: [3, 2] } })).toEqual([])
   })
 
-  it('spells the middle Z plane out', () => {
+  // Models trained before `zPlanes` are still in people's vaults, and the modal has to keep
+  // describing them rather than dropping the row.
+  it('spells the middle Z plane out for a pre-zPlanes model', () => {
     expect(fieldsOf({ zSlice: -1 }, 'Input')['Z plane']).toBe('middle')
     expect(fieldsOf({ zSlice: 12 }, 'Input')['Z plane']).toBe('12')
+  })
+
+  it('reports the plane count and the indices behind it', () => {
+    const one = fieldsOf({ zPlanes: 1, zPlanesUsed: { a: [15], b: [15] } }, 'Input')
+    expect(one['Z planes']).toBe('1 (middle)')
+    // Every movie agreed, so one list — repeating it per uID would be noise.
+    expect(one.Planes).toBe('[15]')
+  })
+
+  it('names the movies when they disagree about which planes — "3 planes" is not a depth', () => {
+    expect(fieldsOf({ zPlanes: 3, zPlanesUsed: { deep: [5, 15, 25], shallow: [1, 4, 7] } },
+                    'Input').Planes)
+      .toBe('deep: [5, 15, 25]  shallow: [1, 4, 7]')
+  })
+
+  it('says nothing about planes for a 2D model rather than showing an empty row', () => {
+    expect(fieldsOf({ zPlanes: 1, zPlanesUsed: {} }, 'Input')).toEqual({ 'Z planes': '1 (middle)' })
   })
 
   it('says "none" when a model kept every metric, and lists them when it did not', () => {

--- a/frontend/src/utils/flowManifest.ts
+++ b/frontend/src/utils/flowManifest.ts
@@ -23,6 +23,11 @@ export interface FlowManifest {
   sourceImages?: string[]
   sourceValueName?: string
   nFrames?: number
+  /** How many evenly-spaced Z planes per movie. */
+  zPlanes?: number
+  /** uID → the plane indices that movie contributed; depth differs per image. */
+  zPlanesUsed?: Record<string, number[]>
+  /** Pre-`zPlanes` models: a single plane index, `-1` meaning the middle. */
   zSlice?: number
   trainedAt?: string
   lossWeights?: Record<string, number>
@@ -36,7 +41,7 @@ export interface DetailGroup { label: string; fields: DetailField[] }
 const KNOWN = new Set([
   'temporalScales', 'cumulativeWindow', 'droppedMetrics', 'metricKeys', 'channelName',
   'trainChannels', 'epochs', 'embeddingDim', 'seed', 'normalise', 'sourceImages',
-  'sourceValueName', 'nFrames', 'zSlice', 'trainedAt', 'lossWeights',
+  'sourceValueName', 'nFrames', 'zPlanes', 'zPlanesUsed', 'zSlice', 'trainedAt', 'lossWeights',
   // Shown as a plot (Training convergence), not as hundreds of numbers in a dialog.
   'lossCurves',
 ])
@@ -56,6 +61,29 @@ function field(label: string, value: unknown, mono = false): DetailField | null 
 }
 
 /**
+ * How much of the stack the model saw. One row for the count, one for the actual indices.
+ *
+ * The indices are worth their own row because "3 planes" is not a depth: 3 of a 31-plane stack and
+ * 3 of a 9-plane one are different tissue. Only shown when the movies disagree about *which* — with
+ * one set of indices across every image, repeating it per uID is noise.
+ */
+function zPlaneFields(m: FlowManifest): (DetailField | null)[] {
+  if (m.zPlanes === undefined) return [field('Z plane', m.zSlice === -1 ? 'middle' : m.zSlice)]
+
+  const per = Object.entries(m.zPlanesUsed ?? {})
+  const distinct = new Set(per.map(([, v]) => v.join(',')))
+  return [
+    field('Z planes', m.zPlanes === 1 ? '1 (middle)' : m.zPlanes),
+    distinct.size === 1
+      ? field('Planes', `[${[...distinct][0]}]`, true)
+      : per.length
+        ? { label: 'Planes', mono: true,
+            value: per.map(([uid, v]) => `${uid}: [${v.join(', ')}]`).join('  ') }
+        : null,
+  ]
+}
+
+/**
  * The manifest grouped for display. Empty when there is no manifest at all — the caller says so in
  * its own words rather than rendering a set of dashes.
  *
@@ -70,7 +98,10 @@ export function modelDetailGroups(manifest: FlowManifest | null | undefined): De
   const input: (DetailField | null)[] = [
     field('Channels', m.channelName || (m.trainChannels ?? []).join(', ')),
     field('Image version', m.sourceValueName),
-    field('Z plane', m.zSlice === -1 ? 'middle' : m.zSlice),
+    // Two spellings on purpose. `zPlanes` is the count a current run was given; `zSlice` is what
+    // models trained before it recorded, and those models are still in people's vaults. Reading the
+    // old key is how the modal keeps describing them instead of quietly dropping the row.
+    ...zPlaneFields(m),
     field('Temporal scales', m.temporalScales),
     field('Cumulative window', m.cumulativeWindow),
     field('Normalise', m.normalise === undefined ? undefined : `${m.normalise}th percentile`),

--- a/frontend/src/utils/flowManifest.ts
+++ b/frontend/src/utils/flowManifest.ts
@@ -25,6 +25,10 @@ export interface FlowManifest {
   nFrames?: number
   /** How many evenly-spaced Z planes per movie. */
   zPlanes?: number
+  /** Cap on the contiguous frames each movie contributed; 0 = all. */
+  maxFrames?: number
+  /** uID → `[start, stop)` — only the movies that were actually cut. */
+  frameWindows?: Record<string, number[]>
   /** uID → the plane indices that movie contributed; depth differs per image. */
   zPlanesUsed?: Record<string, number[]>
   /** Pre-`zPlanes` models: a single plane index, `-1` meaning the middle. */
@@ -42,6 +46,7 @@ const KNOWN = new Set([
   'temporalScales', 'cumulativeWindow', 'droppedMetrics', 'metricKeys', 'channelName',
   'trainChannels', 'epochs', 'embeddingDim', 'seed', 'normalise', 'sourceImages',
   'sourceValueName', 'nFrames', 'zPlanes', 'zPlanesUsed', 'zSlice', 'trainedAt', 'lossWeights',
+  'maxFrames', 'frameWindows',
   // Shown as a plot (Training convergence), not as hundreds of numbers in a dialog.
   'lossCurves',
 ])
@@ -122,9 +127,18 @@ export function modelDetailGroups(manifest: FlowManifest | null | undefined): De
     ...Object.entries(m.lossWeights ?? {}).map(([term, w]) => field(`${term} weight`, w)),
   ]
 
+  // Which frames, not just how many. The window is seed-derived, so without it "frames 40–89 of
+  // 200" is only recoverable by re-deriving it from the seed by hand — and the pooled total cannot
+  // say whether a movie was cut or simply short.
+  const cut = Object.entries(m.frameWindows ?? {})
   const source: (DetailField | null)[] = [
     field('Trained', m.trainedAt),
     field('Frames pooled', m.nFrames),
+    field('Max frames/movie', m.maxFrames ? m.maxFrames : m.maxFrames === 0 ? 'all' : undefined),
+    cut.length
+      ? { label: `Windows (${cut.length})`, mono: true,
+          value: cut.map(([uid, [a, b]]) => `${uid}: ${a}–${(b ?? 0) - 1}`).join('  ') }
+      : null,
     m.sourceImages?.length
       ? { label: `Images (${m.sourceImages.length})`, value: m.sourceImages.join(', '), mono: true }
       : null,

--- a/frontend/src/utils/flowManifest.ts
+++ b/frontend/src/utils/flowManifest.ts
@@ -27,6 +27,8 @@ export interface FlowManifest {
   zPlanes?: number
   /** Cap on the contiguous frames each movie contributed; 0 = all. */
   maxFrames?: number
+  /** Fraction of each sequence trained on; the rest was held out. 1 = no split. */
+  trainRatio?: number
   /** uID → `[start, stop)` — only the movies that were actually cut. */
   frameWindows?: Record<string, number[]>
   /** uID → the plane indices that movie contributed; depth differs per image. */
@@ -46,7 +48,7 @@ const KNOWN = new Set([
   'temporalScales', 'cumulativeWindow', 'droppedMetrics', 'metricKeys', 'channelName',
   'trainChannels', 'epochs', 'embeddingDim', 'seed', 'normalise', 'sourceImages',
   'sourceValueName', 'nFrames', 'zPlanes', 'zPlanesUsed', 'zSlice', 'trainedAt', 'lossWeights',
-  'maxFrames', 'frameWindows',
+  'maxFrames', 'frameWindows', 'trainRatio',
   // Shown as a plot (Training convergence), not as hundreds of numbers in a dialog.
   'lossCurves',
 ])
@@ -122,6 +124,10 @@ export function modelDetailGroups(manifest: FlowManifest | null | undefined): De
 
   const training: (DetailField | null)[] = [
     field('Epochs', m.epochs),
+    // Spelled out rather than shown as "1": a model with no held-out split has a loss curve that
+    // cannot distinguish convergence from memorising, and that is worth reading off the dialog.
+    field('Train fraction', m.trainRatio === undefined ? undefined
+      : m.trainRatio >= 1 ? 'all (no validation)' : m.trainRatio),
     field('Embedding dim', m.embeddingDim),
     field('Seed', m.seed),
     ...Object.entries(m.lossWeights ?? {}).map(([term, w]) => field(`${term} weight`, w)),

--- a/frontend/src/utils/taskPreview.test.ts
+++ b/frontend/src/utils/taskPreview.test.ts
@@ -252,7 +252,9 @@ describe('previewNotice', () => {
     const n = previewNotice(null, { message: 'worker died' })
     expect(n.warn).toBe(true)
     expect(n.short).toBe('Preview failed')
-    expect(n.detail).toBe('worker died')
+    // The raw text is NOT the detail — an uncoded message is an escaped exception written for
+    // whoever debugs it, and it goes to the log instead. See the block at the end of this file.
+    expect(n.detail).toBe('Unexpected error — see the log')
   })
 
   // The label is the thing the user reads at a glance; the detail is free to be a sentence.
@@ -505,5 +507,32 @@ describe('previewFailureLog — a failure has to be readable, not hover-only', (
     // blockers never reach this function; the store only calls it from a catch. Pinned so a future
     // refactor that starts routing blockers here has to make the decision deliberately.
     expect(previewFailureLog({ message: '', code: 'image-mismatch' })).toBeNull()
+  })
+})
+
+describe('previewNotice — raw exceptions are not copy', () => {
+  // A preview-worker dispatch failure put `ValueError: no preview backend for
+  // 'segment.coastalMeasure'; known: [...]` — a repr'd Python list — straight into a tooltip.
+  it('does not put an uncoded exception in the tooltip', () => {
+    const n = previewNotice(null, {
+      message: "ValueError: no preview backend for 'segment.coastalMeasure'; known: ['a', 'b']",
+    })
+    expect(n.short).toBe('Preview failed')
+    expect(n.detail).toBe('Unexpected error — see the log')
+    expect(n.warn).toBe(true)
+  })
+
+  it('still shows a CODED message — the backend wrote that one for a user', () => {
+    const n = previewNotice(null, { message: 'The viewer has v2 open; this task reads default',
+                                    code: 'version-mismatch' })
+    expect(n.short).toBe('Wrong version open')
+    expect(n.detail).toBe('The viewer has v2 open; this task reads default')
+  })
+
+  it('has a short label for a missing preview backend', () => {
+    const n = previewNotice(null, { message: 'This task has no preview — run it to see the result',
+                                    code: 'no-preview-backend' })
+    expect(n.short).toBe('Not previewable')
+    expect(n.detail).toBe('This task has no preview — run it to see the result')
   })
 })

--- a/frontend/src/utils/taskPreview.ts
+++ b/frontend/src/utils/taskPreview.ts
@@ -136,6 +136,7 @@ const ERROR_SHORT: Record<string, string> = {
   'no-region':              'No region to preview',
   'params-not-previewable': 'Params not usable',
   'timeout':                'Preview timed out',
+  'no-preview-backend':     'Not previewable',
 }
 
 /**
@@ -205,9 +206,20 @@ export function previewNotice(
   error: { message?: string; code?: string } | null,
 ): PreviewNotice {
   if (error?.message) {
+    // A CODED error is one the backend wrote deliberately, for a user, about a situation they can
+    // do something about — "the viewer has a different version open". Its message is the detail,
+    // because the backend knows things the UI does not.
+    //
+    // An UNCODED one is an exception that escaped, and its text is written for whoever debugs it:
+    // a preview-worker dispatch failure put `ValueError: no preview backend for
+    // 'segment.coastalMeasure'; known: ['cleanupImages.afCorrect', …]` — a repr'd Python list — into
+    // a tooltip. That is not copy, and no amount of it helps the person reading it. The raw text
+    // still reaches the log (`previewLogEntry` above), which is where it belongs.
+    const code = error.code ?? ''
+    const known = Object.prototype.hasOwnProperty.call(ERROR_SHORT, code)
     return {
-      short: ERROR_SHORT[error.code ?? ''] ?? 'Preview failed',
-      detail: error.message,
+      short: known ? ERROR_SHORT[code]! : 'Preview failed',
+      detail: known ? error.message : 'Unexpected error — see the log',
       warn: true,
     }
   }

--- a/pixi.lock
+++ b/pixi.lock
@@ -134,7 +134,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: ./python
-      - pypi: git+https://github.com/schienstockd/coastal.git?rev=15f3bf477b4f0520e0ceaefb7f522cc83aab7549#15f3bf477b4f0520e0ceaefb7f522cc83aab7549
+      - pypi: git+https://github.com/schienstockd/coastal.git?rev=0858707385d895d85472a626cbb4f7463d71605f#0858707385d895d85472a626cbb4f7463d71605f
       - pypi: https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl
       - pypi: https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-linux_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/01/72/2067f28fd0ae87978f3b61e8ec30c1d085bbed03f64eb58e43949d526b3a/napari_console-0.1.4-py3-none-any.whl
@@ -450,7 +450,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./python
-      - pypi: git+https://github.com/schienstockd/coastal.git?rev=15f3bf477b4f0520e0ceaefb7f522cc83aab7549#15f3bf477b4f0520e0ceaefb7f522cc83aab7549
+      - pypi: git+https://github.com/schienstockd/coastal.git?rev=0858707385d895d85472a626cbb4f7463d71605f#0858707385d895d85472a626cbb4f7463d71605f
       - pypi: https://files.pythonhosted.org/packages/01/72/2067f28fd0ae87978f3b61e8ec30c1d085bbed03f64eb58e43949d526b3a/napari_console-0.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/a7/fec56dbac873a18930b2127d400794a91dd53898bff811aa4802ddbbfac9/multiscale_spatial_image-2.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/b9/748c3cbcdba20ef01c055a35905cad5c771cc1df29be11b9a82da6fd8e0d/superqt-0.8.2-py3-none-any.whl
@@ -735,7 +735,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: ./python
-      - pypi: git+https://github.com/schienstockd/coastal.git?rev=15f3bf477b4f0520e0ceaefb7f522cc83aab7549#15f3bf477b4f0520e0ceaefb7f522cc83aab7549
+      - pypi: git+https://github.com/schienstockd/coastal.git?rev=0858707385d895d85472a626cbb4f7463d71605f#0858707385d895d85472a626cbb4f7463d71605f
       - pypi: https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl
       - pypi: https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/01/72/2067f28fd0ae87978f3b61e8ec30c1d085bbed03f64eb58e43949d526b3a/napari_console-0.1.4-py3-none-any.whl
@@ -2677,7 +2677,7 @@ packages:
   - python >=3.10
   license: ISC
   purls:
-  - pkg:pypi/certifi?source=compressed-mapping
+  - pkg:pypi/certifi?source=hash-mapping
   run_exports: {}
   size: 133877
   timestamp: 1781719949728
@@ -4547,7 +4547,7 @@ packages:
   - scikit-image>=0.24
   - tqdm
   requires_python: '>=3.11'
-- pypi: git+https://github.com/schienstockd/coastal.git?rev=15f3bf477b4f0520e0ceaefb7f522cc83aab7549#15f3bf477b4f0520e0ceaefb7f522cc83aab7549
+- pypi: git+https://github.com/schienstockd/coastal.git?rev=0858707385d895d85472a626cbb4f7463d71605f#0858707385d895d85472a626cbb4f7463d71605f
   name: coastal
   version: 0.1.0
   requires_dist:

--- a/pixi.lock
+++ b/pixi.lock
@@ -134,7 +134,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: ./python
-      - pypi: git+https://github.com/schienstockd/coastal.git?rev=0858707385d895d85472a626cbb4f7463d71605f#0858707385d895d85472a626cbb4f7463d71605f
+      - pypi: git+https://github.com/schienstockd/coastal.git?rev=cbd56bf266c65f02acaeb13d14c5003b6bc95f3a#cbd56bf266c65f02acaeb13d14c5003b6bc95f3a
       - pypi: https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl
       - pypi: https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-linux_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/01/72/2067f28fd0ae87978f3b61e8ec30c1d085bbed03f64eb58e43949d526b3a/napari_console-0.1.4-py3-none-any.whl
@@ -450,7 +450,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./python
-      - pypi: git+https://github.com/schienstockd/coastal.git?rev=0858707385d895d85472a626cbb4f7463d71605f#0858707385d895d85472a626cbb4f7463d71605f
+      - pypi: git+https://github.com/schienstockd/coastal.git?rev=cbd56bf266c65f02acaeb13d14c5003b6bc95f3a#cbd56bf266c65f02acaeb13d14c5003b6bc95f3a
       - pypi: https://files.pythonhosted.org/packages/01/72/2067f28fd0ae87978f3b61e8ec30c1d085bbed03f64eb58e43949d526b3a/napari_console-0.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/a7/fec56dbac873a18930b2127d400794a91dd53898bff811aa4802ddbbfac9/multiscale_spatial_image-2.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/b9/748c3cbcdba20ef01c055a35905cad5c771cc1df29be11b9a82da6fd8e0d/superqt-0.8.2-py3-none-any.whl
@@ -735,7 +735,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: ./python
-      - pypi: git+https://github.com/schienstockd/coastal.git?rev=0858707385d895d85472a626cbb4f7463d71605f#0858707385d895d85472a626cbb4f7463d71605f
+      - pypi: git+https://github.com/schienstockd/coastal.git?rev=cbd56bf266c65f02acaeb13d14c5003b6bc95f3a#cbd56bf266c65f02acaeb13d14c5003b6bc95f3a
       - pypi: https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl
       - pypi: https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/01/72/2067f28fd0ae87978f3b61e8ec30c1d085bbed03f64eb58e43949d526b3a/napari_console-0.1.4-py3-none-any.whl
@@ -4547,7 +4547,7 @@ packages:
   - scikit-image>=0.24
   - tqdm
   requires_python: '>=3.11'
-- pypi: git+https://github.com/schienstockd/coastal.git?rev=0858707385d895d85472a626cbb4f7463d71605f#0858707385d895d85472a626cbb4f7463d71605f
+- pypi: git+https://github.com/schienstockd/coastal.git?rev=cbd56bf266c65f02acaeb13d14c5003b6bc95f3a#cbd56bf266c65f02acaeb13d14c5003b6bc95f3a
   name: coastal
   version: 0.1.0
   requires_dist:

--- a/pixi.toml
+++ b/pixi.toml
@@ -84,10 +84,11 @@ btrack       = ">=0.7"
 # cecelia's IO/napari helpers lazily); this entry is only cecelia consuming coastal's array-only
 # algorithms, which import nothing from cecelia.
 # The rev is a HARD floor, not a snapshot: `segment.coastal` calls `flow_metrics_for_frame` and
-# `LearnedAffinityInference(seed_blur_sigma=...)`, neither of which exists before this commit. An
-# older rev fails at RUN time (ImportError / TypeError), not at install or in CI — the Python tests
+# `LearnedAffinityInference(seed_blur_sigma=...)`, and `opticalFlow.train` calls
+# `train_with_metrics(val_frames=...)` — none of which exists before this commit. An older rev fails
+# at RUN time (TypeError: unexpected keyword argument), not at install or in CI — the Python tests
 # stub coastal deliberately, so nothing catches a rollback.
-coastal      = { git = "https://github.com/schienstockd/coastal.git", rev = "15f3bf477b4f0520e0ceaefb7f522cc83aab7549" }
+coastal      = { git = "https://github.com/schienstockd/coastal.git", rev = "0858707385d895d85472a626cbb4f7463d71605f" }
 # Leiden clustering (cells + tracks), CPU path. GPU (RAPIDS) is parked — see the gpu stub
 # below and docs/todo/CLUSTERING_PLAN.md.
 leidenalg    = ">=0.10"

--- a/pixi.toml
+++ b/pixi.toml
@@ -85,10 +85,10 @@ btrack       = ">=0.7"
 # algorithms, which import nothing from cecelia.
 # The rev is a HARD floor, not a snapshot: `segment.coastal` calls `flow_metrics_for_frame` and
 # `LearnedAffinityInference(seed_blur_sigma=...)`, and `opticalFlow.train` calls
-# `train_with_metrics(val_frames=...)` — none of which exists before this commit. An older rev fails
-# at RUN time (TypeError: unexpected keyword argument), not at install or in CI — the Python tests
-# stub coastal deliberately, so nothing catches a rollback.
-coastal      = { git = "https://github.com/schienstockd/coastal.git", rev = "0858707385d895d85472a626cbb4f7463d71605f" }
+# `train_with_metrics(val_frames=..., on_epoch=...)` — none of which exists before this commit.
+# An older rev fails at RUN time (TypeError: unexpected keyword argument), not at install or in CI —
+# the Python tests stub coastal deliberately, so nothing catches a rollback.
+coastal      = { git = "https://github.com/schienstockd/coastal.git", rev = "cbd56bf266c65f02acaeb13d14c5003b6bc95f3a" }
 # Leiden clustering (cells + tracks), CPU path. GPU (RAPIDS) is parked — see the gpu stub
 # below and docs/todo/CLUSTERING_PLAN.md.
 leidenalg    = ">=0.10"

--- a/preview/preview_worker.py
+++ b/preview/preview_worker.py
@@ -156,7 +156,12 @@ def _cellpose_imports():
 #:    PNGs, which reads as "the colormap setting does nothing" with no error anywhere.
 #: 9: `opticalFlow.inspect` is pre-training only — no model, no probability plane. An adopted
 #:    protocol-8 worker would still emit `probability` for a request that no longer asks for one.
-PROTOCOL = 9
+#: 10: two new backends — `opticalFlow.probability` (the model's prob map, post-training) and
+#:    `segment.coastalMeasure` (the composite the Segment page actually runs). Backend-set changes
+#:    need the bump for the reason the header gives: an adopted older worker ignores what it has
+#:    never heard of and fails with "no preview backend", which reads as a broken button rather than
+#:    a stale process.
+PROTOCOL = 10
 
 #: Named in the error a channel NAME raises, so the message points at the Julia function that should
 #: have resolved it — see `script_utils.channel_indices`.
@@ -608,8 +613,22 @@ def _preview_flow_inspect(ctx):
     is built by the same `CoastalUtils` the real run uses, so these are the planes a run is actually
     fed. Returns `planes`, not `layers`: canvas plots, nothing near napari.
     """
+    seg, mp, frame, metrics, scales = _flow_frame_and_metrics(ctx)
+    planes = [('input (projected)', frame)] + [(k, metrics[k]) for k in sorted(metrics)]
+    return {**_planes_reply(ctx, planes),
+            'metricKeys': sorted(metrics),
+            'temporalScales': list(scales)}
+
+
+def _flow_frame_and_metrics(ctx):
+    """`(seg, model_params, frame, metrics, scales)` for the timepoint in view.
+
+    Shared by the metric sheet and the probability map because it must be: both claim to show what a
+    RUN is fed, and two copies of the window/projection/metric build would be two chances to drift
+    from `CoastalUtils` — the exact silent-misalignment failure the metric-set contract exists to
+    prevent. One path, used by both, and it is the run's own.
+    """
     from cecelia.utils.coastal_utils import temporal_config
-    from cecelia.utils.plane_render import DEFAULT_COLORMAP, plane_png
 
     models = ctx.params.get('models') or {}
     if not models:
@@ -619,7 +638,7 @@ def _preview_flow_inspect(ctx):
     seg = CoastalUtils(
         {**ctx.params, 'taskDir': ctx.task_dir, 'outputValueName': ctx.value_name}, ctx.dim_utils)
     mp = models[sorted(models.keys())[0]]
-    scales, cumulative, _dropped = temporal_config(seg._manifest(mp))
+    scales, cumulative, dropped = temporal_config(seg._manifest(mp))
 
     t_now = int(ctx.bounds.get('T', (0, 1))[0])
     n_t = int(ctx.axis_len.get('T', 1))
@@ -634,16 +653,45 @@ def _preview_flow_inspect(ctx):
 
     window = seg._project_window(context, mp, STATE.norm_params(seg, ctx.levels, ctx.im_path, mp))
     frame, metrics = seg._flow_metrics(window, t_now - lo, scales, cumulative)
+    if dropped:
+        # The model's OWN dropped set, from its manifest. Keeping a plane the model was not trained
+        # on would show a sheet that does not match the channels it is fed.
+        metrics = {k: v for k, v in metrics.items() if k not in dropped}
+    return seg, mp, frame, metrics, scales
 
-    planes = [('input (projected)', frame)] + [(k, metrics[k]) for k in sorted(metrics)]
 
+def _planes_reply(ctx, planes):
+    """`{planes: [{name, png}]}` — the canvas-plot envelope. No layers, nothing near napari."""
+    from cecelia.utils.plane_render import DEFAULT_COLORMAP, plane_png
     cmap = str(ctx.params.get('colormap') or DEFAULT_COLORMAP)
-    return {
-        'planes': [{'name': n, 'png': base64.b64encode(plane_png(a, colormap=cmap)).decode('ascii')}
-                   for n, a in planes],
-        'metricKeys': sorted(metrics),
-        'temporalScales': list(scales),
-    }
+    return {'planes': [{'name': n,
+                        'png': base64.b64encode(plane_png(a, colormap=cmap)).decode('ascii')}
+                       for n, a in planes]}
+
+
+def _preview_flow_probability(ctx):
+    """"How good is this model" — the projected input beside the model's probability map.
+
+    The POST-training counterpart to `_preview_flow_inspect`, and deliberately a separate view: that
+    one is asked before a model exists and must not take one (a model picker there turned "what
+    should I train on" into "what did I train"). This one is meaningless without a checkpoint.
+
+    Two planes only. Not instances — those are segmentation output and the Segment page previews them
+    through the normal preview path; the question here is whether the model learned to tell cell from
+    background at all, which is exactly what the probability map shows and what instances hide behind
+    a threshold and a growing step.
+
+    `predict_frame` returns `(prob_map, instances, props)` and the run throws the first away
+    (`CoastalUtils._predict_plane`), so this is the one place it is looked at.
+    """
+    seg, mp, frame, metrics, _scales = _flow_frame_and_metrics(ctx)
+    # `_get_inference` is the run's own accessor and it CACHES per model — so scrubbing t or z
+    # re-runs the network but does not rebuild it, which is what makes this fast enough to be a
+    # canvas plot rather than a job.
+    prob, _instances, _props = seg._get_inference(mp).predict_frame(frame, metrics)
+    return {**_planes_reply(ctx, [('input (projected)', frame),
+                                 ('probability', np.asarray(prob, dtype=np.float32))]),
+            'metricKeys': sorted(metrics)}
 
 
 def _preview_af(ctx):
@@ -714,6 +762,7 @@ _BACKENDS = {
     'segment.coastal': _preview_coastal,
     'segment.coastalMeasure': _preview_coastal,
     'opticalFlow.inspect': _preview_flow_inspect,
+    'opticalFlow.probability': _preview_flow_probability,
     'cleanupImages.afCorrect': _preview_af,
     'cleanupImages.afDriftCorrect': _preview_af,
 }

--- a/preview/preview_worker.py
+++ b/preview/preview_worker.py
@@ -702,10 +702,17 @@ def _preview_af(ctx):
 
 #: fun_name → the compute that previews it. A task absent here is not previewable, which the Julia
 #: side already declares via `task_previewable` — this is the other half of the same statement.
+# A COMPOSITE needs its own entry, mapped to the backend of the step a preview actually runs. The
+# module pages run the composites (`segment.cellposeMeasure`, `segment.coastalMeasure`), not the bare
+# segmenters, so a composite missing here is not a corner case — it is the preview button being dead
+# on the page people use. This has now shipped broken twice for exactly that reason, so the pairing is
+# asserted by `test_preview_backends_cover_composites.py` rather than left to whoever adds the next
+# composite noticing that this file exists.
 _BACKENDS = {
     'segment.cellpose': _preview_cellpose,
     'segment.cellposeMeasure': _preview_cellpose,
     'segment.coastal': _preview_coastal,
+    'segment.coastalMeasure': _preview_coastal,
     'opticalFlow.inspect': _preview_flow_inspect,
     'cleanupImages.afCorrect': _preview_af,
     'cleanupImages.afDriftCorrect': _preview_af,

--- a/python/cecelia/tests/test_flow_train_sampling.py
+++ b/python/cecelia/tests/test_flow_train_sampling.py
@@ -1,4 +1,6 @@
-"""Which Z planes an optical-flow training run reads — `app/src/tasks/opticalFlow/train_run.py`.
+"""What an optical-flow training run SAMPLES — `app/src/tasks/opticalFlow/train_run.py`.
+
+Which Z planes, and which frames of each movie.
 
 The runner is executed by path (`run_py`), never imported, so nothing else in the suite touches it.
 This covers the one piece of arithmetic in it that is easy to get subtly wrong and impossible to
@@ -79,6 +81,59 @@ class ZPlanesTest(unittest.TestCase):
         """A chain or REPL caller can pass 0 or a negative; the run must not end up with no data."""
         self.assertEqual(self.z_planes(31, 0), [15])
         self.assertEqual(self.z_planes(31, -3), [15])
+
+
+@unittest.skipUnless(_RUNNER.is_file(), 'app/ not present (IO-library-only install)')
+class FrameWindowTest(unittest.TestCase):
+    """The per-movie frame cap.
+
+    It exists for a bias nothing in the run reported: with no cap, pooling is weighted by how long
+    each recording happened to last, so a 200-frame movie contributes ~7x what a 30-frame one does
+    and the model is mostly fitted to whichever image the microscope was left on longest. The pooled
+    frame count is one number and says nothing about the split.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.frame_window = staticmethod(_load_runner().frame_window)
+
+    def test_no_cap_is_the_whole_movie(self):
+        for max_frames in (0, -1, None):
+            self.assertEqual(self.frame_window(200, max_frames, 42, 0), (0, 200),
+                             f'max_frames={max_frames}')
+
+    def test_a_cap_at_or_above_the_length_does_not_cut(self):
+        self.assertEqual(self.frame_window(30, 30, 42, 0), (0, 30))
+        self.assertEqual(self.frame_window(30, 500, 42, 0), (0, 30))
+
+    def test_the_window_is_contiguous_and_the_requested_length(self):
+        """Contiguous because the metrics are temporal: `mag_8` is the flow between t and t+8, so a
+        random subset is not a shorter movie, it is a movie with the motion taken out."""
+        for movie in range(6):
+            start, stop = self.frame_window(200, 50, 42, movie)
+            self.assertEqual(stop - start, 50)
+            self.assertGreaterEqual(start, 0)
+            self.assertLessEqual(stop, 200)
+
+    def test_it_is_reproducible_from_the_seed(self):
+        """The seed is in the manifest, so the window has to be recoverable from it."""
+        a = [self.frame_window(200, 50, 42, i) for i in range(5)]
+        b = [self.frame_window(200, 50, 42, i) for i in range(5)]
+        self.assertEqual(a, b)
+
+    def test_a_different_seed_gives_a_different_view(self):
+        """Always starting at 0 samples one part of every experiment — as often as not before the
+        interesting event, and at whatever bleaching level the start happens to have."""
+        seeds = {self.frame_window(200, 50, s, 0)[0] for s in range(12)}
+        self.assertGreater(len(seeds), 1, 'every seed produced the same start')
+
+    def test_each_movie_is_seeded_independently(self):
+        """Adding or reordering images must not reshuffle the other movies' windows — otherwise a
+        re-run with one extra image is not comparable with the previous one."""
+        before = [self.frame_window(200, 50, 42, i) for i in (0, 1, 2)]
+        # movie 3 appended; 0-2 keep their windows
+        after = [self.frame_window(200, 50, 42, i) for i in (0, 1, 2, 3)]
+        self.assertEqual(before, after[:3])
 
 
 if __name__ == '__main__':

--- a/python/cecelia/tests/test_flow_train_z_planes.py
+++ b/python/cecelia/tests/test_flow_train_z_planes.py
@@ -1,0 +1,85 @@
+"""Which Z planes an optical-flow training run reads — `app/src/tasks/opticalFlow/train_run.py`.
+
+The runner is executed by path (`run_py`), never imported, so nothing else in the suite touches it.
+This covers the one piece of arithmetic in it that is easy to get subtly wrong and impossible to
+notice afterwards: the model trains fine either way, and the manifest records a number that looks
+right, while the frames it learned from came from the wrong depth.
+
+Two properties do the work:
+
+  - `n = 1` must be the OLD single-plane rule (`n_z // 2`) exactly. The parameter replaced `zSlice`,
+    and if the reduction is off by one then introducing it silently retrains every existing config
+    on different data.
+  - No `n` may reach plane 0 or `n_z - 1` while there is interior left. The top and bottom of an
+    intravital stack are usually outside the tissue; `linspace(0, n_z-1, n)` puts two of five planes
+    there, and the run would report five planes trained while two were noise.
+
+Skipped when `app/` is absent — an external `pip install cecelia` consumer gets the IO library only.
+"""
+import importlib.util
+import unittest
+from pathlib import Path
+
+_RUNNER = (Path(__file__).resolve().parents[3]
+           / 'app' / 'src' / 'tasks' / 'opticalFlow' / 'train_run.py')
+
+
+def _load_runner():
+    """Load the runner from its path, exactly as `run_py` does (it is not an importable module)."""
+    spec = importlib.util.spec_from_file_location('flow_train_run', _RUNNER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@unittest.skipUnless(_RUNNER.is_file(), 'app/ not present (IO-library-only install)')
+class ZPlanesTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # staticmethod: a plain function on a class attribute binds as a method,
+        # and every call would pass `self` as `n_z`.
+        cls.z_planes = staticmethod(_load_runner().z_planes)
+
+    def test_one_plane_is_the_middle_exactly_as_before(self):
+        """The compatibility hinge. `zPlanes=1` has to be `zSlice=-1`, or the default changed."""
+        for n_z in (1, 2, 3, 9, 30, 31, 512):
+            self.assertEqual(self.z_planes(n_z, 1), [n_z // 2], f'n_z={n_z}')
+
+    def test_planes_are_evenly_spaced_and_inside_the_stack(self):
+        got = self.z_planes(31, 3)
+        self.assertEqual(got, [5, 15, 25])
+        gaps = [b - a for a, b in zip(got, got[1:])]
+        self.assertEqual(len(set(gaps)), 1, 'the spacing should be uniform')
+
+    def test_it_avoids_the_top_and_bottom_of_the_stack(self):
+        """Where `linspace(0, n_z-1, n)` would spend 2 of 5 planes outside the tissue."""
+        for n in (2, 3, 4, 5, 8):
+            got = self.z_planes(31, n)
+            self.assertNotIn(0, got, f'n={n} reached the bottom plane')
+            self.assertNotIn(30, got, f'n={n} reached the top plane')
+
+    def test_asking_for_more_planes_than_exist_yields_each_once(self):
+        """Not duplicates — a repeated index would weight those frames twice in the pooled set,
+        silently, and the caller only asked for more planes than the stack has."""
+        self.assertEqual(self.z_planes(4, 10), [0, 1, 2, 3])
+        self.assertEqual(self.z_planes(1, 5), [0])
+
+    def test_every_result_is_a_usable_index(self):
+        for n_z in (1, 2, 5, 9, 31, 64):
+            for n in (1, 2, 3, 5, 9, 20):
+                got = self.z_planes(n_z, n)
+                self.assertTrue(got, f'n_z={n_z} n={n} produced no planes')
+                self.assertEqual(len(got), len(set(got)), f'n_z={n_z} n={n} repeated a plane')
+                self.assertEqual(got, sorted(got), f'n_z={n_z} n={n} is unsorted')
+                self.assertLessEqual(len(got), min(n, n_z), f'n_z={n_z} n={n} over-delivered')
+                for z in got:
+                    self.assertTrue(0 <= z < n_z, f'n_z={n_z} n={n} produced z={z}')
+
+    def test_a_degenerate_count_still_returns_one_plane(self):
+        """A chain or REPL caller can pass 0 or a negative; the run must not end up with no data."""
+        self.assertEqual(self.z_planes(31, 0), [15])
+        self.assertEqual(self.z_planes(31, -3), [15])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/cecelia/tests/test_preview_backends_cover_composites.py
+++ b/python/cecelia/tests/test_preview_backends_cover_composites.py
@@ -1,0 +1,93 @@
+"""Every composite whose step can be previewed must itself have a preview backend.
+
+`preview_worker._BACKENDS` dispatches on the `fun_name` the API sends, and the API sends the task the
+USER ran. Module pages run the composite (`segment.cellposeMeasure`, `segment.coastalMeasure`), never
+the bare segmenter — so a composite absent from `_BACKENDS` means the preview button is dead on the
+page people actually use, and it fails with a `ValueError` naming the known backends rather than
+anything a user can act on.
+
+This has shipped broken twice. `app/src/tasks/task.jl` already warns about the class in its
+CompositeTask header ("Forgetting one is SILENT and looks like 'the feature doesn't work for the
+composite' — which is exactly how the live preview first shipped broken"), and the warning did not
+prevent the second occurrence, because nothing checked. This does.
+
+The keys are read from the SOURCE rather than by importing the worker: `preview_worker` pulls in
+torch and cellpose at module scope, which would make a one-assertion convention test one of the
+slowest in the suite.
+
+Skipped when `app/` or `preview/` is absent — an external `pip install cecelia` consumer has neither.
+"""
+import ast
+import json
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[3]
+_WORKER = _ROOT / 'preview' / 'preview_worker.py'
+_TASKS = _ROOT / 'app' / 'src' / 'tasks'
+
+
+def _backend_keys():
+    """The literal keys of the `_BACKENDS` dict, parsed from the source."""
+    tree = ast.parse(_WORKER.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == '_BACKENDS' for t in node.targets):
+            continue
+        return {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
+    raise AssertionError('_BACKENDS not found in preview_worker.py')
+
+
+def _composites():
+    """`fun_name -> [step fun_names]` for every composite task spec."""
+    out = {}
+    for spec_path in _TASKS.glob('*/*.json'):
+        try:
+            spec = json.loads(spec_path.read_text(encoding='utf-8'))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(spec, dict):     # not every JSON in a task dir is a task spec
+            continue
+        steps = spec.get('composite')
+        fun = spec.get('fun_name')
+        if steps and fun:
+            out[fun] = list(steps)
+    return out
+
+
+@unittest.skipUnless(_WORKER.is_file() and _TASKS.is_dir(), 'app/ or preview/ not present')
+class PreviewBackendCoverageTest(unittest.TestCase):
+    def test_it_found_something_to_police(self):
+        self.assertGreater(len(_backend_keys()), 3)
+        self.assertGreater(len(_composites()), 1)
+
+    def test_every_previewable_composite_has_a_backend(self):
+        backends = _backend_keys()
+        missing = [
+            f'{fun} (step {step!r} is previewable)'
+            for fun, steps in sorted(_composites().items())
+            for step in steps
+            if step in backends and fun not in backends
+        ]
+        self.assertEqual(missing, [], 'composites whose preview would raise "no preview backend"')
+
+    def test_no_backend_names_a_task_that_does_not_exist(self):
+        """The other direction: a renamed task leaves a dead entry, and the preview then fails with
+        the same unactionable error while the registry looks complete."""
+        funs = set()
+        for spec_path in _TASKS.glob('*/*.json'):
+            try:
+                spec = json.loads(spec_path.read_text(encoding='utf-8'))
+            except json.JSONDecodeError:
+                continue
+            if isinstance(spec, dict) and spec.get('fun_name'):
+                funs.add(spec['fun_name'])
+        # `opticalFlow.inspect` is a canvas-plot backend with no task spec — it is reached through
+        # /api/optical-flow/inspect, not through a task, so it is legitimately not in the specs.
+        unknown = sorted(k for k in _backend_keys() if k not in funs and k != 'opticalFlow.inspect')
+        self.assertEqual(unknown, [], 'preview backends naming no known task')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/cecelia/tests/test_preview_backends_cover_composites.py
+++ b/python/cecelia/tests/test_preview_backends_cover_composites.py
@@ -39,6 +39,21 @@ def _backend_keys():
     raise AssertionError('_BACKENDS not found in preview_worker.py')
 
 
+def _canvas_plot_backends(candidates):
+    """Which of `candidates` the optical-flow API names — canvas plots, not tasks.
+
+    Membership rather than extraction: the route picks its `fun_name` with a ternary, so a
+    `fun_name\s*=\s*"..."` pattern sees neither branch. Asking "does this file mention this backend
+    by name" is both simpler and exactly the invariant — a backend is legitimate if something calls
+    it.
+    """
+    src = (_ROOT / 'api' / 'src' / 'optical_flow_api.jl')
+    if not src.is_file():
+        return set()
+    text = src.read_text(encoding='utf-8')
+    return {k for k in candidates if f'"{k}"' in text}
+
+
 def _composites():
     """`fun_name -> [step fun_names]` for every composite task spec."""
     out = {}
@@ -83,9 +98,12 @@ class PreviewBackendCoverageTest(unittest.TestCase):
                 continue
             if isinstance(spec, dict) and spec.get('fun_name'):
                 funs.add(spec['fun_name'])
-        # `opticalFlow.inspect` is a canvas-plot backend with no task spec — it is reached through
-        # /api/optical-flow/inspect, not through a task, so it is legitimately not in the specs.
-        unknown = sorted(k for k in _backend_keys() if k not in funs and k != 'opticalFlow.inspect')
+        # Some backends are CANVAS PLOTS, reached through /api/optical-flow/* rather than through a
+        # task, so they legitimately have no spec. Read from the route that dispatches them instead
+        # of allow-listed by name: an allow-list is a second place to remember, and the thing this
+        # file exists to prevent is exactly a registry nobody remembered to update.
+        funs |= _canvas_plot_backends(_backend_keys())
+        unknown = sorted(k for k in _backend_keys() if k not in funs)
         self.assertEqual(unknown, [], 'preview backends naming no known task')
 
 


### PR DESCRIPTION
Three parameters deciding what a training run sees and whether its result can be read: **how much of the stack** (`zPlanes`), **how much of each movie** (`maxFrames`), and **how much is held back** (`trainRatio`). One PR because they interlock — `maxFrames` is what bounds `zPlanes`'s memory multiplier, and all three land in the same runner and the same manifest.

Requires coastal ≥ `0858707` (schienstockd/coastal#22), so the pin moves. It is a **hard floor**: an older rev fails at run time with an unexpected keyword argument, not at install or in CI, because the Python tests stub coastal.

## `zPlanes` — from one plane to N

`zSlice` (one plane index, `-1` = middle) becomes `zPlanes` (a count).

Inference runs the model per plane over the whole stack, so training on one plane made the model's entire experience of the data a **single depth** — for an intravital stack, one slice through the tissue at one signal level.

### Why bin centres and not `linspace`

The planes are the centres of N equal bins. That choice is load-bearing at both ends of N:

- **`zPlanes = 1` lands on `n_z // 2`** — exactly the rule it replaces. Introducing the parameter cannot quietly retrain an existing config on different data.
- **No N reaches plane 0 or `n_z - 1`** while there is interior left. `linspace(0, n_z-1, 5)` spends two of five planes on the top and bottom of the stack, which in an intravital movie is usually outside the tissue. The run would report five planes trained and two would be noise, with nothing saying so.

`z_planes(31, 3) == [5, 15, 25]`.

### Each (movie × plane) is its own sequence

Flow between plane *k* and plane *k+1* of one timepoint is no more motion than flow across a movie boundary. Metrics stay per-sequence and the pooling goes through `prepare_data_for_unet_batch`, exactly as it already did per movie.

### The manifest records which planes, not just how many

Planes resolve per movie, because depth does — 3 of a 31-plane stack and 3 of a 9-plane one are different tissue. So the manifest carries `zPlanes` (count) **and** `zPlanesUsed` (uID → indices). The details modal shows one list when every movie agreed and names them when they did not. Models carrying the old `zSlice` are still in people's vaults and still render.

Two comments asserting "the middle is what training reads" were true and now are not; both corrected.

## `maxFrames` — the cap, and the bias it fixes

Pooling was weighted by how long each recording happened to last. A 200-frame movie contributes ~7× what a 30-frame one does, so a model trained on a mixed set is mostly fitted to whichever image the microscope was left on longest — and nothing showed it, because the frame count is one pooled number. `maxFrames` caps the per-movie contribution; `0` keeps the old behaviour.

The window is **contiguous**: the metrics are temporal, so a random subset of frames is not a shorter movie, it is a movie with the motion taken out.

Its start is **derived from the seed and the movie index**, not 0. Always taking the head of every movie samples one part of the experiment — as often as not before the interesting event, at whatever bleaching level the start happens to have. Seeding per movie also means adding or reordering images leaves the other windows alone, so two runs stay comparable.

Two ordering constraints, both silent when broken:

- **Normalise over the whole movie, then cut.** The percentiles are the global statistic `normaliseToWhole` reproduces at inference. Cutting first would scale a 50-frame window by its own percentiles while inference scales the 200-frame movie by the movie's — same structure, different brightness, no error.
- **Check `max(scales) + 1` against the capped length.** A 200-frame movie capped to 5 produces no `mag_8` plane, corrupting the pooled channel layout exactly as a genuinely short movie would.

Recorded as `maxFrames` + `frameWindows` (uID → `[start, stop)`, only the movies actually cut), because a seed-derived window is otherwise recoverable only by hand and the pooled total cannot say whether a movie was cut or was simply short.

### Memory

This is also what bounds the plane multiplier. Pooled frames = movies × planes × timepoints and every metric plane is resident, so five planes of three 200-frame movies is ~33 GB at 418×434. The run logs the pooled frame count before the expensive step and the real total once the metrics exist, warning past 16 GB — and `maxFrames` is the knob that actually caps it.

## `trainRatio` — holding frames back so the curve means something

A training loss is measured on the frames the weights were just fitted to, so it goes down whether the model learned what a cell looks like or memorised these frames. With a split, coastal evaluates every term on the held-out frames each epoch (no grad, no augmentation) and `lossCurves` gains a `val_<term>` beside each one. The **gap** is the reading.

`train_test_split_per_movie` cuts **within** each sequence, so every movie and every Z plane appears on both sides. Holding whole movies out would ask "does this transfer to another recording" — a different and much harder question than "has this converged or memorised".

**One honest caveat**, in the code and the docs: metrics are computed over the full sequence *before* the split, so a held-out frame's flow metrics derive partly from frames that ended up in training — roughly `max(scales)` frames of overlap at the seam. That is not label leakage (coastal is unsupervised; there are no labels), and the held-out frames themselves never reach the optimiser, which is what the comparison rests on. Computing metrics per side would change the metrics at *both* seams, which is worse.

### On the plot: same colour, dashed

Each `val_` curve attaches to its term rather than becoming its own series. That matters twice — the chip list would otherwise double, and the pair would get two colours, when the only thing anyone reads off a validation curve is its **distance from its own training line**. Two colours make that a legend lookup; one colour and a dash make it the picture. The val curve is scaled by the same weight, because the two are only comparable as one quantity. The CSV gets a `val_<term>` column beside each term, so the gap is a subtraction.

### QC

Gains the arm the training curve cannot see: `valFinalLoss` / `valLossDrop`, and a warning when the held-out loss does not come down *even though the training loss did*. `valLossDrop` is the cohort-comparable one — `lossDrop` can be high across a whole cohort of models that all memorised.

### Tests

12 Python tests on the sampling arithmetic (loaded by path, the way `run_py` runs it — the runner is never imported, so nothing else in the suite touches it) on the sampling arithmetic, 7 on the manifest rendering, 7 on the train/val curve pairing (including: an orphan `val_warp` with no `warp` must not invent a term, and `val_total` is never rescaled), and 4 on the QC arm. The package suite's two-sentence tip rule caught the first version of the `zPlanes` tip.

All four suites green: 623 python / 4285 package / api / 977 frontend, `vue-tsc -b` clean.

### Known limits

- **Nothing here has had a real training run.** The arithmetic is exhaustively covered and the coastal side has its own bit-identical equivalence proof, but the runner's restructure — three sampling params and a split feeding one loop — has not been exercised against real data, and that is where a shape bug would live.
- The seed-derived start means two runs of the same config with different seeds train on different frames. That is deliberate, but it makes seed-to-seed variation larger than it was — worth knowing before reading a small difference between runs as a real one.
- `zPlanesUsed` is keyed by uID, so a movie with an empty uID would collide with another. Real images always have one; a hand-built REPL call might not.
- The 16 GB warning threshold is a judgement ("more than a workstation comfortably holds alongside torch"), not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: eight fixes from a real run

The above shipped, a model got trained, and it got used. What that turned up:

**No progress at all.** `run_py` routes `[PROGRESS] n/total` to `on_progress` and the runner never printed one, so a job of tens of minutes was indistinguishable from a wedged one. One monotonic scale now — a tick per movie prepared, one for the flow metrics, one per epoch via coastal's new `on_epoch` ([coastal#23](https://github.com/schienstockd/coastal/pull/23), hence the second pin bump). The phases are wildly unequal in wall-clock, so the bar does not move smoothly; weighting them would be a guess dressed up as a measurement.

**The active image version was never preferred — on any page.** `ParamRenderer` keeps an already-valid selection (right for a chain-propagated `cpCorrected`), but every task JSON declares `"default": "default"`, valid on essentially every image. So the guard fired on first render everywhere and `preferredValueName` never ran: its docstring described behaviour the app did not have, including for the four tasks recorded in it as fixed. A value equal to the spec's *own* default no longer counts as a choice. **This touches every page with a version selector**, not just the flow ones.

**A raw Python exception was UI copy.** A worker dispatch failure put `ValueError: no preview backend for 'segment.coastalMeasure'; known: [...]` — a repr'd list — into a tooltip. A message now reaches the tooltip only if the backend *coded* it, i.e. wrote it for a user; an escaped exception gets a short line and goes to the log.

**`segment.coastalMeasure` had no preview backend.** The module pages run the composites, never the bare segmenters, so this was the preview button being dead on the page people use. `task.jl` already warns that forgetting one is silent and "is exactly how the live preview first shipped broken" — and the warning did not prevent the second occurrence, because nothing checked. Now a test does, in both directions.

**Cancelling wrote seventeen error lines.** `_kill_tree` enumerates a tree then kills it, and killing one member takes its siblings (a torch DataLoader's workers exit with their parent). Every already-gone pid made `kill` print "No such process" for the *success* case. `ignorestatus` suppresses the exit code, not stderr.

**Param defaults, each checked rather than assumed:**

| | Was | Now | Why |
|---|---|---|---|
| coastal inline sliders | 6 | 2 | Seed window + Foreground threshold stay; Growing threshold goes to Advanced because coastal's own defaults treat it as a per-pass internal (0.2 large / 0.8 small), not a user knob |
| `stitchThreshold` | 0.0 | **0.2** | 0.0 is not "gentle" — `match_masks_3d` never matches, so every Z plane gets independent label IDs |
| `maxFrames` max | 2000 | **500** | Measured: 26 timeseries images in the projects dir, longest 201 frames, most 180–181 |
| `embeddingBlurSigma` | 0.5 µm | *unchanged* | coastal's tuned 1.5 is **pixels**; this spec is **microns** and the data is 0.33–0.60 µm/px, so 1.5 here would be 2.5–4.5 px. 0.5 µm is already 1.0–1.5 px |
| `probBlurSigma` | 0.0 | *unchanged* | coastal's own default, and its docs record the measurement — once the target was supervised at cell scale the blur stopped being a repair |

Plus the convergence plot's linear y axis is anchored at zero (Plot starts at the data minimum, so a loss settling at 0.2 and one at 0.02 drew identically). Never on log, where log(0) is undefined.

### Still not covered

- The preview worker is resident, so the new backend needs a worker restart to take effect.
- `no-preview-backend` is detected by matching the worker's message text; if that wording changes it falls back to the generic "Preview failed".
