### PR TITLE
The regex "original path" is the original path

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -1336,8 +1336,8 @@ capture group `()` is used if present, else the whole match (`extractWith` in
 `frontend/src/utils/regexBuilder.ts` — the single extractor, so the live preview equals the applied
 result). The field's tooltip carries a brief example for people who don't know regex. There is **one** regex
 input with **one** live preview (`regexSample → regexPreview` against the first target image); a
-collapsible **Builder** with two modes — **Split into fields** (separator × 1st/2nd/3rd/last field ×
-drop-extension, `buildFieldRegex`) and **Around a marker** (extract a token *preceded/followed by*
+collapsible **Builder** with two modes — **Split into fields** (separator × 1st/2nd/3rd or
+3rd-/2nd-last/last field × drop-extension, `buildFieldRegex`) and **Around a marker** (extract a token *preceded/followed by*
 context via lookbehind/lookahead, `buildLookaroundRegex`). Each context side is a **literal text +
 a class that varies** (so "M" `+ number` → `(?<=M\d+)` anchors M1b/M2a/M4f without hardcoding the
 mouse number → `b`/`a`/`f`); the extract token is a class or a raw custom pattern. Both modes write
@@ -1345,6 +1345,20 @@ straight into that same field on any change, so it's a way to construct the visi
 second input.
 The user then watches the preview and can hand-edit the pattern. The pure builder/extract logic
 lives in the util (Vitest-covered); the component only wires refs.
+
+*The **Original path** source is `oriPath` — `meta.ori_path`, the location the image was imported
+from — resolved by `regexSampleFor`, never `filepath`.* `filepath` is the converted store inside the
+project (`ccidImage.ome.zarr`, or `ccidDriftCorrected.ome.zarr` once a processed version is active),
+which is the same uninformative name for every image; matching against it made the option useless.
+The point of the path source is the **upstream folders** people organise by — `…/20260714/M1b-MERTK.ori`
+→ the imaging date. That is what the from-the-end field positions and the `/ folder` separator are
+for: an absolute path has a variable number of leading folders, so the containing folder is only
+reachable as the *2nd-last* field. The folder separator is the **class `[/\]`** — either character
+splits — because a Windows `ori_path` can be a drive letter, a UNC share, or (the browse route and
+Julia's `joinpath` disagreeing) mixed. `stripExt` applies to the **last field only**, the one an
+extension can be on; anywhere else it would mangle a legitimately dotted token such as a
+`2026.07.16` date folder, so the *no ext* toggle is hidden for the other positions. Images with no
+recorded `ori_path` fall back to the name, and the preview shows the string actually matched.
 
 **Physical size & timing editor** (`frontend/src/components/PhysicalSizeDialog.vue`) is a modal,
 not a sidebar section — the first version crammed six fields + long explanatory paragraphs into

--- a/frontend/src/modules/metadata/MetadataPanel.vue
+++ b/frontend/src/modules/metadata/MetadataPanel.vue
@@ -4,8 +4,8 @@ import { useProjectStore } from '../../stores/project'
 import { useProjectMetaStore } from '../../stores/projectMeta'
 import { useLogStore } from '../../stores/log'
 import { metadataWarning } from '../../lib/imageMetadataWarnings'
-import { buildFieldRegex, buildLookaroundRegex, extractWith,
-         type FieldPos, type CtxClass, type ExtractKind } from '../../utils/regexBuilder'
+import { buildFieldRegex, buildLookaroundRegex, extractWith, regexSampleFor,
+         type FieldPos, type CtxClass, type ExtractKind, type RegexSource } from '../../utils/regexBuilder'
 import { parseChannelNameList, channelNamesAsText, referenceCandidates,
          splitByChannelCount, skippedChannelCountMsg } from '../../utils/channelNames'
 import { usePanelResize } from '../../composables/usePanelResize'
@@ -122,7 +122,7 @@ async function assignSingleValue() {
 // ── Extract via regex ──────────────────────────────────────────────────────────
 
 const regexpValue  = ref('')
-const regexpSource = ref<'name' | 'filepath'>('name')
+const regexpSource = ref<RegexSource>('name')
 
 // ── Regex builder (split by a separator, take the Nth/last field) ────────────────
 // Covers the trivial "just pull the treatment/mouse/etc. out of the filename" cases people usually
@@ -130,7 +130,7 @@ const regexpSource = ref<'name' | 'filepath'>('name')
 const builderOpen      = ref(false)
 const builderMode      = ref<'field' | 'around'>('field')
 // field mode: split by a separator, take a field
-const builderSep       = ref<'-' | '_' | '.' | 'space' | 'custom'>('-')
+const builderSep       = ref<'-' | '_' | '.' | 'space' | 'folder' | 'custom'>('-')
 const builderCustomSep = ref('')
 const builderPos       = ref<FieldPos>('last')
 const builderStripExt  = ref(true)
@@ -143,7 +143,8 @@ const extractText      = ref('')
 const afterText        = ref('')
 const afterCls         = ref<CtxClass>('none')
 const effectiveSep = computed(() =>
-  builderSep.value === 'space'  ? ' ' :
+  builderSep.value === 'space'  ? ' '   :
+  builderSep.value === 'folder' ? '/\\' :   // both platforms' separators, either splits
   builderSep.value === 'custom' ? builderCustomSep.value : builderSep.value)
 // Live preview of the SINGLE regex field against the first image Apply would target. The builder
 // writes straight into `regexpValue` (below), so there's one input and one preview — never two.
@@ -151,7 +152,7 @@ const regexSample = computed(() => {
   const uid = targetUids.value[0] ?? setImages.value[0]?.uid
   const img = setImages.value.find(i => i.uid === uid)
   if (!img) return ''
-  return regexpSource.value === 'filepath' ? (img.filepath ?? img.name) : img.name
+  return regexSampleFor(img, regexpSource.value)
 })
 const regexPreview = computed(() => extractWith(regexpValue.value, regexSample.value))
 // Adjusting any builder control rebuilds the pattern into the regex field (user interaction only —
@@ -178,9 +179,8 @@ async function assignRegexp() {
   for (const uid of targetUids.value) {
     const img  = setImages.value.find(i => i.uid === uid)
     if (!img) continue
-    const src  = regexpSource.value === 'filepath' ? (img.filepath ?? img.name) : img.name
     // first capture group wins (the builder always makes one), else the whole match
-    values[uid] = extractWith(regexpValue.value, src)
+    values[uid] = extractWith(regexpValue.value, regexSampleFor(img, regexpSource.value))
   }
 
   const res = await fetch('/api/images/attr/set', {
@@ -395,8 +395,8 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
           Filename
         </label>
         <label class="radio-label">
-          <input type="radio" v-model="regexpSource" value="filepath" :disabled="attrDisabled"
-            v-tooltip.bottom="'Match against the full original path'" />
+          <input type="radio" v-model="regexpSource" value="path" :disabled="attrDisabled"
+            v-tooltip.bottom="'Match against the full path of the imported file'" />
           Original path
         </label>
       </div>
@@ -427,6 +427,7 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
               <option value="_">_ underscore</option>
               <option value=".">. dot</option>
               <option value="space">␣ space</option>
+              <option value="folder">/ folder</option>
               <option value="custom">custom…</option>
             </select>
             <input v-if="builderSep === 'custom'" type="text" class="field-input builder-custom"
@@ -440,9 +441,12 @@ const flaggedCount = computed(() => setImages.value.filter(i => metadataWarning(
               <option value="first">1st field</option>
               <option value="second">2nd field</option>
               <option value="third">3rd field</option>
+              <option value="thirdLast">3rd-last field</option>
+              <option value="secondLast">2nd-last field</option>
               <option value="last">last field</option>
             </select>
-            <CcToggle class="radio-label" label="no ext" :disabled="attrDisabled"
+            <!-- only the last field can carry the file extension — see buildFieldRegex -->
+            <CcToggle v-if="builderPos === 'last'" class="radio-label" label="no ext" :disabled="attrDisabled"
               :model-value="builderStripExt" @update:model-value="builderStripExt = $event; applyBuilder()"
               v-tooltip.bottom="'Drop a trailing .extension from the captured value'" />
           </div>

--- a/frontend/src/utils/regexBuilder.test.ts
+++ b/frontend/src/utils/regexBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildFieldRegex, buildLookaroundRegex, extractWith } from './regexBuilder'
+import { buildFieldRegex, buildLookaroundRegex, extractWith, regexSampleFor } from './regexBuilder'
 
 // End-to-end: build a regex for a common case, then apply it to the sample the user would type it for.
 const field = (sample: string, sep: string, pos: Parameters<typeof buildFieldRegex>[1], stripExt = true) =>
@@ -39,6 +39,84 @@ describe('regexBuilder — field split', () => {
   it('empty separator → empty regex → empty extraction', () => {
     expect(buildFieldRegex('', 'last', true)).toBe('')
     expect(field('a-b', '', 'last')).toBe('')
+  })
+
+  it('counts fields from the end', () => {
+    expect(field('M4d-CD8-GFP-CD20-Tom', '-', 'secondLast')).toBe('CD20')
+    expect(field('M4d-CD8-GFP-CD20-Tom', '-', 'thirdLast')).toBe('GFP')
+    expect(field('mouse_03_ctrl.czi', '_', 'secondLast')).toBe('03')
+  })
+
+  it('from-the-end positions do not match when there are too few fields', () => {
+    expect(field('a-b', '-', 'thirdLast')).toBe('')
+    expect(field('Image1.tif', '-', 'secondLast')).toBe('')
+  })
+
+  it('a multi-char separator means "any of these characters"', () => {
+    // the folder separator: `/` and `\`, so one pattern covers both platforms
+    expect(field('/data/20260714/M1b-MERTK.ori', '/\\', 'last')).toBe('M1b-MERTK')
+    expect(field('C:\\data\\20260714\\M1b-MERTK.ori', '/\\', 'last')).toBe('M1b-MERTK')
+  })
+})
+
+// The point of the "Original path" source: pull acquisition info out of the UPSTREAM FOLDERS the
+// user organises by (a date directory per session), not out of the filename.
+describe('regexBuilder — extracting from the folders of a path', () => {
+  const PATHS = [
+    '/mnt/imaging/20260714/M1b-MERTK.ori',
+    'C:\\imaging\\20260714\\M1b-MERTK.ori',
+    '/mnt/imaging/two/levels/deep/20260714/M1b-MERTK.ori',
+  ]
+
+  it('takes the containing folder as the 2nd-last field, at any depth', () => {
+    const re = buildFieldRegex('/\\', 'secondLast', true)
+    for (const p of PATHS) expect(extractWith(re, p)).toBe('20260714')
+  })
+
+  // Windows source paths reach ccid.json as-is (drive letters, UNC shares, and — since the browse
+  // route and Julia's joinpath can disagree — mixed separators), so the folder separator is the
+  // CLASS [/\\] rather than one platform's character.
+  it('handles Windows paths: drive letter, UNC share, mixed separators', () => {
+    const re = buildFieldRegex('/\\', 'secondLast', true)
+    expect(extractWith(re, 'C:\\imaging\\INCITe\\20260716\\M1b-MERTK.oir')).toBe('20260716')
+    expect(extractWith(re, '\\\\garvan-fs\\imaging\\20260716\\M1b-MERTK.oir')).toBe('20260716')
+    expect(extractWith(re, 'C:/imaging/INCITe\\20260716\\M1b-MERTK.oir')).toBe('20260716')
+    expect(extractWith(buildFieldRegex('/\\', 'last', true), 'C:\\imaging\\20260716\\M1b-MERTK.oir'))
+      .toBe('M1b-MERTK')
+  })
+
+  // stripExt is about the FILE extension, so it must not apply to a folder field — a `2026.07.16`
+  // date folder used to match nothing at all because the dot-free token class was applied to it.
+  it('a dotted folder name survives, with or without the extension toggle', () => {
+    for (const stripExt of [true, false])
+      expect(extractWith(buildFieldRegex('/\\', 'secondLast', stripExt),
+                         'C:\\imaging\\2026.07.16\\M1b-MERTK.oir')).toBe('2026.07.16')
+    // …while the last field still drops its extension as before
+    expect(extractWith(buildFieldRegex('/\\', 'last', true),
+                       'C:\\imaging\\2026.07.16\\M1b-MERTK.oir')).toBe('M1b-MERTK')
+  })
+
+  it('the look-around builder reaches it too (digits between separators)', () => {
+    const re = buildLookaroundRegex(
+      { text: '/', cls: 'none' }, { kind: 'digits', text: '' }, { text: '/', cls: 'none' })
+    expect(extractWith(re, PATHS[0])).toBe('20260714')
+  })
+})
+
+describe('regexSampleFor', () => {
+  // The bug this fixes: `filepath` is the CONVERTED store inside the project
+  // (ccidDriftCorrected.ome.zarr), so matching against it can never see the source folders.
+  const img = { name: 'M1b-MERTK', oriPath: '/mnt/imaging/20260714/M1b-MERTK.ori' }
+
+  it('path → the original source location, name → the image name', () => {
+    expect(regexSampleFor(img, 'path')).toBe('/mnt/imaging/20260714/M1b-MERTK.ori')
+    expect(regexSampleFor(img, 'name')).toBe('M1b-MERTK')
+  })
+
+  it('falls back to the name when no source path was recorded', () => {
+    expect(regexSampleFor({ name: 'M1b-MERTK' }, 'path')).toBe('M1b-MERTK')
+    expect(regexSampleFor({ name: 'M1b-MERTK', oriPath: null }, 'path')).toBe('M1b-MERTK')
+    expect(regexSampleFor({ name: 'M1b-MERTK', oriPath: '' }, 'path')).toBe('M1b-MERTK')
   })
 })
 

--- a/frontend/src/utils/regexBuilder.ts
+++ b/frontend/src/utils/regexBuilder.ts
@@ -3,7 +3,7 @@
 // string for that case (which is written into the visible regex field, so the user sees/edits the
 // real thing and learns), plus a preview that mirrors how the panel applies it.
 
-export type FieldPos = 'first' | 'second' | 'third' | 'last'
+export type FieldPos = 'first' | 'second' | 'third' | 'thirdLast' | 'secondLast' | 'last'
 
 const SPECIAL = /[.*+?^${}()|[\]\\]/g
 /** Escape a char for use OUTSIDE a character class (as a literal). */
@@ -11,23 +11,61 @@ function escLiteral(c: string): string { return c.replace(SPECIAL, '\\$&') }
 /** Escape a char for use INSIDE a [...] class. */
 function escClass(c: string): string { return c.replace(/[\]^\\-]/g, '\\$&').replace(/\./g, '\\.') }
 
-const POS_INDEX: Record<Exclude<FieldPos, 'last'>, number> = { first: 1, second: 2, third: 3 }
+const FROM_START: Record<'first' | 'second' | 'third', number>      = { first: 1, second: 2, third: 3 }
+const FROM_END:   Record<'last' | 'secondLast' | 'thirdLast', number> = { last: 1, secondLast: 2, thirdLast: 3 }
+const isFromEnd = (p: FieldPos): p is 'last' | 'secondLast' | 'thirdLast' => p in FROM_END
 
 /**
- * Regex source capturing the chosen field of `sample.split(sep)`. `stripExt` excludes a trailing
- * `.extension` from the captured token (so "Image2-testB.tif" split by "-", last → "testB", not
- * "testB.tif"). Returns "" for an empty separator. The captured value is the first group.
+ * Regex source capturing the chosen field of `sample.split(sep)`. `sep` is one or more separator
+ * CHARACTERS — any of them splits (so the folder separator can be `/\` and cover both platforms).
+ * `stripExt` excludes a trailing `.extension` from the captured token (so "Image2-testB.tif" split
+ * by "-", last → "testB", not "testB.tif"). Returns "" for an empty separator. The captured value
+ * is the first group.
+ *
+ * Positions count from the start (first/second/third) OR from the end (last/secondLast/thirdLast).
+ * From-the-end matters for the *path* source: an absolute path has a variable number of leading
+ * folders, so "the folder the image sits in" (…/20260714/M1b-MERTK.ori → 20260714) is only
+ * reachable as the 2nd-last field.
+ *
+ * `stripExt` applies to the LAST field only — that is the one an extension can be on. Anywhere else
+ * it would just mangle a legitimately dotted token: a `2026.07.16` date folder taken as the 2nd-last
+ * field of a path matched nothing at all while the dot-free token class was applied to it.
  */
 export function buildFieldRegex(sep: string, pos: FieldPos, stripExt: boolean): string {
   if (!sep) return ''
-  const sc   = escClass(sep)
-  const sl   = escLiteral(sep)
-  const cap  = stripExt ? `[^${sc}.]+` : `[^${sc}]+`   // captured token (optionally dot-free)
+  const chars = [...new Set(sep.split(''))]
+  const sc   = chars.map(escClass).join('')                            // inside [...]
+  const sl   = chars.length === 1 ? escLiteral(chars[0]) : `[${sc}]`   // as a literal
+  const ext  = stripExt && pos === 'last'              // only the last field carries the extension
+  const cap  = ext ? `[^${sc}.]+` : `[^${sc}]+`        // captured token (optionally dot-free)
   const any  = `[^${sc}]*`                              // a whole skipped field
-  const tail = stripExt ? '(?:\\.[^.]+)?' : ''         // optional trailing .ext to drop
-  if (pos === 'last') return `(?:^|${sl})(${cap})${tail}$`
-  const n = POS_INDEX[pos]
+  const tail = ext ? '(?:\\.[^.]+)?' : ''              // optional trailing .ext to drop
+  if (isFromEnd(pos)) {
+    const k = FROM_END[pos]
+    return `(?:^|${sl})(${cap})${tail}` + `(?:${sl}${any})`.repeat(k - 1) + '$'
+  }
+  const n = FROM_START[pos]
   return '^' + `${any}${sl}`.repeat(n - 1) + `(${cap})`
+}
+
+// ── What the regex runs on ──────────────────────────────────────────────────────
+
+export type RegexSource = 'name' | 'path'
+
+/**
+ * The string the regex is applied to. `path` means the image's ORIGINAL source location (`oriPath`,
+ * from `meta.ori_path`) — deliberately NOT `filepath`, which is the *converted* OME-Zarr filename
+ * inside the project (`ccidImage.ome.zarr`, `ccidDriftCorrected.ome.zarr`, …) and carries none of
+ * the acquisition information the user is extracting. The point of the path source is the upstream
+ * folders: `…/20260714/M1b-MERTK.ori` → the imaging date.
+ *
+ * Falls back to the name when the image has no recorded source path (pre-`ori_path` data); the
+ * panel's live preview shows the string that will actually be matched.
+ */
+export function regexSampleFor(
+  img: { name: string; oriPath?: string | null }, source: RegexSource,
+): string {
+  return source === 'path' ? (img.oriPath || img.name) : img.name
 }
 
 // ── Look-around builder ─────────────────────────────────────────────────────────


### PR DESCRIPTION
The Metadata panel's **Original path** regex source fed the regex `filepath` — the *converted* store inside the project (`ccidImage.ome.zarr`, or `ccidDriftCorrected.ome.zarr` once a processed version is active). That is the same uninformative name on every image, so the option could never do the thing it exists for: reading acquisition information out of the folders people organise by — `…/20260714/M1b-MERTK.ori` → the imaging date.

The original location was already in the payload as `oriPath` (`meta.ori_path`), just unused here. `regexSampleFor` now resolves it, for both the live preview and Apply, falling back to the image name when there is no recorded source path.

## Fixing the source alone wasn't enough

The Builder had no way to reach a folder, so three things came with it:

- **A `/ folder` separator** — the class `[/\]`, either character splits. A Windows `ori_path` can be a drive letter, a UNC share, or mixed separators (the browse route and Julia's `joinpath` disagreeing), so one platform's character would have been fragile even on Windows alone. `buildFieldRegex`'s separator is a character *set* now; a single character still builds exactly the pattern it did before.
- **2nd-last / 3rd-last field positions.** An absolute path has a variable number of leading folders, so counting from the start is useless on one — the containing folder is only reachable from the end.
- **`stripExt` applies to the last field only**, the one an extension can be on. Applied to a folder it mangled a legitimately dotted token: a `2026.07.16` date folder matched *nothing at all*. The *no ext* toggle is hidden for the other positions.

So `Original path` + split by `/ folder` + `2nd-last field` gives the date directly.

## Verified

Against every `ori_path` in the dev projects dir:

| path | 2nd-last |
|---|---|
| `/mnt/staging/INCITe/domsch/Mertk-Kat-memTom-nucGFP/20260716/M2b-MERTK_KAT-…oir` | `20260716` |
| `/home/dominik/gdrive/Notebook/DATA/TCELL_TYPES/20211128/M2-2-B6-naive-…oir` | `20211128` |
| `/home/dominik/Downloads/TMP/UNIMELB_SPLEEN/M4c-CD8-GFP-CD20-Tom_002.tif` | `UNIMELB_SPLEEN` |

Every image in that dir has `ori_path`; the entries without one are all *sets*. Windows shapes (drive letter, UNC, mixed) and the dotted-folder case are pinned as testsets rather than reasoned about.

`npm test` 1283 passing (107 files), `npm run typecheck` clean. `docs/UI.md` updated.

## Behaviour changes to controls that already shipped

- `stripExt` no longer strips mid-token dots for the **first/second/third** positions. Arguably always wrong — a mid-token dot is not a trailing extension — but it is a change.
- A **multi-character custom separator** now means "any of these characters" rather than that literal sequence. In practice it extracts the same field, and the old version already treated the characters individually in its token class.

Not covered: the panel's regex controls are still bare `ref()`s (reset on remount) — pre-existing, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
