### PR TITLE
Show auto-shared cluster pops to the observer; empty matrix is not an error

### DIFF
--- a/app/src/ai/observer_prompt.jl
+++ b/app/src/ai/observer_prompt.jl
@@ -35,7 +35,9 @@ in T/_qc" or "do the tracked B cells move slower" are answerable directly.
 For behaviour + clustering: get_behaviour_summary(project, image/set) gives the HMM state distribution
 (fraction per state) + transitions; get_cluster_summary(project, image/set) gives each clustering run's
 cluster count / sizes / largest fraction / features. A collapsed state distribution or one cluster
-swallowing most points on ONE image (vs its peers) is worth flagging.
+swallowing most points on ONE image (vs its peers) is worth flagging. One run `suffix` appearing under
+several segmentations is ONE joint clustering over all of them — its named cluster populations are
+shared by every member, so plot them across the whole run, not just the segmentation they were named on.
 Before proposing ANY figure or cross-image comparison, two calls. get_image_attributes(project, set)
 gives the axes the images can be grouped by (e.g. Mouse, Location) — without one you can only plot per
 image or pooled, which throws the experiment's design away: four images from one mouse are not four

--- a/app/src/ai/observer_summary.jl
+++ b/app/src/ai/observer_summary.jl
@@ -31,7 +31,14 @@ const _OBSERVER_POP_TYPES = ("flow", "track", "clust", "trackclust", "region")
 # (definitions AND measures), so the "walk the gating maps" loop lives once.
 function _observer_each_population(f::Function, img::CciaImage)
     for v in sort(img_value_names(img)), pt in _OBSERVER_POP_TYPES
-        isfile(gating_path(img._dir, v; pop_type = pt)) || continue
+        # A CLUSTER pop_type often has NO sidecar of its own: cluster pops are global to a run and
+        # shared across its co-clustered segmentations, so the names are authored under one of them
+        # (e.g. B) and `load_pop_map` lends them, relabeled, to every sibling that carries the same
+        # `clusters.{suffix}` column (see _borrow_cluster_pop_map). Gating on the file existing hid
+        # exactly those borrowers — the observer reported "clusters exist for B only" for a run that
+        # T is equally part of, so a board it authored covered half the data. Gate-drawn maps
+        # (flow/track) ARE per-segmentation, so they keep the cheap isfile skip.
+        (_is_cluster_pop_type(pt) || isfile(gating_path(img._dir, v; pop_type = pt))) || continue
         m = load_pop_map(img; value_name = v, pop_type = pt)
         for path in pop_paths(m)
             p = pop_at(m, path); p.transient && continue

--- a/app/src/plotting/plot_data.jl
+++ b/app/src/plotting/plot_data.jl
@@ -647,14 +647,45 @@ end
 #
 # Returns a flat `cells` list `[{x, y, value, n|count}]` plus ordered `xLabels`/`yLabels` (so the
 # renderer lays out a fixed grid even where a cell is absent). Pure over the frame, headless-testable.
+# The crosstab's value label — what the cell NUMBER is once `normalize` is applied. One derivation,
+# shared by the populated grid and the empty one below (the legend title must not depend on the data).
+_crosstab_value_label(normalize::Symbol) =
+    normalize == :row ? "P(to|from)" : normalize == :col ? "P(from|to)" :
+    normalize == :total ? "fraction" : "count"
+
+# The SAME response shape with an empty grid, for a request whose frame has no rows (an absent
+# population). Keys mirror each mode's populated return exactly — the renderer reads `cells` to decide
+# it has nothing to draw, so a missing key would break the empty state rather than show it.
+function _empty_matrix(mode::AbstractString, cat::AbstractString, normalize::Symbol,
+                       zscore::Bool, granularity::Symbol)::Dict{String,Any}
+    base = Dict{String,Any}("chartType" => "matrix", "matrixMode" => String(mode),
+        "xLabels" => String[], "yLabels" => String[], "cells" => Dict{String,Any}[],
+        "category" => cat, "granularity" => String(granularity), "series" => Any[])
+    mode == "profile"  && return merge(base, Dict{String,Any}(
+        "zscore" => zscore, "valueLabel" => zscore ? "z-score" : "mean"))
+    mode == "crosstab" && return merge(base, Dict{String,Any}(
+        "normalize" => String(normalize), "valueLabel" => _crosstab_value_label(normalize)))
+    error("plot_summary_data: unknown matrix mode '$mode' (expected profile | crosstab)")
+end
+
 function _matrix_agg(df::DataFrame; mode::AbstractString,
                      measures::AbstractVector{<:AbstractString}=String[],
                      category::Union{Nothing,AbstractString}=nothing,
                      separator::AbstractString="_", zscore::Bool=false,
                      normalize::Symbol=:none, granularity::Symbol=:cell)::Dict{String,Any}
     cat = category === nothing ? nothing : String(category)
