### PR TITLE
Fix a reverting name field, labels vanishing in 3D, and trailing separators in filenames

### DIFF
--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -702,6 +702,14 @@ _label_contour(src)::Int = clamp(_to_int(get(src, :labelContour, 0)), 0, LABEL_C
 # it silently would be worse than ignoring it. `nothing` for the slice means "whatever is showing",
 # which is what every recording did before the setting existed.
 _show_3d(src)::Bool = Bool(get(src, :show3D, false))
+# 3D detail level from an authored config: a multiscale LEVEL index (0 = full resolution, higher =
+# coarser), or `nothing` for napari's own choice. Absent means 0, not "auto" — a config written before
+# the control existed still wants visible masks.
+function _detail_3d(src)::Union{Int,Nothing}
+    raw = get(src, :detail3d, 0)
+    raw === nothing ? nothing : max(0, _to_int(raw))
+end
+
 function _z_slice(src)::Union{Int,Nothing}
     _show_3d(src) && return nothing
     raw = get(src, :zSlice, nothing)
@@ -802,6 +810,13 @@ function _apply_movie_config!(project_uid::String, image_uid::String, img, confi
     #     inheriting whatever the previous cell left behind.
     _call_napari_api(api_napari_set_z_view,
                      (; show3D = _show_3d(config), zSlice = _z_slice(config)))
+
+    # 1d. how much detail the 3D render uses. Only in 3D — in 2D napari picks the level from the
+    #     viewport, which is what keeps a large image responsive. Without this a batch 3D movie would
+    #     render its masks at the coarsest pyramid level, i.e. not at all (docs/NAPARI.md → 3D detail).
+    if _show_3d(config)
+        _call_napari_api(api_napari_set_3d_level, (; level = _detail_3d(config)))
+    end
 
     # 2. channel colormaps + visibility. `channels` = {name → colormap} for the channels to SHOW; every
     #    other channel is hidden. Applied via a partial view-state (colormap/visible are whitelisted).
@@ -1583,6 +1598,29 @@ function api_napari_set_z_view(body_bytes::Vector{UInt8})
     end
 end
 
+# ── REST: POST /api/napari/set-3d-level ───────────────────────────────────────
+# How much detail the 3D view renders — a multiscale LEVEL index (0 = full resolution, higher =
+# coarser), or `null` for napari's own choice (the coarsest level). Separate from set-z-view because
+# that one resets the camera on entering 3D and this is dragged on a slider. See docs/NAPARI.md.
+function api_napari_set_3d_level(body_bytes::Vector{UInt8})
+    data  = JSON3.read(String(body_bytes))
+    raw   = get(data, :level, 0)
+    level = raw === nothing ? nothing : _to_int(raw)
+
+    v = _viewer()
+    isnothing(v) && return 400, JSON3.write((; error = "Napari not running"))
+    _with_viewer() do
+        try
+            resp = set_3d_level!(v; level = level)
+            200, JSON3.write((; ok = true, level = get(resp, "level", nothing),
+                                applied = get(resp, "applied", false)))
+        catch e
+            @warn "set_3d_level failed" exception = e
+            500, JSON3.write((; error = sprint(showerror, e)))
+        end
+    end
+end
+
 # ── REST: POST /api/napari/show-populations ───────────────────────────────────
 # Consumer direction: colour each population's cells as a points layer in napari (ports the
 # old napari_utils.show_pop_mapping). Julia owns membership; the bridge reads centroids from
@@ -2097,6 +2135,8 @@ function api_napari_status(req::HTTP.Request)
     bridge_started = nothing
     canvas_x = nothing
     canvas_y = nothing
+    ms_levels = nothing
+    detail = nothing
     if v !== nothing
         try
             resp = send(v, Dict("type" => "ping"))
@@ -2106,6 +2146,10 @@ function api_napari_status(req::HTTP.Request)
             # placeholder, so the honest default is visible (docs/NAPARI.md)
             canvas_x = get(resp, "canvas_size_x", nothing)
             canvas_y = get(resp, "canvas_size_y", nothing)
+            # levels the OPEN IMAGE has + the level 3D is currently pinned to — the range and value of
+            # the 3D detail control (docs/NAPARI.md → *3D detail*)
+            ms_levels = get(resp, "multiscale_levels", nothing)
+            detail    = get(resp, "detail_level", nothing)
         catch
         end
     end
@@ -2116,7 +2160,8 @@ function api_napari_status(req::HTTP.Request)
     200, JSON3.write((; alive = alive, starting = _viewer_starting[],
                         bridgeStartedAt = bridge_started, bridgeUptimeSeconds = bridge_uptime,
                         bridgeStale = bridge_stale,
-                        canvasSizeX = canvas_x, canvasSizeY = canvas_y))
+                        canvasSizeX = canvas_x, canvasSizeY = canvas_y,
+                        multiscaleLevels = ms_levels, detailLevel = detail))
 end
 
 # ── REST: discrete-GPU toggle ─────────────────────────────────────────────────

--- a/api/src/napari_api.jl
+++ b/api/src/napari_api.jl
@@ -573,11 +573,24 @@ function _movies_dir(img)::String
     d
 end
 
+# One filename-safe fragment: keep [A-Za-z0-9._-], collapse every run of anything else to `_`, and
+# drop the separators the collapse leaves at the EDGES.
+#
+# The edge strip is the whole point. An image called "… -res (cropped)" ends in `)`, so sanitising
+# alone gave "…-res_cropped_" — a name ending in a separator, which is what the movies list showed —
+# and the animation variant compounded it to "…-res_cropped__animation.mp4". `_movie_suffix` had the
+# strip and the image-name path did not, while claiming in a comment to use "the same character rule";
+# they are now the same function, so a movie name cannot be sanitised two ways.
+function _safe_name_part(raw)::String
+    s = replace(strip(String(raw === nothing ? "" : raw)), r"[^A-Za-z0-9._-]+" => "_")
+    String(strip(s, ['_', '.']))
+end
+
 # Movie output path named by the IMAGE (not attrs) — used by the single-image recorders. Sanitises
 # img.name, falls back to the uid when blank/unsafe. `suffix` distinguishes timelapse ("") from
 # animation ("_animation").
 function _movie_named_path(img, uid::AbstractString; suffix::AbstractString = "")::String
-    safe = replace(strip(img.name), r"[^A-Za-z0-9._-]+" => "_")
+    safe = _safe_name_part(img.name)
     joinpath(_movies_dir(img), (isempty(safe) ? String(uid) : safe) * suffix * ".mp4")
 end
 
@@ -590,10 +603,7 @@ end
 # but it is free text — the comparison someone wants to label is not always a version.
 const MOVIE_SUFFIX_MAX = 40
 function _movie_suffix(raw)::String
-    s = strip(String(raw === nothing ? "" : raw))
-    isempty(s) && return ""
-    safe = replace(s, r"[^A-Za-z0-9._-]+" => "_")
-    safe = strip(safe, ['_', '.'])                      # no leading/trailing separators in a filename
+    safe = _safe_name_part(raw)                         # shared rule: no leading/trailing separators
     isempty(safe) && return ""
     "_" * first(safe, MOVIE_SUFFIX_MAX)
 end
