### PR TITLE
The Chat-to-Claude prompt never mentioned boards or attributes

### DIFF
--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -842,10 +842,59 @@ end
     # The artifacts it can author are named, so the agent knows they exist — the prompt listed
     # neither for a while, and an unmentioned tool is an unused one.
     @test occursin("create_notebook", fp) && occursin("create_chain", fp)
+    # the Phase-0 read tools + the discipline that makes them worth having (a figure proposed without
+    # checking how the images are annotated throws the experiment's design away)
+    @test occursin("get_image_attributes", fp) && occursin("get_analysis_boards", fp)
+    # match on unwrapped text — the prompt is hard-wrapped, so a phrase can straddle a newline
+    @test occursin("not four replicates", replace(fp, r"\s+" => " "))
     # …and the boundary is stated: authoring a chain is not running it. This is the line that keeps
     # the assistant from telling a user their pipeline has started.
     @test occursin("cannot start", fp) || occursin("cannot rename", fp)
     @test occursin("press Run", fp)
+end
+
+@testset "the two observer prompts name the same MCP tools" begin
+    # THE recurring bug in this area, twice now: an MCP tool is added, ONE of the two prompts is
+    # updated, and the other silently goes stale — an unmentioned tool is an unused one, so the
+    # capability just never gets offered. It surfaced both times only because Dominik pasted his
+    # Chat-to-Claude prompt and noticed something missing (create_chain the first time,
+    # get_analysis_boards/get_image_attributes the second).
+    #
+    # A warning comment inside one of the files cannot fix this — you only read it if you already knew
+    # the other file existed. So the invariant is enforced here instead, across all three sources.
+    # Same idea as "calibration writers agree across languages": two implementations that cannot call
+    # each other get a test that compares them.
+    #
+    # The prompts are NOT required to name the same set — they address different surfaces — but every
+    # difference must be DELIBERATE and listed below. Adding a tool to one prompt and not the other now
+    # fails here, naming the offender.
+    root = normpath(joinpath(@__DIR__, "..", ".."))
+    server = read(joinpath(root, "mcp", "cecelia_mcp", "server.py"), String)
+    jl     = read(joinpath(root, "app", "src", "ai", "observer_prompt.jl"), String)
+    ts     = read(joinpath(root, "frontend", "src", "lib", "chatHandoff.ts"), String)
+
+    tools = Set(String[m.captures[1] for m in eachmatch(r"@mcp\.tool\(\)\s*\ndef (\w+)", server)])
+    @test length(tools) >= 30                          # anti-vacuity: a bad regex must not pass
+    named_jl = Set(t for t in tools if occursin(t, jl))
+    named_ts = Set(t for t in tools if occursin(t, ts))
+
+    # In the IN-APP prompt only — it drives the autonomous observer loop, which the user's own session
+    # has no use for.
+    @test setdiff(named_jl, named_ts) == Set(["poll_observations"])
+    # In the CHAT HAND-OFF only — orientation + authoring aids for a session the user starts fresh;
+    # the in-app agent is already oriented and does not browse notebooks.
+    @test setdiff(named_ts, named_jl) ==
+        Set(["get_available_plots", "get_session_briefing", "list_notebooks", "set_notebook_description"])
+    # Named by NEITHER: per-image detail an agent reaches for from a summary rather than from the
+    # prompt, plus the observer's own bookkeeping.
+    @test setdiff(tools, union(named_jl, named_ts)) ==
+        Set(["get_image_notes", "get_observer_stats", "get_qc_metrics", "get_spatial_stats",
+             "set_observer_active"])
+    # Every WRITE must be offered by both: a mutating capability nobody mentions is a capability the
+    # assistant never uses, which is how create_chain sat unmentioned in the hand-off.
+    for w in ("append_lab_log", "create_notebook", "revise_notebook", "create_chain")
+        @test w in named_jl && w in named_ts
+    end
 end
 
 @testset "AI observer session sidecar (tokens + clear)" begin

--- a/docs/ai-assist/OBSERVER.md
+++ b/docs/ai-assist/OBSERVER.md
@@ -29,6 +29,18 @@ The value of the observer session depends entirely on what Claude can see. Claud
 
 ## MCP tools to implement
 
