### PR TITLE
docs(observer): say that Claude can add boards now

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -30,6 +30,15 @@ on edit via its own routes, and `lastOpenedAt` is stamped on open. Restored on o
 `boards`. **Backend restart** is needed the first time these routes are active (`api/` is not
 Revise-tracked; see `CLAUDE.md`).
 
+**Claude can ADD a board.** The MCP observer's `add_analysis_board` (write 6/6) posts a semantic spec
+— which plots, which populations, in what order — to `POST /api/boards/add`, and the server expands it
+into a `LayoutEntry` and validates it against the project (`app/src/analysis_board_spec.jl`). Add-only:
+it cannot modify, rename, reorder or delete a board, so an authored board lands beside the user's own
+and is one click to remove. The in-app *"What can Claude do here?"* dialog
+(`frontend/src/lib/claudeOverview.ts`) states both halves — the capability and the add-only limit —
+and is where a user checks before letting Claude near their Analysis page. See
+`docs/ai-assist/OBSERVER.md` and `docs/todo/MCP_BOARD_AUTHORING_PLAN.md`.
+
 **The document has ONE reader/writer** — `app/src/analysis_boards.jl` (`read_boards_doc` /
 `normalise_boards` / `write_boards_doc`), used by the autosave route, the project-open payload and
 `board_summaries` alike. The last time this file had two parsers they disagreed about its shape and
@@ -49,8 +58,11 @@ Each write echoes the version it last read; a stale write is rejected 409, and t
 `GET /api/projects/boards` rather than retrying — the file is one blob, so re-sending our copy would
 just move the clobber one step later and lose the *other* tab's boards instead. The debounced edit that
 lost the race is dropped, with a warning in the log. A successful write broadcasts `boards:changed`
-(`projectUid`, `version`) so other clients converge; the writer ignores its own echo by version
-(`frontend/src/utils/boardDoc.ts`), and the reload goes through the existing `_restoring` suppression.
+(`projectUid`, `version`, `clientId`) so other clients converge; the writer ignores its own echo by
+**`clientId`, not version** (`frontend/src/utils/boardDoc.ts`) — the route broadcasts before it returns,
+so a writer still holds the pre-write version when its own frame arrives, and a version test made every
+autosave reload and re-render the board it had just saved. A frame with no `clientId` is a non-browser
+writer (the MCP add route) and IS honoured. The reload goes through the existing `_restoring` suppression.
 
 **Layout keys are stored project-RELATIVE** (`tab:<id>`, no uid) via `frontend/src/utils/boardKeys.ts`
 — `serialize` strips the `analysis:<uid>:` prefix on save, `load(groupKey, …)` re-applies the *current*

--- a/docs/ai-assist/OBSERVER.md
+++ b/docs/ai-assist/OBSERVER.md
@@ -252,14 +252,22 @@ verifiable artifacts. Shipped as PRs #250–#258; this is the durable summary (t
   **`revise_notebook`** makes a new version of an existing one (`/api/notebooks/revise` — snapshots then
   overwrites; real versioning, not a `-v2` copy). `set_notebook_description` rewords its blurb afterwards
   (`/api/notebooks/describe`, description text only).
