### PR TITLE
docs: prompts stay in docs/prompts, not a folder that never existed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,9 @@ and use the canonical component/utility (`CcToggle`, `.cc-btn*`, `ChipSelect`, `
 new variant of a primitive that already has a canonical form is a bug — same rule as H5AD/zarr/`run_py`.
 Unification status + what's not-yet-extracted lives in [`docs/todo/UX_PRIMITIVES_PLAN.md`](docs/todo/UX_PRIMITIVES_PLAN.md).
 
-## Previous prompts
+## Prompts (`docs/prompts/`)
 
-Completed prompt files are kept in a `previous-prompts/` folder in the **workspace root** (outside `cecelia-feijoa/`) — set aside but accessible. They are **reference only**: historical context for finished work, not instructions to be re-run.
+Feature briefs and one-off audits stay where they are written — `docs/prompts/`, in the repo — including once the work has shipped. They are a **frozen record, reference only**: what was asked and investigated, never instructions to re-run. Convention + how they differ from `docs/todo/`: [`docs/prompts/README.md`](docs/prompts/README.md).
 
 ## TODO.md
 


### PR DESCRIPTION
## The problem

`CLAUDE.md` told every fresh session that completed prompt files live in a `previous-prompts/` folder in the workspace root. **There has never been such a folder** — searched the whole workspace, unbounded. So the rule could only ever send a session looking for something that isn't there, or prompt one to create it and start moving files *out* of a tracked directory.

## The fix

Prompts stay in `docs/prompts/` — 27 tracked files with its own README — shipped work included. The section becomes a one-line pointer to [`docs/prompts/README.md`](../blob/main/docs/prompts/README.md), which already documents the convention and how it differs from `docs/todo/`.

A pointer rather than a second copy of the rule, so the two can't drift — which is how this one went stale in the first place.

Two lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