@@ -623,7 +633,7 @@ function _movie_basename(attr::AbstractDict, uid::AbstractString, file_attrs::Ve
     push!(parts, String(uid))
     # the user's filename addition goes BEFORE the extension (it arrives already sanitised + `_`-led
     # from `_movie_suffix`), so the file is still an .mp4 to every listing that filters on the suffix
-    replace(join(parts, "_"), r"[^A-Za-z0-9._-]+" => "_") * suffix * ".mp4"
+    _safe_name_part(join(parts, "_")) * suffix * ".mp4"
 end
 
 # Channels shown in the movie for `img` = the `config.channels` keys (the ones given a colormap),

--- a/api/src/server.jl
+++ b/api/src/server.jl
@@ -403,6 +403,7 @@ const _POST_ROUTES = Dict{String, Function}(
     "/api/napari/gpu" => (req, body_bytes) -> (api_napari_gpu_set(body_bytes)),
     "/api/napari/configure-autosave" => (req, body_bytes) -> (api_napari_configure_autosave(body_bytes)),
     "/api/napari/set-z-view" => (req, body_bytes) -> (api_napari_set_z_view(body_bytes)),
+    "/api/napari/set-3d-level" => (req, body_bytes) -> (api_napari_set_3d_level(body_bytes)),
     "/api/napari/show-labels" => (req, body_bytes) -> (api_napari_show_labels(body_bytes)),
     "/api/napari/refresh-labels" => (req, body_bytes) -> (api_napari_refresh_labels(body_bytes)),
     "/api/napari/show-populations" => (req, body_bytes) -> (api_napari_show_populations(body_bytes)),

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -1560,7 +1560,34 @@ end
         # blank / unsafe name falls back to the uid
         blank = (; _dir = joinpath(tmp, "proj", "1", "uid7"), name = "   ")
         @test _movie_named_path(blank, "uid7") == joinpath(tmp, "proj", "movies", "uid7.mp4")
+        # A name ENDING in a character a filename can't hold — the crop task's "(cropped)" is the one
+        # that showed up in the movies list — must not leave the separator it collapses to. It used to,
+        # and the animation variant then doubled it ("…_cropped__animation.mp4").
+        cropped = (; _dir = joinpath(tmp, "proj", "1", "uid7"),
+                     name = "M2b-MERTK_KAT-SWHL-GFP-Tom-res (cropped)")
+        @test _movie_named_path(cropped, "uid7") ==
+              joinpath(tmp, "proj", "movies", "M2b-MERTK_KAT-SWHL-GFP-Tom-res_cropped.mp4")
+        @test _movie_named_path(cropped, "uid7"; suffix = "_animation") ==
+              joinpath(tmp, "proj", "movies", "M2b-MERTK_KAT-SWHL-GFP-Tom-res_cropped_animation.mp4")
+        # a name with nothing usable left also falls back to the uid
+        parens = (; _dir = joinpath(tmp, "proj", "1", "uid7"), name = "()")
+        @test _movie_named_path(parens, "uid7") == joinpath(tmp, "proj", "movies", "uid7.mp4")
     end
+end
+
+# ONE sanitiser behind the image name, the user's suffix and the attr-composed basename — they used to
+# be three near-copies and only one of them stripped edge separators. Mirrored in the frontend by
+# `safeNamePart` (frontend/src/utils/batchMovie.ts), whose testset asserts the same cases.
+@testset "API: filename fragments are sanitised one way" begin
+    @test _safe_name_part("M2b-MERTK_KAT-SWHL-GFP-Tom-res (cropped)") ==
+          "M2b-MERTK_KAT-SWHL-GFP-Tom-res_cropped"
+    @test _safe_name_part("a/b c:d") == "a_b_c_d"
+    @test _safe_name_part("Day 3.v2-final") == "Day_3.v2-final"
+    @test _safe_name_part("../../etc/passwd") == "etc_passwd"
+    @test _safe_name_part("__x__") == "x"
+    @test _safe_name_part("   ") == ""
+    @test _safe_name_part("()") == ""
+    @test _safe_name_part(nothing) == ""
 end
 
 # Side-by-side version comparison (docs/todo/MOVIE_COMPARE_PLAN.md). The pure parts: which versions a

--- a/api/test/runtests.jl
+++ b/api/test/runtests.jl
@@ -1578,6 +1578,18 @@ end
 # ONE sanitiser behind the image name, the user's suffix and the attr-composed basename — they used to
 # be three near-copies and only one of them stripped edge separators. Mirrored in the frontend by
 # `safeNamePart` (frontend/src/utils/batchMovie.ts), whose testset asserts the same cases.
+# The 3D detail level an authored/batch movie config asks for. Absent means FULL RESOLUTION, not
+# napari's automatic choice: napari picks the coarsest level in 3D, which erases a strided label
+# pyramid, and a config written before this control existed still wants visible masks.
+@testset "API: 3D detail level from a movie config" begin
+    @test _detail_3d(Dict(:detail3d => 0)) == 0
+    @test _detail_3d(Dict(:detail3d => 2)) == 2
+    @test _detail_3d(Dict(:detail3d => "3")) == 3          # JSON numbers may arrive as strings
+    @test _detail_3d(Dict{Symbol,Any}()) == 0              # absent → full resolution
+    @test _detail_3d(Dict(:detail3d => nothing)) === nothing   # explicit null → leave it to napari
+    @test _detail_3d(Dict(:detail3d => -1)) == 0           # never a negative index
+end
+
 @testset "API: filename fragments are sanitised one way" begin
     @test _safe_name_part("M2b-MERTK_KAT-SWHL-GFP-Tom-res (cropped)") ==
           "M2b-MERTK_KAT-SWHL-GFP-Tom-res_cropped"
@@ -3280,7 +3292,8 @@ end
         "/api/napari/gpu", "/api/napari/open",
         "/api/napari/overlay-legend", "/api/napari/refresh-labels",
         "/api/napari/restart", "/api/napari/screenshot",
-        "/api/napari/selection-scope", "/api/napari/set-z-view", "/api/napari/show-labels",
+        "/api/napari/selection-scope", "/api/napari/set-z-view", "/api/napari/set-3d-level",
+        "/api/napari/show-labels",
         "/api/napari/show-populations", "/api/napari/show-tracks",
         "/api/napari/start-selection", "/api/napari/stop-selection",
         "/api/napari/view-state", "/api/notebooks/build-sysimage",
@@ -3347,7 +3360,7 @@ end
 
     # Anti-vacuity: a loop over nothing passes trivially.
     @test checked >= 130
-    @test length(GET_ROUTES) == 71 && length(POST_ROUTES) == 100
+    @test length(GET_ROUTES) == 71 && length(POST_ROUTES) == 101
 
     # A path nobody registered must still 404, else "dispatched" means nothing.
     @test !dispatched("GET",  "/api/definitely-not-a-route")

--- a/app/src/Cecelia.jl
+++ b/app/src/Cecelia.jl
@@ -143,7 +143,7 @@ export chain_node, make_chain
 # ── Napari viewer ─────────────────────────────────────────────────────────────
 export NapariViewer
 export launch!, close!, restart!, send
-export open_image!, show_labels!, show_branch_labels!, refresh_labels!, set_z_view!
+export open_image!, show_labels!, show_branch_labels!, refresh_labels!, set_z_view!, set_3d_level!
 export show_layer!, hide_layer!, remove_layer!, clear!
 export centre!, save_layer_props!, load_layer_props!, save_screenshot!, record_timelapse!, record_keyframes!, stitch_movies!
 export capture_view_state, apply_view_state!, preview_region

--- a/app/src/napari.jl
+++ b/app/src/napari.jl
@@ -13,7 +13,7 @@ const NAPARI_BRIDGE = joinpath(@__DIR__, "..", "..", "napari", "napari_bridge.py
 # argument, or a changed reply. Asserted equal by the "language boundaries agree on their protocol"
 # testset. Losing the window on a mismatch is recoverable — layer props and the T/Z position are
 # autosaved (`save_layer_props`), so a relaunch reopens where the user was.
-const NAPARI_PROTOCOL = 3
+const NAPARI_PROTOCOL = 4
 # Python interpreter comes from `python_bin_path()` (config default "python3"), resolved within
 # the activated Pixi env — i.e. launch via `pixi run`. No hardcoded venv path; see docs/SHIPPING.md.
 
@@ -206,6 +206,17 @@ function set_z_view!(v::NapariViewer; show_3d::Bool=false, z::Union{Int,Nothing}
     cmd = Dict{String,Any}("type" => "set_z_view", "show_3d" => show_3d)
     z === nothing || (cmd["z"] = z)
     send(v, cmd)
+end
+
+# How much detail the 3D view renders: a multiscale LEVEL index (0 = full resolution, higher = coarser;
+# levels halve X and Y, never Z). `nothing` hands the choice back to napari, which in 3D always takes
+# the COARSEST level — fine for an intensity image, and fatal for a strided label pyramid, which is why
+# this is a setting rather than napari's default. See docs/NAPARI.md → *3D detail*.
+#
+# Its own command, not an argument to `set_z_view!`: that one resets the camera when it enters 3D, and
+# dragging a detail slider must not keep throwing the user's view away.
+function set_3d_level!(v::NapariViewer; level::Union{Int,Nothing}=0)
+    send(v, Dict{String,Any}("type" => "set_3d_level", "level" => level))
 end
 
 # Skeleton labels written by `segment.branching` — stored under `branchLabels/` and namespaced

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -779,7 +779,7 @@ if show_3d and (self._z_axis_len() or 0) > 1:
     self._viewer.reset_view()
 ```
 
-### Label layers must be PINNED to full resolution in 3D
+### 3D detail — the multiscale level is a setting, not napari's default
 
 napari renders a multiscale layer at its **coarsest** level in 3D — automatic level selection is a
 2D-viewport calculation, and there is nothing to compute once the whole volume is on screen:
@@ -791,17 +791,31 @@ elif slice_input.ndisplay == 3:
 
 For an intensity image that is fine — a coarse image still looks like the image. For **labels** it is
 not. Our pyramids are built by **strided subsampling** (`create_slices_multiscales`), not by a mode
-filter, so level *n* keeps every 2ⁿ-th voxel per axis and at the coarsest level a segmentation of
-ordinary-sized cells is almost entirely background. Toggling the movie's z control to 3D therefore made
-the masks disappear.
+filter, and they downsample **X and Y only** (Z is never reduced), so level *n* keeps every 2ⁿ-th voxel
+per axis. At the coarsest level a segmentation of ordinary-sized cells is almost entirely background:
+a 2-level image lands on labels ¼ the width — blocky but present — while a 4-level image lands on
+1/16, where a 12-px cell is under a pixel and the mask reads as *gone*. Toggling the movie's z control
+to 3D therefore made the masks disappear, and how badly depended on the image.
 
-`NapariState._sync_label_levels` pins every multiscale `Labels` layer to level 0 while `ndisplay == 3`
-and hands the level back to napari in 2D, where the automatic choice is what keeps panning a large image
-fast. **Level 0, not a memory-budgeted choice** — full resolution costs memory on a large volume and that
-is accepted; pixelated masks are not an acceptable 3D view (Dominik, 2026-08-08). It is wired to `viewer.dims.events.ndisplay` — not to the places we set `ndisplay` ourselves —
-because the user can also flip 2D/3D from napari's own button, and both routes must behave the same; and
-it is called again after adding a label layer, since a layer added during a 3D session never sees that
-event.
+So the level is a **setting**. `NapariState._sync_multiscale_levels` applies it to every multiscale
+layer — image and labels alike — while `ndisplay == 3`, and hands the choice back to napari in 2D,
+where the automatic behaviour is what keeps panning a large image fast.
+
+| | |
+|---|---|
+| **Default** | level 0 — full resolution. A pixelated mask is not a usable 3D view. |
+| **Control** | Movie options → *detail*, shown only in 3D and only when the image has more than one level. Readout is the fraction of full width (`full`, `1/2`, `1/4`…), not the index, because an index means nothing. |
+| **Why a control** | Full resolution costs memory on a large volume, and only the person looking at the image can weigh that against sharpness. Ship the trade, don't hardcode it. |
+| **Command** | `POST /api/napari/set-3d-level {level}` → `set_3d_level!` → bridge `set_3d_level`. `null` = napari's own choice. |
+| **Per layer** | The request is per viewer, the depth is per layer — a live-preview label store is opened at one level while the image beside it has four — so it is clamped per layer by `napari_utils.clamped_level` (tested). napari silently ignores an out-of-range index, which would leave that layer wherever it was. |
+
+Mixing levels never *misplaces* anything: napari derives a level's world scale from its shape
+(`downsample_factors = level_shapes[0] / level_shapes`), so a layer at level 0 and one at level 3
+occupy the same world extent. Only sharpness differs.
+
+Its own command rather than an argument to `set_z_view` — that one calls `reset_view()` on entering
+3D, and dragging a detail slider must not keep throwing the user's camera away. (`set_z_view` now only
+resets on the actual 2D→3D transition, for the same reason.)
 
 > `Labels.locked_data_level` is public API **as of napari 0.7.1** (the version in `pixi.lock`; the
 > `pixi.toml` bound is the looser `napari >= 0.7`). The bridge guards with `hasattr` and logs, so an

--- a/docs/NAPARI.md
+++ b/docs/NAPARI.md
@@ -779,6 +779,34 @@ if show_3d and (self._z_axis_len() or 0) > 1:
     self._viewer.reset_view()
 ```
 
+### Label layers must be PINNED to full resolution in 3D
+
+napari renders a multiscale layer at its **coarsest** level in 3D — automatic level selection is a
+2D-viewport calculation, and there is nothing to compute once the whole volume is on screen:
+
+```python
+elif slice_input.ndisplay == 3:
+    data_level = len(data) - 1        # napari/layers/_scalar_field/scalar_field.py
+```
+
+For an intensity image that is fine — a coarse image still looks like the image. For **labels** it is
+not. Our pyramids are built by **strided subsampling** (`create_slices_multiscales`), not by a mode
+filter, so level *n* keeps every 2ⁿ-th voxel per axis and at the coarsest level a segmentation of
+ordinary-sized cells is almost entirely background. Toggling the movie's z control to 3D therefore made
+the masks disappear.
+
+`NapariState._sync_label_levels` pins every multiscale `Labels` layer to level 0 while `ndisplay == 3`
+and hands the level back to napari in 2D, where the automatic choice is what keeps panning a large image
+fast. **Level 0, not a memory-budgeted choice** — full resolution costs memory on a large volume and that
+is accepted; pixelated masks are not an acceptable 3D view (Dominik, 2026-08-08). It is wired to `viewer.dims.events.ndisplay` — not to the places we set `ndisplay` ourselves —
+because the user can also flip 2D/3D from napari's own button, and both routes must behave the same; and
+it is called again after adding a label layer, since a layer added during a 3D session never sees that
+event.
+
+> `Labels.locked_data_level` is public API **as of napari 0.7.1** (the version in `pixi.lock`; the
+> `pixi.toml` bound is the looser `napari >= 0.7`). The bridge guards with `hasattr` and logs, so an
+> older napari degrades to the coarsest-level behaviour rather than crashing.
+
 ---
 
 ## 3D crop

--- a/frontend/src/components/MovieOutputControls.vue
+++ b/frontend/src/components/MovieOutputControls.vue
@@ -13,6 +13,7 @@
 // viewer and batch panels share a per-set movie config, Animation keeps per-project refs.
 import { computed } from 'vue'
 import { movieAxisPlaceholder, parseMovieAxis } from '../utils/movieSize'
+import { useFieldDraft } from '../composables/useFieldDraft'
 import ChipSelect, { type ChipOption } from './ChipSelect.vue'
 
 const props = defineProps<{
@@ -70,8 +71,18 @@ const overlays = computed<string[]>({
   },
 })
 
-const onAxis = (axis: 'sizeX' | 'sizeY', ev: Event) =>
-  emit(`update:${axis}` as 'update:sizeX', parseMovieAxis((ev.target as HTMLInputElement).value))
+// The three FREE-TEXT fields commit on `@change` (blur / Enter), not per keystroke — parsing a
+// half-typed width would clamp "8" to the minimum before the user reaches "800". That makes them
+// uncontrolled while focused, and Vue force-patches an input's `value` on every element patch, so a
+// re-render mid-typing used to replace what was typed with the bound value: the reported "I enter a
+// name and it jumps back to the prefilled one", on both this surface and the batch panel.
+// `useFieldDraft` keeps the DOM and the binding in lockstep without changing when the value commits.
+const suffixDraft = useFieldDraft(() => props.suffix)
+const sizeXDraft  = useFieldDraft(() => props.sizeX)
+const sizeYDraft  = useFieldDraft(() => props.sizeY)
+
+const onAxis = (axis: 'sizeX' | 'sizeY', raw: string) =>
+  emit(`update:${axis}` as 'update:sizeX', parseMovieAxis(raw))
 </script>
 
 <template>
@@ -93,20 +104,20 @@ const onAxis = (axis: 'sizeX' | 'sizeY', ev: Event) =>
 
     <span class="cc-row-group">
       <span class="cc-lbl-col cc-eyebrow cc-fs-2xs" v-tooltip.bottom="'Output size in pixels; blank = canvas size'">px</span>
-      <input type="number" min="2" max="4096" step="2" class="cc-input-2xs mo-num" :value="sizeX ?? ''"
+      <input type="number" min="2" max="4096" step="2" class="cc-input-2xs mo-num" v-model="sizeXDraft"
              :placeholder="movieAxisPlaceholder(canvasX)" v-tooltip.bottom="'Width; blank = canvas width'"
-             @change="onAxis('sizeX', $event)" />
+             @change="onAxis('sizeX', sizeXDraft)" />
       <span class="cc-muted cc-fs-2xs">×</span>
-      <input type="number" min="2" max="4096" step="2" class="cc-input-2xs mo-num" :value="sizeY ?? ''"
+      <input type="number" min="2" max="4096" step="2" class="cc-input-2xs mo-num" v-model="sizeYDraft"
              :placeholder="movieAxisPlaceholder(canvasY)" v-tooltip.bottom="'Height; blank = canvas height'"
-             @change="onAxis('sizeY', $event)" />
+             @change="onAxis('sizeY', sizeYDraft)" />
     </span>
 
     <span class="cc-row-group mo-own-row">
       <span class="cc-lbl-col cc-eyebrow cc-fs-2xs" v-tooltip.bottom="'Added to the file name'">name</span>
-      <input type="text" class="cc-input-2xs mo-txt" :value="suffix" placeholder="suffix"
+      <input type="text" class="cc-input-2xs mo-txt" v-model="suffixDraft" placeholder="suffix"
              v-tooltip.bottom="'Added to the file name; keeps versions apart'"
-             @change="$emit('update:suffix', ($event.target as HTMLInputElement).value)" />
+             @change="$emit('update:suffix', suffixDraft)" />
     </span>
 
     <!-- How much of the z stack the movie shows. ONE switch for both the image and the mask layers:

--- a/frontend/src/components/MovieOutputControls.vue
+++ b/frontend/src/components/MovieOutputControls.vue
@@ -36,6 +36,10 @@ const props = defineProps<{
   sizeZ?: number | null
   show3D?: boolean
   zSlice?: number | null
+  // multiscale levels the open image has. >1 makes the 3D detail control meaningful (and visible);
+  // omit it, or pass 0/1, and the row is exactly what it was.
+  levels?: number | null
+  detail3d?: number | null
 }>()
 const emit = defineEmits<{
   (e: 'update:fps', v: number): void
@@ -46,6 +50,7 @@ const emit = defineEmits<{
   (e: 'update:scaleBar', v: boolean): void
   (e: 'update:show3D', v: boolean): void
   (e: 'update:zSlice', v: number): void
+  (e: 'update:detail3d', v: number): void
 }>()
 
 const hasOverlays = computed(() => props.timestamp !== undefined || props.scaleBar !== undefined)
@@ -80,6 +85,12 @@ const overlays = computed<string[]>({
 const suffixDraft = useFieldDraft(() => props.suffix)
 const sizeXDraft  = useFieldDraft(() => props.sizeX)
 const sizeYDraft  = useFieldDraft(() => props.sizeY)
+
+// The 3D detail row: only when 3D is selected AND there is more than one level to choose between.
+const hasDetail = computed(() => props.show3D === true && (props.levels ?? 0) > 1)
+// what a level actually costs you, in the terms you can see: levels halve X and Y (never Z), so level
+// n is 1/2^n of the image's width. Said as a fraction rather than an index, because "2" means nothing.
+const detailLabel = (lv: number) => (lv <= 0 ? 'full' : `1/${2 ** lv}`)
 
 const onAxis = (axis: 'sizeX' | 'sizeY', raw: string) =>
   emit(`update:${axis}` as 'update:sizeX', parseMovieAxis(raw))
@@ -135,6 +146,18 @@ const onAxis = (axis: 'sizeX' | 'sizeY', raw: string) =>
                @input="$emit('update:zSlice', ($event.target as HTMLInputElement).valueAsNumber)" />
         <span class="mo-val cc-readout">{{ zSlice ?? 0 }}</span>
       </template>
+    </span>
+
+    <!-- How much detail the 3D render uses. napari's own choice in 3D is the COARSEST pyramid level,
+         which erases a segmentation; full resolution costs memory on a big volume. Only the person
+         looking at the image can weigh that, so it is a control. -->
+    <span v-if="hasDetail" class="cc-row-group">
+      <span class="cc-lbl-col cc-eyebrow cc-fs-2xs" v-tooltip.bottom="'3D render detail'">detail</span>
+      <input type="range" min="0" :max="(levels ?? 1) - 1" step="1" class="mo-range"
+             :value="detail3d ?? 0"
+             v-tooltip.bottom="'Full resolution is sharpest and heaviest; coarser is faster'"
+             @input="$emit('update:detail3d', ($event.target as HTMLInputElement).valueAsNumber)" />
+      <span class="mo-val cc-readout">{{ detailLabel(detail3d ?? 0) }}</span>
     </span>
 
     <span v-if="hasOverlays" class="cc-row-group mo-own-row">

--- a/frontend/src/components/ViewerPanel.vue
+++ b/frontend/src/components/ViewerPanel.vue
@@ -6,7 +6,7 @@ import { useSettingsStore } from '../stores/settings'
 import { useWsStore } from '../stores/ws'
 import { useLogStore } from '../stores/log'
 import { useTaskStore } from '../stores/tasks'
-import { pushLabels as apiPushLabels, buildTitleCard, pushZView, pushLabelContour,
+import { pushLabels as apiPushLabels, buildTitleCard, pushZView, pushLabelContour, pushDetail3d,
          type TitleCardPayload } from '../utils/napariOverlays'
 import {
   pushAllOverlays, pushTracksNow, pushPopulationsNow, pushColourLabelsNow,
@@ -163,6 +163,15 @@ const movieSuffix = computed<string>({
     return stored ?? movieSuffixDefault.value
   },
   set: v => { if (currentSetUid.value) settings.setMovieConfig(currentSetUid.value, { suffix: v }) } })
+// How much detail the 3D render uses — a multiscale LEVEL index (0 = full resolution, higher =
+// coarser). Pushed live like the z choice: it is a display property you judge by looking at it.
+const detail3d = computed<number>({
+  get: () => currentSetUid.value ? (settings.getMovieConfig(currentSetUid.value).detail3d ?? 0) : 0,
+  set: v => {
+    if (currentSetUid.value) settings.setMovieConfig(currentSetUid.value, { detail3d: v })
+    pushDetail3d(v)
+  } })
+
 // Side-by-side version comparison (docs/todo/MOVIE_COMPARE_PLAN.md). The selection IS the mode: none
 // records what's on screen (unchanged), two or more record a column per version into one movie.
 const compareVersions = computed<string[]>({
@@ -594,7 +603,7 @@ watch(() => projectStore.napariReloadTick, () => reloadViewer())
 // Bridge status (shared poll — see useNapariStatus): `bridgeStale` warns that napari is running older
 // code than the checkout (it's a separate process that survives a backend restart), and the canvas size
 // is what a movie records at when no size is asked for, shown as the size fields' placeholder.
-const { bridgeStale, canvasSizeX, canvasSizeY, poll: pollBridge } = useNapariStatus()
+const { bridgeStale, canvasSizeX, canvasSizeY, multiscaleLevels, poll: pollBridge } = useNapariStatus()
 async function restartNapari() {
   try {
     const res = await fetch('/api/napari/restart', {
@@ -818,7 +827,8 @@ onUnmounted(() => {
                                  v-model:suffix="movieSuffix" :canvas-x="canvasSizeX" :canvas-y="canvasSizeY"
                                  v-model:timestamp="movieTimestamp" v-model:scale-bar="movieScaleBar"
                                  :size-z="napariImage?.sizeZ" v-model:show3D="show3D"
-                                 v-model:zSlice="zSlice" />
+                                 v-model:zSlice="zSlice"
+                                 :levels="multiscaleLevels" v-model:detail3d="detail3d" />
             <TitleCardControls v-model="movieTitleCardModel" />
           </MovieOptionsButton>
           <button class="opt-btn cc-btn cc-btn-ghost cc-btn-icon movie-rec" :class="{ 'cc-btn-on cc-btn-on-tint': recording || recordingTask }" :disabled="recording || recordingTask"

--- a/frontend/src/components/canvas/PlotOptions.vue
+++ b/frontend/src/components/canvas/PlotOptions.vue
@@ -14,6 +14,7 @@ import type { VisProps } from '../../plots/plot'
 import CcToggle from '../CcToggle.vue'
 import { emptyReadout, overrideFor, type PlotReadout } from '../../plots/plotReadout'
 import { overrideTooltip, effectiveOf } from '../../plots/autoOverride'
+import { useFieldDraft } from '../../composables/useFieldDraft'
 
 const props = withDefaults(defineProps<{
   vis: VisProps
@@ -36,6 +37,17 @@ const rotateXShown = computed<boolean>({
 })
 const open = ref<Record<string, boolean>>({ layout: false, points: false, colours: false, labels: false, stats: false })
 const set = (patch: Partial<VisProps>) => emit('update:vis', patch)
+
+// Free-text fields commit on `@change` (blur / Enter) — an axis caption applied per keystroke would
+// re-render the plot on every letter. That leaves them uncontrolled while focused, and Vue force-patches
+// an input's `value` on every element patch, so a board re-render mid-typing replaced what was typed
+// with the stored value. Same defect (and fix) as the movie filename field. See useFieldDraft.
+const titleDraft  = useFieldDraft(() => props.vis.title)
+const labXDraft   = useFieldDraft(() => props.vis.labX)
+const labYDraft   = useFieldDraft(() => props.vis.labY)
+const yMinDraft   = useFieldDraft(() => props.vis.yMin)
+const yMaxDraft   = useFieldDraft(() => props.vis.yMax)
+const coloursDraft = useFieldDraft(() => props.vis.userColors)
 const has = (s: string) => props.sections.includes(s as 'layout')
 </script>
 
@@ -71,9 +83,9 @@ const has = (s: string) => props.sections.includes(s as 'layout')
         <div class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Dark plot background; export always uses light'"><span>Dark theme</span>
           <CcToggle aria-label="Dark theme" :model-value="vis.darkTheme" @update:model-value="set({ darkTheme: $event })" /></div>
         <label class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Measure-axis range (blank = auto)'"><span>Y min</span>
-          <input class="po-txt" type="text" :value="vis.yMin" @change="set({ yMin: ($event.target as HTMLInputElement).value })" /></label>
+          <input class="po-txt" type="text" v-model="yMinDraft" @change="set({ yMin: yMinDraft })" /></label>
         <label class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Measure-axis range (blank = auto)'"><span>Y max</span>
-          <input class="po-txt" type="text" :value="vis.yMax" @change="set({ yMax: ($event.target as HTMLInputElement).value })" /></label>
+          <input class="po-txt" type="text" v-model="yMaxDraft" @change="set({ yMax: yMaxDraft })" /></label>
       </div>
     </template>
 
@@ -116,8 +128,8 @@ const has = (s: string) => props.sections.includes(s as 'layout')
           </select></label>
         <label v-if="vis.palette === 'user'" class="po-row po-col cc-muted cc-fs-xs" v-tooltip.left="'Comma-separated colours/hex, in series order'">
           <span>Colours</span>
-          <input class="po-txt wide" type="text" :value="vis.userColors" placeholder="#4477AA,#EE6677,…"
-                 @change="set({ userColors: ($event.target as HTMLInputElement).value })" /></label>
+          <input class="po-txt wide" type="text" v-model="coloursDraft" placeholder="#4477AA,#EE6677,…"
+                 @change="set({ userColors: coloursDraft })" /></label>
       </div>
     </template>
 
@@ -157,11 +169,11 @@ const has = (s: string) => props.sections.includes(s as 'layout')
       </button>
       <div v-show="open.labels" class="po-body">
         <label class="po-row po-col cc-muted cc-fs-xs" v-tooltip.left="'Heading above the plot (blank = none)'"><span>Title</span>
-          <input class="po-txt wide" type="text" :value="vis.title" @change="set({ title: ($event.target as HTMLInputElement).value })" /></label>
+          <input class="po-txt wide" type="text" v-model="titleDraft" @change="set({ title: titleDraft })" /></label>
         <label class="po-row po-col cc-muted cc-fs-xs" v-tooltip.left="'X axis caption (blank = the measure name)'"><span>X label</span>
-          <input class="po-txt wide" type="text" :value="vis.labX" @change="set({ labX: ($event.target as HTMLInputElement).value })" /></label>
+          <input class="po-txt wide" type="text" v-model="labXDraft" @change="set({ labX: labXDraft })" /></label>
         <label class="po-row po-col cc-muted cc-fs-xs" v-tooltip.left="'Y axis caption (blank = the measure name)'"><span>Y label</span>
-          <input class="po-txt wide" type="text" :value="vis.labY" @change="set({ labY: ($event.target as HTMLInputElement).value })" /></label>
+          <input class="po-txt wide" type="text" v-model="labYDraft" @change="set({ labY: labYDraft })" /></label>
         <label class="po-row cc-muted cc-fs-xs" v-tooltip.left="'Type size for titles, axes and tick labels'"><span>Font size</span>
           <input type="range" min="8" max="20" step="1" :value="vis.fontSize"
                  @input="set({ fontSize: Number(($event.target as HTMLInputElement).value) })" />

--- a/frontend/src/composables/useFieldDraft.test.ts
+++ b/frontend/src/composables/useFieldDraft.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { useFieldDraft } from './useFieldDraft'
+
+describe('useFieldDraft', () => {
+  it('seeds from the committed value', () => {
+    const src = ref('cpCorrected')
+    expect(useFieldDraft(() => src.value).value).toBe('cpCorrected')
+  })
+
+  it('typing is not undone by the committed value staying put', async () => {
+    // the reported bug: the field commits on blur, so while typing the draft and the source disagree.
+    // A re-render must not resolve that disagreement in the source's favour.
+    const src = ref('cpCorrected')
+    const draft = useFieldDraft(() => src.value)
+    draft.value = 'my movie'          // user types
+    await nextTick()                  // …and the panel re-renders (poll, task frame, whatever)
+    expect(draft.value).toBe('my movie')
+  })
+
+  it('re-seeds when the committed value genuinely changes', async () => {
+    const src = ref('cpCorrected')
+    const draft = useFieldDraft(() => src.value)
+    draft.value = 'half typed'
+    src.value = 'AF'                  // e.g. the prefill follows the version now shown
+    await nextTick()
+    expect(draft.value).toBe('AF')
+  })
+
+  it('a commit that normalises the value shows the normalised form', async () => {
+    const src = ref<number | null>(null)
+    const draft = useFieldDraft(() => src.value)
+    draft.value = '801'
+    src.value = 802                   // parseMovieAxis rounds to an even width
+    await nextTick()
+    expect(draft.value).toBe('802')
+  })
+
+  it('null and undefined read as an empty field, not "null"', async () => {
+    const src = ref<number | null | undefined>(null)
+    const draft = useFieldDraft(() => src.value)
+    expect(draft.value).toBe('')
+    src.value = undefined
+    await nextTick()
+    expect(draft.value).toBe('')
+  })
+
+  it('a cleared field is a real value, not an absent one', async () => {
+    // '' means "the user deliberately cleared the suffix", which must survive a re-seed
+    const src = ref<string | null>('AF')
+    const draft = useFieldDraft(() => src.value)
+    src.value = ''
+    await nextTick()
+    expect(draft.value).toBe('')
+  })
+})

--- a/frontend/src/composables/useFieldDraft.ts
+++ b/frontend/src/composables/useFieldDraft.ts
@@ -1,0 +1,41 @@
+import { ref, watch, type Ref } from 'vue'
+
+/**
+ * A text field's in-progress text, for a field that commits on `@change` (blur / Enter) rather than on
+ * every keystroke.
+ *
+ * The bug this exists to stop: `<input :value="model" @change="commit">` looks like an ordinary
+ * controlled field and is not. The model only catches up on blur, so while you are typing the DOM is
+ * AHEAD of the binding — and Vue force-patches `value` on every element patch, comparing against the
+ * DOM's current text rather than the previous binding:
+ *
+ *     if (next !== prev || key === "value") hostPatchProp(el, key, ...)   // runtime-core, patchElement
+ *     const oldValue = el.value                                           // runtime-dom, patchDOMProp
+ *     if (oldValue !== newValue) el.value = newValue
+ *
+ * So ANY re-render of the component while the field has focus silently replaces what the user typed
+ * with the bound value. On a busy panel — one that polls, or re-renders on task/WS traffic — that is
+ * "I typed a name and it jumped back to the placeholder", which is exactly how it was reported for the
+ * movie filename on both the single-shot and batch surfaces.
+ *
+ * `v-model="draft"` keeps the DOM and the binding in lockstep, so there is nothing to clobber, while
+ * `commit on @change` semantics are preserved — which matters for the numeric fields, where parsing a
+ * half-typed number per keystroke would fight the user ("8" clamped to the minimum before they reach
+ * "800").
+ *
+ * The re-seed is a `watch` on the SOURCE, not an effect on every render: a re-render with an unchanged
+ * source leaves the draft alone, and a genuine external change (the prefill following the version you
+ * picked) still lands. Same reasoning as `@input` vs a rendered binding — track the value, not the
+ * render.
+ *
+ * @param source  the committed value, as a getter (`() => props.suffix`)
+ * @param format  how it reads in the field; defaults to `String`, with null/undefined as empty
+ */
+export function useFieldDraft<T>(
+  source: () => T,
+  format: (v: T) => string = v => (v == null ? '' : String(v)),
+): Ref<string> {
+  const draft = ref(format(source()))
+  watch(source, v => { draft.value = format(v) })
+  return draft
+}

--- a/frontend/src/composables/useNapariStatus.ts
+++ b/frontend/src/composables/useNapariStatus.ts
@@ -14,6 +14,9 @@ import { ref, onMounted, onUnmounted } from 'vue'
 const bridgeStale = ref(false)
 const canvasSizeX = ref<number | null>(null)
 const canvasSizeY = ref<number | null>(null)
+// multiscale levels the OPEN IMAGE has — the range the 3D detail control offers (0 or 1 = no choice
+// to make, so the control hides). See docs/NAPARI.md → *3D detail*.
+const multiscaleLevels = ref<number>(0)
 
 let timer: number | undefined
 let watchers = 0
@@ -22,10 +25,12 @@ let watchers = 0
 export async function pollNapariStatus() {
   try {
     const s = await (await fetch('/api/napari/status')).json() as
-      { bridgeStale?: boolean; canvasSizeX?: number | null; canvasSizeY?: number | null }
+      { bridgeStale?: boolean; canvasSizeX?: number | null; canvasSizeY?: number | null
+        multiscaleLevels?: number | null }
     bridgeStale.value = !!s.bridgeStale
     canvasSizeX.value = s.canvasSizeX ?? null
     canvasSizeY.value = s.canvasSizeY ?? null
+    multiscaleLevels.value = s.multiscaleLevels ?? 0
   } catch {
     bridgeStale.value = false            // no bridge → nothing to warn about, and no canvas to report
   }
@@ -45,5 +50,5 @@ export function useNapariStatus() {
     watchers -= 1
     if (watchers <= 0 && timer !== undefined) { clearInterval(timer); timer = undefined }
   })
-  return { bridgeStale, canvasSizeX, canvasSizeY, poll: pollNapariStatus }
+  return { bridgeStale, canvasSizeX, canvasSizeY, multiscaleLevels, poll: pollNapariStatus }
 }

--- a/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
+++ b/frontend/src/modules/batchmovies/BatchMoviesPanel.vue
@@ -46,7 +46,7 @@ const settings    = useSettingsStore()
 const tasks       = useTaskStore()
 const ws          = useWsStore()
 // the canvas size napari would record at, for the size fields' placeholder (shared poll)
-const { canvasSizeX, canvasSizeY } = useNapariStatus()
+const { canvasSizeX, canvasSizeY, multiscaleLevels } = useNapariStatus()
 const log         = useLogStore()
 
 const uniq = (xs: string[]) => [...new Set(xs)]
@@ -102,6 +102,11 @@ const labelContour = computed<number>({
 // Whole z stack (3D) or one slice. Authored per SET here rather than read from the live viewer — the
 // batch opens each image itself, so there is no "what is on screen" to inherit.
 const show3D = computed<boolean>({ get: () => !!cfg.value.show3D, set: v => patch({ show3D: v }) })
+// 3D detail (multiscale level, 0 = full resolution). Stored in the batch config and applied per image
+// by the recorder; the RANGE comes from the image currently open in napari, so the control only offers
+// itself when there is something on screen to judge it against.
+const detail3d = computed<number>({
+  get: () => (cfg.value.detail3d as number | undefined) ?? 0, set: v => patch({ detail3d: v }) })
 const zSlice = computed<number | null>({
   get: () => cfg.value.zSlice ?? null, set: v => patch({ zSlice: v }) })
 // the shallowest stack in the selection — a slice index deeper than that would not exist on every image
@@ -379,7 +384,8 @@ const { pane, toggle: togglePane } = usePaneExpand('cc-batchmovies-pane')
         <MovieOutputControls v-model:fps="fps" v-model:sizeX="sizeX" v-model:sizeY="sizeY"
                              v-model:suffix="suffix" :canvas-x="canvasSizeX" :canvas-y="canvasSizeY"
                              v-model:timestamp="movieTimestamp" v-model:scale-bar="movieScaleBar"
-                             :size-z="zDepth" v-model:show3D="show3D" v-model:zSlice="zSlice" />
+                             :size-z="zDepth" v-model:show3D="show3D" v-model:zSlice="zSlice"
+                             :levels="multiscaleLevels" v-model:detail3d="detail3d" />
         <TitleCardControls v-model="titleCardModel" />
       </section>
 

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -190,6 +190,9 @@ export const useSettingsStore = defineStore('settings', () => {
     movie?: { fps?: number; sizeX?: number | null; sizeY?: number | null; suffix?: string | null
               titleCard?: TitleCardCfg; compareVersions?: string[]; compareSegmentations?: string[]
               labelContour?: number; zSlice?: number | null
+              // 3D multiscale detail: level index (0 = full resolution, higher = coarser), or null for
+              // napari's own choice (its coarsest level). Per set, like the other viewer prefs.
+              detail3d?: number | null
               compareLayout?: CompareLayout; compareContrast?: CompareContrast
               showTimestamp?: boolean; showScaleBar?: boolean }
     // 3D-crop z-range and t-range as 0–100 % (per set — the XY crop box itself is per-session, drawn in
@@ -209,6 +212,7 @@ export const useSettingsStore = defineStore('settings', () => {
       labelContour?: number                 // mask outline width in px (0 = filled)
       show3D?: boolean                      // whole z stack as a 3D render…
       zSlice?: number | null                // …or this slice in 2D (null = whatever is showing)
+      detail3d?: number | null              // 3D detail: multiscale level (0 = full res), null = auto
       compareLayout?: CompareLayout; compareContrast?: CompareContrast
       valueName?: string                    // image version to open ('' = active) — legacy, migrated
       channels?: Record<string, string>     // channelName → colormap (only these shown)
@@ -259,6 +263,7 @@ export const useSettingsStore = defineStore('settings', () => {
     fps: number; sizeX: number | null; sizeY: number | null; suffix: string | null; titleCard: TitleCardCfg
     compareVersions: string[]; compareSegmentations: string[]; labelContour: number
     zSlice: number | null
+    detail3d: number | null
     compareLayout: CompareLayout; compareContrast: CompareContrast
     showTimestamp: boolean; showScaleBar: boolean
   } => ({
@@ -277,6 +282,9 @@ export const useSettingsStore = defineStore('settings', () => {
     // The 3D half is the EXISTING per-set `show3D` pref — one stored value, so the viewer's 3D button
     // and the movie's z control cannot disagree.
     zSlice: _setPrefs.value[setUid]?.movie?.zSlice ?? null,
+    // 0 = full resolution. napari's own 3D choice is the COARSEST level, which erases a strided label
+    // pyramid — so the default is full and the cost is a visible control (docs/NAPARI.md → 3D detail).
+    detail3d: _setPrefs.value[setUid]?.movie?.detail3d ?? 0,
     compareLayout: _setPrefs.value[setUid]?.movie?.compareLayout ?? COMPARE_LAYOUT_DEFAULT,
     compareContrast: _setPrefs.value[setUid]?.movie?.compareContrast ?? COMPARE_CONTRAST_DEFAULT,
     // default ON — what every movie was before the toggles existed
@@ -288,6 +296,7 @@ export const useSettingsStore = defineStore('settings', () => {
                                    suffix?: string | null; titleCard?: TitleCardCfg
                                    compareVersions?: string[]; compareSegmentations?: string[]
                                    labelContour?: number; zSlice?: number | null
+                                   detail3d?: number | null
                                    compareLayout?: CompareLayout
                                    compareContrast?: CompareContrast
                                    showTimestamp?: boolean; showScaleBar?: boolean }) {

--- a/frontend/src/utils/batchMovie.test.ts
+++ b/frontend/src/utils/batchMovie.test.ts
@@ -141,6 +141,22 @@ describe('clampContour / labelContour', () => {
 
 // Mirrors the Julia `_safe_name_part` testset (api/test/runtests.jl) — the two sanitisers must agree,
 // or the filename the batch panel PREVIEWS is not the one the recorder writes.
+// napari's own 3D choice is the COARSEST pyramid level, which erases a strided label pyramid — so an
+// authored batch config says "full resolution" rather than leaving it unsaid. See docs/NAPARI.md.
+describe('buildBatchMovieConfig 3D detail', () => {
+  const build = (cfg: Record<string, unknown>) =>
+    buildBatchMovieConfig(cfg, ['segA'], {})
+  it('sends full resolution by default in 3D', () => {
+    expect(build({ show3D: true }).detail3d).toBe(0)
+  })
+  it('carries an explicitly chosen level', () => {
+    expect(build({ show3D: true, detail3d: 2 }).detail3d).toBe(2)
+  })
+  it('sends nothing in 2D — the level only applies to a volumetric render', () => {
+    expect(build({ show3D: false, detail3d: 2 }).detail3d).toBeNull()
+  })
+})
+
 describe('safeNamePart', () => {
   it('drops the separator a trailing bracket leaves behind', () => {
     // the reported one: an image named "… -res (cropped)" showed up as "…-res_cropped_"

--- a/frontend/src/utils/batchMovie.test.ts
+++ b/frontend/src/utils/batchMovie.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { clampContour, LABEL_CONTOUR_MAX, buildBatchMovieConfig, movieFilename, seedConfigFromViewState, defaultChannelSeed, MOVIE_CHANNELS_TOKEN } from './batchMovie'
+import { clampContour, LABEL_CONTOUR_MAX, buildBatchMovieConfig, movieFilename, seedConfigFromViewState, defaultChannelSeed, MOVIE_CHANNELS_TOKEN, safeNamePart } from './batchMovie'
 
 describe('buildBatchMovieConfig', () => {
   it('fills defaults for an empty config', () => {
@@ -136,5 +136,27 @@ describe('clampContour / labelContour', () => {
     expect(buildBatchMovieConfig({}, [], {}).labelContour).toBe(0)
     expect(buildBatchMovieConfig({ labelContour: 3 }, [], {}).labelContour).toBe(3)
     expect(buildBatchMovieConfig({ labelContour: -1 }, [], {}).labelContour).toBe(0)
+  })
+})
+
+// Mirrors the Julia `_safe_name_part` testset (api/test/runtests.jl) — the two sanitisers must agree,
+// or the filename the batch panel PREVIEWS is not the one the recorder writes.
+describe('safeNamePart', () => {
+  it('drops the separator a trailing bracket leaves behind', () => {
+    // the reported one: an image named "… -res (cropped)" showed up as "…-res_cropped_"
+    expect(safeNamePart('M2b-MERTK_KAT-SWHL-GFP-Tom-res (cropped)'))
+      .toBe('M2b-MERTK_KAT-SWHL-GFP-Tom-res_cropped')
+  })
+  it('keeps the characters a filename may hold, collapses the rest', () => {
+    expect(safeNamePart('a/b c:d')).toBe('a_b_c_d')
+    expect(safeNamePart('Day 3.v2-final')).toBe('Day_3.v2-final')
+  })
+  it('strips leading separators and dots too', () => {
+    expect(safeNamePart('../../etc/passwd')).toBe('etc_passwd')
+    expect(safeNamePart('__x__')).toBe('x')
+  })
+  it('a name with nothing usable in it comes back empty', () => {
+    expect(safeNamePart('   ')).toBe('')
+    expect(safeNamePart('()')).toBe('')
   })
 })

--- a/frontend/src/utils/batchMovie.ts
+++ b/frontend/src/utils/batchMovie.ts
@@ -146,7 +146,15 @@ export function movieFilename(
     }
   }
   parts.push(uid || 'uid')
-  return parts.join('_').replace(/[^A-Za-z0-9._-]+/g, '_') + '.mp4'
+  return safeNamePart(parts.join('_')) + '.mp4'
+}
+
+/** One filename-safe fragment — mirrors `_safe_name_part` (api/src/napari_api.jl); keep the two in
+ *  sync. Keeps [A-Za-z0-9._-], collapses every other run to `_`, and drops the separators that
+ *  collapse leaves at the EDGES: an image called "… -res (cropped)" ends in `)`, so sanitising alone
+ *  produced a name ending in `_`. */
+export function safeNamePart(raw: string): string {
+  return raw.trim().replace(/[^A-Za-z0-9._-]+/g, '_').replace(/^[_.]+|[_.]+$/g, '')
 }
 
 // ── seeding (so the config isn't blank) ────────────────────────────────────────

--- a/frontend/src/utils/batchMovie.ts
+++ b/frontend/src/utils/batchMovie.ts
@@ -31,6 +31,8 @@ export interface BatchMovieCfg {
   // before the setting existed. One switch for both layer kinds — see `set_z_view` in the bridge.
   show3D?: boolean
   zSlice?: number | null
+  // 3D multiscale detail: level index (0 = full resolution, higher = coarser), null = napari's choice
+  detail3d?: number | null
   compareLayout?: CompareLayout
   compareContrast?: CompareContrast
   valueName?: string
@@ -54,6 +56,7 @@ export interface BatchMovieRequestConfig {
   labelContour: number
   show3D: boolean
   zSlice: number | null
+  detail3d: number | null
   compareLayout: CompareLayout
   compareContrast: CompareContrast
   channels: Record<string, string>
@@ -101,6 +104,9 @@ export function buildBatchMovieConfig(
     // a z index alongside show3D is a leftover from the last time 2D was picked — Julia ignores it
     // (`_z_slice`), and sending null rather than dropping the key keeps the two ends reading alike
     zSlice: cfg.show3D ? null : (cfg.zSlice ?? null),
+    // only meaningful in 3D; sent as 0 (full resolution) by default, because napari's own 3D choice is
+    // the coarsest level and that erases a strided label pyramid (docs/NAPARI.md → 3D detail)
+    detail3d: cfg.show3D ? (cfg.detail3d ?? 0) : null,
     compareLayout: cfg.compareLayout ?? COMPARE_LAYOUT_DEFAULT,
     compareContrast: cfg.compareContrast ?? COMPARE_CONTRAST_DEFAULT,
     channels: cfg.channels ?? {},

--- a/frontend/src/utils/continuousControls.test.ts
+++ b/frontend/src/utils/continuousControls.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { openingTags, templateBlock, sinkOf, rangeControls, undeclaredControls, rearmedTimers } from './continuousControls'
+import { openingTags, templateBlock, sinkOf, rangeControls, undeclaredControls, rearmedTimers,
+         driftingTextFields } from './continuousControls'
 
 describe('openingTags', () => {
   it('does not end a tag on a `>` inside an attribute value', () => {
@@ -116,6 +117,35 @@ describe('rearmedTimers', () => {
   })
   it('a one-shot timer is not a re-arm', () => {
     expect(rearmedTimers('const t = setTimeout(go, 200); onUnmounted(() => clearTimeout(t))')).toEqual([])
+  })
+})
+
+describe('driftingTextFields', () => {
+  it('flags a text field bound with :value and committed on @change', () => {
+    expect(driftingTextFields('<input type="text" :value="name" @change="save($event)" />')).toHaveLength(1)
+    expect(driftingTextFields('<input :value="name" @change="save($event)" />')).toHaveLength(1)   // no type = text
+  })
+  it('a v-model draft is the fix, so it is not flagged', () => {
+    expect(driftingTextFields('<input type="text" v-model="draft" @change="save(draft)" />')).toEqual([])
+  })
+  it('a select cannot drift — its value only changes when the user picks, which fires change', () => {
+    expect(driftingTextFields('<select :value="v" @change="set($event)"><option/></select>')).toEqual([])
+  })
+  it('a range input is a different rule (see above), not this one', () => {
+    expect(driftingTextFields('<input type="range" :value="n" @change="apply(n)" />')).toEqual([])
+  })
+})
+
+// The sibling of the coalescing rule, and the same underlying mistake: letting the DOM and the model
+// disagree. A field bound with `:value` and committed on `@change` is uncontrolled while focused, and
+// Vue force-patches `value` against the DOM's current text on every element patch — so a re-render
+// mid-typing throws away what the user typed. Reported as "I enter a movie name and it reverts to the
+// prefilled one"; the plot-styling panel had five more of them. `useFieldDraft` is the fix.
+describe('no text field lets the DOM drift from its binding', () => {
+  it('every :value + @change text field uses a v-model draft', () => {
+    const drifting = sources
+      .flatMap(s => driftingTextFields(s.text).map(tag => `${s.path}: ${tag.slice(0, 80)}`))
+    expect(drifting).toEqual([])
   })
 })
 

--- a/frontend/src/utils/continuousControls.ts
+++ b/frontend/src/utils/continuousControls.ts
@@ -147,3 +147,30 @@ export function rearmedTimers(source: string): string[] {
   }
   return [...out]
 }
+
+/**
+ * Text-ish inputs bound with `:value` and committed on `@change` — the shape whose DOM value runs
+ * AHEAD of its binding while the field has focus.
+ *
+ * Vue force-patches an input's `value` on every element patch and compares against the DOM's current
+ * text, not the previous binding, so a re-render mid-typing silently replaces what the user typed with
+ * the bound value. It reads as "I entered a name and it jumped back to the prefilled one" — reported
+ * for the movie filename, and present in five more fields on the plot-styling panel.
+ *
+ * `v-model` on the draft is the fix (see `composables/useFieldDraft`), not switching to `@input`:
+ * commit-on-blur is deliberate for a field whose value is parsed or drives a re-render.
+ *
+ * A `<select>` is deliberately not matched — its DOM value only changes through a user selection,
+ * which fires `change` at the same moment, so it cannot drift.
+ */
+const DRIFT_PRONE_TYPE = /^(text|number|search|email|url|tel|password)$/
+
+export function driftingTextFields(source: string): string[] {
+  return openingTags(templateBlock(source))
+    .filter(t => t.startsWith('<input') || t.startsWith('<textarea'))
+    .filter(t => {
+      const type = attr(t, 'type') ?? 'text'          // an <input> with no type is a text field
+      return t.startsWith('<textarea') || DRIFT_PRONE_TYPE.test(type)
+    })
+    .filter(t => /\s:value="/.test(t) && /\s@change="/.test(t) && !/\sv-model/.test(t))
+}

--- a/frontend/src/utils/napariOverlays.ts
+++ b/frontend/src/utils/napariOverlays.ts
@@ -53,6 +53,17 @@ export function pushLabelContour(valueNames: string[], contour: number): void {
   _contourPush.schedule(layers)
 }
 
+const _detailPush = debouncedLatest<number | null>(
+  async level => { await _post('/api/napari/set-3d-level', { level }) },
+  { wait: LIVE_PUSH_WAIT },
+)
+/** How much detail the 3D view renders: a multiscale level index (0 = full resolution, higher =
+ *  coarser), or null for napari's own choice. Coalesced — it is a slider, and each change re-slices
+ *  every multiscale layer in the viewer. */
+export function pushDetail3d(level: number | null): void {
+  _detailPush.schedule(level)
+}
+
 /** Apply a WHOLE captured view snapshot (keyframe select, zoom-to-source). One-shot and awaited — it
  *  answers a click, not a drag, so it is deliberately NOT coalesced: the caller wants this exact
  *  snapshot applied, and a later one must not silently replace it. The bridge skips absent layers. */

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -57,7 +57,7 @@ _STARTED_AT = time.time()
 #: `size_x`/`size_y` (and `scale` is gone), and `ping` reports the canvas size. 3: `stitch_movies`
 #: (side-by-side version comparison), the recorders take `frame_offset`/`frame_total` so a multi-pass
 #: job drives one progress bar, and they take `show_timestamp`/`show_scale_bar`.
-PROTOCOL = 3
+PROTOCOL = 4
 
 # name of the Shapes layer used for spatial cell selection (linked brushing → flow plots)
 SELECTION_LAYER = "Cell selection"
@@ -107,6 +107,9 @@ class NapariState:
         self._labels_orig_cmap = {}   # labels layer name → original colormap, to restore on reset
         self._colcol_cache = {}       # (value_name, column) → (labels, vals, is_cat) obs column read
         self._ts_handler = None       # timestamp slider callback, disconnected before reconnecting
+        # 3D multiscale detail level (see _sync_multiscale_levels). 0 = full resolution, the default:
+        # napari's own choice in 3D is the COARSEST level, which erases a strided label pyramid.
+        self._3d_level = 0
 
         # ── layer-props autosave (debounced, atomic) ────────────────────────────
         # Save brightness/contrast/colormap + the T/Z slider position the moment the user changes
@@ -121,10 +124,10 @@ class NapariState:
         self._autosave_timer.setInterval(500)   # debounce window: one write ~500ms after the last change
         self._autosave_timer.timeout.connect(self._autosave_flush)
 
-        # Keep label layers RENDERABLE in 3D — see _sync_label_levels. Connected here, on the viewer's
+        # Keep layers RENDERABLE in 3D — see _sync_multiscale_levels. Connected here, on the viewer's
         # own event, rather than at the places we set `ndisplay` ourselves: the user can also flip 2D/3D
         # from napari's own button, and that has to behave the same as the movie panel's z control.
-        self._viewer.dims.events.ndisplay.connect(lambda _e=None: self._sync_label_levels())
+        self._viewer.dims.events.ndisplay.connect(lambda _e=None: self._sync_multiscale_levels())
 
     # ── Viewer lifecycle ───────────────────────────────────────────────────────
 
@@ -140,28 +143,53 @@ class NapariState:
     # of ordinary-sized cells is almost entirely background. Switching the movie's z control to 3D
     # therefore made the masks vanish.
     #
-    # So pin label layers to full resolution while the viewer is in 3D, and hand the level back to
-    # napari in 2D, where the automatic choice is what keeps panning a large image fast.
+    # So the level becomes a SETTING rather than napari's default, applied while the viewer is in 3D and
+    # handed back to napari in 2D, where the automatic choice is what keeps panning a large image fast.
     #
-    # LEVEL 0, not "the finest level under some memory budget" — full resolution costs memory on a big
-    # volume and that is accepted: pixelated masks are not an acceptable 3D view (Dominik, 2026-08-08).
-    # Don't reintroduce a coarser choice as an optimisation. `locked_data_level`
-    # is public API as of napari 0.7.1 (the pinned version); the guard keeps an older napari on today's
-    # behaviour instead of crashing.
-    def _sync_label_levels(self):
+    # `detail_level` is a level index: 0 = full resolution, higher = coarser (levels downsample X and Y
+    # by 2^n; Z is never downsampled — see `create_slices_multiscales`). `None` means "leave it to
+    # napari", i.e. the coarsest level, which is the behaviour every 3D view had before this existed.
+    # It defaults to 0 because a pixelated mask is not a usable 3D view, and it is exposed as a control
+    # because full resolution costs memory on a large volume and only the person looking at the image
+    # can judge that trade (docs/UI.md → "3D detail").
+    #
+    # Applied to EVERY multiscale scalar layer, image and labels alike. A crisp mask floating over a
+    # coarse image is its own kind of wrong, and the layers stay aligned either way — napari derives a
+    # level's world scale from its shape (`downsample_factors = level_shapes[0] / level_shapes`), so
+    # mixing levels never misplaces anything, it only mixes sharpness.
+    #
+    # `locked_data_level` is public API as of napari 0.7.1 (the version in pixi.lock); the guard keeps an
+    # older napari on its own behaviour instead of crashing.
+    def _sync_multiscale_levels(self):
         in_3d = self._viewer.dims.ndisplay == 3
         for layer in self._viewer.layers:
-            if not isinstance(layer, napari.layers.Labels) or not getattr(layer, "multiscale", False):
+            if not getattr(layer, "multiscale", False):
                 continue
             if not hasattr(layer, "locked_data_level"):
-                print("[labels] napari has no locked_data_level; 3D will render the coarsest level",
-                      flush=True)
+                print("[3d] napari has no locked_data_level; 3D renders the coarsest level", flush=True)
                 return
             try:
-                layer.locked_data_level = 0 if in_3d else None
+                layer.locked_data_level = self._clamp_level(layer) if in_3d else None
             except Exception as e:
                 # never let a display nicety take the viewer down
-                print(f"[labels] could not pin {layer.name} to full resolution: {e}", flush=True)
+                print(f"[3d] could not set the level of {layer.name}: {e}", flush=True)
+
+    def _clamp_level(self, layer):
+        """The requested 3D level, clamped to the levels THIS layer actually has (napari_utils)."""
+        return napari_utils.clamped_level(self._3d_level, len(getattr(layer, "level_shapes", []) or []))
+
+    def set_3d_level(self, level=None):
+        """Set the 3D detail level (None = napari's automatic choice, the coarsest level).
+
+        Separate from `set_z_view` on purpose: moving the slider must not re-run that command's
+        `reset_view()` and throw away the camera the user has just positioned."""
+        self._3d_level = None if level is None else int(level)
+        self._sync_multiscale_levels()
+        return {"level": self._3d_level, "applied": self._viewer.dims.ndisplay == 3}
+
+    def multiscale_levels(self):
+        """Levels the OPEN IMAGE has — the range the detail control offers. 1 (or 0) means no choice."""
+        return len(self._im_data) if self._im_data else 0
 
     def clear(self):
         self._viewer.layers.clear()
@@ -277,8 +305,14 @@ class NapariState:
         """
         z_len = self._z_axis_len() or 0
         if show_3d and z_len > 1:
+            # reset_view ONLY on the 2D→3D transition. Setting ndisplay=3 programmatically leaves the
+            # camera uninitialised for the 3D extent (docs/NAPARI.md), but re-running it on a command
+            # that arrives while already in 3D would throw away the camera the user just positioned —
+            # which is what any repeat of this command does.
+            was_2d = self._viewer.dims.ndisplay != 3
             self._viewer.dims.ndisplay = 3
-            self._viewer.reset_view()
+            if was_2d:
+                self._viewer.reset_view()
             return {"ndisplay": 3, "z": None}
 
         self._viewer.dims.ndisplay = 2
@@ -471,9 +505,9 @@ class NapariState:
             if after_add is not None:
                 after_add(value_name, layer)
 
-        # A layer ADDED while the viewer is already in 3D never sees an `ndisplay` event, so pin it here
-        # too — otherwise turning a mask on during a 3D session shows nothing. Cheap and idempotent.
-        self._sync_label_levels()
+        # A layer ADDED while the viewer is already in 3D never sees an `ndisplay` event, so apply the
+        # level here too — otherwise turning a mask on during a 3D session shows nothing. Idempotent.
+        self._sync_multiscale_levels()
 
     def show_labels(self, value_name: str = "default",
                     label_files: list = None,
@@ -2043,7 +2077,11 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
             hw = napari_utils.canvas_size(state._viewer) if state._viewer is not None else None
             return {"type": "pong", "started_at": _STARTED_AT, "protocol": PROTOCOL,
                     "canvas_size_y": hw[0] if hw else None,
-                    "canvas_size_x": hw[1] if hw else None}
+                    "canvas_size_x": hw[1] if hw else None,
+                    # how many multiscale levels the OPEN IMAGE has — the range the 3D detail control
+                    # offers. Rides the health poll for the same reason the canvas size does.
+                    "multiscale_levels": state.multiscale_levels(),
+                    "detail_level": state._3d_level}
 
         elif t == "gl_info":
             return {"type": "gl_info", **_gl_info()}
@@ -2057,6 +2095,9 @@ def execute_command(state: NapariState, cmd: dict) -> dict:
                 as_dask=cmd.get("as_dask", True),
                 visible=cmd.get("visible", True),
             )
+
+        elif t == "set_3d_level":
+            return state.set_3d_level(cmd.get("level", None))
 
         elif t == "set_z_view":
             return state.set_z_view(show_3d=cmd.get("show_3d", False), z=cmd.get("z", None))

--- a/napari/napari_bridge.py
+++ b/napari/napari_bridge.py
@@ -121,7 +121,47 @@ class NapariState:
         self._autosave_timer.setInterval(500)   # debounce window: one write ~500ms after the last change
         self._autosave_timer.timeout.connect(self._autosave_flush)
 
+        # Keep label layers RENDERABLE in 3D — see _sync_label_levels. Connected here, on the viewer's
+        # own event, rather than at the places we set `ndisplay` ourselves: the user can also flip 2D/3D
+        # from napari's own button, and that has to behave the same as the movie panel's z control.
+        self._viewer.dims.events.ndisplay.connect(lambda _e=None: self._sync_label_levels())
+
     # ── Viewer lifecycle ───────────────────────────────────────────────────────
+
+    # napari renders a MULTISCALE layer at its COARSEST level in 3D — automatic level selection is a
+    # 2D-viewport calculation, so there is nothing to compute once the whole volume is on screen:
+    #
+    #     elif slice_input.ndisplay == 3:
+    #         data_level = len(data) - 1        # napari/layers/_scalar_field/scalar_field.py
+    #
+    # For an intensity image that is fine: a coarse image still looks like the image. For LABELS it is
+    # not, because our pyramids are built by strided subsampling (`create_slices_multiscales`), not by
+    # a mode filter — level n keeps every 2^n-th voxel per axis, so at the coarsest level a segmentation
+    # of ordinary-sized cells is almost entirely background. Switching the movie's z control to 3D
+    # therefore made the masks vanish.
+    #
+    # So pin label layers to full resolution while the viewer is in 3D, and hand the level back to
+    # napari in 2D, where the automatic choice is what keeps panning a large image fast.
+    #
+    # LEVEL 0, not "the finest level under some memory budget" — full resolution costs memory on a big
+    # volume and that is accepted: pixelated masks are not an acceptable 3D view (Dominik, 2026-08-08).
+    # Don't reintroduce a coarser choice as an optimisation. `locked_data_level`
+    # is public API as of napari 0.7.1 (the pinned version); the guard keeps an older napari on today's
+    # behaviour instead of crashing.
+    def _sync_label_levels(self):
+        in_3d = self._viewer.dims.ndisplay == 3
+        for layer in self._viewer.layers:
+            if not isinstance(layer, napari.layers.Labels) or not getattr(layer, "multiscale", False):
+                continue
+            if not hasattr(layer, "locked_data_level"):
+                print("[labels] napari has no locked_data_level; 3D will render the coarsest level",
+                      flush=True)
+                return
+            try:
+                layer.locked_data_level = 0 if in_3d else None
+            except Exception as e:
+                # never let a display nicety take the viewer down
+                print(f"[labels] could not pin {layer.name} to full resolution: {e}", flush=True)
 
     def clear(self):
         self._viewer.layers.clear()
@@ -430,6 +470,10 @@ class NapariState:
                   f"scale={self._im_scale} cache={cache} levels={len(arrays)}", flush=True)
             if after_add is not None:
                 after_add(value_name, layer)
+
+        # A layer ADDED while the viewer is already in 3D never sees an `ndisplay` event, so pin it here
+        # too — otherwise turning a mask on during a 3D session shows nothing. Cheap and idempotent.
+        self._sync_label_levels()
 
     def show_labels(self, value_name: str = "default",
                     label_files: list = None,

--- a/python/cecelia/tests/test_napari_utils.py
+++ b/python/cecelia/tests/test_napari_utils.py
@@ -812,3 +812,27 @@ class PreviewRegionFromCornersTest(unittest.TestCase):
         # whatever level napari picked, the region is expressed in level-0 pixels
         self.assertLessEqual(r['xy']['Y'][1], 1024)
         self.assertLessEqual(r['xy']['X'][1], 1024)
+
+
+class ClampedLevelTest(unittest.TestCase):
+    """The 3D detail level is a request per VIEWER against a depth that is per LAYER."""
+
+    def test_a_valid_level_passes_through(self):
+        self.assertEqual(napari_utils.clamped_level(0, 4), 0)
+        self.assertEqual(napari_utils.clamped_level(2, 4), 2)
+
+    def test_a_shallower_layer_gets_its_own_coarsest(self):
+        # the live-preview label store is opened at ONE level while the image beside it has four;
+        # napari ignores an out-of-range index, which would silently leave that layer alone
+        self.assertEqual(napari_utils.clamped_level(3, 1), 0)
+        self.assertEqual(napari_utils.clamped_level(3, 2), 1)
+
+    def test_none_means_leave_it_to_napari(self):
+        self.assertIsNone(napari_utils.clamped_level(None, 4))
+
+    def test_no_levels_reported_falls_back_to_the_only_valid_index(self):
+        self.assertEqual(napari_utils.clamped_level(2, 0), 0)
+        self.assertEqual(napari_utils.clamped_level(2, None), 0)
+
+    def test_a_negative_request_is_still_a_valid_index(self):
+        self.assertEqual(napari_utils.clamped_level(-1, 4), 0)

--- a/python/cecelia/utils/napari_utils.py
+++ b/python/cecelia/utils/napari_utils.py
@@ -966,3 +966,27 @@ def _frame_sequence(anim):
   A seam of its own (like ``_require_napari_animation``) so tests can stub it without importing napari."""
   from napari_animation.frame_sequence import FrameSequence
   return FrameSequence(anim.key_frames)
+
+
+def clamped_level(requested, n_levels):
+    """Which multiscale level a layer should render at, given what was REQUESTED.
+
+    napari renders a multiscale layer at its coarsest level whenever ``ndisplay == 3`` — automatic
+    level selection is a 2D-viewport calculation. That is fine for an intensity image and fatal for a
+    label store, whose pyramid is built by strided subsampling (``create_slices_multiscales``), so its
+    coarsest level is almost entirely background. The bridge therefore pins the level in 3D.
+
+    The request is per VIEWER but the depth is per LAYER — a live-preview label store is opened at a
+    single level while the image beside it has four — so an index valid for one layer can be out of
+    range for another, and napari's setter silently ignores an out-of-range value (leaving that layer
+    on whatever it had). Clamping here makes "as fine as this layer can manage" the actual behaviour.
+
+    ``requested`` of ``None`` means "leave it to napari" and passes straight through. A layer with no
+    levels reported gets 0, the only index that is always valid.
+    """
+    if requested is None:
+        return None
+    n = int(n_levels or 0)
+    if n <= 0:
+        return 0
+    return max(0, min(int(requested), n - 1))


### PR DESCRIPTION
Three reported bugs, and one of them turned into a setting.

## 1. A movie name reverted to the prefill

`<input :value="model" @change="commit">` looks like an ordinary controlled field and is not — the
model only catches up on blur, so while you type the DOM is *ahead* of the binding. Vue force-patches
`value` on every element patch and compares against the DOM's current text, not the previous binding:

```js
if (next !== prev || key === "value") hostPatchProp(...)   // runtime-core
const oldValue = el.value                                  // runtime-dom
if (oldValue !== newValue) el.value = newValue
```

So any re-render while the field has focus throws away what was typed. The movie options sit on panels
that poll and re-render on task/WS traffic, so it fired within seconds. `useFieldDraft` keeps the DOM
and the binding in lockstep while preserving commit-on-blur (which is what stops the width fields
parsing "8" and clamping it before you reach "800"). The plot-styling panel had five more of the same;
`driftingTextFields` now fails the suite if one reappears.

## 2. Labels vanished in 3D

napari renders a multiscale layer at its **coarsest** level in 3D (`data_level = len(data) - 1`).
Fine for an image; fatal for labels, because our pyramids are **strided subsamples** that downsample X
and Y only. Severity scales with pyramid depth — a 2-level image gives labels at ¼ width (blocky but
there), a 4-level image gives 1/16, where a normal cell is under a pixel and the mask is *gone*.

## 3. Filenames ended in a separator

`… -res (cropped)` → `…-res_cropped_.mp4`, and the animation variant compounded it to
`…_cropped__animation.mp4`. Three near-copies of one sanitising rule and only one stripped edge
separators — the image-name path was the one that didn't, while its neighbour's comment claimed both
used "the same character rule". Now one `_safe_name_part`, mirrored in the frontend as `safeNamePart`
so the batch panel's preview matches what the recorder writes.

## The setting

(2) first landed as a hardcoded pin to level 0. That fixes the masks but decides something only the
person looking at the image can weigh, so it is now a **per-set slider**, defaulting to full
resolution and reading out as a fraction of full width (`full`, `1/2`, `1/4`) rather than a level
index — "1/4" means something, "2" does not. It applies to **image layers too**: a crisp mask over a
coarse image is its own kind of wrong, and nothing is misplaced by mixing levels (napari derives a
level's world scale from its shape), only sharpness differs.

The level is clamped **per layer** — the request is per viewer but the depth is per layer, since a
live-preview label store is opened at one level while the image beside it has four, and napari
silently ignores an out-of-range index. Its own command rather than an argument to `set_z_view`,
because that one resets the camera on entering 3D and a slider must not keep throwing the view away
(`set_z_view` now only resets on the real 2D→3D transition, for the same reason). The batch path
carries it as well, or a batch 3D movie would still render its masks at the coarsest level.

Protocol 3 → 4 on both sides, asserted by the language-boundaries testset.

## Worth your eyes

- **The image default moved.** 3D now renders image layers at full resolution where napari previously
  gave the coarsest level. Sharper, and heavier on a large volume. The slider is the escape, but the
  default changed for everyone, not just the person who wanted crisp labels.
- **`pixi run stop-napari` before testing.** The protocol bump means a stale bridge is now rejected
  rather than adopted.
- **Not browser-verified**: the new slider, the new bridge command, the batch path, or that the name
  field now holds what you type.
- The batch slider's range comes from the image currently open in napari, so with napari closed the
  control hides even though the stored level still applies at record time.
- `Labels.locked_data_level` is napari ≥ 0.7.1 (the lock has it; `pixi.toml` still says `>= 0.7`).
  Guarded with `hasattr` + a log line, so an older napari degrades rather than crashes.
- Existing movie files are untouched, but a re-record of an affected image now writes a *different*
  filename than before, so it will sit beside the old one rather than replacing it.

Rebased onto main past #505 — that one is complementary, not overlapping: it carries the outline on the
`show_labels` REBUILD path, while `pushLabelContour` here is the live partial view-state apply. Its new
dispatcher-parameter detector covers the `set_3d_level` command added here.

Julia package, API, Python and frontend suites all green after the rebase (1135 frontend, 665 Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
