### PR TITLE
Stop the analysis board re-rendering itself to Vue's recursion limit

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -138,6 +138,14 @@ registry `rail` (`canvasManager.ts` → `RailKind`), never a branch in `LayoutCa
 | `'flowModels'` | `FlowModelVault`, docked | `flowTraining`, `flowProbability` |
 | `'none'` | `SeriesPicker` with the list suppressed — the styling block + scope footer only | `gatingStrategy`, `filmstrip`, `flowMetrics` |
 
+**A slot with no `vis` falls back to `DEFAULT_VIS`, never `defaultVis()`.** The factory mints a new bag
+per call, so a template-side `?? defaultVis()` gives every panel a "new" vis on every board render — the
+chart rebuilds, reports its auto-overrides back up, the board stores the readout and renders again
+("Maximum recursive updates exceeded"). Slots lack a `vis` exactly when something other than the GUI
+wrote them (`add_analysis_board` omits the bag on purpose — `app/src/analysis_board_spec.jl`), so the
+loop hit Claude-authored boards only. Use the shared frozen `DEFAULT_VIS` wherever the fallback is READ;
+keep `defaultVis()` where a panel needs its own bag to write into.
+
 `'none'` keeps the panel rather than hiding it because the rail carries two independent things: the
 selection list *and* the shared `PlotOptions` styling + scope footer, which a self-contained plot may
 still use (`GatingStrategyView` reads `vis.fontSize`).

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -27,7 +27,7 @@ import { useAnalysisLayoutStore, type SlotContent } from '../../stores/analysisL
 import { useSummaryData } from '../../composables/useSummaryData'
 import { useClusterContext } from '../../composables/useClusterContext'
 import { tkey, parseTkey } from '../../plots/series'
-import { defaultVis, type VisProps } from '../../plots/plot'
+import { defaultVis, DEFAULT_VIS, type VisProps } from '../../plots/plot'
 import { UNIFORM_PRESETS, COMIC_PRESETS, uniform, A4_PORTRAIT_ASPECT, A4_LANDSCAPE_ASPECT } from '../../plots/layoutTemplates'
 import type { SeriesTarget } from '../../plots/types'
 import { migrateSpecId, isPrecomputedSpec } from '../../plots/popTypes'
@@ -262,12 +262,12 @@ function onDrop(i: number) { if (dragFrom.i >= 0) layout.swap(props.canvasKey, d
 
 // ── global/local scope (drives eye-selection + vis), targeting the ACTIVE slot when local ─────────
 const panelSel = (c: SlotContent) => scope.value === 'global' ? gSel.value : (st(c).sel ?? [])
-const panelVis = (c: SlotContent) => scope.value === 'global' ? gVis.value : (st(c).vis ?? defaultVis())
+const panelVis = (c: SlotContent) => scope.value === 'global' ? gVis.value : (st(c).vis ?? DEFAULT_VIS)
 const activeSel = computed(() => scope.value === 'global' ? gSel.value : (activeContent.value ? st(activeContent.value).sel : []))
 // fall back to defaultVis() when the active slot has no local vis yet (matches ClusterPlots) — else the
 // pop manager's `vis` is undefined and the whole PlotOptions styling block is hidden (the "cluster-tracks
 // manager has no plot params" bug).
-const activeVis = computed(() => scope.value === 'global' ? gVis.value : (activeContent.value ? (st(activeContent.value).vis ?? defaultVis()) : defaultVis()))
+const activeVis = computed(() => scope.value === 'global' ? gVis.value : (activeContent.value ? (st(activeContent.value).vis ?? DEFAULT_VIS) : DEFAULT_VIS))
 const toggle = (arr: string[], v: string) => arr.includes(v) ? arr.filter(x => x !== v) : [...arr, v]
 function toggleTarget(valueName: string, pop: string, pt: string) {
   const k = tkey(pt, valueName, pop)

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -25,7 +25,7 @@ import SeriesPicker from './SeriesPicker.vue'
 import SummaryPanel from './SummaryPanel.vue'
 import CanvasZoomControl from './CanvasZoomControl.vue'
 import { tkey, parseTkey } from '../../plots/series'
-import { defaultVis, type VisProps } from '../../plots/plot'
+import { defaultVis, DEFAULT_VIS, type VisProps } from '../../plots/plot'
 import type { SeriesTarget, ChartType } from '../../plots/types'
 import { migrateSpecId, isPrecomputedSpec } from '../../plots/popTypes'
 import { emptyReadout, type PlotReadout } from '../../plots/plotReadout'
@@ -97,7 +97,7 @@ for (const p of panels.value) migrateSpecId(p.state)
 const panelSel = (s: PanelState) => scope.value === 'global' ? gSel.value : s.sel
 const activeSel = computed(() => scope.value === 'global' ? gSel.value : (activePanel.value?.state.sel ?? []))
 const panelVis = (s: PanelState) => scope.value === 'global' ? gVis.value : s.vis
-const activeVis = computed(() => scope.value === 'global' ? gVis.value : (activePanel.value?.state.vis ?? defaultVis()))
+const activeVis = computed(() => scope.value === 'global' ? gVis.value : (activePanel.value?.state.vis ?? DEFAULT_VIS))
 const toggle = (arr: string[], v: string) => arr.includes(v) ? arr.filter(x => x !== v) : [...arr, v]
 // the stats test each panel's last result actually ran (`auto` resolves it server-side from the group
 // count) — the picker shows the ACTIVE plot's, so the user can see what `auto` chose. Not persisted:

--- a/frontend/src/components/canvas/SummaryPanel.vue
+++ b/frontend/src/components/canvas/SummaryPanel.vue
@@ -17,7 +17,7 @@ import PlotChart from '../plots/PlotChart.vue'
 import PlotSpinner from '../plots/PlotSpinner.vue'
 import { useDelayedLoading } from '../../composables/useDelayedLoading'
 import { plotAxisSuffix, seriesAreGrouped } from '../../utils/csvName'
-import { backendChart, chartsForMeasure, plotDataToCsv, plotStatsToCsv, defaultVis, emptySeriesLabels, heatmapControls, type VisProps, type BuildOpts } from '../../plots/plot'
+import { backendChart, chartsForMeasure, plotDataToCsv, plotStatsToCsv, DEFAULT_VIS, emptySeriesLabels, heatmapControls, type VisProps, type BuildOpts } from '../../plots/plot'
 import { zipTextFiles } from '../../utils/zip'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
 import type { PlotSpec, PlotDataResponse, PlotSeries, ChartType, SeriesTarget } from '../../plots/types'
@@ -515,7 +515,7 @@ watch(readout, n => emit('readout', n), { immediate: true, deep: true })
 
 const byImage = computed(() => crossImage.value && (props.scope ?? 'per_image') === 'per_image')
 
-const vis = computed<VisProps>(() => props.vis ?? defaultVis())
+const vis = computed<VisProps>(() => props.vis ?? DEFAULT_VIS)
 const hasData = computed(() => {
   const r = result.value
   if (!r) return false

--- a/frontend/src/components/plots/PlotChart.vue
+++ b/frontend/src/components/plots/PlotChart.vue
@@ -13,7 +13,7 @@ import { computed, watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue
 import { buildPlotOptions, type BuildOpts } from '../../plots/plot'
 import { svgToImageURL, svgOf } from '../../plots/export'
 import { legendOverlay, titleOverlay } from '../../plots/overlays'
-import { xRotationOverride, type AutoOverride } from '../../plots/autoOverride'
+import { xRotationOverride, sameOverrides, type AutoOverride } from '../../plots/autoOverride'
 import type { PlotDataResponse } from '../../plots/types'
 
 const props = defineProps<{ data: PlotDataResponse | null; opts: BuildOpts }>()
@@ -36,6 +36,10 @@ let titleNode: HTMLElement | null = null
 // reservation was wrong, render ONCE more with the real number. Remembered across renders so a resize
 // starts from the last known height instead of flashing the estimate again.
 let legendH = 0
+// last set announced to the host — the emit is change-gated against it (see below). `null` until the
+// first render, so a REMOUNT always re-announces (the host keeps its own copy and would otherwise
+// stay on the previous chart's note).
+let lastOverrides: AutoOverride[] | null = null
 
 async function render(pass = 0) {
   if (!host.value) return
@@ -60,8 +64,14 @@ async function render(pass = 0) {
   // matches the plot ink.
   ;(node as SVGElement).style.setProperty('--plot-background', props.opts?.darkTheme ? '#1f2226' : 'white')
   host.value.append(node)
-  // report any setting the builder substituted (`_autoRotatedX`)
-  emit('auto-override', [xRotationOverride(!!base._autoRotatedX, !!props.opts.rotateXLabel)].filter(Boolean) as AutoOverride[])
+  // report any setting the builder substituted (`_autoRotatedX`) — but only when it actually CHANGED.
+  // The host stores this and the board stores the host's readout, so an unconditional emit makes every
+  // render a state write, which renders again. See sameOverrides in plots/autoOverride.ts.
+  const overrides = [xRotationOverride(!!base._autoRotatedX, !!props.opts.rotateXLabel)]
+    .filter(Boolean) as AutoOverride[]
+  if (!lastOverrides || !sameOverrides(overrides, lastOverrides)) {
+    lastOverrides = overrides; emit('auto-override', overrides)
+  }
 
   const ink = props.opts.darkTheme ? '#e6e6e6' : '#111'
   if (props.opts.legend && base._colorLegend) {

--- a/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmStatesPanel.vue
@@ -17,7 +17,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef, nextT
 import { useLogStore } from '../../stores/log'
 import { useDataRefresh } from '../../composables/useDataRefresh'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
-import { defaultVis, paletteRange, type VisProps } from '../../plots/plot'
+import { DEFAULT_VIS, paletteRange, type VisProps } from '../../plots/plot'
 import { elementToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
 import { legendOverlay, titleOverlay } from '../../plots/overlays'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
@@ -34,7 +34,7 @@ const props = defineProps<{
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
 const log = useLogStore()
-const v = computed<VisProps>(() => props.vis ?? defaultVis())
+const v = computed<VisProps>(() => props.vis ?? DEFAULT_VIS)
 
 const measure = computed({
   get: () => (props.state.measure && props.hmmCols.includes(props.state.measure)) ? props.state.measure : (props.hmmCols[0] ?? ''),

--- a/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
+++ b/frontend/src/modules/cluster/ClusterHmmTransitionsPanel.vue
@@ -17,7 +17,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef, nextT
 import { useLogStore } from '../../stores/log'
 import { useDataRefresh } from '../../composables/useDataRefresh'
 import CanvasPanel from '../../components/canvas/CanvasPanel.vue'
-import { defaultVis, type VisProps } from '../../plots/plot'
+import { DEFAULT_VIS, type VisProps } from '../../plots/plot'
 import { elementToImageURL, downloadDataUrl, downloadBlob, rowsToCsv } from '../../plots/export'
 import { titleOverlay } from '../../plots/overlays'
 import type { ArrangeCmd } from '../../composables/useFloatingPanel'
@@ -34,7 +34,7 @@ const props = defineProps<{
 }>()
 const emit = defineEmits<{ activate: [number]; remove: []; duplicate: [] }>()
 const log = useLogStore()
-const v = computed<VisProps>(() => props.vis ?? defaultVis())
+const v = computed<VisProps>(() => props.vis ?? DEFAULT_VIS)
 
 const measure = computed({
   get: () => (props.state.measure && props.hmmCols.includes(props.state.measure)) ? props.state.measure : (props.hmmCols[0] ?? ''),

--- a/frontend/src/modules/cluster/ClusterPlots.vue
+++ b/frontend/src/modules/cluster/ClusterPlots.vue
@@ -29,7 +29,7 @@ import InteractivePanel from '../../components/canvas/InteractivePanel.vue'
 import { isInteractiveView, pageViews } from '../../components/canvas/interactiveViews'
 import { CLUSTER_PANELS, isClusterPanel } from './clusterPanels'
 import PopulationManager from '../../components/canvas/PopulationManager.vue'
-import { defaultVis, type VisProps } from '../../plots/plot'
+import { defaultVis, DEFAULT_VIS, type VisProps } from '../../plots/plot'
 
 // index signature so a panel's state is assignable to the generic InteractivePanel's
 // `Record<string, unknown>` state (views read their own keys: umap→labels, heatmap→features).
@@ -103,9 +103,9 @@ const activeHL = computed(() =>
 // plot styling (VisProps) follows the SAME global/local scope as the highlights (like the summary
 // canvas): GLOBAL = one styling bag for every plot; LOCAL = the active plot's own. The pop manager
 // edits the active scope's bag; each panel renders with its own effective bag.
-const panelVis = (s: ClusterPanelState) => scope.value === 'global' ? gVis.value : (s.vis ?? defaultVis())
+const panelVis = (s: ClusterPanelState) => scope.value === 'global' ? gVis.value : (s.vis ?? DEFAULT_VIS)
 const activeVis = computed(() =>
-  scope.value === 'global' ? gVis.value : (activePanel.value?.state.vis ?? defaultVis()))
+  scope.value === 'global' ? gVis.value : (activePanel.value?.state.vis ?? DEFAULT_VIS))
 function setVis(patch: Partial<VisProps>) {
   if (scope.value === 'global') gVis.value = { ...gVis.value, ...patch }
   else if (activePanel.value) activePanel.value.state.vis = { ...(activePanel.value.state.vis ?? defaultVis()), ...patch }

--- a/frontend/src/plots/autoOverride.test.ts
+++ b/frontend/src/plots/autoOverride.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   overrideTooltip, overrideNote, transformOverride, xRotationOverride, needsXRotation, effectiveOf,
+  sameOverrides,
 } from './autoOverride'
 
 // One concept: a setting the app could not honour and substituted. It existed twice, ad hoc — the two
@@ -118,5 +119,32 @@ describe('effectiveOf', () => {
   it('works for any value type, not just booleans (the gating selects)', () => {
     expect(effectiveOf(transformOverride('logicle', 'linear'), 'logicle', 'linear')).toBe('linear')
     expect(effectiveOf(null, 'logicle', 'linear')).toBe('logicle')
+  })
+})
+
+// The emit gate. A re-render that substituted exactly what the last one did must stay silent: the host
+// keeps the set, the board keeps the host's readout, and writing that on every render re-rendered the
+// panel — "Maximum recursive updates exceeded" on any board whose slots carry no vis of their own.
+describe('sameOverrides', () => {
+  const rotated = xRotationOverride(true, false)!
+
+  it('two empty sets are the same — the case that caused the loop', () => {
+    expect(sameOverrides([], [])).toBe(true)
+  })
+
+  it('compares by CONTENT, not identity — a rebuilt equal set is still silent', () => {
+    expect(sameOverrides([rotated], [xRotationOverride(true, false)!])).toBe(true)
+  })
+
+  it('a substitution appearing or lifting is real news', () => {
+    expect(sameOverrides([rotated], [])).toBe(false)
+    expect(sameOverrides([], [rotated])).toBe(false)
+  })
+
+  it('same setting, different substitution', () => {
+    expect(sameOverrides(
+      [transformOverride('logicle', 'linear')!],
+      [transformOverride('biexp', 'linear')!],
+    )).toBe(false)
   })
 })

--- a/frontend/src/plots/autoOverride.ts
+++ b/frontend/src/plots/autoOverride.ts
@@ -52,6 +52,19 @@ export function overrideTooltip(o: AutoOverride | null, fallback: string): strin
 export const effectiveOf = <T>(o: AutoOverride | null, preference: T, whenOverridden: T): T =>
   o ? whenOverridden : preference
 
+/**
+ * Do two override sets say the same thing? The emitter uses this to stay QUIET when a re-render
+ * substituted exactly what the last one did — a fresh `[]` announced as news is still news to Vue,
+ * and the host turns it into a readout the board writes down, which re-renders the panel, which
+ * re-renders the plot ("Maximum recursive updates exceeded"). An override is four short strings, so
+ * compare them; there is no identity to lean on.
+ */
+export function sameOverrides(a: AutoOverride[], b: AutoOverride[]): boolean {
+  return a.length === b.length &&
+    a.every((o, i) => o.setting === b[i].setting && o.from === b[i].from &&
+                      o.to === b[i].to && o.why === b[i].why)
+}
+
 /** A one-line notice for a plot footer, when there is no single control to mark. */
 export function overrideNote(overrides: AutoOverride[]): string {
   if (!overrides.length) return ''

--- a/frontend/src/plots/defaultVis.test.ts
+++ b/frontend/src/plots/defaultVis.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { defaultVis, DEFAULT_VIS } from './plot'
+
+// A panel with no vis of its own falls back to DEFAULT_VIS. The value is the easy half; the IDENTITY is
+// the half that broke — `?? defaultVis()` in a template minted a new bag per render, so every parent
+// render handed each panel a "new" vis, rebuilt its chart, and fed the resulting readout back to the
+// board, which rendered again. Slots lack a vis exactly when something other than the GUI wrote them
+// (add_analysis_board omits the bag on purpose), so it was Claude-authored boards that looped.
+describe('DEFAULT_VIS', () => {
+  it('is the same object every time — the fallback must not churn prop identity', () => {
+    expect(DEFAULT_VIS).toBe(DEFAULT_VIS)
+    expect(defaultVis()).not.toBe(defaultVis())     // the factory still mints, for write sites
+  })
+
+  it('carries the factory values', () => {
+    expect(DEFAULT_VIS).toEqual(defaultVis())
+  })
+
+  it('is frozen — it is shared, so nothing may write through it', () => {
+    expect(Object.isFrozen(DEFAULT_VIS)).toBe(true)
+  })
+})

--- a/frontend/src/plots/plot.ts
+++ b/frontend/src/plots/plot.ts
@@ -225,6 +225,25 @@ export const defaultVis = (): VisProps => ({
   statsEnabled: false, statsTest: 'auto', statsShowNs: false, statsUseStars: false, statsUseLetters: false,
 })
 
+/**
+ * The SHARED fallback for a panel that has no vis of its own — `state.vis ?? DEFAULT_VIS`.
+ *
+ * Identity, not convenience. `defaultVis()` mints a new object per call, so a template-side
+ * `st(c).vis ?? defaultVis()` handed a fresh `vis` prop to every panel on EVERY parent render. That
+ * made the panel's `buildOpts` recompute, PlotChart re-render the whole SVG, and — because the render
+ * reports its auto-overrides back up — the board write the readout, re-render, and start again:
+ * "Maximum recursive updates exceeded". A slot only lacks `vis` when something other than the GUI
+ * wrote it (`add_analysis_board` deliberately omits the bag — see app/src/analysis_board_spec.jl), so
+ * the loop hit exactly the boards Claude authored.
+ *
+ * Frozen because it is shared: every write path already REPLACES the bag (`{...vis, ...patch}`), so
+ * nothing mutates it in place, and freezing keeps it that way.
+ *
+ * Use this wherever the fallback is READ. Keep `defaultVis()` where a panel needs its OWN bag to
+ * write into (new slot state, a spread base).
+ */
+export const DEFAULT_VIS: VisProps = Object.freeze(defaultVis())
+
 export interface BuildOpts extends VisProps {
   chartType: ChartType
   byImage: boolean                       // cross-image per_image scope


### PR DESCRIPTION
The analysis board threw `Maximum recursive updates exceeded` (LayoutCanvas, SummaryPanel, every
CanvasPanel) on any board whose slots carry no `vis` of their own — and because a zoom step, a slot
drag or a population tick each kicked it off, the board rebuilt every Plot SVG up to 100 times per
interaction. That was the board "zoom lag".

**The cycle.** `panelVis()` falls back to `defaultVis()`, which mints a **new object per call**, so
every board render handed each panel a new `vis` → new `buildOpts` → `PlotChart`'s deep watcher fired
→ `render()` announced its auto-overrides unconditionally → the panel recomputed its readout → the
board wrote `readouts[activeIndex]` → the board rendered again.

**Two edges, both cut:**

* `DEFAULT_VIS` — one shared, frozen bag for every site that READS the fallback (LayoutCanvas,
  SummaryCanvas, SummaryPanel, ClusterPlots, the two HMM panels). `defaultVis()` stays the factory
  where a panel needs its own bag to write into.
* `PlotChart` announces an auto-override only when it actually changed (new pure `sameOverrides`), so
  a render that substituted nothing stays quiet. `null` until the first render, so a remount still
  re-announces.

**Why only some boards.** A slot lacks `vis` exactly when something other than the GUI wrote it —
`add_analysis_board` omits the bag on purpose rather than copying ~25 frontend defaults into Julia
(`app/src/analysis_board_spec.jl`). That decision stands; the frontend fallback is what had to be
identity-stable. GUI-created slots always carry a vis, which is why hand-built boards never looped.

Verified in the browser: the console is clean and the board no longer lags on zoom.

Not addressed: `panelSeries()` still rebuilds an array per render, so panels re-render on any board
state change. Cheap now that it can't reach `buildOpts`, but it is still churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