-    (cat === nothing || !(cat in names(df))) &&
-        error("plot_summary_data: matrix needs a `category` column present in the data (got $(cat === nothing ? "none" : repr(cat)))")
+    cat === nothing &&
+        error("plot_summary_data: matrix needs a `category` column present in the data (got none)")
+    # A population with NO rows here is an EMPTY PLOT, not a spec error. pop_df returns a frame with no
+    # columns at all in that case, so the presence check below would fail on a perfectly valid request
+    # and put a raw error string in the panel — which is what a per-image board of cluster pops shows
+    # whenever one cluster is absent from one image (cluster "Directed" exists in 3 of 7 images here).
+    # Every other chart type answers an empty frame with an empty series and the panel renders its
+    # normal "No data for the selected populations."; a matrix must behave the same. A MISSING column on
+    # a NON-empty frame is still a real error.
+    nrow(df) == 0 && return _empty_matrix(mode, cat, normalize, zscore, granularity)
+    !(cat in names(df)) &&
+        error("plot_summary_data: matrix needs a `category` column present in the data (got $(repr(cat)))")
     catvals = df[!, cat]
     # finite/non-missing category key per row (`nothing` for dropped rows)
     catkeys = Union{Nothing,String}[(ismissing(v) || (v isa Real && !isfinite(v))) ? nothing :
@@ -724,8 +755,7 @@ function _matrix_agg(df::DataFrame; mode::AbstractString,
                   normalize == :total ? (total == 0 ? 0.0 : c / total) : Float64(c)
             push!(cells, Dict{String,Any}("x" => t, "y" => f, "value" => val, "count" => c))
         end
-        vlabel = normalize == :row ? "P(to|from)" : normalize == :col ? "P(from|to)" :
-                 normalize == :total ? "fraction" : "count"
+        vlabel = _crosstab_value_label(normalize)
         return Dict{String,Any}("chartType" => "matrix", "matrixMode" => "crosstab",
             "xLabels" => tos, "yLabels" => froms, "cells" => cells, "category" => cat,
             "normalize" => String(normalize), "valueLabel" => vlabel,

--- a/app/test/suite.jl
+++ b/app/test/suite.jl
@@ -7040,6 +7040,24 @@ end
                                measures=["speed"], category="st")
     c2 = first(c for c in prn["cells"] if c["x"] == "2")
     @test c2["value"] === nothing && c2["n"] == 0     # state 2 has only a NaN → null cell
+
+    # EMPTY FRAME (a population with no rows in this image) → an empty GRID, never an error. pop_df
+    # returns a frame with no columns at all, which used to trip the category check and print
+    # "matrix needs a `category` column present in the data" into the panel — the failure a per-image
+    # board of cluster pops hits whenever one cluster is absent from one image. Every other chart type
+    # answers this with an empty series; the response keys must match the populated ones so the
+    # renderer's empty state fires instead of breaking.
+    for (mode, extra) in (("crosstab", "normalize"), ("profile", "zscore"))
+        e = Cecelia._summary_agg(DataFrame(), "matrix"; measure=nothing, granularity=:cell, nbins=0,
+                                 normalize=:none, by_image=false, matrix_mode=mode,
+                                 measures=["speed"], category="tr")
+        @test e["chartType"] == "matrix" && e["matrixMode"] == mode && e["category"] == "tr"
+        @test isempty(e["cells"]) && isempty(e["xLabels"]) && isempty(e["yLabels"])
+        @test haskey(e, extra) && haskey(e, "valueLabel")   # same shape as the populated response
+    end
+    # …but an unknown mode is still an error, empty frame or not
+    @test_throws ErrorException Cecelia._summary_agg(DataFrame(), "matrix"; measure=nothing,
+        granularity=:cell, nbins=0, normalize=:none, by_image=false, matrix_mode="bogus", category="tr")
 end
 
 @testset "plot attribute grouping (compare by attr)" begin
@@ -8832,6 +8850,27 @@ end
         # scoping mirrors lineage
         @test length(populations_summary(proj; image_uid = "i1").images) == 1
         @test isempty(populations_summary(proj; image_uid = "nope").images)
+
+        # AUTO-SHARED cluster pops are reported for the borrowing segmentation too. Cluster pops are
+        # global to a run: the names are authored under ONE co-clustered value_name (A) and every
+        # sibling in the run (B) carries the same `clusters.movement` column, so `load_pop_map` lends
+        # them relabeled. The observer used to skip any value_name with no sidecar FILE, so B looked
+        # unclustered — and a board authored from that covered half the run's data.
+        img.label_props["B"] = "B.h5ad"
+        mkpath(Cecelia.img_label_props_dir(img))
+        for vn in ("A", "B")      # both segments took part in the `movement` track-clustering run
+            write(Cecelia._clustfeatures_path(img_track_props_path(img, vn)),
+                  JSON3.write(Dict("clusters.movement" =>
+                      Dict("features" => ["live.track.speed"], "partOf" => ["i1"]))))
+        end
+        shared = populations_summary(proj).images[1].populations
+        bdir = shared[findall(p -> p.name == "Directed" && p.valueName == "B", shared)]
+        @test length(bdir) == 1 && bdir[1].popType == "trackclust"
+        @test bdir[1].filter.measure == "clusters.movement"        # the SAME run, not a new definition
+        # a segment that is NOT in the run borrows nothing (no clustfeatures sidecar → no pops)
+        img.label_props["C"] = "C.h5ad"
+        cpops = populations_summary(proj).images[1].populations
+        @test isempty(findall(p -> p.valueName == "C", cpops))
     end
 
     @testset "measure summary (Slice C)" begin

--- a/docs/PLOTS.md
+++ b/docs/PLOTS.md
@@ -533,7 +533,12 @@ Backend: `_matrix_agg(df; mode, measures, category, separator, zscore, normalize
 `plot_data.jl`, dispatched from `_summary_agg` when `chart_type == "matrix"` (and threaded through all
 four `plot_summary_data` methods + `/api/plot_data` as `matrixMode`/`measures`/`category`/`separator`/
 `zscore`/`matrixNormalize`). Returns a flat `cells` `[{x,y,value,n|count}]` + ordered `xLabels`/
-`yLabels` + `valueLabel`. Frontend: `buildHeatmap` in `plot.ts` (`Plot.cell`, the colour scale per the
+`yLabels` + `valueLabel`. An **empty frame is an empty grid, not an error** (`_empty_matrix`): a
+population with no rows on this image comes back from `pop_df` with no columns at all, and erroring on
+the then-absent `category` column printed a raw error message into the panel every time a cluster pop
+was absent from one image of a per-image board. Every other chart type answers an empty frame with an
+empty series and lets the panel render "No data for the selected populations" — the matrix matches that;
+a missing `category` on a NON-empty frame is still an error. Frontend: `buildHeatmap` in `plot.ts` (`Plot.cell`, the colour scale per the
 mode above, **white** tile borders + a **black `theme_classic` L-axis**, tight margins; continuous
 legend stashed in `_colorLegend` for `PlotChart` to draw as an overlay). In-cell value text is a
 `heatmapValues` toggle — **off** by default for profile (matches R), on for crosstab. The panel offers

--- a/docs/todo/OBSERVER_DATA_ACCESS_PLAN.md
+++ b/docs/todo/OBSERVER_DATA_ACCESS_PLAN.md
@@ -97,7 +97,10 @@ MCP-tool docstring**, not another copy of the plumbing:
   (`populations_summary`), `GET /api/analysis/populations`, MCP `get_populations`, allow-listed; pkg +
   api + mcp tests. Per-image pop tree + gate/filter DEFINITIONS (cheap sidecar read). Membership COUNTS
   are deferred to Slice C (they need computing gates over the full table — heavy, forbidden on an
-  always-on read).
+  always-on read). The enumerator (`_observer_each_population`, shared with C) skips a value_name with
+  no gating file only for the GATE-drawn types: cluster pops are global to a run and auto-shared across
+  its co-clustered segmentations, so a borrower has no file of its own and must still be listed — else
+  the observer reports a joint B+T clustering as "clusters exist for B only".
 - **C — Measures** (`get_measure_summary`). ✅ **DONE** — `app/src/ai/measures.jl` (`measure_summary`),
   `GET /api/analysis/measures`, MCP `get_measure_summary`, allow-listed; pkg (fixture-gated + pure
   summary logic) + api + mcp tests, validated off-suite on real gated data. Per-population phenotype +

--- a/mcp/cecelia_mcp/server.py
+++ b/mcp/cecelia_mcp/server.py
@@ -386,6 +386,10 @@ def get_cluster_summary(project_uid: str, image_uid: str = "", set_uid: str = ""
       - `suffix` is the run id (e.g. "movement"/"test"); `granularity` "cell" = clustPops, "track" =
         clustTracks. The measure list a run clustered on is in `featuresByRun[suffix]` (same for every
         image, so it's given once — not repeated per entry).
+      - ONE `suffix` on SEVERAL `valueName`s is ONE JOINT run over those segmentations, not a run each:
+        clustering pools the selected populations, so cluster 3 means the same thing on each of them and
+        any named cluster populations are shared across them all (get_populations lists those names
+        under EVERY member segmentation). Read the sizes per valueName, but the run once.
       - `largestFrac` near 1.0 (one cluster swallowing most points) or a very low `nClusters` vs peers
         means a near-uninformative / collapsed clustering for that image — worth flagging.
     Summary-level (sizes, not raw cluster assignments). Reads current on-disk state."""


### PR DESCRIPTION
Two defects found while looking at an observer-authored Analysis board of track-cluster populations.

## The observer couldn't see auto-shared cluster pops

Cluster populations are **global to a run**: the names are authored under one co-clustered segmentation and `load_pop_map` lends them, relabeled, to every sibling carrying the same `clusters.{suffix}` column (`_borrow_cluster_pop_map`). A borrower therefore has **no gating file of its own** — and `_observer_each_population` skipped any value_name without one.

So for a joint B+T track clustering, `get_populations` reported clusters for B only, and the board authored from it covered half the run:

| | Scanning | Meandering | Directed |
|---|---|---|---|
| B | 73 | 62 | **9** |
| T | 73 | 130 | **69** |

"Directed is nearly empty" was an artifact of the blind spot. Gate-drawn maps (flow/track) genuinely are per-segmentation and keep the cheap `isfile` skip; cluster types now resolve through `load_pop_map`. This widens `measure_summary` too (same shared enumerator) — the borrowed pops are now summarised as well.

## An empty population errored instead of rendering empty

The board's transition matrices printed a raw ``matrix needs a `category` column present in the data`` into three panels. That was an empty population, not a bad spec: a cluster absent from an image comes back from `pop_df` with no columns at all, tripping the category presence check. On the reference data `B/Directed` has no tracks in 4 of 7 images.

`_matrix_agg` now answers an empty frame with an empty grid in the same response shape (`_empty_matrix`), so `SummaryPanel`'s existing `hasData` path renders "No data for the selected populations" like every other chart type. A missing `category` on a **non-empty** frame is still an error.

## Docs

`get_cluster_summary`'s tool docstring and `observer_prompt.jl` now state that one run `suffix` appearing under several `valueName`s is **one joint run** whose cluster names are shared — the reading that produced "T has its own clustering run".

## Tests

- New: borrowed cluster pops are listed for the borrowing segmentation, and a segmentation *not* in the run borrows nothing.
- New: empty frame → empty grid for both matrix modes, same keys as the populated response; an unknown mode still errors.
- `test-pkg` 4395 pass / 0 fail; `test-api` and `test-mcp` clean. Both fixes verified in the REPL against real project data.

## Reservations

- Widening the enumerator also widens `measure_summary`; the extra `pop_df` cost per image is real but unmeasured.
- `region` pops get the same treatment (borrowed region pops now surface) — consistent, but broader than the reported bug.
- The empty-matrix outcome relies on the frontend's existing empty state; payload keys match the populated response, but I have not watched it render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
