### PR TITLE
Settings: drop the Blosc link so both storage tables share one header

### DIFF
--- a/api/src/routes.jl
+++ b/api/src/routes.jl
@@ -569,7 +569,6 @@ function api_compressor_get(_req)
     200, JSON3.write((; current = Cecelia.image_compressor(),
                         default = Cecelia.IMAGE_COMPRESSOR_DEFAULT,
                         measuredOn = Cecelia.IMAGE_COMPRESSOR_MEASURED_ON,
-                        docsUrl = Cecelia.IMAGE_COMPRESSOR_DOCS_URL,
                         choices = choices))
 end
 

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -7,7 +7,7 @@ export coastal_models_dir, coastal_model_path, coastal_model_manifest, list_coas
 export projects_dir, setup_required, set_projects_dir!
 export bioformats2raw_bin, python_bin_path, tasks_concurrent_limit, napari_discrete_gpu
 export image_compressor, set_image_compressor!, bf2raw_compression_flags, bf2raw_chunk_flags, bf2raw_format_flags, IMAGE_COMPRESSOR_CHOICES
-export IMAGE_COMPRESSOR_MEASURED_ON, IMAGE_COMPRESSOR_DOCS_URL
+export IMAGE_COMPRESSOR_MEASURED_ON
 export ngff_version, chunk_separator, set_store_layout!
 export NGFF_VERSION_DEFAULT, CHUNK_SEPARATOR_DEFAULT
 export store_layout, STORE_LAYOUT_CHOICES, STORE_LAYOUT_DEFAULT, STORE_LAYOUT_MEASURED_ON

--- a/app/src/config.jl
+++ b/app/src/config.jl
@@ -493,9 +493,6 @@ const IMAGE_COMPRESSOR_CHOICES = [
 const IMAGE_COMPRESSOR_MEASURED_ON =
     "1.7 GB 16-bit timecourse, whole store · zarr v2, nested keys, 512×512 chunks"
 
-#: The byte-shuffle filter belongs to Blosc, not to zstd/lz4 — link it separately.
-const IMAGE_COMPRESSOR_DOCS_URL = "https://www.blosc.org/"
-
 const IMAGE_COMPRESSOR_DEFAULT = "zstd-shuffle"
 
 """

--- a/frontend/src/modules/SettingsModule.vue
+++ b/frontend/src/modules/SettingsModule.vue
@@ -513,8 +513,6 @@ async function switchWt(path: string) {
         <div class="cmp-head">
           <span class="svc-name">Image compression</span>
           <span class="field-hint cc-muted cc-fs-xs">{{ compressor.measuredOn }}</span>
-          <a :href="compressor.docsUrl" target="_blank" rel="noopener"
-             class="cmp-link cc-fs-xs" v-tooltip.top="'Blosc: the shuffle filter'">Blosc <i class="pi pi-external-link" /></a>
         </div>
         <SelectionTable :columns="COMPRESSOR_COLUMNS" :rows="compressor.choices"
                         :model-value="compressor.current" :disabled="compressorBusy"
@@ -941,7 +939,6 @@ async function switchWt(path: string) {
   gap: 0.6rem;
   margin-bottom: 0.35rem;
 }
-.cmp-link { margin-left: auto; }
 .settings-section {
   margin-bottom: 2rem;
 }

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -76,7 +76,6 @@ export interface CompressorSettings {
   current: string
   default: string
   measuredOn: string  // one short line naming what every row was measured on
-  docsUrl: string     // the shuffle filter is Blosc's, not the codec's
   choices: CompressorChoice[]
 }
 


### PR DESCRIPTION
The **Image compression** table's header carried a right-aligned Blosc docs link next to the caption. The two competed for width and both wrapped onto a second line, so the table read differently from the identically-shaped **Store layout** table right below it.

Removing the link leaves both headers as `name + caption`, matching.

- `SettingsModule.vue` — link + its `.cmp-link` rule removed (`.cmp-head` unchanged)
- `frontend/src/utils/storage.ts` — `docsUrl` off `CompressorSettings`
- `api/src/routes.jl` — field dropped from `/api/storage/compressor`
- `app/src/config.jl` + `Cecelia.jl` — `IMAGE_COMPRESSOR_DOCS_URL` const + export removed

The per-codec ↗ links in the table rows (zstd/lz4) are unaffected.

`npm run typecheck` (vue-tsc -b) clean. Not viewed in a browser; `api/test` not run (its only compressor assertion is on `measuredOn`, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
