### PR TITLE
Keep a panel's series list identity-stable across canvas renders

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -146,6 +146,10 @@ wrote them (`add_analysis_board` omits the bag on purpose — `app/src/analysis_
 loop hit Claude-authored boards only. Use the shared frozen `DEFAULT_VIS` wherever the fallback is READ;
 keep `defaultVis()` where a panel needs its own bag to write into.
 
+The general rule: **anything a canvas derives for a panel DURING RENDER must keep its identity while its
+inputs are unchanged.** The panel's series list is the other instance — `seriesMemo` (`plots/series.ts`)
+holds one entry per panel, keyed by the selection it parsed.
+
 `'none'` keeps the panel rather than hiding it because the rail carries two independent things: the
 selection list *and* the shared `PlotOptions` styling + scope footer, which a self-contained plot may
 still use (`GatingStrategyView` reads `vis.fontSize`).

--- a/frontend/src/components/canvas/LayoutCanvas.vue
+++ b/frontend/src/components/canvas/LayoutCanvas.vue
@@ -26,7 +26,7 @@ import { useProjectMetaStore } from '../../stores/projectMeta'
 import { useAnalysisLayoutStore, type SlotContent } from '../../stores/analysisLayout'
 import { useSummaryData } from '../../composables/useSummaryData'
 import { useClusterContext } from '../../composables/useClusterContext'
-import { tkey, parseTkey } from '../../plots/series'
+import { tkey, parseTkey, seriesMemo } from '../../plots/series'
 import { defaultVis, DEFAULT_VIS, type VisProps } from '../../plots/plot'
 import { UNIFORM_PRESETS, COMIC_PRESETS, uniform, A4_PORTRAIT_ASPECT, A4_LANDSCAPE_ASPECT } from '../../plots/layoutTemplates'
 import type { SeriesTarget } from '../../plots/types'
@@ -278,7 +278,10 @@ function setVis(patch: Partial<VisProps>) {
   if (scope.value === 'global') gVis.value = { ...gVis.value, ...patch }
   else if (activeContent.value) st(activeContent.value).vis = { ...(st(activeContent.value).vis ?? defaultVis()), ...patch }
 }
-const panelSeries = (c: SlotContent): SeriesTarget[] => panelSel(c).map(parseTkey)
+// keyed by SLOT INDEX so a slot keeps one entry; identity holds while its selection does (see
+// seriesMemo) — a template-built list must not hand every panel a "new" series array per render.
+const memoSeries = seriesMemo<number>()
+const panelSeries = (i: number, c: SlotContent): SeriesTarget[] => memoSeries(i, panelSel(c))
 
 // the stats test each summary slot's last result actually ran (`auto` resolves it server-side from the
 // group count) — the rail shows the ACTIVE slot's, so the user can see what `auto` chose. Keyed by slot
@@ -588,7 +591,7 @@ defineExpose({ capturePage, collectCsvs })
                           :spec="specById[entry.contents[i]!.ref]"
                           :project-uid="projectUid" :image-uid="imageUid"
                           :set-uid="panelSetUid" :image-uids="panelImageUids" :scope="panelScope"
-                          :group-attr="panelGroupAttr" :series="panelSeries(entry.contents[i]!)" :series-color="seriesColor"
+                          :group-attr="panelGroupAttr" :series="panelSeries(i, entry.contents[i]!)" :series-color="seriesColor"
                           :vis="panelVis(entry.contents[i]!)" :ui="entry.contents[i]!.state" :collapse-series="poolGroups"
                           :reload-token="reloadToken" :persist-key="`${canvasKey}:slot:${i}`"
                           @activate="layout.setActive(canvasKey, i)" @remove="clearSlot(i)" @duplicate="duplicateSlot(i)"

--- a/frontend/src/components/canvas/SummaryCanvas.vue
+++ b/frontend/src/components/canvas/SummaryCanvas.vue
@@ -24,7 +24,7 @@ import { useCanvasZoom, CANVAS_ZOOM_KEY } from '../../composables/useCanvasZoom'
 import SeriesPicker from './SeriesPicker.vue'
 import SummaryPanel from './SummaryPanel.vue'
 import CanvasZoomControl from './CanvasZoomControl.vue'
-import { tkey, parseTkey } from '../../plots/series'
+import { tkey, parseTkey, seriesMemo } from '../../plots/series'
 import { defaultVis, DEFAULT_VIS, type VisProps } from '../../plots/plot'
 import type { SeriesTarget, ChartType } from '../../plots/types'
 import { migrateSpecId, isPrecomputedSpec } from '../../plots/popTypes'
@@ -122,7 +122,9 @@ function setVis(patch: Partial<VisProps>) {
   else if (activePanel.value) activePanel.value.state.vis = { ...activePanel.value.state.vis, ...patch }
 }
 // a panel's series = its selected target keys parsed back into {valueName, pop}
-const panelSeries = (s: PanelState): SeriesTarget[] => panelSel(s).map(parseTkey)
+// keyed by PANEL ID (panels are free-floating, not slot-indexed) — see seriesMemo
+const memoSeries = seriesMemo<number>()
+const panelSeries = (id: number, s: PanelState): SeriesTarget[] => memoSeries(id, panelSel(s))
 
 function addPanel(specId: string) { if (specId) { add(); const p = panels.value.at(-1); if (p) p.state.specId = specId } }
 
@@ -216,7 +218,7 @@ watch(segPops, () => {
                         :project-uid="projectUid" :image-uid="imageUid"
                         :set-uid="panelSetUid" :image-uids="panelImageUids" :scope="panelScope"
                         :group-attr="panelGroupAttr"
-                        :series="panelSeries(p.state)" :series-color="seriesColor" :vis="panelVis(p.state)"
+                        :series="panelSeries(p.id, p.state)" :series-color="seriesColor" :vis="panelVis(p.state)"
                         :ui="p.state" :collapse-series="poolGroups"
                         :reload-token="reloadToken" :persist-key="`${ckey}:${p.id}`"
                         @activate="activeId = p.id" @remove="removePanel(p.id)"

--- a/frontend/src/plots/series.test.ts
+++ b/frontend/src/plots/series.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { tkey, parseTkey, seriesMemo } from './series'
+
+describe('tkey / parseTkey', () => {
+  it('round-trips a population on a segmentation', () => {
+    expect(parseTkey(tkey('live', 'T', '/qc/_tracked')))
+      .toEqual({ popType: 'live', valueName: 'T', pop: '/qc/_tracked' })
+  })
+
+  it('splits on the FIRST separator of each kind — pop paths keep their slashes', () => {
+    expect(parseTkey('track::B/qc/_tracked'))
+      .toEqual({ popType: 'track', valueName: 'B', pop: '/qc/_tracked' })
+  })
+
+  it('defaults a key with no pop_type to live, and a whole-segmentation key to an empty pop', () => {
+    expect(parseTkey('T')).toEqual({ popType: 'live', valueName: 'T', pop: '' })
+  })
+})
+
+// The canvases build each panel's series list DURING RENDER, so a plain `.map(parseTkey)` handed every
+// panel a new array of new objects on every canvas render — a prop that says the same thing it said
+// before, and a re-render for it. Same family as DEFAULT_VIS.
+describe('seriesMemo', () => {
+  it('keeps identity while the keys are unchanged', () => {
+    const memo = seriesMemo<number>()
+    const a = memo(0, ['live::T/qc/_tracked'])
+    expect(memo(0, ['live::T/qc/_tracked'])).toBe(a)     // rebuilt list, same identity
+  })
+
+  it('rebuilds when the selection changes — and again when it changes back', () => {
+    const memo = seriesMemo<number>()
+    const a = memo(0, ['live::T/qc/_tracked'])
+    const b = memo(0, ['live::T/qc/_tracked', 'live::B/qc/_tracked'])
+    expect(b).not.toBe(a)
+    expect(b).toHaveLength(2)
+    expect(memo(0, ['live::T/qc/_tracked'])).not.toBe(a)  // cache holds one entry per panel
+  })
+
+  it('order is part of the selection, not an implementation detail', () => {
+    const memo = seriesMemo<number>()
+    const a = memo(0, ['live::T/qc/_tracked', 'live::B/qc/_tracked'])
+    expect(memo(0, ['live::B/qc/_tracked', 'live::T/qc/_tracked'])).not.toBe(a)
+  })
+
+  it('panels do not evict each other', () => {
+    const memo = seriesMemo<number>()
+    const a = memo(0, ['live::T/qc/_tracked'])
+    memo(1, ['live::B/qc/_tracked'])
+    expect(memo(0, ['live::T/qc/_tracked'])).toBe(a)
+  })
+
+  it('an empty selection is memoised too — the every-render case for a fresh slot', () => {
+    const memo = seriesMemo<number>()
+    const a = memo(0, [])
+    expect(memo(0, [])).toBe(a)
+    expect(a).toEqual([])
+  })
+})

--- a/frontend/src/plots/series.ts
+++ b/frontend/src/plots/series.ts
@@ -13,3 +13,27 @@ export function parseTkey(key: string): SeriesTarget {
   const i = rest.indexOf('/')
   return i < 0 ? { popType, valueName: rest, pop: '' } : { popType, valueName: rest.slice(0, i), pop: rest.slice(i) }
 }
+
+/**
+ * Per-panel `parseTkey` map that keeps its RESULT IDENTITY while the keys are unchanged.
+ *
+ * A canvas builds each panel's series list in the template (`:series="panelSeries(…)"`), so a plain
+ * `.map(parseTkey)` mints a new array of new objects on every canvas render — the panel then re-renders
+ * for a list that says exactly what it said before. Same family as `DEFAULT_VIS` (plots/plot.ts): a
+ * fallback or a derivation evaluated during render must not churn prop identity.
+ *
+ * Keyed by the joined keys, which is COMPLETE — the targets are a pure function of them and of nothing
+ * else — so a cached list can never be stale. `id` is the panel (slot index / panel id); one entry each,
+ * so panels don't evict each other.
+ */
+export function seriesMemo<K>(): (id: K, keys: readonly string[]) => SeriesTarget[] {
+  const cache = new Map<K, { key: string; targets: SeriesTarget[] }>()
+  return (id, keys) => {
+    const key = keys.join('|')
+    const hit = cache.get(id)
+    if (hit && hit.key === key) return hit.targets
+    const targets = keys.map(parseTkey)
+    cache.set(id, { key, targets })
+    return targets
+  }
+}


### PR DESCRIPTION
Follow-up to #500 — the last of the render-time identity churn on the analysis canvases.

The canvases build each panel's series list in the template (`:series="panelSeries(…)"`), so
`panelSel(c).map(parseTkey)` minted a new array of new objects on **every** canvas render. Each panel
then re-rendered for a list that said exactly what it said the render before. Harmless on its own now
that it can no longer reach `buildOpts` (that was the recursion loop in #500), but it is the same
defect, and it costs a re-render of every panel on any board change.

`seriesMemo` (`plots/series.ts`) holds one entry per panel, keyed by the joined selection keys. The key
is **complete** — a series target is a pure function of its key and of nothing else — so a cached list
cannot be stale. Wired into both canvases: `LayoutCanvas` by slot index, `SummaryCanvas` by panel id.

`docs/ANALYSIS.md` generalises the rule the two fixes share: anything a canvas derives for a panel
during render must keep its identity while its inputs are unchanged.

Also backfills tests for `tkey`/`parseTkey`, which had none.

**Not memoised, deliberately:** `ctxFor()` and `clusterPanelProps()` mint fresh objects the same way.
Their keys would have to cover 6–10 reactive fields each, and a missed field means a panel silently
stops updating — a worse failure than the churn it saves. Build-then-compare (return the previous
object when structurally equal) is the safe shape for those, and is a bigger change than this one.

Not run in a browser; the memo is unit-tested and `SummaryPanel` only reads `props.series` (verified —
filter/map, never mutates), so sharing a cached array is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
