### PR TITLE
Declare the categorical bar x scale as a band scale

### DIFF
--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -1046,7 +1046,7 @@ function frequency(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts,
     return {
       ...THEME, color,
       fx: { label: r.measure },
-      x: { axis: null },
+      x: { axis: null, type: 'band' },   // same reason as the stacked branch below
       y: { label: yLabel, grid: false },
       marks: [
         Plot.barY(rows, { fx: 'category', x: 'series', y: 'value', fill: 'series', tip: true }),
@@ -1056,7 +1056,11 @@ function frequency(Plot: PlotModule, r: PlotDataResponse, o: BuildOpts,
   }
   return {
     ...THEME, color,
-    x: { label: r.measure },
+    // `type: 'band'` is not cosmetic: categories that LOOK numeric ("1"/"2"/"3" — every HMM state
+    // column is an integer code) make Plot infer an ordinal scale from strings-that-are-numbers and
+    // emit its own ⚠️ glyph into the SVG ("Please check the console"), which lands in the BROWSER
+    // console, not ours. Saying band explicitly is the documented way to state the intent.
+    x: { label: r.measure, type: 'band' },
     y: { label: yLabel, grid: false },
     marks: [
       Plot.barY(rows, { x: 'category', y: 'value', fill: 'series',


### PR DESCRIPTION
The first plot on an analysis board's behaviour-states tab showed a warning triangle whose tooltip
said "Please check the console" — with nothing in the app's Error Console.

**It isn't ours.** `Plot.plot()` appends a `<text>⚠️</text>` with an SVG `<title>` child when it has
emitted warnings. Two consequences, both of which read as bugs: the tooltip is a native browser one
(no teleport, no app styling), and "the console" means the *browser devtools* console — Plot calls
`console.warn`, which our log store doesn't capture.

**Why it fired.** HMM state columns are integer codes, so `_catkey` (`app/src/plotting/plot_data.jl`)
sends the categories as `"1"`/`"2"`/`"3"`. Plot infers an ordinal x scale from
strings-that-look-like-numbers and warns (`scales.js` → *"some data associated with the x scale are
strings that appear to be numbers"*), suggesting you declare the scale type. The grouped `frequency`
variant was silent only because it puts the category on `fx`, which Plot's check explicitly skips.

**Fix.** `type: 'band'` on the x scale of both `frequency()` branches — the type `barY` already
infers, stated explicitly.

Not verified in a browser: the warning was identified from Plot's source plus the real category
values, not from the devtools message. If the glyph survives a reload, devtools will name the actual
warning.

Future Plot warnings still land only in devtools. Routing them into the app's Error Console would
mean wrapping `console.warn` globally — deliberately not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