-- **`get_available_plots`** — the board's plot types, for viz suggestions.
+- **`get_available_plots`** — the board's plot types, for viz suggestions; also the spec ids and
+  chart types `add_analysis_board` authors against.
+- **`add_analysis_board`** — ADD one board to `/analysis` from a semantic spec (which plots, which
+  populations, in what order); the server expands it to the stored layout and refuses a spec the
+  project cannot plot, because a bad selection renders an EMPTY panel with no error. Add-only.
+  See `docs/todo/MCP_BOARD_AUTHORING_PLAN.md` and `docs/ANALYSIS.md`.
 - **In-app overview** — `ClaudeOverviewDialog` (`?` in the lab-log toolbar): a brief how-to.
 
 **Durable boundaries (why, so they aren't relitigated)**
 - **Additive writes only.** The MCP allow-list permits exactly `POST /api/lablog/append`
   (append-only), `POST /api/notebooks/write` (create-only, 409 on existing), `POST
   /api/notebooks/describe` (a notebook's description string only — not its cells), `POST
-  /api/notebooks/revise` (snapshots first) and `POST /api/chains/create` (create-only + validated).
+  /api/notebooks/revise` (snapshots first), `POST /api/chains/create` (create-only + validated) and
+  `POST /api/boards/add` (create-only + validated — ADDS one Analysis board; cannot modify, rename,
+  reorder or delete one, and is deliberately NOT the browser's whole-document board autosave, which
+  would let a single request replace every board in the project).
   None touch cell data, images, gates, QC, or notebook content; the invariant test asserts the exact
   set. No task-run, gate, h5ad, or config write.
 - **Claude designs; the user runs — enforced by the transport.** `create_chain` writes a chain

--- a/frontend/src/lib/claudeOverview.test.ts
+++ b/frontend/src/lib/claudeOverview.test.ts
@@ -20,6 +20,7 @@ describe('claudeOverview content model', () => {
     expect(byKey.cant.tone).toBe('muted')                // the "can't" group reads as recessive
     expect(byKey.creates.items.join(' ')).toMatch(/notebook/i)   // notebooks are the headline "create"
     expect(byKey.creates.items.join(' ')).toMatch(/chain/i)      // …and chains, since it can author one
+    expect(byKey.creates.items.join(' ')).toMatch(/board/i)      // …and boards (add_analysis_board)
     for (const g of CLAUDE_CAPABILITIES) expect(g.items.length).toBeGreaterThan(0)
   })
 
@@ -31,6 +32,9 @@ describe('claudeOverview content model', () => {
     expect(cant).toMatch(/run anything|cannot run|can't run/i)
     expect(cant).toMatch(/chain/i)
     expect(cant).toMatch(/overwrite|rename|delete/i)
+    // boards are ADD-ONLY, and this dialog is where someone checks before letting Claude near their
+    // Analysis page — the limit has to be stated wherever the capability is
+    expect(cant).toMatch(/board/i)
   })
 
   it('offers example prompts spanning QC → notebook → chain', () => {

--- a/frontend/src/lib/claudeOverview.ts
+++ b/frontend/src/lib/claudeOverview.ts
@@ -64,6 +64,7 @@ export const CLAUDE_CAPABILITIES: CapabilityGroup[] = [
   {
     key: 'creates', title: 'Creates', icon: 'pi-file-edit', tone: 'good',
     items: [
+      'Analysis boards — a page of plots, added beside your own',
       'Chains — a wired pipeline you review, then run',
       'Pluto notebooks — runnable analysis you then own & edit',
       'CSV exports for Prism / R',
@@ -75,7 +76,7 @@ export const CLAUDE_CAPABILITIES: CapabilityGroup[] = [
     items: [
       'Change your data (h5ad, gates, project config)',
       'Run anything — not a task, not a chain it built',
-      'Overwrite, rename or delete your chains & notebooks',
+      'Overwrite, rename or delete your chains, notebooks & boards',
       'Open raw image pixels',
       'Draw the biological conclusion — that stays yours',
     ],
@@ -111,7 +112,7 @@ export const CLAUDE_TERMINAL = {
 // Keep them short and uniform so they read as a clean row of chips.
 export const CLAUDE_EXAMPLES: string[] = [
   'Why is this image off?',
-  'Plot the behaviour differences',
+  'Add a board of behaviour plots',
   'Build a cell-speed notebook',
   'Design a segment + track chain',
 ]


### PR DESCRIPTION
`add_analysis_board` shipped in #496, but the places a **user** looks to find out what Claude can do still described the previous capability set — so the feature was effectively invisible unless you already knew to ask for it.

## The dialog (the point of this PR)

`ClaudeOverviewDialog` — the `?` in the lab-log toolbar — is backed by `frontend/src/lib/claudeOverview.ts`:

- **Creates** listed chains, notebooks, CSVs and lab-log notes. Boards are now first: *"Analysis boards — a page of plots, added beside your own"*.
- **Can't** is the half that matters more here. This dialog is exactly where someone checks before letting Claude near their Analysis page, so the add-only limit belongs next to the capability: *"Overwrite, rename or delete your chains, notebooks & boards"*.
- One example chip swapped to *"Add a board of behaviour plots"*, so the row of prompts shows the range including boards.

The file header already said it mirrors the observer's real capabilities and to keep it honest. Its test now **pins boards in both groups**, so the capability and its limit can't drift apart the way the two prompts did before the parity test existed.

## Docs

- **`docs/ai-assist/OBSERVER.md`** — `add_analysis_board` gets its own entry, and the *additive writes only* boundary now lists `POST /api/boards/add` with why it is deliberately **not** the browser's whole-document board autosave (allow-listing that would let one request replace every board in the project).
- **`docs/ANALYSIS.md`** — a short section on authored boards, pointing at the expander (`analysis_board_spec.jl`) and at the dialog.

## Drive-by fix

`docs/ANALYSIS.md` still claimed the writer ignores its own `boards:changed` broadcast *"by version"*. That is exactly the race the last commit on #496 replaced with a `clientId` — the route broadcasts before it returns, so the writer still holds the pre-write version when its own frame arrives. The doc went stale inside its own PR; corrected here.

## Tests

Frontend 1022 across 95 files, `vue-tsc -b` clean. Docs-and-content only — no runtime behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
