### PR TITLE
fix(tracking): track in µm, not pixels

### DIFF
--- a/app/src/tasks/tracking/bayesian_tracking.jl
+++ b/app/src/tasks/tracking/bayesian_tracking.jl
@@ -46,8 +46,14 @@ function _run_task(task::BayesianTracking, img::CciaImage, params::Dict{String,A
 
     on_log("[INFO] Tracking labelProps: $props_path")
 
+    # µm per pixel, skimage order [sz, sy, sx] — the same accessor every other spatial task uses
+    # (cellNeighbours, the mesh tasks, track_measures). Tracking was the only one not calling it, so
+    # the linking ran in pixels while the measures computed on its own output ran in µm.
+    (pixel_res, _time_step) = img_physical_sizes(img)
+
     ok = run_py("tasks/tracking/bayesian_tracking_run.py",
         (; taskDir              = task_dir,
+           physicalSizes        = pixel_res,
            valueName            = value_name,
            labelIds             = label_ids,                          # null = whole segmentation
            maxSearchRadius      = Int(get(params, "maxSearchRadius", 20)),

--- a/app/src/tasks/tracking/bayesian_tracking.json
+++ b/app/src/tasks/tracking/bayesian_tracking.json
@@ -31,13 +31,13 @@
     },
     {
       "key": "maxSearchRadius",
-      "label": "Max search radius (px)",
+      "label": "Max search radius (µm)",
       "type": "int",
       "min": 1,
       "max": 200,
       "step": 1,
       "default": 20,
-      "tip": "Furthest a cell may move between consecutive frames; bounds XY only"
+      "tip": "Furthest a cell may move between consecutive frames; ~20 for T cells"
     },
     {
       "key": "maxLost",
@@ -124,13 +124,13 @@
         },
         {
           "key": "distThresh",
-          "label": "Distance threshold",
+          "label": "Distance threshold (µm)",
           "type": "float",
           "min": 1,
           "max": 50,
           "step": 0.2,
           "default": 10,
-          "tip": "Furthest apart two track ends may be joined (px)"
+          "tip": "Furthest apart two track ends may be joined"
         },
         {
           "key": "timeThresh",
@@ -204,13 +204,13 @@
         },
         {
           "key": "thetaDist",
-          "label": "Theta dist",
+          "label": "Theta dist (µm)",
           "type": "float",
           "min": 1,
           "max": 50,
           "step": 0.2,
           "default": 5,
-          "tip": "Distance (px) at which a join becomes unlikely; shapes the score, not a limit"
+          "tip": "Distance at which a join becomes unlikely; shapes the score, not a limit"
         }
       ]
     }

--- a/app/src/tasks/tracking/bayesian_tracking.json
+++ b/app/src/tasks/tracking/bayesian_tracking.json
@@ -3,9 +3,15 @@
   "fun_name": "tracking.bayesian_tracking",
   "label": "Bayesian tracking",
   "category": "Tracking",
-  "env": ["local"],
+  "env": [
+    "local"
+  ],
   "resource_pool": "cpu",
-  "requires": { "axes": ["T"] },
+  "requires": {
+    "axes": [
+      "T"
+    ]
+  },
   "params": [
     {
       "key": "valueName",
@@ -25,23 +31,23 @@
     },
     {
       "key": "maxSearchRadius",
-      "label": "Max search radius",
+      "label": "Max search radius (px)",
       "type": "int",
       "min": 1,
       "max": 200,
       "step": 1,
       "default": 20,
-      "tip": "Maximum distance (px) a cell may move between consecutive frames"
+      "tip": "Furthest a cell may move between consecutive frames; bounds XY only"
     },
     {
       "key": "maxLost",
-      "label": "Allowed gaps",
+      "label": "Allowed gaps (linking)",
       "type": "int",
       "min": 1,
       "max": 20,
       "step": 1,
       "default": 3,
-      "tip": "Maximum number of frames a track may be missing before it is ended"
+      "tip": "Frames a track may be unobserved while being built; joins use Time threshold"
     },
     {
       "key": "trackBranching",
@@ -86,18 +92,126 @@
       "type": "section",
       "collapsed": true,
       "params": [
-        { "key": "noiseInital",        "label": "Initial noise",        "type": "int",   "min": 1,     "max": 500, "step": 1,     "default": 300, "tip": "Multiplier for the motion model initial covariance (P)" },
-        { "key": "noiseProcessing",    "label": "Processing noise",     "type": "int",   "min": 1,     "max": 200, "step": 1,     "default": 100, "tip": "Multiplier for the motion model process noise (G)" },
-        { "key": "noiseMeasurements",  "label": "Measurement noise",    "type": "int",   "min": 1,     "max": 200, "step": 1,     "default": 100, "tip": "Multiplier for the motion model measurement noise (R)" },
-        { "key": "distThresh",         "label": "Distance threshold",   "type": "float", "min": 1,     "max": 50,  "step": 0.2,   "default": 10,  "tip": "Hypothesis-model distance threshold (physical units)" },
-        { "key": "timeThresh",         "label": "Time threshold",       "type": "int",   "min": 1,     "max": 20,  "step": 1,     "default": 5,   "tip": "Hypothesis-model time threshold (frames)" },
-        { "key": "segmentationMissRate","label": "Segmentation miss rate","type": "float","min": 0.001,"max": 0.2, "step": 0.001, "default": 0.1, "tip": "Prior probability that a cell is undetected in a frame" },
-        { "key": "lambdaLink",         "label": "Lambda link",          "type": "int",   "min": 1,     "max": 20,  "step": 1,     "default": 5,   "tip": "Hypothesis-model link-events rate" },
-        { "key": "lambdaBranch",       "label": "Lambda branch",        "type": "int",   "min": 1,     "max": 100, "step": 1,     "default": 50,  "tip": "Hypothesis-model branching-events rate" },
-        { "key": "lambdaTime",         "label": "Lambda time",          "type": "int",   "min": 1,     "max": 20,  "step": 1,     "default": 5,   "tip": "Hypothesis-model time factor" },
-        { "key": "lambdaDist",         "label": "Lambda dist",          "type": "float", "min": 1,     "max": 50,  "step": 0.2,   "default": 5,   "tip": "Hypothesis-model distance factor" },
-        { "key": "thetaTime",          "label": "Theta time",           "type": "int",   "min": 1,     "max": 20,  "step": 1,     "default": 5,   "tip": "Hypothesis-model time threshold" },
-        { "key": "thetaDist",          "label": "Theta dist",           "type": "float", "min": 1,     "max": 50,  "step": 0.2,   "default": 5,   "tip": "Hypothesis-model distance threshold" }
+        {
+          "key": "noiseInital",
+          "label": "Initial noise",
+          "type": "int",
+          "min": 1,
+          "max": 500,
+          "step": 1,
+          "default": 300,
+          "tip": "Multiplier for the motion model initial covariance (P)"
+        },
+        {
+          "key": "noiseProcessing",
+          "label": "Processing noise",
+          "type": "int",
+          "min": 1,
+          "max": 200,
+          "step": 1,
+          "default": 100,
+          "tip": "Multiplier for the motion model process noise (G)"
+        },
+        {
+          "key": "noiseMeasurements",
+          "label": "Measurement noise",
+          "type": "int",
+          "min": 1,
+          "max": 200,
+          "step": 1,
+          "default": 100,
+          "tip": "Multiplier for the motion model measurement noise (R)"
+        },
+        {
+          "key": "distThresh",
+          "label": "Distance threshold",
+          "type": "float",
+          "min": 1,
+          "max": 50,
+          "step": 0.2,
+          "default": 10,
+          "tip": "Furthest apart two track ends may be joined (px)"
+        },
+        {
+          "key": "timeThresh",
+          "label": "Time threshold",
+          "type": "int",
+          "min": 1,
+          "max": 20,
+          "step": 1,
+          "default": 5,
+          "tip": "Frames apart two track ends may be joined — this is what gaps end up being"
+        },
+        {
+          "key": "segmentationMissRate",
+          "label": "Segmentation miss rate",
+          "type": "float",
+          "min": 0.001,
+          "max": 0.2,
+          "step": 0.001,
+          "default": 0.1,
+          "tip": "Prior probability that a cell is undetected in a frame"
+        },
+        {
+          "key": "lambdaLink",
+          "label": "Lambda link",
+          "type": "int",
+          "min": 1,
+          "max": 20,
+          "step": 1,
+          "default": 5,
+          "tip": "Hypothesis-model link-events rate"
+        },
+        {
+          "key": "lambdaBranch",
+          "label": "Lambda branch",
+          "type": "int",
+          "min": 1,
+          "max": 100,
+          "step": 1,
+          "default": 50,
+          "tip": "Hypothesis-model branching-events rate"
+        },
+        {
+          "key": "lambdaTime",
+          "label": "Lambda time",
+          "type": "int",
+          "min": 1,
+          "max": 20,
+          "step": 1,
+          "default": 5,
+          "tip": "Hypothesis-model time factor"
+        },
+        {
+          "key": "lambdaDist",
+          "label": "Lambda dist",
+          "type": "float",
+          "min": 1,
+          "max": 50,
+          "step": 0.2,
+          "default": 5,
+          "tip": "Hypothesis-model distance factor"
+        },
+        {
+          "key": "thetaTime",
+          "label": "Theta time",
+          "type": "int",
+          "min": 1,
+          "max": 20,
+          "step": 1,
+          "default": 5,
+          "tip": "Hypothesis-model time threshold"
+        },
+        {
+          "key": "thetaDist",
+          "label": "Theta dist",
+          "type": "float",
+          "min": 1,
+          "max": 50,
+          "step": 0.2,
+          "default": 5,
+          "tip": "Distance (px) at which a join becomes unlikely; shapes the score, not a limit"
+        }
       ]
     }
   ]

--- a/docs/TRACKING.md
+++ b/docs/TRACKING.md
@@ -80,10 +80,30 @@ just cells with `track_id` present (the old `live` filter `track_id > 0`).
 - **Timecourse required.** Tracking needs `obsm['temporal']` + `uns['temporal_cols']`
   containing `t`. The runner raises a clear error on a single-timepoint segmentation. The
   `B.h5ad` fixture has 20 timepoints and can be used for end-to-end btrack verification.
-- **Pixel-space tracking.** Centroids are fed to btrack in **pixel** coordinates (no
-  physical-unit scaling), so `maxSearchRadius` is in pixels (matches the UI label). The old
-  module scaled by `omeXMLPixelRes`; we deferred that. For anisotropic-Z 3D data this may
-  need physical pixel sizes passed from Julia later.
+- **µm-space tracking (2026-08-07).** Centroids are scaled to **µm** before btrack sees them
+  — `physicalSizes` from `img_physical_sizes`, skimage order `[sz, sy, sx]`, the same
+  accessor `track_measures`, `cellNeighbours` and the mesh tasks already use. Every distance
+  param is therefore µm: `maxSearchRadius` (default **20**, ~T cell), `distThresh`,
+  `thetaDist`. Time stays in **frames** (`maxLost`, `timeThresh`) because btrack's `t` is a
+  frame index.
+
+  It was pixels until then, and tracking was the ONLY spatial task not calling
+  `img_physical_sizes` — so the linking ran in pixels while `track_measures` reported µm/min
+  on its own output. One pipeline, two coordinate systems.
+
+  **Scaling the coordinates, not each param**, for a reason no per-param conversion could
+  reach: at 0.33 µm XY and 2 µm Z, pixel space scored a one-plane hop as 0.33 µm of motion
+  when it is 2 µm — a **6× under-count**, in exactly the direction that links cells at
+  different depths. In µm the axes are commensurate by construction.
+
+  **This reinterprets saved values.** `maxSearchRadius = 20` used to mean 20 px (6.6 µm at
+  0.33 µm/px) and now means 20 µm — ~3× looser in XY, stricter in Z. The DEFAULTS did not
+  change numerically (20/10/5), which preserves their tuned ratios but makes the change
+  invisible on the form. Same class as the `minCellSize`/`labelExpansion` µm migration.
+  3D results will not reproduce; re-run to regenerate.
+
+  An image with no calibration falls back to unscaled — old pixel behaviour — rather than
+  pretending 1 px = 1 µm.
 - **btrack runs TWO phases, and different params bound each.** `tracker.track()` links
   frame to frame under `maxSearchRadius` (per STEP) and `maxLost`. Then
   `tracker.optimize()` runs the global hypothesis optimiser, which **joins finished track

--- a/docs/TRACKING.md
+++ b/docs/TRACKING.md
@@ -84,6 +84,30 @@ just cells with `track_id` present (the old `live` filter `track_id > 0`).
   physical-unit scaling), so `maxSearchRadius` is in pixels (matches the UI label). The old
   module scaled by `omeXMLPixelRes`; we deferred that. For anisotropic-Z 3D data this may
   need physical pixel sizes passed from Julia later.