+> **Adding a tool touches THREE files.** `mcp/cecelia_mcp/server.py` (the tool, plus a `client.py`
+> method and its `ALLOWED_ROUTES` entry) — and **both** prompts: `app/src/ai/observer_prompt.jl`
+> (`_OBSERVER_RULES`, the in-app observer) and `frontend/src/lib/chatHandoff.ts` (`buildChatPrompt`,
+> the Chat-to-Claude prompt the user pastes). An unmentioned tool is an unused one: the assistant
+> never offers the capability. This has gone stale **twice** — `create_chain`, then
+> `get_analysis_boards`/`get_image_attributes` — both caught only when Dominik pasted his prompt and
+> noticed the gap. The ⚠️ comment in `chatHandoff.ts` did not prevent either, because you only read it
+> if you already knew the second file existed. It is now enforced by `app/test/suite.jl` →
+> *"the two observer prompts name the same MCP tools"*, which parses `@mcp.tool()` out of `server.py`
+> and asserts the prompts' asymmetry equals an explicit, commented allowlist.
+
+
 **Read-only (Phase 1 — implement now):**
 ```
 get_project_info          → name, version, image count, current stage

--- a/frontend/src/lib/chatHandoff.test.ts
+++ b/frontend/src/lib/chatHandoff.test.ts
@@ -29,6 +29,13 @@ describe('buildChatPrompt', () => {
     expect(p).toMatch(/edit and run/i)                 // Claude bootstraps; the user owns/iterates it
   })
 
+  it('names the board + attribute tools, and says to check them before proposing a figure', () => {
+    const p = buildChatPrompt('NRUBxU')
+    expect(p).toContain('get_analysis_boards')     // don't rebuild a board the user already has
+    expect(p).toContain('get_image_attributes')    // the axes a cross-image comparison can group by
+    expect(p).toContain('not four replicates')     // the discipline, not just the tool name
+  })
+
   it('names the available-plots tool for suggesting visualizations', () => {
     expect(buildChatPrompt('NRUBxU')).toContain('get_available_plots')
   })

--- a/frontend/src/lib/chatHandoff.ts
+++ b/frontend/src/lib/chatHandoff.ts
@@ -24,7 +24,9 @@ export function buildChatPrompt(projectUid: string, projectName?: string): strin
       `(get_session_briefing), its state (get_project_info, list_images, get_task_history, ` +
       `get_task_log/get_recent_logs), how the data was produced (get_analysis_lineage, get_chains), the ` +
       `analysis itself (get_populations, get_measure_summary, get_behaviour_summary, get_cluster_summary), ` +
-      `the board's plot types (get_available_plots), ` +
+      `the board's plot types (get_available_plots), the boards I already built and what each one plots ` +
+      `(get_analysis_boards), how my images are annotated (get_image_attributes — the axes a comparison ` +
+      `can group by, e.g. Mouse or Location), ` +
       `cross-set QC (get_cohort_qc), the lab log (read_lab_log), the notebook/REPL data-access ` +
       `surface (get_repl_api), and the notebooks themselves (list_notebooks, get_notebook — so you can ` +
       `read one I'm stuck in and walk me through the fix). They are read-only except five additive ` +
@@ -32,6 +34,13 @@ export function buildChatPrompt(projectUid: string, projectName?: string): strin
       `(create_notebook), making a new version of one (revise_notebook — it snapshots first, so nothing is ` +
       `lost), rewording a notebook's description (set_notebook_description), and designing a chain — the ` +
       `wired task pipeline — with create_chain.`,
+    ``,
+    `Before you propose any figure or cross-image comparison: call get_image_attributes for the axes my ` +
+      `images can be grouped by, and use list_images' per-image attr to size the groups once excluded ` +
+      `images are dropped — four images from one mouse are not four replicates, and a group of one is not ` +
+      `a comparison. If a set has no attributes, say the grouping is unavailable rather than inventing one ` +
+      `from my filenames. And call get_analysis_boards first, so you extend the boards I already built ` +
+      `instead of rebuilding them — match the measures and populations I already chose.`,
     ``,
     `On chains: you can DESIGN one but you cannot run it. create_chain writes a template that sits ` +
       `inert in my Chains whiteboard until I press Run, and there is no tool that starts it — so hand it ` +


### PR DESCRIPTION
`get_analysis_boards` and `get_image_attributes` shipped in #494, but the **Chat-to-Claude** prompt never mentioned them — so the assistant you actually talk to was never offered the capability.

## Why it happened, twice

Adding an MCP tool touches **three** files: `mcp/cecelia_mcp/server.py`, `_OBSERVER_RULES` in `app/src/ai/observer_prompt.jl` (in-app observer), and `buildChatPrompt` in `frontend/src/lib/chatHandoff.ts` (the prompt the user pastes). Phase 0 updated the first two.

`chatHandoff.ts`'s own header already records this happening with `create_chain` — landed in the Julia prompt first, this file went stale, "which is how the user found out (their pasted prompt never mentioned chains)". Same discovery route this time: Dominik pasted his prompt and noticed.

A ⚠️ comment inside one of the two files cannot prevent it. You only read it if you already knew the second file existed, and the failure mode is *not knowing*.

## The guard

`app/test/suite.jl` → *"the two observer prompts name the same MCP tools"* parses `@mcp.tool()` out of `server.py` and asserts each prompt's tool set. The prompts aren't required to match — they address different surfaces — but every difference is now an explicit, commented allowlist:

- **in-app only**: `poll_observations` (the autonomous loop)
- **hand-off only**: `get_session_briefing`, `get_available_plots`, `list_notebooks`, `set_notebook_description` (orientation + authoring aids for a fresh session)
- **neither**: per-image detail an agent reaches for from a summary, plus observer bookkeeping

…and every **write** tool must appear in both — a mutating capability nobody mentions is one the assistant never uses, which is exactly what happened to `create_chain`.

Same shape as the existing `calibration writers agree across languages` test: two implementations that can't call each other get a test that compares them. I verified it fails on introduced drift (renamed one tool in the hand-off) and names the offender, rather than passing vacuously.

## Also

- The rule now sits in `docs/ai-assist/OBSERVER.md` → *MCP tools*, where someone looks **before** writing a tool.
- Both prompts gained the discipline that makes the Phase 0 tools worth having: check the attribute axes before proposing any cross-image comparison (four images from one mouse are not four replicates; an unannotated set means say so rather than inferring groups from filenames), and read the boards the user already built rather than rebuilding them.

**Reservations**
- The allowlist encodes today's deliberate asymmetry. If a prompt is legitimately restructured the test will fail and someone may widen the allowlist rather than fix the prompt — the comments say which is which, but it's a judgement the test can't make.
- Prompt wording is unverified in use; I only assert the tool names and one discipline phrase are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