+- **btrack runs TWO phases, and different params bound each.** `tracker.track()` links
+  frame to frame under `maxSearchRadius` (per STEP) and `maxLost`. Then
+  `tracker.optimize()` runs the global hypothesis optimiser, which **joins finished track
+  ends** under `distThresh` / `timeThresh` / `thetaDist` / `lambdaDist`. `maxSearchRadius`
+  and `maxLost` are not consulted there.
+
+  Two consequences that read as bugs and are not:
+
+  * **A drawn track is longer than the search radius, by design.** The radius bounds one
+    step; the viewer draws the accumulated trail. Measured on `zolIMa/fXgbTl`
+    (`maxSearchRadius = 8`, 0.33 µm/px): worst single step 8.2 px/frame — the limit is
+    honoured — while a 31-frame track covers ~25 µm at the median step and ~70 µm at p95.
+    So check whether the long thing is one STEP or a whole trail before suspecting the
+    tracker. (Open: on that run a single-frame jump was still reported by eye across two
+    consecutive frames, which the cell table does not contain — the drawn vertices come
+    from `napari_bridge._tracks_matrix`, so that is where to look, not at the params.)
+  * **`maxLost` does not bound the gaps you end up with.** Same run, `maxLost = 1`, and
+    final tracks contain gaps of 2–5 frames: each tracklet respected `max_lost`, then the
+    optimiser joined them across up to `timeThresh` (5). To limit gaps, set `timeThresh`.
+
+  To diagnose "why is this linked", measure per-step displacement from the tracked
+  `labelProps` (`LabelPropsView(...).view_centroid_cols()`, group by `track_id`, diff the
+  centroids) rather than judging trail length by eye.
+
 - **Centroid axis order.** `obsm['spatial']`/`uns['spatial_cols']` are skimage order:
   2D = `(y, x)`, 3D = `(z, y, x)`. The runner maps these to btrack `x/y/z` by dimensionality.
 - **Vendored btrack config.** `btrack.datasets.cell_config()` **downloads from the

--- a/python/cecelia/tests/test_tracking_units.py
+++ b/python/cecelia/tests/test_tracking_units.py
@@ -1,0 +1,113 @@
+"""Tracking coordinates reach btrack in µm — `cecelia.utils.tracking_utils`.
+
+Nothing covered this, and the gap was the bug. btrack works in whatever space it is handed, so
+`maxSearchRadius` meant PIXELS while `track_measures` — computing speed on the very same tracks —
+reported µm/min from `img_physical_sizes`. One pipeline, two coordinate systems, and the form said
+neither: "radius 8" and "an 8 µm jump" could both be true at once.
+
+The Z half is the part a per-param conversion could never fix. At 0.33 µm XY and 2 µm Z, pixel-space
+tracking scored a one-plane hop as 0.33 µm of motion when it is 2 µm — a 6x under-count, in exactly
+the direction that links cells at different depths.
+"""
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from cecelia.utils.tracking_utils import BayesianTrackingUtils
+
+
+class _View:
+    """The two methods `_centroids_from_view` uses, over a fixed frame."""
+
+    def __init__(self, df, temporal=('centroid_t',)):
+        self._df, self._t = df, list(temporal)
+
+    def temporal_columns(self):
+        return self._t
+
+    def view_centroid_cols(self):
+        return self
+
+    def as_df(self):
+        return self._df
+
+
+class _Log:
+    def log(self, *_a, **_k):
+        pass
+
+
+def _utils(physical_sizes=None):
+    params = {'taskDir': '/tmp', 'btrackConfig': '/tmp/cfg.json', 'maxSearchRadius': 20,
+              'maxLost': 1, 'trackBranching': False, 'minTimepoints': 5, 'accuracy': 0.8,
+              'probToAssign': 0.8, 'noiseInital': 300, 'noiseProcessing': 100,
+              'noiseMeasurements': 100, 'distThresh': 10, 'timeThresh': 5,
+              'segmentationMissRate': 0.1, 'lambdaLink': 5, 'lambdaBranch': 50, 'lambdaTime': 5,
+              'lambdaDist': 5, 'thetaTime': 5, 'thetaDist': 5}
+    if physical_sizes is not None:
+        params['physicalSizes'] = physical_sizes
+    return BayesianTrackingUtils(params, _Log())
+
+
+def _frame(z=True):
+    d = {'centroid_t': [0.0, 1.0], 'centroid_y': [10.0, 20.0], 'centroid_x': [30.0, 40.0],
+         'label': [1, 2]}
+    if z:
+        d['centroid_z'] = [2.0, 5.0]
+    return pd.DataFrame(d)
+
+
+class TrackingUnitsTest(unittest.TestCase):
+    def test_centroids_are_scaled_to_microns(self):
+        # [sz, sy, sx] — skimage order, as `img_physical_sizes` returns it
+        got = _utils([2.0, 0.5, 0.25])._centroids_from_view(_View(_frame()))
+        np.testing.assert_allclose(got['x'], [30 * 0.25, 40 * 0.25])
+        np.testing.assert_allclose(got['y'], [10 * 0.5, 20 * 0.5])
+        np.testing.assert_allclose(got['z'], [2 * 2.0, 5 * 2.0])
+
+    def test_the_axis_order_is_z_y_x_not_x_y_z(self):
+        """The one way to get this silently wrong. With distinct sizes per axis, swapping the order
+        still produces plausible coordinates — just the wrong distances, on the wrong axis."""
+        got = _utils([2.0, 0.5, 0.25])._centroids_from_view(_View(_frame()))
+        # x used the LAST size (0.25); had the order been read x,y,z it would be 30*2.0 = 60
+        self.assertAlmostEqual(got['x'].iloc[0], 7.5)
+        self.assertNotAlmostEqual(got['x'].iloc[0], 60.0)
+
+    def test_anisotropic_z_is_no_longer_under_counted(self):
+        """The 6x. One Z plane at 2 µm must not score as 0.33 µm of motion."""
+        px, pz = 0.33, 2.0
+        got = _utils([pz, px, px])._centroids_from_view(_View(_frame()))
+        step_z = abs(got['z'].iloc[1] - got['z'].iloc[0])
+        self.assertAlmostEqual(step_z, 3 * pz)                 # 3 planes → 6 µm
+        self.assertGreater(step_z / (3 * px), 5.9)             # ~6x what pixel space scored it
+
+    def test_time_is_left_in_frames(self):
+        """btrack's `t` is a frame index and the config's time params are in frames; scaling it here
+        would silently redefine `maxLost`/`timeThresh`. Minutes are `track_measures`' business."""
+        got = _utils([2.0, 0.5, 0.25])._centroids_from_view(_View(_frame()))
+        np.testing.assert_allclose(got['t'], [0.0, 1.0])
+
+    def test_no_sizes_means_unscaled_not_a_fake_micron(self):
+        """An uncalibrated image keeps the old pixel behaviour rather than pretending 1 px = 1 µm."""
+        for sizes in (None, []):
+            got = _utils(sizes)._centroids_from_view(_View(_frame()))
+            np.testing.assert_allclose(got['x'], [30.0, 40.0])
+            np.testing.assert_allclose(got['z'], [2.0, 5.0])
+
+    def test_2d_has_no_z_column_and_still_scales_xy(self):
+        got = _utils([2.0, 0.5, 0.25])._centroids_from_view(_View(_frame(z=False)))
+        np.testing.assert_allclose(got['z'], [0.0, 0.0])
+        np.testing.assert_allclose(got['x'], [7.5, 10.0])
+
+    def test_labels_survive_unscaled(self):
+        got = _utils([2.0, 0.5, 0.25])._centroids_from_view(_View(_frame()))
+        np.testing.assert_array_equal(got['label_id'], [1, 2])
+
+    def test_a_missing_temporal_axis_still_stops_the_run(self):
+        with self.assertRaises(SystemExit):
+            _utils([1.0, 1.0, 1.0])._centroids_from_view(_View(_frame(), temporal=()))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/cecelia/utils/tracking_utils.py
+++ b/python/cecelia/utils/tracking_utils.py
@@ -19,9 +19,11 @@ properties is a later phase (docs/POPULATION.md).
 Membership for the gated case is resolved by Julia (the sole gate evaluator) and handed to
 us as an explicit list of label IDs — we never evaluate gates here.
 
-Coordinates are tracked in **pixel space** (no physical-unit scaling); `maxSearchRadius`
-is therefore in pixels, matching the UI label. Anisotropic-Z scaling can be added later if
-needed by passing physical pixel sizes from Julia.
+Coordinates are scaled to **µm** before btrack sees them (`physicalSizes` from Julia's
+`img_physical_sizes`, skimage order `[sz, sy, sx]`), so every distance param —
+`maxSearchRadius`, `distThresh`, `thetaDist` — is in µm. This matches `track_measures`,
+which already reports µm/min from the same accessor, and handles anisotropic Z: at
+0.33 µm XY vs 2 µm Z, pixel-space tracking under-counted a one-plane hop 6-fold.
 """
 import os
 
@@ -53,6 +55,10 @@ class BayesianTrackingUtils:
         self.label_ids  = params.get("labelIds", None)
 
         self.max_search_radius   = params["maxSearchRadius"]
+        # [sz, sy, sx] in µm — skimage axis order, matching the centroid columns, the same shape
+        # `img_physical_sizes` hands every other spatial task (cellNeighbours, the mesh tasks,
+        # track_measures). Absent/empty for an uncalibrated image.
+        self.physical_sizes      = params.get("physicalSizes") or None
         self.max_lost            = params["maxLost"]
         self.track_branching     = bool(params["trackBranching"])
         self.min_timepoints      = params["minTimepoints"]
@@ -126,6 +132,24 @@ class BayesianTrackingUtils:
         y = df["centroid_y"].to_numpy(dtype=np.float64)
         z = (df["centroid_z"].to_numpy(dtype=np.float64)
              if "centroid_z" in df.columns else np.zeros_like(labels, dtype=np.float64))
+
+        # ── pixels → µm ─────────────────────────────────────────────────────────────
+        # Scaling the COORDINATES, not each spatial param, for two reasons.
+        #
+        # 1. It makes every distance param physical at once — `maxSearchRadius`, `distThresh`,
+        #    `thetaDist` — and any added later, with one conversion rather than one per param.
+        #    `track_measures` already reports µm/min from the same `img_physical_sizes`, so the
+        #    linking and the measures computed on its own output now share a coordinate system;
+        #    they did not, which is how "radius 8" and "a 8 µm jump" could both be true.
+        # 2. It fixes Z ANISOTROPY, which no per-param conversion can. On this data a voxel is
+        #    ~0.33 µm in XY and 2 µm in Z, so in pixel space btrack scored a one-plane hop as
+        #    0.33 µm of motion when it is 2 µm — a 6x under-count, and exactly the direction that
+        #    links cells at different depths. In µm the axes are commensurate by construction.
+        #
+        # No sizes (an image with no calibration) → unscaled, i.e. the old pixel behaviour, rather
+        # than a silent factor of 1 pretending to be microns.
+        sz, sy, sx = (self.physical_sizes if self.physical_sizes else (1.0, 1.0, 1.0))
+        x, y, z = x * sx, y * sy, z * sz
 
         return pd.DataFrame({"t": t, "x": x, "y": y, "z": z, "label_id": labels})
 


### PR DESCRIPTION
Tracking was the **only spatially-aware task not calling `img_physical_sizes`**. `track_measures`, `cellNeighbours` and both mesh tasks all convert; the linking did not — so btrack ran in **pixels** while the measures computed on its own output reported **µm/min**.

One pipeline, two coordinate systems, and the form named neither. That is how "search radius 8" and "an 8 µm jump" could both be true at once.

## What changed

Centroids are scaled to µm before btrack sees them (`physicalSizes`, skimage order `[sz, sy, sx]`), so every distance param is µm:

| Param | Unit | Default |
|---|---|---|
| `maxSearchRadius` | **µm** | 20 (~a T cell) |
| `distThresh` | **µm** | 10 |
| `thetaDist` | **µm** | 5 |
| `maxLost`, `timeThresh` | **frames** (unchanged) | 1 / 5 |

Time deliberately stays in frames — btrack's `t` is a frame index, and scaling it would silently redefine `maxLost` and `timeThresh`.

## Why scale the coordinates, not each param

Because of the part no per-param conversion can reach: **Z anisotropy**. At 0.33 µm XY and 2 µm Z, pixel space scored a one-plane hop as 0.33 µm of motion when it is 2 µm — a **6× under-count**, in exactly the direction that links cells at different depths. `tracking_utils.py`'s own docstring had this flagged as deferred. In µm the axes are commensurate by construction, and any distance param added later is physical for free.

## Considered and rejected: a `physical=true` option on `pop_df`

Counted the call sites first. **10 files call `pop_df`; exactly one needs physical units.** Five consumers that *do* scale never touch it — both tracking tasks read the props path or a Python-side view directly. It would have bought one call site and would not have prevented this.

(Worth a separate look: 8 `pop_df` consumers use pixel centroids today, and two of them **pool across images** — that project has four different pixel sizes, so a 10 px feature is 3.3 µm in one image and 6 µm in another. Same family of bug, if any of them treats centroid distance as a quantity.)

## Also — copy that was misleading

- `distThresh`'s tip said *"(physical units)"* while the radius's said *"(px)"*, for parameters on the same coordinates
- `Allowed gaps` → **`Allowed gaps (linking)`**: it does not bound the gaps you get. Measured on `zolIMa/fXgbTl` with `maxLost = 1`, final tracks contain gaps of **2–5 frames** — each tracklet respected it, then `tracker.optimize()` joined them across `timeThresh` (5). `docs/TRACKING.md` now documents the two phases and which params bound each.

## Reservations

- **This reinterprets saved values.** `maxSearchRadius = 20` meant 20 px (6.6 µm) and now means 20 µm — ~3× looser in XY, stricter in Z. Defaults are numerically unchanged (20/10/5, preserving their tuned ratios), which makes the change **invisible on the form**. Same class as the `minCellSize`/`labelExpansion` µm migration.
- **3D results will not reproduce.** Re-run to regenerate.
- **Not run against real data.** The arithmetic has 8 new tests (there were none for tracking at all); a tracking run is not covered. The check worth doing: re-track `fXgbTl` and re-measure per-step displacement — it should now cap near 20 µm rather than 8 px.
- Uncalibrated images fall back to unscaled — old pixel behaviour — rather than pretending 1 px = 1 µm.
- Still open, and unrelated to these params: a single-frame jump reported by eye is not present in the cell table, which points at `napari_bridge._tracks_matrix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
